### PR TITLE
862099: Fix several dialog closing issues.

### DIFF
--- a/src/subscription_manager/gui/data/registration.glade
+++ b/src/subscription_manager/gui/data/registration.glade
@@ -15,6 +15,7 @@
     <accessibility>
       <atkproperty name="AtkObject::accessible-name">register_dialog</atkproperty>
     </accessibility>
+    <signal name="delete_event" handler="on_register_dialog_delete_event"/>
     <child internal-child="vbox">
       <widget class="GtkVBox" id="dialog-vbox6">
         <property name="visible">True</property>

--- a/src/subscription_manager/gui/importsub.py
+++ b/src/subscription_manager/gui/importsub.py
@@ -55,6 +55,7 @@ class ImportSubDialog(object):
         self.dialog.add_filter(afilter)
 
         self.dialog.connect("response", self._on_dialog_response)
+        self.dialog.connect("delete-event", self._delete_event)
 
     def _on_dialog_response(self, dialog, response_id):
         if response_id == gtk.RESPONSE_CANCEL:

--- a/src/subscription_manager/gui/redeem.py
+++ b/src/subscription_manager/gui/redeem.py
@@ -34,7 +34,7 @@ class RedeemDialog(widgets.GladeWidget):
         super(RedeemDialog, self).__init__('redeem.glade')
 
         self.glade.signal_autoconnect({
-            "on_reeem_dialog_delete_event": self._hide_callback,
+            "on_redeem_dialog_delete_event": self._hide_callback,
             "on_close_button_clicked": self._hide_callback,
             "on_redeem_button_clicked": self._redeem,
         })
@@ -66,8 +66,8 @@ class RedeemDialog(widgets.GladeWidget):
     def set_parent_window(self, window):
         self.redeem_dialog.set_transient_for(window)
 
-    # GTK callback function for hiding this dialog.
     def _hide_callback(self, button, event=None):
+        """ Callback for cancel button and window closed. """
         self.hide()
 
         # Stop the gtk signal from propogating

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -96,7 +96,7 @@ class RegisterScreen(widgets.GladeWidget):
         dic = {"on_register_cancel_button_clicked": self.cancel,
                "on_register_button_clicked": self._on_register_button_clicked,
                "hide": self.cancel,
-               "delete_event": self._delete_event,
+               "on_register_dialog_delete_event": self._delete_event,
             }
         self.glade.signal_autoconnect(dic)
 


### PR DESCRIPTION
Three dialogs were improperly handling delete-event when closed with ESC
key or closing the window. (as opposed to using the cancel buttons)

Registration, redeem subscription, and import cert were all affected.

Fixed by hooking up proper signals.
