### PR TITLE
Make rhsm-icon work on gnome 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,19 +48,10 @@ check-syntax:
 	${CC} ${CFLAGS} ${ICON_FLAGS} -o nul -S $(CHK_SOURCES)
 
 
-ICON_FLAGS=`pkg-config --cflags --libs gtk+-2.0 libnotify gconf-2.0`
+ICON_FLAGS=`pkg-config --cflags --libs gtk+-2.0 libnotify gconf-2.0 dbus-glib-1`
 
 rhsm-icon: src/rhsm_icon.c bin
-	# RHSM Status icon needs to be skipped in Fedora 15+ and RHEL7+:
-	if [ ${OS} = Fedora ]; then \
-		if [ ${OS_VERSION} -lt 15 ]; then \
-			${CC} ${CFLAGS} ${ICON_FLAGS} -o bin/rhsm-icon src/rhsm_icon.c;\
-		fi;\
-	else \
-		if [ ${OS_VERSION} -lt 7 ]; then \
-			${CC} ${CFLAGS} ${ICON_FLAGS} -o bin/rhsm-icon src/rhsm_icon.c;\
-		fi;\
-	fi;\
+	${CC} ${CFLAGS} ${ICON_FLAGS} -o bin/rhsm-icon src/rhsm_icon.c;\
 
 dbus-service-install:
 	install -d ${PREFIX}/etc/dbus-1/system.d
@@ -207,20 +198,9 @@ install-files: dbus-service-install compile-po desktop-files
 	install -m 644 man/subscription-manager-gui.8 ${PREFIX}/${INSTALL_DIR}/man/man8/
 	if [ ${OS_VERSION} = 5 ]; then install -m 644 man/install-num-migrate-to-rhsm.8 ${PREFIX}/${INSTALL_DIR}/man/man8/; fi
 
-	# RHSM Status icon needs to be skipped in Fedora 15+ and RHEL7+:
-	if [ ${OS} = Fedora ]; then \
-		if [ ${OS_VERSION} -lt 15 ]; then \
-			install -m 644 etc-conf/rhsm-icon.desktop \
-				${PREFIX}/etc/xdg/autostart;\
-			install bin/rhsm-icon ${PREFIX}/usr/bin;\
-		fi;\
-	else \
-		if [ ${OS_VERSION} -lt 7 ]; then \
-			install -m 644 etc-conf/rhsm-icon.desktop \
-				${PREFIX}/etc/xdg/autostart;\
-			install bin/rhsm-icon ${PREFIX}/usr/bin;\
-		fi;\
-	fi;\
+	install -m 644 etc-conf/rhsm-icon.desktop \
+		${PREFIX}/etc/xdg/autostart;\
+	install bin/rhsm-icon ${PREFIX}/usr/bin;\
 
 	install -m 755 etc-conf/rhsmd.cron \
 		${PREFIX}/etc/cron.daily/rhsmd

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1,5 +1,3 @@
-# Skip rhsm-icon on Fedora 15+ and RHEL 7+
-%define use_rhsm_icon (0%{?fedora} && 0%{?fedora} < 15) || (0%{?rhel} && 0%{?rhel} < 7)
 # Prefer systemd over sysv on Fedora 17+ and RHEL 7+
 %define use_systemd (0%{?fedora} && 0%{?fedora} >= 17) || (0%{?rhel} && 0%{?rhel} >= 7)
 
@@ -122,10 +120,8 @@ make -f Makefile
 rm -rf %{buildroot}
 make -f Makefile install VERSION=%{version}-%{release} PREFIX=%{buildroot} MANPATH=%{_mandir}
 
-%if %use_rhsm_icon
 desktop-file-validate \
         %{buildroot}/etc/xdg/autostart/rhsm-icon.desktop
-%endif
 
 desktop-file-validate \
         %{buildroot}/usr/share/applications/subscription-manager.desktop
@@ -263,10 +259,8 @@ rm -rf %{buildroot}
 %attr(755,root,root) %{_sbindir}/subscription-manager-gui
 %attr(755,root,root) %{_bindir}/subscription-manager-gui
 
-%if %use_rhsm_icon
 %{_bindir}/rhsm-icon
 %{_sysconfdir}/xdg/autostart/rhsm-icon.desktop
-%endif
 
 %{_sysconfdir}/pam.d/subscription-manager-gui
 %{_sysconfdir}/security/console.apps/subscription-manager-gui


### PR DESCRIPTION
re-#define the notification creation function for the new API, and stub
out the systray icon.
