### PR TITLE
mock out utils.is_valid_server_info for tests

### DIFF
--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -17,6 +17,13 @@ import mock
 from rhsm import connection
 from M2Crypto import SSL
 
+# FIXME: temp fix till we merge test fixture merged
+# Note: we don't tear this patch down, everything needs it mocked,
+# and we don't actually test this method
+is_valid_server_patcher = mock.patch("subscription_manager.managercli.is_valid_server_info")
+is_valid_server_mock = is_valid_server_patcher.start()
+is_valid_server_mock.return_value = True
+
 
 class TestCli(unittest.TestCase):
     # shut up stdout spew


### PR DESCRIPTION
This test would fail if the hostname/port from
/etc/rhsm.conf pointed to machine that could be
found, listened on the right port, had insecure=0,
and was running as a user that couldn't read the
needed ca cert.

mock it in test_managercli for now, will be replaced
with a test fixture that sets this up.
