### PR TITLE
874749, 874804: Use the terms Attach and Remove instead of Subscibe and ...

### DIFF
--- a/src/subscription_manager/gui/data/allsubs.glade
+++ b/src/subscription_manager/gui/data/allsubs.glade
@@ -217,13 +217,13 @@
                 <property name="layout_style">end</property>
                 <child>
                   <widget class="GtkButton" id="subscribe_button">
-                    <property name="label" translatable="yes">Subscribe</property>
+                    <property name="label" translatable="yes">Attach</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <accessibility>
-                      <atkproperty name="AtkObject::accessible-name" translatable="yes">Subscribe</atkproperty>
+                      <atkproperty name="AtkObject::accessible-name" translatable="yes">Attach</atkproperty>
                     </accessibility>
                     <signal name="clicked" handler="on_subscribe_button_clicked"/>
                   </widget>

--- a/src/subscription_manager/gui/data/confirmsubs.glade
+++ b/src/subscription_manager/gui/data/confirmsubs.glade
@@ -70,7 +70,7 @@
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
                 <property name="xpad">10</property>
-                <property name="label" translatable="yes">You will be subscribed to:</property>
+                <property name="label" translatable="yes">The following susbcriptions will be attached:</property>
                 <property name="use_markup">True</property>
               </widget>
               <packing>

--- a/src/subscription_manager/gui/data/contract_selection.glade
+++ b/src/subscription_manager/gui/data/contract_selection.glade
@@ -196,7 +196,7 @@
             </child>
             <child>
               <widget class="GtkButton" id="subscribe_button">
-                <property name="label" translatable="yes">Subscribe</property>
+                <property name="label" translatable="yes">Attach</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>

--- a/src/subscription_manager/gui/data/credentials.glade
+++ b/src/subscription_manager/gui/data/credentials.glade
@@ -228,7 +228,7 @@
             </child>
             <child>
               <widget class="GtkCheckButton" id="skip_auto_bind">
-                <property name="label" translatable="yes">Manually assign subscriptions after registration</property>
+                <property name="label" translatable="yes">Manually attach subscriptions after registration</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>

--- a/src/subscription_manager/gui/data/installed.glade
+++ b/src/subscription_manager/gui/data/installed.glade
@@ -72,11 +72,11 @@
                         </child>
                         <child>
                           <widget class="GtkButton" id="update_certificates_button">
-                            <property name="label" translatable="yes">Auto-subscribe</property>
+                            <property name="label" translatable="yes">Auto-attach</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <accessibility>
-                              <atkproperty name="AtkObject::accessible-name" translatable="yes">Auto-subscribe</atkproperty>
+                              <atkproperty name="AtkObject::accessible-name" translatable="yes">Auto-attach</atkproperty>
                             </accessibility>
                             <signal name="clicked" handler="on_update_certificates_button_clicked"/>
                           </widget>

--- a/src/subscription_manager/gui/data/manually_subscribe.glade
+++ b/src/subscription_manager/gui/data/manually_subscribe.glade
@@ -30,7 +30,7 @@
         <property name="yalign">0</property>
         <property name="xpad">10</property>
         <property name="ypad">10</property>
-        <property name="label" translatable="yes">You will need to use Red Hat Subscription Manager to manually subscribe this system after completing firstboot.</property>
+        <property name="label" translatable="yes">You will need to use Red Hat Subscription Manager to manually attach subscriptions to this system after completing firstboot.</property>
         <property name="use_markup">True</property>
         <property name="wrap">True</property>
       </widget>
@@ -48,7 +48,7 @@
         <property name="yalign">0</property>
         <property name="xpad">10</property>
         <property name="ypad">10</property>
-        <property name="label" translatable="yes">After opening Red Hat Subscription Manager, manually subscribe via the &lt;b&gt;All Available Subscriptions&lt;/b&gt; tab.</property>
+        <property name="label" translatable="yes">After opening Red Hat Subscription Manager, manually attach subscriptions via the &lt;b&gt;All Available Subscriptions&lt;/b&gt; tab.</property>
         <property name="use_markup">True</property>
         <property name="wrap">True</property>
       </widget>

--- a/src/subscription_manager/gui/data/mysubs.glade
+++ b/src/subscription_manager/gui/data/mysubs.glade
@@ -61,13 +61,13 @@
                     <property name="layout_style">end</property>
                     <child>
                       <widget class="GtkButton" id="unsubscribe_button">
