### PR TITLE
810360: update wording in gnome help file

### DIFF
--- a/docs/subscription-manager.xml
+++ b/docs/subscription-manager.xml
@@ -296,7 +296,7 @@
 		<secondary>registering</secondary>
 	</indexterm>
 		<para>
-			For infrastructures which use Red Hat's hosted subscription and content delivery network, all that is required to register the system is the username and password of the Red Hat Network account.
+			For infrastructures which use Red Hat's hosted subscription and content delivery network, all that is required to register the system is the username and password of the Red Hat account.
 		</para>
 			<orderedlist>
 				<listitem>


### PR DESCRIPTION
a text change was missed in the gnome help file
