### PR TITLE
852328: Report Classic and Subscription Management consistently in the v...

### DIFF
--- a/src/subscription_manager/branding/redhat_branding.py
+++ b/src/subscription_manager/branding/redhat_branding.py
@@ -16,7 +16,7 @@ class Branding(object):
             "\n\n" + \
             _("To learn how to unregister from either service please consult this Knowledge Base Article: https://access.redhat.com/kb/docs/DOC-45563")
         self.REGISTERED_TO_OTHER_SUMMARY = _("RHN Classic")
-
+        self.REGISTERED_TO_SUBSCRIPTION_MANAGEMENT_SUMMARY = _("Red Hat Subscription Management")
         self.GUI_REGISTRATION_HEADER = \
                 _("Please enter your Red Hat account information:")
         self.REGISTERED_TO_BOTH_WARNING = \
@@ -25,6 +25,6 @@ class Branding(object):
                 _("Red Hat recommends that customers only register to one service.") + \
                 "\n\n" + \
                 _("To learn more about RHN registration and technologies please consult this Knowledge Base Article: https://access.redhat.com/kb/docs/DOC-45563")
-        self.REGISTERED_TO_BOTH_SUMMARY = _("RHN classic and Red Hat Subscription Management")
+        self.REGISTERED_TO_BOTH_SUMMARY = _("RHN Classic and Red Hat Subscription Management")
         self.GUI_FORGOT_LOGIN_TIP = \
                 _("Tip: Forgot your login or password? Look it up at http://red.ht/lost_password")

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -17,6 +17,7 @@ import re
 import logging
 from rhsm.config import DEFAULT_PORT, DEFAULT_PREFIX, DEFAULT_HOSTNAME, \
     DEFAULT_CDN_HOSTNAME, DEFAULT_CDN_PORT, DEFAULT_CDN_PREFIX
+from subscription_manager.branding import get_branding
 from urlparse import urlparse
 import os
 import signal
@@ -306,10 +307,10 @@ def get_client_versions():
 
 
 def get_server_versions(cp):
-    cp_version = _("Unable to reach server")
+    cp_version = _("Unknown")
     server_type = _("Unknown")
     if cp:
-        server_type = _("subscription management service")
+        server_type = get_branding().REGISTERED_TO_SUBSCRIPTION_MANAGEMENT_SUMMARY
         try:
             if cp.supports_resource("status"):
                 status = cp.getStatus()
@@ -331,8 +332,10 @@ def get_server_versions(cp):
     # this isn't particularly important, so log any exceptions and carry on
     try:
         if ClassicCheck().is_registered_with_classic():
-            server_type = _("RHN Classic")
-            cp_version = _("Unknown")
+            if server_type == _("Unknown"):
+                server_type = _("RHN Classic")
+            else:
+                server_type = get_branding().REGISTERED_TO_BOTH_SUMMARY
     except Exception, e:
         log.debug("Server Versions: Unable to check RHN Classic version")
         log.exception(e)


### PR DESCRIPTION
...ersion and identity commands

The version command will always report server type. It will show 'Red Hat Subscription Management' if there is no systemid field, and will show 'RHN Classic and Red Hat Subscription Management' if there is.

The identity command will omit the server type unless there is a system id field. In that case it will show 'RHN Classic' if not registered with Subscription Management, and the same both string as above if registered to both.
