### PR TITLE
Check identity cert permissions when running CLI commands

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1962,6 +1962,10 @@ class ManagerCLI(CLI):
                        VersionCommand]
         CLI.__init__(self, command_classes=commands)
 
+    def main(self):
+        managerlib.check_identity_cert_perms()
+        return CLI.main(self)
+
 
 # from http://farmdev.com/talks/unicode/
 def to_unicode_or_bust(obj, encoding='utf-8'):

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -14,6 +14,7 @@ from stubs import MockStderr, MockStdout, StubProductDirectory, \
 from test_handle_gui_exception import FakeException, FakeLogger
 
 import mock
+from mock import patch
 # for some exceptions
 from rhsm import connection
 from M2Crypto import SSL
@@ -42,6 +43,13 @@ class TestCli(unittest.TestCase):
     def test_cli(self):
         cli = managercli.ManagerCLI()
         self.assertTrue('register' in cli.cli_commands)
+
+    @patch.object(managerlib, "check_identity_cert_perms")
+    def test_main_checks_identity_cert_perms(self, check_identity_cert_perms_mock):
+        cli = managercli.ManagerCLI()
+        # Catch the expected SystemExit so that the test can continue.
+        self.assertRaises(SystemExit, cli.main)
+        check_identity_cert_perms_mock.assert_called_with()
 
     def test_main_empty(self):
         cli = managercli.ManagerCLI()


### PR DESCRIPTION
This was missed when the refactor of the CLI framework was done for RCT.
