### PR TITLE
Revert "878986: refactor to use curses/textwrap for format"

### DIFF
--- a/test/stubs.py
+++ b/test/stubs.py
@@ -106,7 +106,7 @@ class MockStdout:
         self.buffer = self.buffer + buf
 
     @staticmethod
-    def isatty():
+    def isatty(buf):
         return False
 
 

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -313,9 +313,7 @@ class TestListCommand(TestCliProxyCommand):
         new_name = self.cc._format_name(name, self.indent, self.max_length)
         self.assertEquals(name, new_name)
 
-    @mock.patch('curses.tigetnum')
-    def test_format_name_null_width(self, mc):
-        mc.return_value = None
+    def test_format_name_null_width(self):
         name = "This is a Really Long Name For A Product That We Do Not Want To See But Should Be Able To Deal With"
         new_name = self.cc._format_name(name, self.indent, None)
         self.assertEquals(name, new_name)


### PR DESCRIPTION
This reverts commit 0eebba0ab85c2aa3905e60a38e6368b24f718a52.

expect driven scripts dont seem to setup a term in
a way that curses will work, so revert this.
