### PR TITLE
812410: Show product name on CLI subscribe to pool.

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1221,10 +1221,14 @@ class SubscribeCommand(CliCommand):
                         # odd html strings will cause issues, reject them here.
                         if (pool.find("#") >= 0):
                             systemExit(-1, _("Please enter a valid numeric pool id."))
-                        self.cp.bindByEntitlementPool(consumer_uuid, pool, self.options.quantity)
-                        print _("Successfully consumed a subscription from the pool with id %s.") % pool
-                        subscribed = True
-                        log.info("Info: Successfully subscribed the system to the Entitlement Pool %s" % pool)
+                        ents = self.cp.bindByEntitlementPool(consumer_uuid, pool, self.options.quantity)
+                        # Usually just one, but may as well be safe:
+                        for ent in ents:
+                            pool_json = ent['pool']
+                            print _("Successfully consumed a subscription for: %s") % pool_json['productName']
+                            log.info("Successfully consumed a subscription for: %s (%s)" %
+                                    (pool_json['productName'], pool))
+                            subscribed = True
                     except connection.RestlibException, re:
                         log.exception(re)
                         if re.code == 403:


### PR DESCRIPTION
Just showing name, as the pool IDs are pretty visible in the command you
just ran.

Switched the logging to show both.
