### PR TITLE
Use ISO8601 date format in allsubs tab

### DIFF
--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -708,23 +708,6 @@ class ImportFileExtractor(object):
         return "%s.pem" % (ent_cert.serialNumber())
 
 
-def find_date_picker_locale():
-    # this is a fairly terrible work around
-    # bz #744136 and #704069. Basically, we don't
-    # seem to be able to parse dates with time.strptime()
-    # in some locales, even if the date is exactly the
-    # string created by today.strftime("%x"). So we
-    # just set LC_TIME to en_GB which we can parse
-    try:
-        today = datetime.date.today()
-        time.strptime(today.strftime("%x"), "%x")
-    except ValueError:
-        # we can't parse our own "preferred" date format
-        # for whatever reason, so let's use en_GB
-        return 'en_GB'
-    return ''
-
-
 def _sub_dict(datadict, subkeys, default=None):
     return dict([(k, datadict.get(k, default)) for k in subkeys])
 

--- a/test/test_po_files.py
+++ b/test/test_po_files.py
@@ -1,9 +1,7 @@
 import os
 import glob
 import unittest
-import datetime
 import sys
-import time
 
 # easy_install polib http://polib.readthedocs.org/
 import polib
@@ -84,47 +82,6 @@ class TestLocale(unittest.TestCase):
         gettext.bindtextdomain(APP, DIR)
 
 
-class TestLocaleDate(TestLocale):
-
-    def tearDown(self):
-        self._setupLang("en_US")
-
-    # FIXME
-    # we work around this dynamicaly in managergui.py, but this
-    # is here to see if we get anything new, or if the known
-    # busted start working
-
-    def test_strftime_1_1_2012(self):
-        # yeah, this is weird. parsing the localized date format
-        # for ja_JP and ko_KR fails in double digit months (10,11,12) even
-        # though it seems to use a zero padded month field.
-        # wibbly wobbly timey wimey
-        self.known_busted = ["or_IN.UTF-8"]
-        self.__test_strftime(datetime.date(2012, 1, 1))
-
-    def test_strftime_10_30_2011(self):
-        # zh_CN filed as https://bugzilla.redhat.com/show_bug.cgi?id=838647
-        self.known_busted = ["zh_CN.UTF-8", "or_IN.UTF-8", "ja_JP.UTF-8", "ko_KR.UTF-8"]
-        self.__test_strftime(datetime.date(2011, 10, 30))
-
-    def __test_strftime(self, dt):
-        for test_locale in self.test_locales:
-            lc = "%s.UTF-8" % test_locale
-            self._setupLang(lc)
-            try:
-                time.strptime(dt.strftime("%x"), "%x")
-            except ValueError:
-                if lc not in self.known_busted:
-                    raise
-                continue
-# The above fails on f17/rhel6.3, but not f16, so don't
-# worry about the "no longer busted" test for now. We should
-# probably dump '%x' stuff anyway and just use iso8601 date
-#           if lc in self.known_busted:
-#               self.fail("%s used to be busted, but works now" % test_locale)
-
-
-# These are meant to catch bugs like bz #744536
 class TestUnicodeGettext(TestLocale):
     def setUp(self):
         self._setupLang("ja_JP.UTF-8")


### PR DESCRIPTION
Previously we were using the localized date
format (ala, strftime('%s')) which is lovely,
but is more or less impossible to parse, even
by the tools that claim to (for ex, strptime('%x')).

We had worked around this in a few cases, by
falling back to en_GB localized date format,
but that was pretty much just a kluge. For
bonus fun, some of the dates would only
fail to parse on double digit months. Or for
some locales, specific months that had
unicode char's the date parser didn't like.
In addition, strptime() is especially broken
on python 2.4 available on RHEL 5 and earlier.

So, enough of that. ISO8601 dates it is.
- remove locale kluge
- remove unit tests specifically for that kluge
- add test cases for widgets.DatePicker
