### PR TITLE
853876: No need to check for GoneException when getting status

### DIFF
--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -316,13 +316,13 @@ def get_server_versions(cp):
                 cp_version = '-'.join([status['version'], status['release']])
             else:
                 cp_version = _("Unknown")
-        except GoneException, e:
-            log.info("Server Versions: Error: consumer has been deleted, unable to check server version")
-            log.info(e)
-            raise
         except Exception, e:
-            # a more useful error would be handy here
-            log.error(("Error while checking server version: %s") % e)
+            if isinstance(e, GoneException):
+                log.info("Server Versions: Error: consumer has been deleted, unable to check server version")
+            else:
+                # a more useful error would be handy here
+                log.error(("Error while checking server version: %s") % e)
+
             log.exception(e)
 
             server_type = _("Unknown")


### PR DESCRIPTION
All commands were checking the server version before executing.
When we were registering with the --force command it would fail
because the user didn't exist on the server and the client was
raising the GoneException.
## Note

I checked to make sure that nothing was relying on the raise'  call
that I removed and didn't see anything. When reviewing, please
take a look to make sure that I didn't miss anything.

Thanks.
