### PR TITLE
855957: Unsubscribe now properly updates repo file.

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -55,6 +55,7 @@ import webbrowser
 import urllib2
 
 import gettext
+from subscription_manager.repolib import RepoLib
 _ = gettext.gettext
 gettext.textdomain("rhsm")
 gtk.glade.bindtextdomain("rhsm")
@@ -94,6 +95,7 @@ class Backend(object):
         self.product_dir = ProductDirectory()
         self.entitlement_dir = EntitlementDirectory()
         self.certlib = CertLib(uep=self.uep)
+        self.repolib = RepoLib(uep=self.uep)
 
         self.product_monitor = file_monitor.Monitor(self.product_dir.path)
         self.entitlement_monitor = file_monitor.Monitor(

--- a/src/subscription_manager/gui/mysubstab.py
+++ b/src/subscription_manager/gui/mysubstab.py
@@ -138,6 +138,10 @@ class MySubscriptionsTab(widgets.SubscriptionManagerTab):
             # unregistered, just delete the certs directly
             self.backend.certlib.delete([serial])
 
+        # Ensure that the repo file gets updated right after any
+        # certs are removed.
+        self.backend.repolib.update()
+
         self.update_subscriptions()
 
     def unsubscribe_button_clicked(self, widget):

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1404,9 +1404,15 @@ class UnSubscribeCommand(CliCommand):
             except Exception, e:
                 handle_exception(_("Unable to perform unsubscribe due to the following exception: %s") % e, e)
 
+        # Update the repo file so that it is in sync with our entitlements.
+        self._repolib().update()
+
         # it is okay to call this no matter what happens above,
         # it's just a notification to perform a check
         self._request_validity_check()
+
+    def _repolib(self):
+        return RepoLib(uep=self.cp)
 
 
 class FactsCommand(CliCommand):

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -453,9 +453,20 @@ class StubConsumer:
         return "12341234234"
 
 
-class StubCertLib:
+class StubLib:
     def __init__(self, uep=StubUEP()):
         self.uep = uep
+        self.update_called = False
 
     def update(self):
-        pass
+        self.update_called = True
+
+
+class StubCertLib(StubLib):
+    def __init__(self, uep=StubUEP()):
+        StubLib.__init__(self, uep)
+
+
+class StubRepoLib(StubLib):
+    def __init__(self, uep=StubUEP()):
+        StubLib.__init__(self, uep)


### PR DESCRIPTION
When unsubscribing from the CLI/GUI, subman will now
refresh the repo file to ensure its contents are current.
