### PR TITLE
840644: replace optional usage of usage option "[OPTIONS"]

### DIFF
--- a/bin/rhn-migrate-classic-to-rhsm
+++ b/bin/rhn-migrate-classic-to-rhsm
@@ -72,7 +72,7 @@ options_table = [
                   "level use --service-level=\"\"")),
 ]
 
-parser = OptionParser(usage=_("%prog [OPTIONS]"),
+parser = OptionParser(usage=_("%prog [options]"),
                       option_list=options_table,
                       formatter=WrappedIndentedHelpFormatter())
 

--- a/test/test_i18n_optparse.py
+++ b/test/test_i18n_optparse.py
@@ -27,6 +27,9 @@ class TestWrappedIndentedHelpFormatter(unittest.TestCase):
         fu = self.hf.format_usage("%%prog [OPTIONS]")
         self.assertEquals(fu[:6], "Usage:")
 
+        fu = self.hf.format_usage("%%prog [options]")
+        self.assertEquals(fu[:6], "Usage:")
+
     # just to verify the old broken way continues
     # to be broken and the way we detect that still works
     def test_old(self):


### PR DESCRIPTION
rhn-migrate-classic-to-rhsm described it's usage string
as "%prog [OPTIONS]" while everything else used "[options]"

Now our usage of options usage string "[OPTIONS]" is no
longer optional. "[options]" is what we use for usage
now.
