### PR TITLE
Call post explicity if a user has only one org.

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -388,6 +388,8 @@ class OrganizationScreen(Screen):
 
         if len(owners) == 1:
             self._owner_key = owners[0][0]
+            # Run post since this is not done by the parent.
+            self.post()
             self._parent.pre_done(False)
         else:
             self.set_model(owners)


### PR DESCRIPTION
If this is not done, then the parent owner_key is None which fails when looking for Envrionments.
