### PR TITLE
853233: Do not allow 68.pem and 71.pem to coexist after migration.

### DIFF
--- a/bin/install-num-migrate-to-rhsm
+++ b/bin/install-num-migrate-to-rhsm
@@ -130,14 +130,16 @@ def main():
     #flatten the list of lists
     paths = [item for sublist in paths for item in sublist]
 
+    path_dict = {}
     for path in paths:
-        dest_file = path.split('-')[-1]
+        dest = path.split('-')[-1]
+        path_dict[dest] = path
 
-        #even though 68.pem is a match, skip it for Workstation
-        #71.pem will be installed instead.
-        if dest_file == '68.pem' and 'Workstation' in repo_dict.keys():
-            continue
+    # Hack for BZ #853233: 68.pem and 71.pem should never coexist.
+    if "68.pem" in path_dict.keys() and "71.pem" in path_dict.keys():
+        del path_dict["68.pem"]
 
+    for dest_file, path in path_dict.items():
         dest_file = os.path.join(PRODUCT_CERT_DIR, dest_file)
         print _("Installing %s to %s") % (path, dest_file)
         if not options.dryrun:

--- a/bin/rhn-migrate-classic-to-rhsm
+++ b/bin/rhn-migrate-classic-to-rhsm
@@ -597,22 +597,15 @@ def writeMigrationFacts():
 
 
 def cleanUp(subscribedChannels):
-    #Hack to address BZ 786257.
-    ch = (
-            ('rhel-x86_64-client-supplementary-5', 'rhel-x86_64-client-workstation-5'),
-            ('rhel-x86_64-client-5', 'rhel-x86_64-client-workstation-5'),
-            ('rhel-i386-client-supplementary-5', 'rhel-i386-client-workstation-5'),
-            ('rhel-i386-client-5', 'rhel-i386-client-workstation-5')
-         )
-
+    #Hack to address BZ 853233
     productDir = ProductDirectory()
-    for channelPair in ch:
-        if channelPair[0] in subscribedChannels and channelPair[1] in subscribedChannels:
-            try:
-                os.remove(os.path.join(str(productDir), "68.pem"))
-                log.info("Removed 68.pem due to existence of both %s and %s" % (channelPair[0], channelPair[1]))
-            except OSError, e:
-                log.info(e)
+    if os.path.isfile(os.path.join(str(productDir), "68.pem")) and \
+        os.path.isfile(os.path.join(str(productDir), "71.pem")):
+        try:
+            os.remove(os.path.join(str(productDir), "68.pem"))
+            log.info("Removed 68.pem due to existence of 71.pem")
+        except OSError, e:
+            log.info(e)
 
     #Hack to address double mapping for 180.pem and 17{6|8}.pem
     double_mapped = "rhel-.*?-(client|server)-dts-(5|6)-beta(-debuginfo)?"


### PR DESCRIPTION
If a system is subscribed to channels that map to both 68.pem
and 71.pem, remove 68.pem.
