### PR TITLE
852911: Add padding around firstboot tooltips icon.

### DIFF
--- a/src/subscription_manager/gui/data/choose_server.glade
+++ b/src/subscription_manager/gui/data/choose_server.glade
@@ -38,6 +38,7 @@
                   <widget class="GtkImage" id="image2">
                     <property name="visible">True</property>
                     <property name="tooltip" translatable="yes">Registering with Customer Portal, Subscription Asset Manager, CloudForms System Engine or Candlepin servers can be used to provide your system with updates and allow management through the selected server's interface.</property>
+                    <property name="xpad">16</property>
                     <property name="stock">gtk-info</property>
                   </widget>
                 </child>


### PR DESCRIPTION
Tooltip was fixed in a recent fix, now just needed some padding as in
firstboot, the icon rendered right up against the left edge of the
screen.
