### PR TITLE
822057: do not hard-code cdn to port 443

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1103,10 +1103,14 @@ class ReleaseCommand(CliCommand):
         cdn_url = cfg.get('rhsm', 'baseurl')
         parsed_url = urlparse.urlparse(cdn_url)
 
-        self.cc = connection.ContentConnection(host=parsed_url[1],
-                                               #FIXME: should be using the parsed value
-                                               # we can use utils.parse_server_info
-                                               ssl_port=443,
+        # default to 443 if urlprase can't interpret the port
+        if parsed_url.port:
+            cdn_port = parsed_url.port
+        else:
+            cdn_port = 443
+
+        self.cc = connection.ContentConnection(host=parsed_url.hostname,
+                                               ssl_port=cdn_port,
                                                proxy_hostname=self.proxy_hostname,
                                                proxy_port=self.proxy_port,
                                                proxy_user=self.proxy_user,


### PR DESCRIPTION
Previously, the CDN port was hard-coded to 443. This did not work properly with
thumbslug, which uses port 8088.

Instead, we can use urlparse's hostname/port functionality to find what port we
should be connecting to. If the port is unreadable, assume 443.
