### PR TITLE
852001: output the orgs key as part of the identity command.

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -570,7 +570,7 @@ class IdentityCommand(UserPassCommand):
             if not self.options.regenerate:
                 owner = self.cp.getOwner(consumerid)
                 ownername = owner['displayName']
-                ownerid = owner['id']
+                ownerid = owner['key']
                 print _('Current identity is: %s') % consumerid
                 print _('name: %s') % consumer_name
                 print _('org name: %s') % ownername


### PR DESCRIPTION
The key is needed to register with the --org option. The id, which was shown, is not used.
