### PR TITLE
818383: display better messages for yum plugin usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ pyflakes:
 # and other tools detect the valid cases, so ignore these
 #
 	@TMPFILE=`mktemp` || exit 1; \
-	pyflakes $(STYLEFILES) |  grep -v "redefinition of unused.*from line.*" | tee $$TMPFILE; \
+	pyflakes $(STYLEFILES) |  grep -v "redefinition of unused.*from line.*" |  grep -v "undefined name 'ConsumerIdentity'" |  tee $$TMPFILE; \
 	! test -s $$TMPFILE
 
 pylint:


### PR DESCRIPTION
this was already acked on the mailing list, re-sending since we changed repos in the middle of the patch process

Display more verbose info and warning messages to users.

The try/except in warnOrGiveUsageMessage() should be sufficient to catch
anything unexpected that crops up, we never want to bail on a yum update due to
exceptions during messaging.

This is purposefully not marked for translation, these strings need to be
translated but not as part of this patch (see bz for more detail).

Also, there is a pyflakes warning that occurs due to an import happening in the
update method, and then that import is referenced elsewhere. This is due to the
requirement that the import occur after we know we're running as root. I
altered the Makefile to disregard this warning.
