### PR TITLE
Bumping required python-rhsm version

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -30,7 +30,7 @@ Requires:  python-iniparse
 Requires:  pygobject2
 Requires:  PyXML
 Requires:  virt-what
-Requires:  python-rhsm >= 1.1.0
+Requires:  python-rhsm >= 1.1.1
 Requires:  dbus-python
 Requires:  yum >= 3.2.19-15
 


### PR DESCRIPTION
Required for new certv3 changes in python-rhsm
