### PR TITLE
logging change to unbreak product cert deletion

### DIFF
--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -206,7 +206,7 @@ class ProductManager:
             if repo in active:
                 continue
 
-            log.info("product cert %s for %s is being deleted" % (prod_hash, p.getName()))
+            log.info("product cert %s for %s is being deleted" % (prod_hash, p.name))
             cert.delete()
             self.pdir.refresh()
 


### PR DESCRIPTION
The Product.getName() method no longer exists. Instead, use .name property.

To test, install a package from a second repo, and ensure you get a new product
cert. Then, remove the package. The product cert deletion will fail if
getName() is being used.
