### PR TITLE
838113: 'unregister' was not cleaning up repos

### DIFF
--- a/src/subscription_manager/certlib.py
+++ b/src/subscription_manager/certlib.py
@@ -163,7 +163,14 @@ class IdentityCertLib(DataLib):
         super(IdentityCertLib, self).__init__(lock, uep)
 
     def _do_update(self):
+        if not ConsumerIdentity.existsAndValid():
+            # we could in theory try to update the id in the
+            # case of it being bogus/corrupted, ala #844069,
+            # but that seems unneeded
+            return 0
+
         from subscription_manager import managerlib
+
         idcert = ConsumerIdentity.read()
         uuid = idcert.getConsumerId()
         consumer = self.uep.getConsumer(uuid)

--- a/src/subscription_manager/certmgr.py
+++ b/src/subscription_manager/certmgr.py
@@ -22,6 +22,9 @@ from subscription_manager.factlib import FactLib
 from subscription_manager.facts import Facts
 from subscription_manager.cache import PackageProfileLib, InstalledProductsLib
 
+import logging
+log = logging.getLogger('rhsm-app.' + __name__)
+
 import gettext
 _ = gettext.gettext
 
@@ -78,12 +81,16 @@ class CertManager:
             try:
                 ret = self.certlib.update()
             except Exception, e:
+                log.exception(e)
                 print e
             # run the certlib update first as it will talk to candlepin,
             # and we can find out if we got deleted or not.
             for lib in libset:
-                updates += lib.update()
-
+                try:
+                    updates += lib.update()
+                except Exception, e:
+                    log.exception(e)
+                    print e
             # NOTE: with no consumer cert, most of these actually
             # fail
             if ret:


### PR DESCRIPTION
After unregistering, we were running IdentityCertLib update
actions, which assumed consumer cert existed, and were
raising exceptions. certmgt.update was not handling
exceptions there well, and raised them up into
the UnRegister.do_command, where it was ignored.
This prevented the rest of the update methods from
running, which included repolib, so repo's were
not being cleaned up.

Try to handle exceptions in the update actions
better (and log them). Also make IdentityCertLib.update
not fail on unregistered systems.
