### PR TITLE
861443: Re-raise GoneException in rhsmcertd-worker

### DIFF
--- a/src/rhsmcertd-worker.py
+++ b/src/rhsmcertd-worker.py
@@ -51,8 +51,8 @@ def main(options, log):
             log.critical(_("This consumer's profile has been deleted from the server. It's local certificates will now be archived"))
             managerlib.clean_all_data()
             log.critical(_("Certificates archived to '/etc/pki/consumer.old'. Contact your system administrator if you need more information."))
-        else:
-            raise ge
+
+        raise ge
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Re-raise the GoneException after cleaning up so
that the failure is reported to rhsmcertd.

https://bugzilla.redhat.com/show_bug.cgi?id=861443
