### PR TITLE
Add support for migrating to Katello.

### DIFF
--- a/bin/rhn-migrate-classic-to-rhsm
+++ b/bin/rhn-migrate-classic-to-rhsm
@@ -35,6 +35,7 @@ _LIBPATH = "/usr/share/rhsm"
 if _LIBPATH not in sys.path:
     sys.path.append(_LIBPATH)
 
+from subscription_manager.utils import parse_server_info, ServerUrlParseError
 from subscription_manager.i18n import configure_i18n
 configure_i18n()
 
@@ -70,6 +71,8 @@ options_table = [
     Option("-s", "--servicelevel", dest="servicelevel",
            help=_("Service level to subscribe this system to. For no service "
                   "level use --service-level=\"\"")),
+    Option("--serverurl", dest='serverurl',
+           help=_("Specify the SAM/System Engine server to migrate TO.")),
 ]
 
 parser = OptionParser(usage=_("%prog [OPTIONS]"),
@@ -170,29 +173,38 @@ def systemExit(code, msgs=None):
             sys.stderr.write(unicode(msg).encode('utf-8') + '\n')
     sys.exit(code)
 
+def checkOkToProceed(secreds, serverurl):
 
-def checkOkToProceed(username, password):
     # check if this machine is already registered to Certicate-based RHN
     if ConsumerIdentity.existsAndValid():
         print _("\nThis machine appears to be already registered to Certificate-based RHN.  Exiting.")
         consumer = ConsumerIdentity.read()
         systemExit(1, _("\nPlease visit https://access.redhat.com/management/consumers/%s to view the profile details.") % consumer.getConsumerId())
 
-    # Check to make sure we're hooked up to Hosted.
-    serverURL = rhncfg['serverURL']
-    if not re.search('xmlrpc\.rhn\..*redhat\.com', serverURL):
-        log.info("serverURL = %s" % serverURL)
-        systemExit(1, _("This migration script requires the system to be registered to RHN Classic.\nHowever this system appears to be registered to '%s'.\nExiting.") % serverURL.split('/')[2])
+    try:
+        if serverurl is None:
+            hostname = rhsmcfg.get('server', 'hostname')
+            port = rhsmcfg.get('server', 'port')
+            prefix = rhsmcfg.get('server', 'prefix')
+        else:
+            (hostname, port, prefix) = parse_server_info(serverurl)
+    except ServerUrlParseError, e:
+        print _("Error parsing serverurl: %s" % e.msg)
+        sys.exit(-1)
 
     # Check to make sure we can connect to the certificate server.
-    cp = UEPConnection(username=username, password=password,
+    cp = UEPConnection(host=hostname,
+            ssl_port=int(port),
+            handler=prefix,
+            username=secreds.username,
+            password=secreds.password,
             proxy_hostname=rhsmcfg.get('server', 'proxy_hostname'),
             proxy_port=rhsmcfg.get('server', 'proxy_port'),
             proxy_user=rhsmcfg.get('server', 'proxy_user'),
             proxy_password=rhsmcfg.get('server', 'proxy_password'))
 
     try:
-        cp.getOwnerList(username)
+        cp.getOwnerList(secreds.username)
     except Exception, e:
         log.error(e)
         log.error(traceback.format_exc())
@@ -211,14 +223,20 @@ def checkIsOrgAdmin(sc, sk, username):
 
 
 def selectServiceLevel(cp, consumer, servicelevel):
+    not_supported = _("Error: The service-level command is not supported by "
+                      "the server.")
     uuid = consumer.getConsumerId()
     try:
         org_key = cp.getOwner(uuid)['key']
         levels = cp.getServiceLevelList(org_key)
-    except Exception, e:
-        log.error(e)
-        log.error(traceback.format_exc())
-        systemExit(1, CONNECTION_FAILURE % e)
+    except connection.RemoteServerException, e:
+        systemExit(-1, not_supported)
+    except connection.RestlibException, e:
+        if e.code == 404 and\
+            e.msg.find('/servicelevels') > 0:
+            systemExit(-1, not_supported)
+        else:
+            raise e
 
     # Create the sla tuple before appending the empty string to the list of
     # valid slas.
@@ -256,7 +274,7 @@ def getSystemId():
     return systemId
 
 
-def connectToRhn(username, password):
+def connectToRhn(credentials):
     hostname = rhncfg['serverURL'].split('/')[2]
     server_url = 'https://%s/rpc/api' % (hostname)
     try:
@@ -273,7 +291,7 @@ def connectToRhn(username, password):
         else:
             sc = xmlrpclib.Server(server_url)
 
-        sk = sc.auth.login(username, password)
+        sk = sc.auth.login(credentials.username, credentials.password)
         return (sc, sk)
     except:
         log.error(traceback.format_exc())
@@ -356,10 +374,16 @@ def transferHttpProxySettings():
         rhsmcfg.save()
 
 
-def register(username, password):
+def register(credentials, serverurl):
     # For registering the machine, use the CLI tool to reuse the username/password (because the GUI will prompt for them again)
     print _("\nAttempting to register system to Certificate-based RHN ...")
-    result = subprocess.call(['subscription-manager', 'register', '--username=' + username, '--password=' + password])
+    cmd = ['subscription-manager', 'register', '--username=' + credentials.username, '--password=' + credentials.password]
+    if serverurl:
+        # insert just after register (not sure if order matters,
+        # but just in case)
+        cmd.insert(2, '--serverurl=' + serverurl)
+    result = subprocess.call(cmd)
+
     if result != 0:
         systemExit(2, _("\nUnable to register.\nFor further assistance, please contact Red Hat Global Support Services."))
     else:
@@ -375,10 +399,18 @@ def subscribe(consumer, servicelevel):
         result = subprocess.call(['subscription-manager-gui'], stderr=open(os.devnull, 'w'))
     else:
         print _("Attempting to auto-subscribe to appropriate subscriptions ...")
-        result = subprocess.call(['subscription-manager', 'subscribe', '--auto', '--servicelevel=' + servicelevel])
+        cmd = ['subscription-manager', 'subscribe', '--auto']
+
+        # only add servicelevel if one was passed in
+        if servicelevel:
+            cmd.append('--servicelevel=' + servicelevel)
+
+        result = subprocess.call(cmd)
         if result != 0:
             print _("\nUnable to auto-subscribe.  Do your existing subscriptions match the products installed on this system?")
-    print _("\nPlease visit https://access.redhat.com/management/consumers/%s to view the details, and to make changes if necessary.") % consumer.getConsumerId()
+    # don't show url for katello/CFSE/SAM
+    if options.serverurl:
+        print _("\nPlease visit https://access.redhat.com/management/consumers/%s to view the details, and to make changes if necessary.") % consumer.getConsumerId()
 
 
 def deployProdCertificates(subscribedChannels):
@@ -525,15 +557,32 @@ def cleanUp(subscribedChannels):
             except OSError, e:
                 log.info(e)
 
+class UserCredentials(object):
+    def __init__(self, username, password):
+        self.username = username
+        self.password = password
+
+def authenticate(prompt):
+    username = raw_input(prompt).strip()
+    password = getpass.getpass()
+    return UserCredentials(username, password)
+
 
 def main():
-    username = raw_input(_("RHN Username: ")).strip()
-    password = getpass.getpass()
-    transferHttpProxySettings()
-    cp = checkOkToProceed(username, password)
+    serverurl = None
+    if options.serverurl:
+        rhncreds = authenticate(_("RHN Username: "))
+        secreds = authenticate(_("System Engine Username: "))
+        serverurl = options.serverurl
+    else:
+        rhncreds = authenticate(_("RHN Username: "))
+        secreds = rhncreds # make them the same
 
-    (sc, sk) = connectToRhn(username, password)
-    checkIsOrgAdmin(sc, sk, username)
+    transferHttpProxySettings()
+    cp = checkOkToProceed(secreds, serverurl)
+
+    (sc, sk) = connectToRhn(rhncreds)
+    checkIsOrgAdmin(sc, sk, rhncreds.username)
 
     # get a list of RHN classic channels this machine is subscribed to
     print _("\nRetrieving existing RHN Classic subscription information ...")
@@ -552,9 +601,12 @@ def main():
 
     # register the system to Certificate-based RHN and consume a subscription
     if not options.noauto:
-        consumer = register(username, password)
-        servicelevel = selectServiceLevel(cp, consumer, options.servicelevel)
-        subscribe(consumer, servicelevel)
+        consumer = register(secreds, serverurl)
+        if options.servicelevel:
+            servicelevel = selectServiceLevel(cp, consumer, options.servicelevel)
+            subscribe(consumer, servicelevel)
+        else:
+            subscribe(consumer, None)
     # check if we need to enable to supplementary/optional channels
     enableExtraChannels(subscribedChannels, cp)
     cleanUp(subscribedChannels)


### PR DESCRIPTION
Added --serverurl parameter to specify the CFSE/Katello/SAM url (full path).
As well as make --servicelevel optional in case it isn't supported by the
server.
