### PR TITLE
859197: Fix product cert cleanup.

### DIFF
--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -206,7 +206,7 @@ class ProductManager:
             if repo in active:
                 continue
 
-            log.info("product cert %s for %s is being deleted" % (prod_hash, p.getName()))
+            log.info("product cert %s for %s is being deleted" % (prod_hash, p.name))
             cert.delete()
             self.pdir.refresh()
 

--- a/test/test_productid.py
+++ b/test/test_productid.py
@@ -13,6 +13,13 @@ class TestProductManager(unittest.TestCase):
         self.prod_mgr = productid.ProductManager(product_dir=self.prod_dir,
                 product_db=self.prod_db_mock)
 
+    def test_removed(self):
+        self.prod_db_mock.findRepo.return_value = "repo1"
+        cert = self._create_desktop_cert()
+        self.prod_dir.certs.append(cert)
+        self.prod_mgr.updateRemoved([])
+        self.assertTrue(cert.delete.called)
+
     def _create_desktop_cert(self):
         cert = stubs.StubProductCertificate(
             stubs.StubProduct("68", "Red Hat Enterprise Linux Desktop",


### PR DESCRIPTION
product-id plugin getName() call was missed, would break if you
triggered product cert cleanup.
