### PR TITLE
Explicitly set GMT when doing entitlement date math

### DIFF
--- a/src/subscription_manager/validity.py
+++ b/src/subscription_manager/validity.py
@@ -219,7 +219,7 @@ class ValidProductDateRangeCalculator(object):
         for group in groups:
             for ent in group:
                 # DateRange is in GMT so convert now to GMT before compare
-                if ent.valid_range.has_date(datetime.now().replace(tzinfo=GMT())):
+                if ent.valid_range.has_date(datetime.now(tz=GMT())):
                     return group
         return []
 


### PR DESCRIPTION
There were two places that were using non-GMT dates for entitlement math. The
first was in test_validity when making cert dates. The second was in
validity.py, in _get_entitlements_spanning_now.

The time zone attribute on the date was being altered, but without affecting
the date itself. For example, see https://gist.github.com/3666602.