-                        <property name="label" translatable="yes">Unsubscribe</property>
+                        <property name="label" translatable="yes">Remove</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
                         <property name="yalign">0.46000000834465027</property>
                         <accessibility>
-                          <atkproperty name="AtkObject::accessible-name" translatable="yes">Unsubscribe</atkproperty>
+                          <atkproperty name="AtkObject::accessible-name" translatable="yes">Remove</atkproperty>
                         </accessibility>
                         <signal name="clicked" handler="on_unsubscribe_button_clicked"/>
                       </widget>

--- a/src/subscription_manager/gui/data/selectsla.glade
+++ b/src/subscription_manager/gui/data/selectsla.glade
@@ -82,7 +82,7 @@ want them assigned.</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
             <property name="xpad">10</property>
-            <property name="label" translatable="yes">&lt;b&gt;Subscribe all detected products as:&lt;/b&gt;</property>
+            <property name="label" translatable="yes">&lt;b&gt;Attach subscriptions with service level:&lt;/b&gt;</property>
             <property name="use_markup">True</property>
           </widget>
           <packing>

--- a/src/subscription_manager/gui/firstboot/rhsm_login.py
+++ b/src/subscription_manager/gui/firstboot/rhsm_login.py
@@ -41,9 +41,9 @@ class SelectSLAScreen(registergui.SelectSLAScreen):
     def _on_get_service_levels_cb(self, result, error=None):
         if error != None:
             if isinstance(error, ServiceLevelNotSupportedException):
-                message = _("Unable to auto-subscribe, server does not support "
+                message = _("Unable to auto-attach, server does not support "
                             "service levels. Please run 'Subscription Manager' "
-                            "to manually subscribe.")
+                            "to manually attach a subscription.")
                 self._parent.manual_message = message
                 self._parent.pre_done(MANUALLY_SUBSCRIBE_PAGE)
             elif isinstance(error, NoProductsException):
@@ -69,7 +69,7 @@ class SelectSLAScreen(registergui.SelectSLAScreen):
             # when we cannot fix any unentitled products:
             if current_sla is not None and \
                     not self._can_add_more_subs(current_sla, sla_data_map):
-                message = _("Unable to subscribe to any additional products at "
+                message = _("Unable to attach any additional subscriptions at "
                             "current service level: %s") % current_sla
                 self._parent.manual_message = message
                 self._parent.pre_done(MANUALLY_SUBSCRIBE_PAGE)
@@ -84,7 +84,7 @@ class SelectSLAScreen(registergui.SelectSLAScreen):
         else:
             message = _("No service levels will cover all installed products. "
                 "Please run 'Subscription Manager' to manually "
-                "subscribe this system.")
+                "attach subscriptions.")
             self._parent.manual_message = message
             self._parent.pre_done(MANUALLY_SUBSCRIBE_PAGE)
 

--- a/src/subscription_manager/gui/mysubstab.py
+++ b/src/subscription_manager/gui/mysubstab.py
@@ -128,7 +128,7 @@ class MySubscriptionsTab(widgets.SubscriptionManagerTab):
             try:
                 self.backend.uep.unbindBySerial(self.consumer.uuid, serial)
             except Exception, e:
-                handle_gui_exception(e, _("There was an error unsubscribing from %s with serial number %s") % (selection['subscription'], serial), self.parent_win, formatMsg=False)
+                handle_gui_exception(e, _("There was an error removing %s with serial number %s") % (selection['subscription'], serial), self.parent_win, formatMsg=False)
 
             try:
                 self.backend.certlib.update()
@@ -147,7 +147,7 @@ class MySubscriptionsTab(widgets.SubscriptionManagerTab):
         if not selection.is_valid():
             return
 
