### PR TITLE
Make "Usage" consistent across rhel5/6

### DIFF
--- a/bin/rhn-migrate-classic-to-rhsm
+++ b/bin/rhn-migrate-classic-to-rhsm
@@ -72,7 +72,7 @@ options_table = [
                   "level use --service-level=\"\"")),
 ]
 
-parser = OptionParser(usage=_("%s [OPTIONS]") % os.path.basename(sys.argv[0]),
+parser = OptionParser(usage=_("%prog [OPTIONS]"),
                       option_list=options_table,
                       formatter=WrappedIndentedHelpFormatter())
 

--- a/src/subscription_manager/i18n_optparse.py
+++ b/src/subscription_manager/i18n_optparse.py
@@ -117,6 +117,11 @@ class WrappedIndentedHelpFormatter(_IndentedHelpFormatter):
             result.append("\n")
         return "".join(result)
 
+    # 2.4 uses lower case "usage", 2.6 uses "Usage"
+    # This was making QE jittery, always use upper
+    def format_usage(self, usage):
+        return _("Usage: %s\n") % usage
+
 
 class OptionParser(_OptionParser):
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -176,7 +176,9 @@ class CliCommand(object):
                  prod_dir=None):
         self.shortdesc = shortdesc
 
-        usage = _("usage: %%prog %s [OPTIONS]") % name
+        # usage format strips any leading 'usage' so
+        # do not iclude it
+        usage = _("%%prog %s [OPTIONS]") % name
 
        # include our own HelpFormatter that doesn't try to break
        # long words, since that fails on multibyte words

--- a/test/test_i18n_optparse.py
+++ b/test/test_i18n_optparse.py
@@ -20,6 +20,13 @@ class TestWrappedIndentedHelpFormatter(unittest.TestCase):
         fh = self.parser.format_option_help(self.hf)
         fh.decode("utf8")
 
+    def test_format_usage(self):
+        # optparses default format_usage uses lower cases
+        # usage on 2.4, upper case on 2.6. We include our
+        # own for consistency
+        fu = self.hf.format_usage("%%prog [OPTIONS]")
+        self.assertEquals(fu[:6], "Usage:")
+
     # just to verify the old broken way continues
     # to be broken and the way we detect that still works
     def test_old(self):


### PR DESCRIPTION
On python2.4, optparse formats the usage string
as "usage" while on 2.6 it uses "Usage". This
was making QE jittery.

Fix this by including our own format_usage
on our optparse HelpFormatter class.

Clean up some usage usage while we are at
it.
