### PR TITLE
862852: Fix double separator in redeem dialog.

### DIFF
--- a/src/subscription_manager/gui/data/redeem.glade
+++ b/src/subscription_manager/gui/data/redeem.glade
@@ -61,15 +61,6 @@ when the redemption is complete.</property>
                 <property name="position">1</property>
               </packing>
             </child>
-            <child>
-              <widget class="GtkHSeparator" id="hseparator1">
-                <property name="visible">True</property>
-              </widget>
-              <packing>
-                <property name="expand">False</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
           </widget>
           <packing>
             <property name="position">1</property>


### PR DESCRIPTION
The double separator is not appearing in Fedora 17 due to (presumably)
Gnome 3/GTK changes.

It is still appearing on RHEL 6 however.

The glade specifies an explicit separator, and then an HButtonBox, which
appears to include it's own separator automatically.

Removing the explicit separator fixes the issue, but on F17/Gnome 3 you
will now see no separator at all. However this looks completely fine,
and I think it's safe to assume we can rely on Gnome/GTK decisions. So
now we just show the HButtonBox, and let GTK do the rest.
