### PR TITLE
871146: Fix proxy errors on first yum operation after registration.

### DIFF
--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -321,14 +321,15 @@ class Repo(dict):
         """
         Called when we fetch the items for this yum repo to write to disk.
         """
-        # Skip anything set to 'None', as this is likely not intended for
-        # a yum repo file. None can result here if the default is None,
-        # or the entitlement certificate did not have the value set.
+        # Skip anything set to 'None' or empty string, as this is likely
+        # not intended for a yum repo file. None can result here if the
+        # default is None, or the entitlement certificate did not have the
+        # value set.
         #
         # all values will be in _order, since the key has to have been set
         # to get into our dict.
         return tuple([(k, self[k]) for k in self._order if \
-                k in self and self[k] is not None])
+                k in self and self[k]])
 
     def update(self, new_repo):
         """
@@ -486,10 +487,7 @@ class RepoFile(ConfigParser):
 
     def section(self, section):
         if self.has_section(section):
-            repo = Repo(section, self.items(section))
-            for k, v in self.items(section):
-                repo[k] = v
-            return repo
+            return Repo(section, self.items(section))
 
     def create(self):
         if os.path.exists(self.path) or not self.manage_repos:

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -103,6 +103,13 @@ class RepoTests(unittest.TestCase):
         repo = Repo('testrepo', config)
         self.assertEquals(config, repo.items()[:3])
 
+    def test_empty_strings_not_set_in_file(self):
+        r = Repo('testrepo', (('proxy', ""),))
+        r['proxy'] = ""
+        self.assertFalse(("proxy", "") in r.items())
+        r.update({"proxy": ""})
+        self.assertFalse(("proxy", "") in r.items())
+
 
 class UpdateActionTests(unittest.TestCase):
 


### PR DESCRIPTION
Change in behavior from RHEL 5 to RHEL 6. The previous code was doing a
check like "if value:", if false it was skipped.

New code compared with "is not None", which for empty strings evaluates to
true, where as previously this would have been skipped as well. Proxy
just happens to start out as an empty string.

Result was that on repo creation, the empty string was going in and
making yum upset, but any repo update would catch it and remove it. (as
there seem to be several places where we're watching for empty strings)

Make sure we don't let empty strings slip out into the repo file by
restoring the old behavior when getting the actual list of items to go
into each repo.

Also removing a block of code in the RepoFile that looks unecessary,
after passing in section items we were then going through each item and
setting them manually. The two attempts were from different commits, the
constructor now does this for us, I think the other version was just old
code that was meant to be removed.
