### PR TITLE
865954: Return to creds screen if consumer name is invalid

### DIFF
--- a/src/subscription_manager/gui/firstboot/rhsm_login.py
+++ b/src/subscription_manager/gui/firstboot/rhsm_login.py
@@ -21,6 +21,8 @@ from subscription_manager.gui.autobind import \
         ServiceLevelNotSupportedException, NoProductsException, \
         AllProductsCoveredException
 
+from rhsm.connection import RestlibException
+
 sys.path.append("/usr/share/rhn")
 from up2date_client import config
 
@@ -97,6 +99,15 @@ class PerformRegisterScreen(registergui.PerformRegisterScreen):
                 self._parent.pre_done(MANUALLY_SUBSCRIBE_PAGE)
             else:
                 self._parent.pre_done(registergui.SELECT_SLA_PAGE)
+
+        # If we get errors related to consumer name on register,
+        # go back to the credentials screen where we set the
+        # consumer name. See bz#865954
+        except RestlibException, e:
+            handle_gui_exception(e, registergui.REGISTER_ERROR,
+                self._parent.window)
+            if e.code == 400:
+                self._parent.pre_done(registergui.CREDENTIALS_PAGE)
 
         except Exception, e:
             handle_gui_exception(e, registergui.REGISTER_ERROR,


### PR DESCRIPTION
When we register a consumer, if the consumer name is in
an invalid format, we were raising an error, but handling
it poorly. Now we send the user back to the credentials
screen (where the consumer name field is).
