### PR TITLE
820294: Let candlepin handle org/env/key validation

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -821,12 +821,6 @@ class RegisterCommand(UserPassCommand):
         elif (self.options.consumerid and self.options.activation_keys):
             print(_("Error: Activation keys can not be used with previously registered ids."))
             sys.exit(-1)
-        elif (self.options.environment and not self.options.org):
-            print(_("Error: Must specify --org to register to an environment."))
-            sys.exit(-1)
-        elif (self.options.activation_keys and not self.options.org):
-            print(_("Error: Must specify --org to register with activation keys."))
-            sys.exit(-1)
         #746259: Don't allow the user to pass in an empty string as an activation key
         elif (self.options.activation_keys and '' in self.options.activation_keys):
             print(_("Error: Must specify an activation key"))


### PR DESCRIPTION
We don't need to verify if the user specifies a org with an environment
or with an activation key, as the user might only have one org, or a
default org, and so not need to actually supply one on the cli. Let
candlepin take care of notifying the user they need to specify one.
