### PR TITLE
851346: Remove special case channel certs before subscribing.

### DIFF
--- a/bin/rhn-migrate-classic-to-rhsm
+++ b/bin/rhn-migrate-classic-to-rhsm
@@ -656,6 +656,7 @@ def main():
         print channel
 
     deployProdCertificates(subscribedChannels)
+    cleanUp(subscribedChannels)
 
     writeMigrationFacts()
     print _("\nPreparing to unregister system from RHN Classic ...")
@@ -671,7 +672,6 @@ def main():
             subscribe(consumer, None)
     # check if we need to enable to supplementary/optional channels
     enableExtraChannels(subscribedChannels, cp)
-    cleanUp(subscribedChannels)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are several products which require special handling during
migration.  These products are sometimes meant to not coexist with
other products on the same system.  Previously, these special
cases were dealt with after auto-subscription.  This patch moves
the handling up in the order of events.
