### PR TITLE
876692: more consistent formating of usage msg's

### DIFF
--- a/bin/install-num-migrate-to-rhsm
+++ b/bin/install-num-migrate-to-rhsm
@@ -31,7 +31,8 @@ if _LIBPATH not in sys.path:
     sys.path.append(_LIBPATH)
 
 from subscription_manager.i18n import configure_i18n
-from subscription_manager.i18n_optparse import OptionParser
+from subscription_manager.i18n_optparse import OptionParser, \
+     WrappedIndentedHelpFormatter, USAGE
 
 configure_i18n()
 
@@ -48,7 +49,8 @@ _("Unsupported string length")
 _("Checksum verification failed")
 
 # Set up command line options
-parser = OptionParser(usage=_("%prog [OPTIONS]"))
+parser = OptionParser(usage=USAGE,
+                      formatter=WrappedIndentedHelpFormatter())
 parser.add_option('-i',
                   '--instnumber',
                   help=_("install number to run against"))

--- a/bin/rhn-migrate-classic-to-rhsm
+++ b/bin/rhn-migrate-classic-to-rhsm
@@ -60,7 +60,8 @@ import up2date_client.config
 rhncfg = up2date_client.config.initUp2dateConfig()
 
 from optparse import Option
-from subscription_manager.i18n_optparse import OptionParser, WrappedIndentedHelpFormatter
+from subscription_manager.i18n_optparse import OptionParser, \
+     WrappedIndentedHelpFormatter, USAGE
 
 options_table = [
     Option("-f", "--force", action="store_true", default=False,
@@ -76,7 +77,7 @@ options_table = [
            help=_("specify the subscription management server to migrate to")),
 ]
 
-parser = OptionParser(usage=_("%prog [OPTIONS]"),
+parser = OptionParser(usage=USAGE,
                       option_list=options_table,
                       formatter=WrappedIndentedHelpFormatter())
 

--- a/bin/subscription-manager-gui
+++ b/bin/subscription-manager-gui
@@ -85,7 +85,8 @@ try:
 
     from subscription_manager.gui import managergui
     from subscription_manager import logutil
-    from subscription_manager.i18n_optparse import OptionParser
+    from subscription_manager.i18n_optparse import OptionParser, \
+        WrappedIndentedHelpFormatter, USAGE
 except ImportError, e:
     systemExit(2, "Unable to find Subscription Manager module.\n"
                   "Error: %s" % e)
@@ -103,7 +104,8 @@ class SubscriptionManagerService(dbus.service.Object):
         self.window.present()
 
 if __name__ == '__main__':
-    parser = OptionParser(usage=_("%prog [OPTIONS]"))
+    parser = OptionParser(usage=USAGE,
+                          formatter=WrappedIndentedHelpFormatter())
     parser.add_option("--register", action='store_true',
                       help=_("launches the registration dialog on startup."))
     options, args = parser.parse_args(args=sys.argv)

--- a/src/rhsm_d.py
+++ b/src/rhsm_d.py
@@ -23,8 +23,6 @@ import dbus
 import dbus.service
 import dbus.glib
 
-from optparse import OptionParser
-
 import sys
 sys.path.append("/usr/share/rhsm")
 from subscription_manager.certlib import ConsumerIdentity
@@ -33,6 +31,8 @@ from subscription_manager import certdirectory
 from subscription_manager.cert_sorter import CertSorter
 from subscription_manager.hwprobe import ClassicCheck
 from subscription_manager.facts import Facts
+from subscription_manager.i18n_optparse import OptionParser, \
+    WrappedIndentedHelpFormatter, USAGE
 import rhsm.certificate as certificate
 
 enable_debug = False
@@ -172,7 +172,8 @@ def parse_force_signal(cli_arg):
 
 
 def main():
-    parser = OptionParser()
+    parser = OptionParser(usage=USAGE,
+                          formatter=WrappedIndentedHelpFormatter())
     parser.add_option("-d", "--debug", dest="debug",
             help="Display debug messages", action="store_true", default=False)
     parser.add_option("-k", "--keep-alive", dest="keep_alive",

--- a/src/rhsmcertd-worker.py
+++ b/src/rhsmcertd-worker.py
@@ -24,7 +24,8 @@ from subscription_manager import certmgr
 from subscription_manager import logutil
 from subscription_manager import managerlib
 from subscription_manager.certlib import ConsumerIdentity
-from subscription_manager.i18n_optparse import OptionParser
+from subscription_manager.i18n_optparse import OptionParser, \
+    WrappedIndentedHelpFormatter, USAGE
 
 import gettext
 _ = gettext.gettext
@@ -60,7 +61,8 @@ if __name__ == '__main__':
     logutil.init_logger()
     log = logging.getLogger('rhsm-app.' + __name__)
 
-    parser = OptionParser()
+    parser = OptionParser(usage=USAGE,
+                          formatter=WrappedIndentedHelpFormatter())
     parser.add_option("--autoheal", dest="autoheal", action="store_true",
             default=False, help="perform an autoheal check")
     (options, args) = parser.parse_args()

--- a/src/subscription_manager/i18n_optparse.py
+++ b/src/subscription_manager/i18n_optparse.py
@@ -32,6 +32,9 @@ from optparse import OptionParser as _OptionParser
 from optparse import IndentedHelpFormatter as _IndentedHelpFormatter
 import textwrap
 
+# note default is lower caps
+USAGE = _("%prog [OPTIONS]")
+
 
 #
 # This is pulled from the python dist, in optparse.py


### PR DESCRIPTION
Make all usages of OptionParser use our version from
i18n_optparse. Make all OptionParser use USAGE.
Also make all of them use our WrappedIndentedHelpFormatter
for help formatting.

This should make all the python cli tools show
"%prog [OPTIONS]" for the default usage string.
