### PR TITLE
remove test cases that use si_LK locale

### DIFF
--- a/test/test_po_files.py
+++ b/test/test_po_files.py
@@ -69,7 +69,7 @@ class TestLocale(unittest.TestCase):
         #"br_IN", # Maithili
         "pt_BR",  # Portugese
         "ru_RU",  # Russian
-        "si_LK",   # Sri Lankan
+        #"si_LK",   # Sri Lankan
         "ta_IN",  # Tamil
         "te_IN",  # telgu
         "zh_CN",  # Chinese Simplified


### PR DESCRIPTION
si_LK only partially supported on rhel5, and not
supported on rhel6.
