### PR TITLE
Close registration window even if it failed.

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -192,8 +192,7 @@ class RegisterScreen(widgets.GladeWidget):
         # XXX it would be cool here to do some async spinning while the
         # main window gui refreshes itself
 
-        if not failed:
-            self.close_window()
+        self.close_window()
 
         self.emit_consumer_signal()
 


### PR DESCRIPTION
Window was being open left open and dead in some situations
(environments supported but none available). Close it always now in
finish registration.

Situations where we want the GUI to stay open will be handled
explicitly. (as per server unreachable)
