### PR TITLE
Fix to LocalTz DST determination

### DIFF
--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -776,17 +776,17 @@ class LocalTz(datetime.tzinfo):
     """
 
     def utcoffset(self, dt):
-        if time.daylight:
+        if time.daylight and time.localtime().tm_isdst:
             return datetime.timedelta(seconds=-time.altzone)
         return datetime.timedelta(seconds=-time.timezone)
 
     def dst(self, dt):
-        if time.daylight:
+        if time.daylight and time.localtime().tm_isdst:
             return datetime.timedelta(seconds=(time.timezone - time.altzone))
         return datetime.timedelta(seconds=0)
 
     def tzname(self, dt):
-        if time.daylight:
+        if time.daylight and time.localtime().tm_isdst:
             return time.tzname[1]
 
         return time.tzname[0]


### PR DESCRIPTION
Previously, LocalTz() was using "time.daylight" to determine if DST was in
effect. This is incorrect, see http://bugs.python.org/issue7229 for more
detail. The time.daylight attribute will only tell if the timezone has a DST
component at all, not if DST is currently in effect. To do the latter,
time.localtime().tm_isdst is used.

This is difficult to unit test depending on the time of year, but the following
script can be used:

---

import sys
import datetime
sys.path.append("/usr/share/rhsm")
from subscription_manager.managerlib import LocalTz

now = datetime.datetime.now(LocalTz())
print now.astimezone(LocalTz()).strftime("%x %X")

---

During the non-DST part of the year, this will exercise the bug that is fixed
by this patch.
