### PR TITLE
878820: Fix console error when yum.repos.d does not exist.

### DIFF
--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -448,6 +448,13 @@ class RepoFile(ConfigParser):
         self.manage_repos = 1
         if CFG.has_option('rhsm', 'manage_repos'):
             self.manage_repos = int(CFG.get('rhsm', 'manage_repos'))
+        # Simulate manage repos turned off if no yum.repos.d directory exists.
+        # This indicates yum is not installed so clearly no need for us to
+        # manage repos.
+        if not os.path.exists(self.PATH):
+            log.warn("%s does not exist, turning manage_repos off." %
+                    self.PATH)
+            self.manage_repos = 0
         self.create()
 
     def exists(self):


### PR DESCRIPTION
Error would display on console when yum is not installed (RHEV-H) when
unregistering or subscribing.

If this directory does not exist, it's a good indication that we
shouldn't bother trying to write redhat.repo. This is effectively the
exact same as the manage_repos setting in rhsm.conf, so when creating
we'll assume manage_repos=0 if the directory does not exist.
