### PR TITLE
800459: Config command removes the existing value from /etc/rhsm/rhsm.co...

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1748,6 +1748,12 @@ class ConfigCommand(CliCommand):
                 for name, value in cfg.items(section):
                     test = "%s" % getattr(self.options, section + "." + name)
                     has = has or (test != 'None')
+                    if (test != 'None') and len(test) == 0:
+                        sys.stderr.write(
+                            _("To remove the value for %s.%s, use the --remove option.") % (section, name)
+                        )
+                        sys.stderr.write("\n")
+                        sys.exit(-1)
             if not has:
                 # if no options are given, default to --list
                 self.options.list = True

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -452,6 +452,10 @@ class TestConfigCommand(TestCliCommand):
         self.cc.main(['--rhsm.baseurl', baseurl])
         self.assertEquals(managercli.cfg.store['rhsm.baseurl'], baseurl)
 
+    def test_set_empty(self):
+        self.cc._do_command = self._orig_do_command
+        self.assertRaises(SystemExit, self.cc.main, ['--rhsm.baseurl', ''])
+
     def test_remove_config_default(self):
         self.cc._do_command = self._orig_do_command
         self.cc.main(['--remove', 'rhsm.baseurl'])


### PR DESCRIPTION
...nf file if a new value is not specified

[Entry] = [] causes existing entry to be cleared.
Added error message urging the user to employ the --remove option.
