### PR TITLE
789182: Fix UnicodeEncodeError when logging.

### DIFF
--- a/src/subscription_manager/logutil.py
+++ b/src/subscription_manager/logutil.py
@@ -25,11 +25,11 @@ def _get_handler():
             os.mkdir("/var/log/rhsm")
     except:
         pass
-    fmt = '%(asctime)s [%(levelname)s]  @%(filename)s:%(lineno)d - %(message)s'
+    fmt = u'%(asctime)s [%(levelname)s]  @%(filename)s:%(lineno)d - %(message)s'
 
     # Try to write to /var/log, fallback on console logging:
     try:
-        handler = RotatingFileHandler(path, maxBytes=0x100000, backupCount=5)
+        handler = RotatingFileHandler(path, maxBytes=0x100000, backupCount=5, encoding='utf-8')
     except IOError:
         handler = logging.StreamHandler()
     except:

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -545,7 +545,7 @@ class IdentityCommand(UserPassCommand):
                 log.info("Successfully generated a new identity from Entitlement Platform.")
         except connection.RestlibException, re:
             log.exception(re)
-            log.error("Error: Unable to generate a new identity for the system: %s" % re)
+            log.error(u"Error: Unable to generate a new identity for the system: %s" % re)
             systemExit(-1, re.msg)
         except Exception, e:
             handle_exception(_("Error: Unable to generate a new identity for the system"), e)
@@ -584,7 +584,7 @@ class OwnersCommand(UserPassCommand):
 
         except connection.RestlibException, re:
             log.exception(re)
-            log.error("Error: Unable to retrieve org list from Entitlement Platform: %s" % re)
+            log.error(u"Error: Unable to retrieve org list from Entitlement Platform: %s" % re)
             systemExit(-1, re.msg)
         except Exception, e:
             handle_exception(_("Error: Unable to retrieve org list from Entitlement Platform"), e)
@@ -642,7 +642,7 @@ class EnvironmentsCommand(UserPassCommand):
             log.info("Successfully retrieved environment list from Entitlement Platform.")
         except connection.RestlibException, re:
             log.exception(re)
-            log.error("Error: Unable to retrieve environment list from Entitlement Platform: %s" % re)
+            log.error(u"Error: Unable to retrieve environment list from Entitlement Platform: %s" % re)
             systemExit(-1, re.msg)
         except Exception, e:
             handle_exception(_("Error: Unable to retrieve environment list from Entitlement Platform"), e)
@@ -714,7 +714,7 @@ class ServiceLevelCommand(UserPassCommand):
 
         except connection.RestlibException, re:
             log.exception(re)
-            log.error("Error: Unable to retrieve service levels: %s" % re)
+            log.error(u"Error: Unable to retrieve service levels: %s" % re)
             systemExit(-1, re.msg)
         except Exception, e:
             handle_exception(_("Error: Unable to retrieve service levels."), e)


### PR DESCRIPTION
Strings sent to the logger that may have unicode text in them
must be prefaced with a "u".
