### PR TITLE
869934: make "release" related cdn usage use proper urlparse

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -20,7 +20,6 @@
 import locale
 import logging
 import subprocess
-import urlparse
 
 import gtk
 import gtk.glade
@@ -38,7 +37,7 @@ from subscription_manager.certdirectory import ProductDirectory, EntitlementDire
 from subscription_manager.certlib import ConsumerIdentity, CertLib
 from subscription_manager.branding import get_branding
 from subscription_manager.utils import get_client_versions, get_server_versions, \
-restart_virt_who
+restart_virt_who, parse_baseurl_info
 
 from subscription_manager.gui import redeem
 from subscription_manager.gui import factsgui
@@ -141,8 +140,9 @@ class Backend(object):
         self.content_connection = self._create_content_connection()
 
     def _create_content_connection(self):
-        return connection.ContentConnection(host=urlparse.urlparse(cfg.get('rhsm', 'baseurl'))[1],
-                                            ssl_port=443,
+        (cdn_hostname, cdn_port, cdn_prefix) = parse_baseurl_info(cfg.get('rhsm', 'baseurl'))
+        return connection.ContentConnection(host=cdn_hostname,
+                                            ssl_port=cdn_port,
                                             proxy_hostname=cfg.get('server', 'proxy_hostname'),
                                             proxy_port=cfg.get('server', 'proxy_port'),
                                             proxy_user=cfg.get('server', 'proxy_user'),

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -23,7 +23,6 @@ import getpass
 import dbus
 import datetime
 from time import strftime, strptime, localtime
-import urlparse
 from M2Crypto import X509
 from M2Crypto import SSL
 
@@ -1190,15 +1189,10 @@ class ReleaseCommand(CliCommand):
 
     def _do_command(self):
         cdn_url = cfg.get('rhsm', 'baseurl')
-        parsed_url = urlparse.urlparse(cdn_url)
+        # note: parse_baseurl_info will populate with defaults if not found
+        (cdn_hostname, cdn_port, cdn_prefix) = parse_baseurl_info(cdn_url)
 
-        # default to 443 if urlprase can't interpret the port
-        if parsed_url[2]:
-            cdn_port = parsed_url[2]
-        else:
-            cdn_port = 443
-
-        self.cc = connection.ContentConnection(host=parsed_url[1],
+        self.cc = connection.ContentConnection(host=cdn_hostname,
                                                ssl_port=cdn_port,
                                                proxy_hostname=self.proxy_hostname,
                                                proxy_port=self.proxy_port,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -220,7 +220,7 @@ class TestParseBaseUrlInfo(unittest.TestCase):
         # this is the default, so test it here
         local_url = "https://cdn.redhat.com"
         (hostname, port, prefix) = parse_baseurl_info(local_url)
-        self.assertEquals("cdn.redhat.com", hostname)
+        self.assertEquals(DEFAULT_CDN_HOSTNAME, hostname)
         self.assertEquals(DEFAULT_CDN_PORT, port)
         self.assertEquals("/", prefix)
 
@@ -233,7 +233,19 @@ class TestParseBaseUrlInfo(unittest.TestCase):
         local_url = "https://cdn.redhat.com:443"
         (hostname, port, prefix) = parse_baseurl_info(local_url)
         self.assertEquals(prefix, DEFAULT_CDN_PREFIX)
-        self.assertEquals("https://%s" % DEFAULT_CDN_HOSTNAME, format_baseurl(hostname, port, prefix))
+        self.assertEquals("https://cdn.redhat.com", format_baseurl(hostname, port, prefix))
+
+    def test_format_thumbslug_url_with_port(self):
+        local_url = "https://someserver.example.com:8088"
+        (hostname, port, prefix) = parse_baseurl_info(local_url)
+        self.assertEquals(prefix, DEFAULT_CDN_PREFIX)
+        self.assertEquals("https://someserver.example.com:8088", format_baseurl(hostname, port, prefix))
+
+    def test_format_not_fqdn_with_port(self):
+        local_url = "https://foo-bar:8088"
+        (hostname, port, prefix) = parse_baseurl_info(local_url)
+        self.assertEquals(prefix, DEFAULT_CDN_PREFIX)
+        self.assertEquals("https://foo-bar:8088", format_baseurl(hostname, port, prefix))
 
 
 class TestRemoveScheme(unittest.TestCase):


### PR DESCRIPTION
We were incorrectly parsing rhsm.baseurl when we were
creating connection objects for use with release related
commands. Update them to use parse_baseurl_info.

This fixes issues using "subscription-manager release --list"
with cdns that used a non default port (for example, a
system pointing at a thumbslug proxy).
