### PR TITLE
850531: Change the label 'Certificate Status' to 'Status'

### DIFF
--- a/src/subscription_manager/gui/data/installed.glade
+++ b/src/subscription_manager/gui/data/installed.glade
@@ -30,7 +30,7 @@
                             <property name="visible">True</property>
                             <property name="yalign">0</property>
                             <property name="ypad">6</property>
-                            <property name="label" translatable="yes">&lt;b&gt;Certificate Status:&lt;/b&gt;</property>
+                            <property name="label" translatable="yes">&lt;b&gt;Status:&lt;/b&gt;</property>
                             <property name="use_markup">True</property>
                           </widget>
                           <packing>
@@ -238,7 +238,7 @@
                                           <widget class="GtkLabel" id="validity_label">
                                             <property name="visible">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">&lt;b&gt;Certificate Status:&lt;/b&gt;</property>
+                                            <property name="label" translatable="yes">&lt;b&gt;Status:&lt;/b&gt;</property>
                                             <property name="use_markup">True</property>
                                           </widget>
                                           <packing>


### PR DESCRIPTION
The acessability name remains unchanged, so as to not break any automated testing frameworks.
