### PR TITLE
877579: Fix -1 quantity to consume for unlimited pools.

### DIFF
--- a/src/subscription_manager/gui/contract_selection.py
+++ b/src/subscription_manager/gui/contract_selection.py
@@ -130,8 +130,9 @@ class ContractSelectionWindow(object):
             quantity_available = int(pool['quantity']) - int(pool['consumed'])
 
         # cap the default selected quantity at the max available
-        # for that pool. See #855257
-        if default_quantity_value > quantity_available:
+        # for that pool. See #855257. Watch out for quantity_available
+        # being -1 (unlimited).
+        if default_quantity_value > quantity_available and quantity_available >= 0:
             default_quantity_value = quantity_available
 
         row = [pool['contractNumber'],

--- a/test/test_quantity.py
+++ b/test/test_quantity.py
@@ -95,6 +95,14 @@ class TestQuantityDefaultValueCalculator(unittest.TestCase):
         # 10 are already consumed, so 4/2 - 10 = -8
         self.assertEquals(0, qty)
 
+    def test_unlimited_pool_quantity(self):
+        facts = StubFacts({})
+        calculator = QuantityDefaultValueCalculator(facts, [])
+
+        pool = create_pool("my-test-product", "My Test Product", quantity=-1)
+        qty = calculator.calculate(pool)
+        self.assertEquals(1, qty)
+
     def test_total_consumed_does_not_include_future_entitlements(self):
         calculator = QuantityDefaultValueCalculator(StubFacts({}), entitlements)
         self.assertEquals(9, calculator._get_total_consumed(product_id_2))


### PR DESCRIPTION
Caused by a check to use the quantity available if quantity available is
less than what we need to go green. In this case however available is -1
indicating unlimited, which breaks that logic.
