### PR TITLE
843191: 'version' command showed wrong info with no network

### DIFF
--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -303,7 +303,12 @@ def get_version_dict(cp):
                 cp_version = '-'.join([status['version'], status['release']])
             else:
                 cp_version = _("Unknown")
-        except Exception:
+        except Exception, e:
+            # a more useful error would be handy here
+            print _("Error while checking server version: %s") % e
+            log.exception(e)
+
+            server_type = _("Unknown")
             cp_version = _("Unknown")
 
     if ClassicCheck().is_registered_with_classic():


### PR DESCRIPTION
If the attempt to get the status and version info from the
candlepin server failed (for example, wrong host name or
missing certs) the server type defaulted to
'subscription management service' which is not particular
correct.

Errors were also being ignored, so at least show the
error and log it now. server-type should be "Unknown"
in these cases now.
