### PR TITLE
818282: Sort virtual subscriptions to the top of contract selector.

### DIFF
--- a/src/subscription_manager/gui/allsubs.py
+++ b/src/subscription_manager/gui/allsubs.py
@@ -397,22 +397,21 @@ class AllSubscriptionsTab(widgets.SubscriptionManagerTab):
 
     def subscribe_button_clicked(self, button):
         model, tree_iter = self.top_view.get_selection().get_selected()
-        pools = model.get_value(tree_iter, self.store['merged_pools'])
+        merged_pools = model.get_value(tree_iter, self.store['merged_pools'])
         quantity_to_consume = model.get_value(tree_iter, self.store['quantity_to_consume'])
 
         # Decide if we need to show the contract selection dialog or not.
         # If there's just one pool and does not allow multi-entitlement,
         # shortcut right to the callback that the dialog would have run.
-        if len(pools.pools) == 1:
-            self._contract_selected(pools.pools[0], quantity_to_consume)
+        if len(merged_pools.pools) == 1:
+            self._contract_selected(merged_pools.pools[0], quantity_to_consume)
             return
 
         self.contract_selection = ContractSelectionWindow(
                 self._contract_selected, self._contract_selection_cancelled)
 
         self.contract_selection.set_parent_window(self.content.get_parent_window().get_user_data())
-
-        for pool in pools.pools:
+        for pool in merged_pools.pools:
             self.contract_selection.add_pool(pool, quantity_to_consume)
 
         self.contract_selection.show()

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -383,6 +383,26 @@ class MergedPools(object):
         # is added and hope they are consistent.
         self.bundled_products = len(pool['providedProducts'])
 
+    def _virt_physical_sorter(self, pool):
+        """
+        Used to sort the pools, return Physical or Virt depending on
+        the value or existence of the virt_only attribute.
+
+        Returning numeric values to simulate the behavior we want.
+        """
+        for attr in pool['attributes']:
+            if attr['name'] == 'virt_only' and attr['value'] == 'true':
+                return 1
+        return 2
+
+    def sort_virt_to_top(self):
+        """
+        Prioritizes virt pools to the front of the list, if any are present.
+
+        Used by contract selector to show these first in the list.
+        """
+        self.pools.sort(key=lambda pool: self._virt_physical_sorter(pool))
+
 
 def merge_pools(pools):
     """

--- a/test/test_managerlib.py
+++ b/test/test_managerlib.py
@@ -23,7 +23,7 @@ from stubs import StubCertificateDirectory, StubProductCertificate, \
         StubProduct, StubEntitlementCertificate
 from subscription_manager.managerlib import merge_pools, PoolFilter, \
         getInstalledProductStatus, LocalTz, parseDate, \
-        MergedPoolsStackingGroupSorter
+        MergedPoolsStackingGroupSorter, MergedPools
 from modelhelpers import create_pool
 from subscription_manager import managerlib
 import rhsm
@@ -730,3 +730,50 @@ class ParseDateTests(unittest.TestCase):
         self.assertEquals(2038, parsed.year)
         self.assertEquals(1, parsed.month)
         self.assertEquals(1, parsed.day)
+
+class MergedPoolsTests(unittest.TestCase):
+
+    def test_sort_virt_to_top(self):
+        # Fake some pool JSON with the bare minimum of data:
+        pools = [
+            {
+                'id': 1,
+                'attributes': [],
+                'consumed': 0,
+                'quantity': 10,
+                'providedProducts': [],
+            },
+            {
+                'id': 2,
+                'attributes': [{'name': 'virt_only', 'value': 'true'}],
+                'consumed': 0,
+                'quantity': 10,
+                'providedProducts': [],
+            },
+            {
+                'id': 3,
+                'attributes': [],
+                'consumed': 0,
+                'quantity': 10,
+                'providedProducts': [],
+            },
+            {
+                'id': 4,
+                'attributes': [{'name': 'virt_only', 'value': 'true'}],
+                'consumed': 0,
+                'quantity': 10,
+                'providedProducts': [],
+            }]
+
+        merged_pools = MergedPools('product', 'A Product')
+        for p in pools:
+            merged_pools.add_pool(p)
+
+        merged_pools.sort_virt_to_top()
+        # If we sort, the virt pools should become the first two in the list:
+        self.assertEquals(merged_pools.pools[0]['attributes'][0]['value'],
+                "true")
+        self.assertEquals(merged_pools.pools[1]['attributes'][0]['value'],
+                "true")
+        self.assertFalse('virt_only' in merged_pools.pools[2]['attributes'])
+        self.assertFalse('virt_only' in merged_pools.pools[3]['attributes'])


### PR DESCRIPTION
By default, we want virtual subscriptions to appear at the top of the
list if any are present, as these are generally more relevant to the
user than the physical pools they can also use.

Implemented by just sorting the list of merged pools being handed off to
the contract selector, placing anything virtual at the start.
