### PR TITLE
854879: Fixes for Anaconda desktop/workstation product cert installation...

### DIFF
--- a/test/stubs.py
+++ b/test/stubs.py
@@ -159,6 +159,9 @@ class StubProductCertificate(ProductCertificate):
         if provided_products:
             products = products + provided_products
 
+        self.name = product.name
+        version = product.version
+
         # TODO: product should be a StubProduct, check for strings coming in and error out
         self.product = product
         self.provided_products = []
@@ -177,7 +180,8 @@ class StubProductCertificate(ProductCertificate):
         ProductCertificate.__init__(self, products=products,
                 serial=random.randint(1, 10000000),
                 start=start_date,
-                end=end_date)
+                end=end_date,
+                version=version)
 
     def __str__(self):
         s = []

--- a/test/test_productid.py
+++ b/test/test_productid.py
@@ -1,39 +1,103 @@
 import unittest
-import datetime
-import sys
-import tempfile
 
 import stubs
 from subscription_manager import productid
-from yum import YumBase
+from mock import Mock
 
 
 class TestProductManager(unittest.TestCase):
 
     def setUp(self):
-        self.db_dir = tempfile.mkdtemp()
-        productid.DatabaseDirectory.PATH = self.db_dir
-        self.pm = productid.ProductManager()
-        cert1 = stubs.StubEntitlementCertificate(
-            stubs.StubProduct('product1'),
-            start_date=datetime.datetime(2010, 1, 1),
-            end_date=datetime.datetime(2050, 1, 1))
-        cert2 = stubs.StubEntitlementCertificate(
-            stubs.StubProduct('product2'),
-            start_date=datetime.datetime(2010, 1, 1),
-            end_date=datetime.datetime(2060, 1, 1))
-        self.pm.pdir = stubs.StubProductDirectory([cert1, cert2])
-        sys.stdout = stubs.MockStdout()
-        self.yb = YumBase()
+        self.prod_dir = stubs.StubProductDirectory([])
+        self.prod_db_mock = Mock()
+        self.prod_mgr = productid.ProductManager(product_dir=self.prod_dir,
+                product_db=self.prod_db_mock)
 
-    def tearDown(self):
-        sys.stdout = sys.__stdout__
+    def _create_desktop_cert(self):
+        cert = stubs.StubProductCertificate(
+            stubs.StubProduct("68", "Red Hat Enterprise Linux Desktop",
+                version="5", provided_tags="rhel-5-client"))
+        cert.delete = Mock()
+        cert.write = Mock()
+        return cert
 
-#    def test_get_active(self):
-#        self.pm.getActive(yb=self.yb)
+    def _create_workstation_cert(self):
+        cert = stubs.StubProductCertificate(
+            stubs.StubProduct("71", "Red Hat Enterprise Linux Workstation",
+                version="5", provided_tags="rhel-5-client-workstation"))
+        cert.delete = Mock()
+        cert.write = Mock()
+        return cert
 
-#    def test_get_enabled(self):
-#        self.pm.getEnabled(yb=self.yb)
+    def test_is_workstation(self):
+        workstation_cert = self._create_workstation_cert()
+        self.assertTrue(self.prod_mgr._isWorkstation(
+            workstation_cert.products[0]))
 
-#    def test_update(self):
-#        self.pm.update(yb=self.yb)
+    def test_is_desktop(self):
+        desktop_cert = self._create_desktop_cert()
+        self.assertTrue(self.prod_mgr._isDesktop(
+            desktop_cert.products[0]))
+
+    # If Desktop cert exists, delete it and then write Workstation:
+    def test_workstation_overrides_desktop(self):
+
+        desktop_cert = self._create_desktop_cert()
+        workstation_cert = self._create_workstation_cert()
+
+        def write_cert_side_effect(path):
+            self.prod_dir.certs.append(desktop_cert)
+
+        desktop_cert.write.side_effect = write_cert_side_effect
+        workstation_cert.write.side_effect = write_cert_side_effect
+
+        # Desktop comes first in this scenario:
+        enabled = [
+                (desktop_cert, 'repo1'),
+                (workstation_cert, 'repo2'),
+        ]
+
+        self.prod_mgr.updateInstalled(enabled, ['repo1', 'repo2'])
+
+        self.assertTrue(desktop_cert.write.called)
+        self.assertTrue(desktop_cert.delete.called)
+
+        self.assertTrue(workstation_cert.write.called)
+        self.prod_db_mock.delete.assert_called_with("68")
+
+    # If workstation cert exists, desktop write should be skipped:
+    def test_workstation_skips_desktop(self):
+
+        desktop_cert = self._create_desktop_cert()
+        workstation_cert = self._create_workstation_cert()
+        some_other_cert = stubs.StubProductCertificate(
+            stubs.StubProduct("8127", "Some Other Product"))
+        some_other_cert.delete = Mock()
+        some_other_cert.write = Mock()
+
+        def write_cert_side_effect(path):
+            self.prod_dir.certs.append(workstation_cert)
+
+        desktop_cert.write.side_effect = write_cert_side_effect
+        workstation_cert.write.side_effect = write_cert_side_effect
+
+        # Workstation comes first in this scenario:
+        enabled = [
+                (workstation_cert, 'repo2'),
+                (desktop_cert, 'repo1'),
+                (some_other_cert, 'repo3'),
+        ]
+
+        self.prod_mgr.updateInstalled(enabled, ['repo1', 'repo2', 'repo3'])
+
+        self.assertTrue(workstation_cert.write.called)
+        self.assertFalse(workstation_cert.delete.called)
+
+        self.assertFalse(desktop_cert.write.called)
+        self.assertFalse(desktop_cert.delete.called)
+
+        # Testing a bug where desktop cert skipping ended the whole process:
+        self.assertTrue(some_other_cert.write.called)
+        self.assertFalse(some_other_cert.delete.called)
+
+        self.assertFalse(self.prod_db_mock.delete.called)


### PR DESCRIPTION
....

Recent performance fixes added an internal cache to the product
directory object, it only looks for new certs once refresh is explicitly
called. In this case we are writing and sometimes deleting certs and
then expecting the list() call to give accurate results but the refresh
call was missed here.

Fixed an issue where we delete the now obsolete desktop cert, but delete
the workstation product ID from the product database.

Fixed an issue where any certs after the desktop cert would be ignored
because we're returning when we should be continuing to the next
iteration of the loop.
