### PR TITLE
842170: replace None service level/type with "" not None

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1819,9 +1819,9 @@ class ListCommand(CliCommand):
             print(self._none_wrap(_("Quantity Used:        \t%s"),
                   order.quantity_used))
             print(_("Service Level:        \t%s") %
-                  order.service_level or "")
+                  (order.service_level or ""))
             print(_("Service Type:         \t%s") %
-                  order.service_type or "")
+                  (order.service_type or ""))
             print(_("Starts:               \t%s") %
                   managerlib.formatDate(cert.valid_range.begin()))
             print(_("Ends:                 \t%s") %


### PR DESCRIPTION
Empty or null/None service levels were being listed as
None in list --consumed. Which is confusing since
"None" (the string)[1] is a valid service level, so
it was also wrong.

Issue was "%s" % None or "blip", the % has precedence,
so the LHS was always a non empty string (because
we sub in a translated "None" string for None objects)
and therefore never False.

[1] yeah, I know...
