### PR TITLE
817901: Disable the match installed products filter.

### DIFF
--- a/src/subscription_manager/gui/data/allsubs.glade
+++ b/src/subscription_manager/gui/data/allsubs.glade
@@ -168,7 +168,7 @@
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
-                                        <property name="active">True</property>
+                                        <property name="active">False</property>
                                         <property name="draw_indicator">True</property>
                                         <accessibility>
                                           <atkproperty name="AtkObject::accessible-name" translatable="yes">Match Installed</atkproperty>


### PR DESCRIPTION
Having this on too frequently results in the user seeing nothing after
updating the list of pools. Instead we'll try to show a bit more
information which can be removed by turning filters on.
