### PR TITLE
883735: load branding module slightly differently

### DIFF
--- a/src/subscription_manager/branding/__init__.py
+++ b/src/subscription_manager/branding/__init__.py
@@ -37,11 +37,11 @@ _branding = None
 
 def find_custom_branding():
     mod_path = os.path.dirname(__file__)
-    mods = glob.glob(mod_path + "/*_branding.py")
+    mods = glob.glob(mod_path + "/*_branding.*")
     if len(mods) == 0:
         return None
     # we don't support multiple brandings
-    branding_module = os.path.basename(mods[0])[:-3]
+    branding_module = os.path.basename(mods[0]).split('.')[0]
     __import__(__name__ + "." + branding_module)
     mod = sys.modules[__name__ + "." + branding_module]
     return mod.Branding()


### PR DESCRIPTION
In RHEV-H all of the .py files are removed, and looking for the .pyc files will
break running the code from source, so it's best to load them all and pick the
first one. It'll either be the .py or the .pyc.
## TEST PLAN
- build rpm
  `tito build --test --rpm`
- deploy rpm to test machine:
  `rpm -Uvh /path/to/rpm`
- REMOVE redhat_branding.py file:
  `mv /usr/share/rhsm/subscription_manager/branding/redhat_branding.py /tmp/`
- register machine to candlepin: 
  `subscription-manager register --org admin ...`
- It should work. 

To see the actual error reported do the above steps using **MASTER**. You will see this:

> subscription-manager register --org admin
> Username: admin
> Password: 
> The system has been registered with id: ae215e9e-7fa6-4301-940d-e9f67e3bd4e3  'DefaultBranding' object has no attribute 'REGISTERED_TO_SUBSCRIPTION_MANAGEMENT_SUMMARY'`
