### PR TITLE
865590: Fix broken offline unsubscribe.

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1372,7 +1372,6 @@ class UnSubscribeCommand(CliCommand):
         Executes the command.
         """
         self._validate_options()
-        self.certlib.update()
         if ConsumerIdentity.exists():
             consumer = ConsumerIdentity.read().getConsumerId()
             try:

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -256,11 +256,6 @@ class StubCertificateDirectory(EntitlementDirectory):
         self.list_called = True
         return self.certs
 
-    def listExpired(self):
-        if self.expired:
-            return self.certs
-        return []
-
     def _check_key(self, cert):
         """
         Fake filesystem access here so we don't try to read real keys.

--- a/test/test_certmgr.py
+++ b/test/test_certmgr.py
@@ -296,7 +296,8 @@ class TestCertmgr(unittest.TestCase):
 
         # this makes the stub_entdir report all ents as being expired
         # so we fetch new ones
-        self.stub_entdir.expired = True
+        self.stub_entdir.listExpired = mock.Mock(
+                return_value=self.stub_entdir.list())
 
         # we don't want to find replacements, so this forces a delete
         self.mock_uep.getCertificateSerials = mock.Mock(return_value=[])


### PR DESCRIPTION
This bug was actually caused by a recent fix for 852630, where to
prevent a duplicate attempt to clean up an expired cert we do an update
without first checking if we're even registered anywhere.

Instead we should just not duplicate attempts to delete a cert which is
both no longer reported by the server, and expired by refreshing the
entitlement directory if we've deleted anything.

Cleanup some unclear methods in UpdateAction.

Attempted to add tests but too difficult to mock an entitlement
directory (which is a stub of the real thing) changing midway through
the call we're testing.
