### PR TITLE
Fixed systemd/rhsmcertd failure on OS restart.

### DIFF
--- a/etc-conf/rhsmcertd.service
+++ b/etc-conf/rhsmcertd.service
@@ -1,9 +1,12 @@
 [Unit]
 Description=Enable periodic update of entitlement certificates.
+After=network.target
 
 [Service]
 Type=forking
 ExecStart=/usr/bin/rhsmcertd 
+Restart=on-failure
+RestartSec=60
 
 [Install]
 WantedBy=multi-user.target

--- a/src/rhsmcertd-worker.py
+++ b/src/rhsmcertd-worker.py
@@ -15,6 +15,8 @@
 #
 
 import sys
+import socket
+from M2Crypto.Err import SSLError
 sys.path.append("/usr/share/rhsm")
 
 import logging
@@ -74,6 +76,17 @@ if __name__ == '__main__':
         if se.code:
             sys.exit(-1)
         pass
+    except socket.error, e:
+        # 101 Network is Unreachable
+        log.error("caught socket exception")
+        log.info(e.errno)
+        if e.errno == 101:
+            log.error("Unable to establish network connection.")
+            log.exception(e)
+            sys.exit(e.errno)
+        else:
+            log.exception(e)
+            sys.exit(-1)
     except Exception, e:
         log.error("Error while updating certificates using daemon")
         print _('Unable to update entitlement certificates and repositories')

--- a/src/rhsmcertd.c
+++ b/src/rhsmcertd.c
@@ -138,6 +138,16 @@ cert_check (gboolean heal)
 	if (status == 0) {
 		fprintf (log, "%s: certificates updated\n", ts ());
 		fflush (log);
+	} else if (status == 101) {
+		fprintf (log,
+			 "%s: [%d] Network is unreachable. Shutting down.\n",
+			 ts (), status);
+		fprintf (log,
+			 "%s: NOTE: If the process was run by systemd, it will be automatically restarted. Otherwise, please attempt to restart the service manually.\n",
+			 ts ());
+		fflush (log);
+		fclose (log);
+		exit (status);
 	} else {
 		fprintf (log,
 			 "%s: update failed (%d), retry will occur on next run\n",


### PR DESCRIPTION
- Updated rhsmcertd-worker to return error code (101) for "Network is unavailable".
- Updated rhsmcertd to exit process when 101 is encountered.
- Updated rhsmcertd systemd configuration to restart on failure (after 1 min).
