### PR TITLE
Clear cached activation key or environment values.

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -802,6 +802,9 @@ class ActivationKeyScreen(Screen):
         self._parent.owner_key = self._owner_key
         self._parent.consumername = self._consumername
         self._parent.skip_auto_bind = self._skip_auto_bind
+        # Environments aren't used with activation keys so clear any
+        # cached value.
+        self._parent.environment = None
         self._backend.create_admin_uep()
 
 


### PR DESCRIPTION
When a user registers with an activation key, then unregisters, then re-registers without an activation key, we need to clear the cached activation key value before sending the registration information to the server.  The same principle applies with the environment value if a user registers without an activation key, unregisters, then re-registers with an activation key.
