### PR TITLE
844069: Allow register --force even if ID cert is totally invalid.

### DIFF
--- a/src/subscription_manager/certlib.py
+++ b/src/subscription_manager/certlib.py
@@ -358,14 +358,13 @@ class ConsumerIdentity:
 
     @classmethod
     def existsAndValid(cls):
-        from M2Crypto import X509
         if cls.exists():
             try:
                 cls.read()
                 return True
-            except X509.X509Error, e:
-                log.error(e)
+            except Exception, e:
                 log.warn('possible certificate corruption')
+                log.error(e)
         return False
 
     def __init__(self, keystring, certstring):


### PR DESCRIPTION
If you somehow modify you identity cert such that it can't even be
loaded, register with --force would no longer work, erroring out instead
with a message about invalid certificate. Previously it would still
allow you to register.

Changed method to handle _any_ exception trying to load the identity
cert, and return False if so.