-        prompt = messageWindow.YesNoDialog(_("Are you sure you want to unsubscribe from %s?") % selection['subscription'],
+        prompt = messageWindow.YesNoDialog(_("Are you sure you want to remove %s?") % selection['subscription'],
                 self.content.get_toplevel())
         prompt.connect('response', self._on_unsubscribe_prompt_response, selection)
 

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -372,7 +372,7 @@ class ConfirmSubscriptionsScreen(Screen):
         super(ConfirmSubscriptionsScreen, self).__init__("confirmsubs.glade",
                                                          parent,
                                                          backend)
-        self.button_label = _("Subscribe")
+        self.button_label = _("Attach")
 
         self.store = gtk.ListStore(str)
         # For now just going to set up one product name column, we will need
@@ -474,13 +474,13 @@ class SelectSLAScreen(Screen):
         # BZ #855762.
         if error != None:
             if isinstance(error, ServiceLevelNotSupportedException):
-                OkDialog(_("Unable to auto-subscribe, server does not support service levels."),
+                OkDialog(_("Unable to auto-attach, server does not support service levels."),
                         parent=self._parent.parent)
             elif isinstance(error, NoProductsException):
-                InfoDialog(_("No installed products on system. No need to update subscriptions at this time."),
+                InfoDialog(_("No installed products on system. No need to attach subscriptions at this time."),
                            parent=self._parent.parent)
             elif isinstance(error, AllProductsCoveredException):
-                InfoDialog(_("All installed products are covered by valid entitlements. No need to update subscriptions at this time."),
+                InfoDialog(_("All installed products are covered by valid entitlements. No need to attach subscriptions at this time."),
                            parent=self._parent.parent)
             else:
                 handle_gui_exception(error, _("Error subscribing"),
@@ -501,7 +501,7 @@ class SelectSLAScreen(Screen):
                                      "the current service level: %s. "
                                      "Please use the \"All Available "
                                      "Subscriptions\" tab to manually "
-                                     "subscribe this system.") % current_sla,
+                                     "attach subscriptions.") % current_sla,
                                     self._parent.parent)
                 self._parent.finish_registration(failed=True)
                 return
@@ -516,10 +516,8 @@ class SelectSLAScreen(Screen):
             log.info("No suitable service levels found.")
             handle_gui_exception(None,
                                  _("No service level will cover all installed "
-                                 "products. Please manually subscribe "
-                                 "using multiple service levels via "
-                                 "the \"All Available Subscriptions\" tab "
-                                 "or purchase additional subscriptions"),
+                                 "products. Please run Subscription Manager to "
+                                 "manually attach subscriptions"),
                                  parent=self._parent.parent)
             self._parent.finish_registration(failed=True)
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -152,7 +152,7 @@ def autosubscribe(cp, consumer_uuid, service_level=None):
         cp.bind(consumer_uuid)  # new style
 
     except Exception, e:
-        log.warning("Error during auto-subscribe.")
+        log.warning("Error during auto-attach.")
         log.exception(e)
 
 
@@ -160,7 +160,7 @@ def show_autosubscribe_output():
     installed_status = managerlib.getInstalledProductStatus(ProductDirectory(),
             EntitlementDirectory())
 
-    log.info("Attempted to auto-subscribe/heal the system.")
+    log.info("Attempted to auto-attach/heal the system.")
     print _("Installed Product Current Status:")
     subscribed = False
     for prod_status in installed_status:
@@ -528,7 +528,6 @@ class RefreshCommand(CliCommand):
 
 
 class IdentityCommand(UserPassCommand):
-
     def __init__(self, ent_dir=None, prod_dir=None):
         shortdesc = _("Display the identity certificate for this system or " \
                       "request a new one")
@@ -860,7 +859,9 @@ class RegisterCommand(UserPassCommand):
         self.parser.add_option("--release", dest="release",
                                help=_("set a release version"))
         self.parser.add_option("--autosubscribe", action='store_true',
-                               help=_("automatically subscribe this system to\
+                               help=_("Deprecated, see --autoattach"))
+        self.parser.add_option("--autoattach", action='store_true',
+                               help=_("automatically attach this system to\
                                      compatible subscriptions."))
         self.parser.add_option("--force", action='store_true',
                                help=_("register the system even if it is already registered"))
@@ -874,6 +875,7 @@ class RegisterCommand(UserPassCommand):
         self.installed_mgr = InstalledProductsManager()
 
     def _validate_options(self):
+        self.autoattach = self.options.autosubscribe or self.options.autoattach
         if self.consumerIdentity.exists() and not self.options.force:
             print(_("This system is already registered. Use --force to override"))
             sys.exit(1)
@@ -889,15 +891,15 @@ class RegisterCommand(UserPassCommand):
         elif (self.options.environment and self.options.activation_keys):
             print(_("Error: Activation keys do not allow environments to be specified."))
             sys.exit(-1)
-        elif (self.options.autosubscribe and self.options.activation_keys):
-            print(_("Error: Activation keys cannot be used with --autosubscribe."))
+        elif (self.autoattach and self.options.activation_keys):
+            print(_("Error: Activation keys cannot be used with --autoattach."))
             sys.exit(-1)
         #746259: Don't allow the user to pass in an empty string as an activation key
         elif (self.options.activation_keys and '' in self.options.activation_keys):
             print(_("Error: Must specify an activation key"))
             sys.exit(-1)
-        elif (self.options.service_level and not self.options.autosubscribe):
-            print(_("Error: Must use --autosubscribe with --servicelevel."))
+        elif (self.options.service_level and not self.autoattach):
+            print(_("Error: Must use --autoattach with --servicelevel."))
             sys.exit(-1)
         elif (self.options.activation_keys and not self.options.org):
             print(_("Error: Must provide --org with activation keys."))
@@ -1001,19 +1003,19 @@ class RegisterCommand(UserPassCommand):
             # TODO: grab the list of valid options, and check
             self.cp.updateConsumer(consumer['uuid'], release=self.options.release)
 
-        if self.options.autosubscribe:
+        if self.autoattach:
             if 'serviceLevel' not in consumer and self.options.service_level:
                 systemExit(-1, _("Error: The --servicelevel option is not supported "
-                                 "by the server. Did not perform autosubscribe."))
+                                 "by the server. Did not perform autoattach."))
             autosubscribe(self.cp, consumer['uuid'],
                     service_level=self.options.service_level)
         if (self.options.consumerid or self.options.activation_keys or
-                self.options.autosubscribe):
+                self.autoattach):
             self.certlib.update()
 
         # run this after certlib update, so we have the new entitlements
         return_code = 0
