### PR TITLE
814378: disable linkify if we are running as firstboot

### DIFF
--- a/src/subscription_manager/gui/about.py
+++ b/src/subscription_manager/gui/about.py
@@ -18,6 +18,7 @@ import datetime
 from gtk import RESPONSE_DELETE_EVENT, RESPONSE_CANCEL, \
                 AboutDialog as GtkAboutDialog, Label
 from subscription_manager.utils import get_client_versions, get_server_versions
+from subscription_manager.gui.utils import get_running_as_firstboot
 
 import gettext
 _ = gettext.gettext
@@ -46,7 +47,8 @@ class AboutDialog(object):
         self.dialog.set_name(_("Subscription Manager"))
         self.dialog.set_license(LICENSE)
         self.dialog.set_wrap_license(True)
-        self.dialog.set_website("https://fedorahosted.org/subscription-manager/")
+        if not get_running_as_firstboot():
+            self.dialog.set_website("https://fedorahosted.org/subscription-manager/")
         self.dialog.set_copyright(_("Copyright (c) 2012 Red Hat, Inc."))
         self.dialog.set_logo_icon_name("subscription-manager")
         self.dialog.set_icon_name("subscription-manager")

--- a/src/subscription_manager/gui/firstboot/rhsm_login.py
+++ b/src/subscription_manager/gui/firstboot/rhsm_login.py
@@ -13,6 +13,10 @@ sys.path.append("/usr/share/rhsm")
 from subscription_manager import logutil
 logutil.init_logger()
 
+# neuter linkify in firstboot
+from subscription_manager.gui.utils import running_as_firstboot
+running_as_firstboot()
+
 from subscription_manager.gui import managergui
 from subscription_manager import managerlib
 from subscription_manager.gui import registergui

--- a/src/subscription_manager/gui/utils.py
+++ b/src/subscription_manager/gui/utils.py
@@ -39,6 +39,18 @@ MIN_GTK_MICRO = 0
 
 EVEN_ROW_COLOR = '#eeeeee'
 
+# set if we are in firstboot, to disable linkify, see bz#814378
+FIRSTBOOT = False
+
+
+def running_as_firstboot():
+    global FIRSTBOOT
+    FIRSTBOOT = True
+
+
+def get_running_as_firstboot():
+    return FIRSTBOOT
+
 
 def handle_gui_exception(e, msg, parent, formatMsg=True, logMsg=None):
     """
@@ -114,6 +126,10 @@ def linkify(msg):
     url_regex = re.compile("""https?://[\w\.\?\(\)\-\/]*""")
 
     if gtk.check_version(MIN_GTK_MAJOR, MIN_GTK_MINOR, MIN_GTK_MICRO):
+        return msg
+
+    # dont linkify in firstboot
+    if FIRSTBOOT:
         return msg
 
     def add_markup(mo):


### PR DESCRIPTION
Instead of trying to hit a few known usages, this tries to neuter linkify() if
we are running as firstboot. 

Also, disable showing linkable url's in the about dialog if running
as firstboot (we don't currently, but figured it was worth being
careful). 

Some info on testing can be found in the bug report. also,
make sure subscription-manager-gui does the right thing
with this code, aka, it shouldn't disable linkfify, and about
dialog should still show a link. 
