### PR TITLE
819665: print msg if user is registered to RHN Classic on "identity" command

### DIFF
--- a/src/subscription_manager/branding/redhat_branding.py
+++ b/src/subscription_manager/branding/redhat_branding.py
@@ -18,5 +18,11 @@ class Branding(object):
 
         self.GUI_REGISTRATION_HEADER = \
                 _("Please enter your Red Hat account information:")
+        self.REGISTERED_TO_BOTH_WARNING = \
+                _("This system is registered using both RHN Classic technology and RHN Certificate-Based technology.") + \
+                "\n\n" + \
+                _("Red Hat recommends (except in a few cases) that customers only register with RHN via one method.") + \
+                "\n\n" + \
+                _("To learn more about RHN registration and technologies please consult this Knowledge Base Article: https://access.redhat.com/kb/docs/DOC-45563")
         self.GUI_FORGOT_LOGIN_TIP = \
                 _("Tip: Forgot your login or password? Look it up at http://red.ht/lost_password")

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -522,6 +522,14 @@ class IdentityCommand(UserPassCommand):
             sys.exit(-1)
 
     def _do_command(self):
+        # check for Classic before doing anything else
+        if ClassicCheck().is_registered_with_classic():
+            if ConsumerIdentity.existsAndValid():
+                print get_branding().REGISTERED_TO_BOTH_WARNING
+            else:
+                # no need to continue if user is only registered to Classic
+                print get_branding().RHSMD_REGISTERED_TO_OTHER
+                return
 
         try:
             consumer = check_registration()


### PR DESCRIPTION
If a user runs the "identity" command, they previously would not receive
messaging if they were registered to RHN Classic or not.

Instead, the user will get a notice stating they are registered to RHN Classic.
If the user is registered to both Classic and cert-based RHN, they will get a
warning message before then cert-based portion of the "identity" command runs.
