### PR TITLE
853006: Wrap label in the manually subscribe firstboot screen.

### DIFF
--- a/src/subscription_manager/gui/data/manually_subscribe.glade
+++ b/src/subscription_manager/gui/data/manually_subscribe.glade
@@ -14,6 +14,7 @@
         <property name="yalign">0</property>
         <property name="xpad">10</property>
         <property name="ypad">10</property>
+        <property name="wrap">True</property>
       </widget>
       <packing>
         <property name="expand">False</property>


### PR DESCRIPTION
Simple one, can wrap like the other labels on the screen and avoid any string changes.
