### PR TITLE
Fix entitlement facts tests to not read /etc/sysconfig

### DIFF
--- a/test/test_facts.py
+++ b/test/test_facts.py
@@ -190,6 +190,17 @@ class TestFacts(unittest.TestCase):
 
 class InstalledProductStatusTests(unittest.TestCase):
 
+    # facts for system entitlement valid check for an rhn "classic"
+    # susbcription, so mock it out
+    def setUp(self):
+        self.rhn_check_patcher = patch('subscription_manager.facts.ClassicCheck')
+        self.rhn_check_mock = self.rhn_check_patcher.start()
+        self.rhn_check_mock_instance = self.rhn_check_mock.return_value
+        self.rhn_check_mock_instance.is_registered_with_classic.return_value = False
+
+    def tearDown(self):
+        self.rhn_check_patcher.stop()
+
     @patch.object(Facts, "_load_custom_facts")
     def test_entitlement_for_installed_product_shows_valid(self, mockCustomFacts):
         product = StubProduct("product1")


### PR DESCRIPTION
facts for system entitlement valid check for an rhn "classic"
subscription (aka, look for /etc/sysconfig/rhn/systemid) but
the tests were looking for the real one, so mock it.