-        if self.options.autosubscribe:
+        if self.autoattach:
             subscribed = show_autosubscribe_output()
             if not subscribed:
                 return_code = 1
@@ -1235,24 +1237,36 @@ class ReleaseCommand(CliCommand):
             self.show_current_release()
 
 
-class SubscribeCommand(CliCommand):
+class AttachCommand(CliCommand):
 
     def __init__(self, ent_dir=None, prod_dir=None):
-        shortdesc = _("Subscribe the registered system to a specified product")
-        super(SubscribeCommand, self).__init__("subscribe", shortdesc, True,
-                                               ent_dir, prod_dir)
+        super(AttachCommand, self).__init__(
+            self._command_name(),
+            self._short_description(),
+            self._primary(),
+            ent_dir,
+            prod_dir)
 
         self.product = None
         self.substoken = None
         self.parser.add_option("--pool", dest="pool", action='append',
-                               help=_("the id of the pool to subscribe to"))
+                               help=_("the id of the pool to attach"))
         self.parser.add_option("--quantity", dest="quantity",
-                               help=_("number of subscriptions to consume"))
+                               help=_("number of subscriptions to attach"))
         self.parser.add_option("--auto", action='store_true',
-                               help=_("automatically subscribe this system to\
-                                     compatible subscriptions."))
+                               help=_("automatically attach compatible \
+                               subscriptions to this syste"))
         self.parser.add_option("--servicelevel", dest="service_level",
                                help=_("service level to apply to this system"))
+
+    def _short_description(self):
+        return _("Attach a specified subscription to the registered system")
+
+    def _command_name(self):
+        return "attach"
+
+    def _primary(self):
+        return True
 
     def _validate_options(self):
         if not (self.options.pool or self.options.auto):
@@ -1296,8 +1310,8 @@ class SubscribeCommand(CliCommand):
                         # Usually just one, but may as well be safe:
                         for ent in ents:
                             pool_json = ent['pool']
-                            print _("Successfully consumed a subscription for: %s") % pool_json['productName']
-                            log.info("Successfully consumed a subscription for: %s (%s)" %
+                            print _("Successfully attached a subscription for: %s") % pool_json['productName']
+                            log.info("Successfully attached a subscription for: %s (%s)" %
                                     (pool_json['productName'], pool))
                             subscribed = True
                     except connection.RestlibException, re:
@@ -1319,7 +1333,7 @@ class SubscribeCommand(CliCommand):
                     if 'serviceLevel' not in consumer:
                         systemExit(-1, _("Error: The --servicelevel option is not "
                                          "supported by the server. Did not perform "
-                                         "autosubscribe."))
+                                         "autoattach."))
                 autosubscribe(self.cp, consumer_uuid,
                               service_level=self.options.service_level)
 
