### PR TITLE
Display Register button on Installed Product tab if not registered.

### DIFF
--- a/src/subscription_manager/gui/data/installed.glade
+++ b/src/subscription_manager/gui/data/installed.glade
@@ -55,9 +55,20 @@
                           <placeholder/>
                         </child>
                         <child>
+                          <widget class="GtkButton" id="register_button">
+                            <property name="label" translatable="yes">Register</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <signal name="clicked" handler="on_register_button_clicked"/>
+                          </widget>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                        <child>
                           <widget class="GtkButton" id="update_certificates_button">
                             <property name="label" translatable="yes">Auto-subscribe</property>
-                            <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <accessibility>
@@ -69,7 +80,7 @@
                             <property name="expand">False</property>
                             <property name="fill">False</property>
                             <property name="pack_type">end</property>
-                            <property name="position">3</property>
+                            <property name="position">4</property>
                           </packing>
                         </child>
                       </widget>

--- a/test/test_managergui.py
+++ b/test/test_managergui.py
@@ -1,7 +1,7 @@
 import unittest
 
 import stubs
-from subscription_manager.gui import managergui, registergui
+from subscription_manager.gui import managergui, registergui, installedtab
 
 
 class StubConsumer:
@@ -15,6 +15,7 @@ class StubConsumer:
 class TestManagerGuiMainWindow(unittest.TestCase):
     def test_main_window(self):
         managergui.ConsumerIdentity = stubs.StubConsumerIdentity
+        installedtab.ConsumerIdentity = stubs.StubConsumerIdentity
         managergui.Backend = stubs.StubBackend
         managergui.Consumer = StubConsumer
         managergui.Facts = stubs.StubFacts()


### PR DESCRIPTION
Register button and custom Cert Status message is displayed
on the installed product tab if the system is not registered.

Otherwise, the Auto-Subscribe button is displayed along with
original messaging.
