### PR TITLE
Remove reference to InstalledProductsTab.product_id_text

### DIFF
--- a/src/subscription_manager/gui/installedtab.py
+++ b/src/subscription_manager/gui/installedtab.py
@@ -245,7 +245,7 @@ class InstalledProductsTab(widgets.SubscriptionManagerTab):
 
     def on_no_selection(self):
         self.product_text.get_buffer().set_text("")
-        self.product_id_text.get_buffer().set_text("")
+        self.product_arch_text.get_buffer().set_text("")
         self.validity_text.get_buffer().set_text("")
         self.subscription_text.get_buffer().set_text("")
 


### PR DESCRIPTION
It was removed in 9e25792073096f993a2503e8cc28b844ceb2fb09