@@ -1335,7 +1349,7 @@ class SubscribeCommand(CliCommand):
                     return_code = 1
 
         except Exception, e:
-            handle_exception("Unable to subscribe: %s" % e, e)
+            handle_exception("Unable to attach: %s" % e, e)
 
         # it is okay to call this no matter what happens above,
         # it's just a notification to perform a check
@@ -1343,17 +1357,43 @@ class SubscribeCommand(CliCommand):
         return return_code
 
 
-class UnSubscribeCommand(CliCommand):
+class SubscribeCommand(AttachCommand):
+    def __init__(self, ent_dir=None, prod_dir=None):
+        super(SubscribeCommand, self).__init__(ent_dir, prod_dir)
+
+    def _short_description(self):
+        return _("Deprecated, see attach")
+
+    def _command_name(self):
+        return "subscribe"
+
+    def _primary(self):
+        return False
+
+
+class RemoveCommand(CliCommand):
 
     def __init__(self, ent_dir=None, prod_dir=None):
-        shortdesc = _("Unsubscribe the system from all or specific subscriptions")
-        super(UnSubscribeCommand, self).__init__("unsubscribe", shortdesc, True,
-                                                 ent_dir, prod_dir)
+        super(RemoveCommand, self).__init__(
+            self._command_name(),
+            self._short_description(),
+            self._primary(),
+            ent_dir,
+            prod_dir)
 
         self.parser.add_option("--serial", action='append', dest="serials",
-                       help=_("One or more Certificate serials to unsubscribe"))
+                       help=_("One or more Certificate serials to remove"))
         self.parser.add_option("--all", dest="all", action="store_true",
-                               help=_("Unsubscribe from all subscriptions"))
+                               help=_("Remove all subscriptions from this system"))
+
+    def _short_description(self):
+        return _("Remove all or specific subscriptions from this system")
+
+    def _command_name(self):
+        return "remove"
+
+    def _primary(self):
+        return True
 
     def _validate_options(self):
         if self.options.serials:
@@ -1381,13 +1421,13 @@ class UnSubscribeCommand(CliCommand):
                     # total will be None on older Candlepins that don't
                     # support returning the number of subscriptions unsubscribed from
                     if total is None:
-                        print _("This system has been unsubscribed from all subscriptions.")
+                        print _("All subscriptions have been removed from this system.")
                     else:
                         count = total['deletedRecords']
                         if count == 1:
-                            print _("This system has been unsubscribed from 1 subscription.")
+                            print _("1 subscription removed from this system.")
                         else:
-                            print _("This system has been unsubscribed from %s subscriptions." \
+                            print _("%s subscriptions removed from this system." \
                                 % total['deletedRecords'])
                 else:
                     success = []
@@ -1402,11 +1442,11 @@ class UnSubscribeCommand(CliCommand):
                                 systemExit(-1)
                             failure.append(re.msg)
                     if success:
-                        print _("Successfully unsubscribed serial numbers:")
+                        print _("Successfully removed serial numbers:")
                         for ser in success:
                             print "   %s" % ser
                     if failure:
-                        print _("Unsuccessfully unsubscribed serial numbers:")
+                        print _("Unsuccessfully removed serial numbers:")
                         for fail in failure:
                             print "   %s" % fail
                 self.certlib.update()
@@ -1414,7 +1454,7 @@ class UnSubscribeCommand(CliCommand):
                 log.error(re)
                 systemExit(-1, re.msg)
             except Exception, e:
-                handle_exception(_("Unable to perform unsubscribe due to the following exception: %s") % e, e)
+                handle_exception(_("Unable to perform remove due to the following exception: %s") % e, e)
         else:
             # We never got registered, just remove the cert
             try:
@@ -1423,19 +1463,33 @@ class UnSubscribeCommand(CliCommand):
                     for ent in self.entitlement_dir.list():
                         ent.delete()
                         total = total + 1
-                    print _("This system has been unsubscribed from %s subscriptions" % total)
+                    print _("%s subscriptions removed from this system." % total)
                 else:
                     for ent in self.entitlement_dir.list():
                         if str(ent.serial) in self.options.serials:
                             ent.delete()
-                            print _("This system has been unsubscribed from subscription "
-                                    "with serial number %s" % str(ent.serial))
+                            print _("Subscription with serial number %s removed from this system"
+                                % str(ent.serial))
             except Exception, e:
-                handle_exception(_("Unable to perform unsubscribe due to the following exception: %s") % e, e)
+                handle_exception(_("Unable to perform remove due to the following exception: %s") % e, e)
 
         # it is okay to call this no matter what happens above,
         # it's just a notification to perform a check
         self._request_validity_check()
+
+
+class UnSubscribeCommand(RemoveCommand):
+    def __init__(self, ent_dir=None, prod_dir=None):
+        super(UnSubscribeCommand, self).__init__(ent_dir, prod_dir)
+
+    def _short_description(self):
+        return _("Deprecated, see remove")
+
+    def _command_name(self):
+        return "unsubscribe"
+
+    def _primary(self):
+        return False
 
 
 class FactsCommand(CliCommand):
@@ -1993,7 +2047,7 @@ class ManagerCLI(CLI):
                        UnSubscribeCommand, FactsCommand, IdentityCommand, OwnersCommand, \
                        RefreshCommand, CleanCommand, RedeemCommand, ReposCommand, ReleaseCommand, \
                        EnvironmentsCommand, ImportCertCommand, ServiceLevelCommand, \
-                       VersionCommand]
+                       VersionCommand, RemoveCommand, AttachCommand]
         CLI.__init__(self, command_classes=commands)
 
     def main(self):

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -457,6 +457,41 @@ class TestConfigCommand(TestCliCommand):
         self.assertRaises(SystemExit, self.cc.main, ['--remove', 'notdotted'])
 
 
