### PR TITLE
Display remote entitlement server version in about dialog

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -436,7 +436,7 @@ class MainWindow(widgets.GladeWidget):
             log.warn("Unable to open help documentation: %s", e)
 
     def _about_item_clicked(self, widget):
-        about = AboutDialog(self._get_window())
+        about = AboutDialog(self._get_window(), self.backend)
         about.show()
 
     def _online_docs_item_clicked(self, widget):

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -53,7 +53,7 @@ from subscription_manager.cert_sorter import FUTURE_SUBSCRIBED, SUBSCRIBED, \
         NOT_SUBSCRIBED, EXPIRED, PARTIALLY_SUBSCRIBED
 from subscription_manager.utils import remove_scheme, parse_server_info, \
         ServerUrlParseError, parse_baseurl_info, format_baseurl, is_valid_server_info, \
-        MissingCaCertException
+        MissingCaCertException, get_upstream_server_version
 
 log = logging.getLogger('rhsm-app.' + __name__)
 cfg = rhsm.config.initConfig()
@@ -1863,14 +1863,9 @@ class VersionCommand(CliCommand):
         pass
 
     def _do_command(self):
-        try:
-            cp_version = self.cp.getStatus()['version']
-        except Exception, e:
-            cp_version = "Unknown"
-            log.error("Unable to communicate with Candlepin")
-            log.exception(e)
+        uep_version = get_upstream_server_version(self.cp)
 
-        print (_("Candlepin version: %s") % cp_version)
+        print (_("remote entitlement server version: %s") % uep_version)
 
         versions = Versions()
         print (_("subscription-manager version: %s") % \

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -233,3 +233,13 @@ def is_valid_server_info(hostname, port, prefix):
     except Exception, e:
         log.exception(e)
         return False
+
+
+def get_upstream_server_version(uep):
+    try:
+        uep_version = uep.getStatus()['version']
+    except Exception, e:
+        uep_version = "Unknown"
+        log.error("Unable to communicate with upstream server")
+        log.exception(e)
+    return uep_version


### PR DESCRIPTION
In addition, change the word "candlepin" to "remote entitlement server" so it
makes more sense to SAM/CFSE users.
