### PR TITLE
865545: Added report log when cert has no products.

### DIFF
--- a/src/subscription_manager/certlib.py
+++ b/src/subscription_manager/certlib.py
@@ -458,7 +458,11 @@ class UpdateReport:
             for c in certificates:
                 products = c.products
                 if not products:
-                    product = c.order
+                    s.append('%s[sn:%d (%s) @ %s]' % \
+                        (indent,
+                         c.serial,
+                         c.order.name,
+                         c.path))
                 for product in products:
                     s.append('%s[sn:%d (%s,) @ %s]' % \
                         (indent,


### PR DESCRIPTION
Initially we were only printing the products in the cert.
This fix addresses the case where there are no products
associated with the cert.