+# Test Attach and Subscribe are the same
+class TestAttachCommand(TestCliProxyCommand):
+    command_class = managercli.AttachCommand
+
+    def _test_quantity_exception(self, arg):
+        try:
+            self.cc.main(["--auto", "--quantity", arg])
+            self.cc._validate_options()
+        except SystemExit, e:
+            self.assertEquals(e.code, -1)
+        else:
+            self.fail("No Exception Raised")
+
+    def test_zero_quantity(self):
+        self._test_quantity_exception("0")
+
+    def test_negative_quantity(self):
+        self._test_quantity_exception("-1")
+
+    def test_text_quantity(self):
+        self._test_quantity_exception("JarJarBinks")
+
+    def test_positive_quantity(self):
+        self.cc.main(["--auto", "--quantity", "1"])
+        self.cc._validate_options()
+
+    def test_positive_quantity_with_plus(self):
+        self.cc.main(["--auto", "--quantity", "+1"])
+        self.cc._validate_options()
+
+    def test_positive_quantity_as_float(self):
+        self._test_quantity_exception("2.0")
+
+
+# Test Attach and Subscribe are the same
 class TestSubscribeCommand(TestCliProxyCommand):
     command_class = managercli.SubscribeCommand
 
@@ -488,6 +523,10 @@ class TestSubscribeCommand(TestCliProxyCommand):
 
     def test_positive_quantity_as_float(self):
         self._test_quantity_exception("2.0")
+
+
+class TestRemoveCommand(TestCliProxyCommand):
+    command_class = managercli.RemoveCommand
 
 
 class TestUnSubscribeCommand(TestCliProxyCommand):

--- a/test/test_unsubscribe.py
+++ b/test/test_unsubscribe.py
@@ -21,7 +21,11 @@ import rhsm.connection as connection
 from subscription_manager import managercli
 
 
+# This is a dupe of test_remove
 class CliUnSubscribeTests(unittest.TestCase):
+
+    def setUp(self):
+        self.oldCI = managercli.ConsumerIdentity
 
     def test_unsubscribe_registered(self):
         connection.UEPConnection = StubUEP
@@ -79,3 +83,6 @@ class CliUnSubscribeTests(unittest.TestCase):
         self.assertTrue(ent1.is_deleted)
         self.assertFalse(ent2.is_deleted)
         self.assertTrue(ent3.is_deleted)
+
+    def tearDown(self):
+        managercli.ConsumerIdentity = self.oldCI


### PR DESCRIPTION
...Unsubscribe.

For the GUI, this is a basic string change. For the CLI, the terms subscirbe and unsubscribe are command names. To resolve this, the commands were renamed to the new name and a new command was created for the old terms. This new command is marked as deprecated, and is shown in the secondary section. Both command should work.

The only other nutty change is around auto-subscribe at register. Now, either autosubscibe or autoattach  can be used.
