### PR TITLE
871016: Pool associated with activation key is not consumed after GUI re...

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -308,6 +308,7 @@ class PerformRegisterScreen(NoGuiScreen):
                 raise error
 
             managerlib.persist_consumer_cert(new_account)
+            managerlib.fetch_certificates(self._backend)
             self._parent.consumer.reload()
             if self._parent.skip_auto_bind:
                 self._parent.pre_done(FINISH)
@@ -964,7 +965,6 @@ class AsyncBackend(object):
 
             ProfileManager().update_check(self.backend.admin_uep,
                                           retval['uuid'])
-
             # We have new credentials, restart virt-who
             restart_virt_who()
 


### PR DESCRIPTION
...gistration

Needed explicit entitlement retrieval after registration
