### PR TITLE
878986: refactor to use curses/textwrap for format

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -22,6 +22,7 @@ import socket
 import getpass
 import dbus
 import datetime
+import textwrap
 from time import strftime, strptime, localtime
 from M2Crypto import X509
 from M2Crypto import SSL
@@ -191,6 +192,8 @@ class CliCommand(AbstractCLICommand):
 
         self.client_versions = self._default_client_version()
         self.server_versions = self._default_server_version()
+
+        self.columns = get_terminal_width()
 
     def _request_validity_check(self):
         try:
@@ -1865,7 +1868,6 @@ class ListCommand(CliCommand):
         """
 
         self._validate_options()
-        columns = get_terminal_width()
         if self.options.installed:
             iproducts = managerlib.getInstalledProductStatus(self.product_dir,
                     self.entitlement_dir, self.facts.get_facts())
@@ -1877,7 +1879,7 @@ class ListCommand(CliCommand):
             print "+-------------------------------------------+"
             for product in iproducts:
                 status = STATUS_MAP[product[4]]
-                product_name = self._format_name(product[0], 24, columns)
+                product_name = self._format_name(product[0], 24)
                 print self._none_wrap(INSTALLED_PRODUCT_STATUS, product_name,
                                 product[1], product[2], product[3], status,
                                 product[5], product[6])
@@ -1911,7 +1913,7 @@ class ListCommand(CliCommand):
             print("+-------------------------------------------+")
             for data in epools:
                 # TODO:  Something about these magic numbers!
-                product_name = self._format_name(data['productName'], 24, columns)
+                product_name = self._format_name(data['productName'], 24)
 
                 if PoolWrapper(data).is_virt_only():
                     machine_type = machine_type = _("Virtual")
@@ -1968,16 +1970,15 @@ class ListCommand(CliCommand):
         print("   " + _("Consumed Subscriptions"))
         print("+-------------------------------------------+\n")
 
-        columns = get_terminal_width()
         for cert in certs:
             order = cert.order
-            order_name = self._format_name(order.name, 24, columns)
+            order_name = self._format_name(order.name, 24)
             print(self._none_wrap(_("Subscription Name:    \t%s"),
                   order_name))
 
             prefix = _("Provides:             \t%s")
             for product in cert.products:
-                print(self._none_wrap(prefix, self._format_name(product.name, 24, columns)))
+                print(self._none_wrap(prefix, self._format_name(product.name, 24)))
                 prefix = _("                      \t%s")
             # print an empty provides line for certs with no provided products
             if len(cert.products) == 0:
@@ -2005,41 +2006,22 @@ class ListCommand(CliCommand):
                   managerlib.formatDate(cert.valid_range.end()))
             print("")
 
-    def _format_name(self, name, indent, max_length):
+    def _format_name(self, name, indent, max_width=None):
         """
         Formats a potentially long name for multi-line display, giving
         it a columned effect.
         """
+        width = self.columns
+        if max_width:
+            width = max_width
 
-        if not name or not max_length:
+        if not name or not self.columns:
             return name
 
-        words = name.split()
-        current = indent
-        lines = []
-        # handle emtpty names
-        if not words:
-            return name
-
-        first_word = words.pop(0)
-        line = [first_word]
-        current += len(first_word) + 1
-
-        def add_line():
-            lines.append(' '.join(line))
-
-        # Split here and build it back up by word, this way we get word wrapping
-        for word in words:
-            if current + len(word) < max_length:
-                current += len(word) + 1  # Have to account for the extra space
-                line.append(word)
-            else:
-                add_line()
-                line = [' ' * (indent - 1), word]
-                current = indent + len(word) + 1
-
-        add_line()
-        return '\n'.join(lines)
+        return textwrap.fill(width=width - indent, initial_indent='',
+                             subsequent_indent=' ' * indent,
+                             break_long_words=False,
+                             text=name)
 
 
 class VersionCommand(CliCommand):

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -22,6 +22,8 @@ from subscription_manager.certlib import ConsumerIdentity
 from urlparse import urlparse
 import os
 import signal
+import sys
+import curses
 
 log = logging.getLogger('rhsm-app.' + __name__)
 
@@ -287,42 +289,15 @@ def get_version(versions, package_name):
     return "%s%s" % (package_version, package_release)
 
 
-# This code was modified by from
-# http://stackoverflow.com/questions/566746/how-to-get-console-window-width-in-python
+# find the width of the current console
 def get_terminal_width():
-    """
-    Attempt to determine the current terminal size.
-    """
-    dim = None
-    try:
-        def ioctl_GWINSZ(fd):
-            try:
-                import fcntl
-                import termios
-                import struct
-                cr = struct.unpack('hh',
-                                fcntl.ioctl(fd,
-                                    termios.TIOCGWINSZ,
-                                    '1234'))
-            except:
-                return
-            return cr
 
-        dim = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
-        if not dim:
-            try:
-                fd = os.open(os.ctermid(), os.O_RDONLY)
-                dim = ioctl_GWINSZ(fd)
-                os.close(fd)
-            except:
-                pass
-    except:
-        pass
-
-    if dim:
-        return int(dim[1])
-    else:
+    # TODO:  Something about these magic numbers!
+    if not sys.stdout.isatty():
         return None
+
+    curses.setupterm()
+    return curses.tigetnum('cols')
 
 
 def get_client_versions():

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -106,7 +106,7 @@ class MockStdout:
         self.buffer = self.buffer + buf
 
     @staticmethod
-    def isatty(buf):
+    def isatty():
         return False
 
 

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -313,7 +313,9 @@ class TestListCommand(TestCliProxyCommand):
         new_name = self.cc._format_name(name, self.indent, self.max_length)
         self.assertEquals(name, new_name)
 
-    def test_format_name_null_width(self):
+    @mock.patch('curses.tigetnum')
+    def test_format_name_null_width(self, mc):
+        mc.return_value = None
         name = "This is a Really Long Name For A Product That We Do Not Want To See But Should Be Able To Deal With"
         new_name = self.cc._format_name(name, self.indent, None)
         self.assertEquals(name, new_name)


### PR DESCRIPTION
Remove ioctl calls, and replace with curses calls,
and replace ListCommand._format_name with a
use of textwrap.
