### PR TITLE
844072: remove use and dep of PyXML

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -26,7 +26,7 @@ Requires:  python-ethtool
 Requires:  python-simplejson
 Requires:  python-iniparse
 Requires:  pygobject2
-Requires:  PyXML
+Requires:  python-dateutil
 Requires:  virt-what
 Requires:  python-rhsm >= 1.1.1
 Requires:  dbus-python


### PR DESCRIPTION
PyXML is deprecated in Fedora, so remove it.
Only use of pyxml was for it's iso8601 date parsing,
so replace it's usage with dateutil (and require
that now).

dateutil.parser.parse() behaviour is slightly different,
especially for year 2038 issues. Dateutil handles this
better at least till year 9999, so update test cases
for those cases.

Note: previous parseDate was actually incorrect for cases
where the server returned iso8601 dates with a tz (instead
of UTC). This doesn't seem to matter because the server
always returns iso8601 dates with UTC tz. Updated
test cases for this scenario.
