### PR TITLE
Check the full version info of the yum api in productid

### DIFF
--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -106,9 +106,9 @@ class ProductManager:
         enabled = self.getEnabled(yb)
         active = self.getActive(yb)
 
-        #only execute this on versions of yum that track
-        #which repo a package came from
-        if yum.__version_info__[2] >= 28:
+        # only execute this on versions of yum that track
+        # which repo a package came from, aka, 3.2.28 and newer
+        if self._check_yum_version_tracks_repos():
             # check that we have any repo's enabled
             # and that we have some enabled repo's. Not just
             # that we have packages from repo's that are
@@ -116,6 +116,12 @@ class ProductManager:
             if enabled and active:
                 self.updateRemoved(active)
         self.updateInstalled(enabled, active)
+
+    def _check_yum_version_tracks_repos(self):
+        major, minor, micro = yum.__version_info__
+        if major >= 3 and minor >= 2 and micro >= 28:
+            return True
+        return False
 
     def _isWorkstation(self, product_cert):
         if product_cert.name == "Red Hat Enterprise Linux Workstation" and \

--- a/test/test_productid.py
+++ b/test/test_productid.py
@@ -2,7 +2,7 @@ import unittest
 
 import stubs
 from subscription_manager import productid
-from mock import Mock
+from mock import Mock, patch
 
 
 class TestProductManager(unittest.TestCase):
@@ -108,3 +108,14 @@ class TestProductManager(unittest.TestCase):
         self.assertFalse(some_other_cert.delete.called)
 
         self.assertFalse(self.prod_db_mock.delete.called)
+
+    @patch("subscription_manager.productid.yum")
+    def test_yum_version_tracks_repos(self, yum_mock):
+        yum_mock.__version_info__ = (1, 2, 2)
+        self.assertFalse(self.prod_mgr._check_yum_version_tracks_repos())
+
+        yum_mock.__version_info__ = (3, 2, 35)
+        self.assertTrue(self.prod_mgr._check_yum_version_tracks_repos())
+
+        yum_mock.__version_info__ = (3, 2, 28)
+        self.assertTrue(self.prod_mgr._check_yum_version_tracks_repos())


### PR DESCRIPTION
We want to verify we are on yum > 3.2.28 before
we trust it's idea of what repo's a package
was installed from. Previously we were just
checking that micro > 28, now verify the whole
thing in case we rev major/minor versions.
