### PR TITLE
798788: Results from subscription-manager facts --update after a server-...

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -24,6 +24,7 @@ import os
 import simplejson as json
 import gettext
 _ = gettext.gettext
+import rhsm.connection as connection
 
 from rhsm.profile import get_profile, RPMProfile
 from subscription_manager.certlib import DataLib, ConsumerIdentity
@@ -166,6 +167,8 @@ class CacheManager(object):
                 # Return the number of 'updates' we did, assuming updating all
                 # packages at once is one update.
                 return 1
+            except connection.RestlibException, re:
+                raise re
             except Exception, e:
                 log.error("Error updating system data on the server")
                 log.exception(e)

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1567,7 +1567,11 @@ class FactsCommand(CliCommand):
             facts = Facts(ent_dir=self.entitlement_dir,
                           prod_dir=self.product_dir)
             consumer = check_registration()['uuid']
-            facts.update_check(self.cp, consumer, force=True)
+            try:
+                facts.update_check(self.cp, consumer, force=True)
+            except connection.RestlibException, re:
+                log.exception(re)
+                systemExit(-1, re.msg)
             print _("Successfully updated the system facts.")
 
 


### PR DESCRIPTION
...side consumer was deleted.

Updated exception handling for cache updates that are sent server side.
RestlibException is separated out from other server side errors so that the message can be displayed.
