### PR TITLE
add za_CN.utf to list of known busted locales

### DIFF
--- a/test/test_po_files.py
+++ b/test/test_po_files.py
@@ -103,7 +103,8 @@ class TestLocaleDate(TestLocale):
         self.__test_strftime(datetime.date(2012, 1, 1))
 
     def test_strftime_10_30_2011(self):
-        self.known_busted = ["or_IN.UTF-8", "ja_JP.UTF-8", "ko_KR.UTF-8"]
+        # zh_CN filed as https://bugzilla.redhat.com/show_bug.cgi?id=838647
+        self.known_busted = ["zh_CN.UTF-8", "or_IN.UTF-8", "ja_JP.UTF-8", "ko_KR.UTF-8"]
         self.__test_strftime(datetime.date(2011, 10, 30))
 
     def __test_strftime(self, dt):


### PR DESCRIPTION
Busted for strptime('%x', strftime('%x')) that
is
