### PR TITLE
886110: help blurb for --auto-attach formatted poorly

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -872,8 +872,7 @@ class RegisterCommand(UserPassCommand):
         self.parser.add_option("--autosubscribe", action='store_true',
                                help=_("Deprecated, see --auto-attach"))
         self.parser.add_option("--auto-attach", action='store_true', dest="autoattach",
-                               help=_("automatically attach this system to\
-                                     compatible subscriptions."))
+                               help=_("automatically attach this system to compatible subscriptions."))
         self.parser.add_option("--force", action='store_true',
                                help=_("register the system even if it is already registered"))
         self.parser.add_option("--activationkey", action='append', dest="activation_keys",


### PR DESCRIPTION
Fix so right string get's extracted for translations.
