### PR TITLE
Remove 'swapped=on' from glade signal markup.

### DIFF
--- a/src/subscription_manager/gui/data/allsubs.glade
+++ b/src/subscription_manager/gui/data/allsubs.glade
@@ -57,7 +57,7 @@
                     <accessibility>
                       <atkproperty name="AtkObject::accessible-name" translatable="yes">Search</atkproperty>
                     </accessibility>
-                    <signal name="clicked" handler="on_search_button_clicked" swapped="no"/>
+                    <signal name="clicked" handler="on_search_button_clicked" />
                   </widget>
                   <packing>
                     <property name="expand">False</property>
@@ -104,7 +104,7 @@
                     <accessibility>
                       <atkproperty name="AtkObject::accessible-name" translatable="yes">Text in Subscription</atkproperty>
                     </accessibility>
-                    <signal name="changed" handler="on_contain_text_entry_changed" swapped="no"/>
+                    <signal name="changed" handler="on_contain_text_entry_changed" />
                   </widget>
                   <packing>
                     <property name="expand">False</property>
@@ -170,7 +170,7 @@
                                         <accessibility>
                                           <atkproperty name="AtkObject::accessible-name" translatable="yes">Match System</atkproperty>
                                         </accessibility>
-                                        <signal name="clicked" handler="on_compatible_checkbutton_clicked" swapped="no"/>
+                                        <signal name="clicked" handler="on_compatible_checkbutton_clicked" />
                                       </widget>
                                       <packing>
                                         <property name="expand">False</property>
@@ -188,7 +188,7 @@
                                         <accessibility>
                                           <atkproperty name="AtkObject::accessible-name" translatable="yes">Match Installed</atkproperty>
                                         </accessibility>
-                                        <signal name="clicked" handler="on_installed_checkbutton_clicked" swapped="no"/>
+                                        <signal name="clicked" handler="on_installed_checkbutton_clicked" />
                                       </widget>
                                       <packing>
                                         <property name="expand">False</property>
@@ -207,7 +207,7 @@
                                         <accessibility>
                                           <atkproperty name="AtkObject::accessible-name" translatable="yes">Do Not Overlap</atkproperty>
                                         </accessibility>
-                                        <signal name="clicked" handler="on_overlap_checkbutton_clicked" swapped="no"/>
+                                        <signal name="clicked" handler="on_overlap_checkbutton_clicked" />
                                       </widget>
                                       <packing>
                                         <property name="expand">False</property>
@@ -396,7 +396,7 @@
                     <accessibility>
                       <atkproperty name="AtkObject::accessible-name" translatable="yes">Subscribe</atkproperty>
                     </accessibility>
-                    <signal name="clicked" handler="on_subscribe_button_clicked" swapped="no"/>
+                    <signal name="clicked" handler="on_subscribe_button_clicked" />
                   </widget>
                   <packing>
                     <property name="expand">False</property>

--- a/src/subscription_manager/gui/data/choose_server.glade
+++ b/src/subscription_manager/gui/data/choose_server.glade
@@ -63,7 +63,7 @@
                     <accessibility>
                       <atkproperty name="AtkObject::accessible-name" translatable="yes">proxy_config_button</atkproperty>
                     </accessibility>
-                    <signal name="clicked" handler="on_proxy_config_button_clicked" swapped="no"/>
+                    <signal name="clicked" handler="on_proxy_config_button_clicked" />
                   </widget>
                   <packing>
                     <property name="expand">False</property>
@@ -97,7 +97,7 @@
                 <property name="receives_default">False</property>
                 <property name="active">True</property>
                 <property name="draw_indicator">True</property>
-                <signal name="toggled" handler="on_rhn_radio_toggled" swapped="no"/>
+                <signal name="toggled" handler="on_rhn_radio_toggled" />
                 <accessibility>
                   <atkproperty name="AtkObject::accessible-name" translatable="yes">rhn_radio</atkproperty>
                 </accessibility>
@@ -160,7 +160,7 @@
                         <accessibility>
                             <atkproperty name="AtkObject::accessible-name" translatable="yes">local_radio</atkproperty>
                         </accessibility>
-                        <signal name="toggled" handler="on_local_radio_toggled" swapped="no"/>
+                        <signal name="toggled" handler="on_local_radio_toggled" />
                       </widget>
                     </child>
                   </widget>
@@ -315,7 +315,7 @@
                         <accessibility>
                           <atkaction action_name="click" description="offline_radio"/>
                         </accessibility>
-                        <signal name="toggled" handler="on_offline_radio_toggled" swapped="no"/>
+                        <signal name="toggled" handler="on_offline_radio_toggled" />
                       </widget>
                     </child>
                   </widget>
@@ -413,7 +413,7 @@
                         <accessibility>
                             <atkproperty name="AtkObject::accessible-name" translatable="yes">import_certs_button</atkproperty>
                         </accessibility>
-                        <signal name="clicked" handler="on_import_certs_button_clicked" swapped="no"/>
+                        <signal name="clicked" handler="on_import_certs_button_clicked" />
                       </widget>
                       <packing>
                         <property name="expand">False</property>

--- a/src/subscription_manager/gui/data/registration.glade
+++ b/src/subscription_manager/gui/data/registration.glade
@@ -43,7 +43,7 @@
                 <accessibility>
                   <atkproperty name="AtkObject::accessible-name">cancel_button</atkproperty>
                 </accessibility>
-                <signal name="clicked" handler="on_register_cancel_button_clicked" swapped="no"/>
+                <signal name="clicked" handler="on_register_cancel_button_clicked" />
               </widget>
               <packing>
                 <property name="expand">False</property>
@@ -62,7 +62,7 @@
                   <atkproperty name="AtkObject::accessible-name" translatable="yes">register_button</atkproperty>
                   <atkproperty name="AtkObject::accessible-description">register_button</atkproperty>
                 </accessibility>
-                <signal name="clicked" handler="on_register_button_clicked" swapped="no"/>
+                <signal name="clicked" handler="on_register_button_clicked" />
               </widget>
               <packing>
                 <property name="expand">False</property>


### PR DESCRIPTION
Seems to just cause warnings on RHEL6

(this branch has the results of running https://github.com/candlepin/subscription-manager/tree/alikins/fix-glade-swapped) 
