### PR TITLE
Add two manifest commands to rct.

### DIFF
--- a/etc-conf/rct.completion.sh
+++ b/etc-conf/rct.completion.sh
@@ -6,7 +6,7 @@
 # main complete function
 _rct()
 {
-  local opts="cat-cert stat-cert"
+  local opts="cat-cert stat-cert cat-man dump-man"
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local first="${COMP_WORDS[1]}"
 
@@ -17,6 +17,12 @@ _rct()
         opts="--no-products --no-content"
         ;;
     stat-cert)
+        opts=""
+        ;;
+    cat-man)
+        opts=""
+        ;;
+    dump-man)
         opts=""
         ;;
   esac

--- a/src/rct/cert_commands.py
+++ b/src/rct/cert_commands.py
@@ -1,0 +1,108 @@
+#
+# Copyright (c) 2010 - 2012 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+import base64
+import os
+from rhsm import certificate, _certificate
+from rhsm.certificate2 import EntitlementCertificate
+from rct.commands import RCTCliCommand
+from rct.printing import printc, type_to_string
+
+import gettext
+from subscription_manager.cli import InvalidCLIOptionError
+_ = gettext.gettext
+
+
+class RCTCertCommand(RCTCliCommand):
+
+    def __init__(self, name="cli", aliases=[], shortdesc=None, primary=False):
+        RCTCliCommand.__init__(self, name=name, aliases=aliases,
+                shortdesc=shortdesc, primary=primary)
+
+    def _get_usage(self):
+        return _("%%prog %s [OPTIONS] CERT_FILE") % self.name
+
+    def _create_cert(self):
+        cert_file = self._get_file_from_args()
+        try:
+            return certificate.create_from_file(cert_file)
+        except certificate.CertificateException, ce:
+            raise InvalidCLIOptionError(
+                    _("Unable to read certificate file '%s': %s") % (cert_file,
+                        ce))
+
+    def _validate_options(self):
+        cert_file = self._get_file_from_args()
+        if not cert_file:
+            raise InvalidCLIOptionError(_("You must specify a certificate file."))
+
+        if not os.path.isfile(cert_file):
+            raise InvalidCLIOptionError(_("The specified certificate file does not exist."))
+
+
+class CatCertCommand(RCTCertCommand):
+
+    def __init__(self):
+        RCTCliCommand.__init__(self, name="cat-cert", aliases=['cc'],
+                               shortdesc=_("Print certificate information"),
+                               primary=True)
+
+        self.parser.add_option("--no-products", dest="no_products", action="store_true",
+                               help=_("do not show the cert's product information"))
+        self.parser.add_option("--no-content", dest="no_content", action="store_true",
+                               help=_("do not show the cert's content info"))
+
+    def _do_command(self):
+        """
+        Does the work that this command intends.
+        """
+        cert = self._create_cert()
+        printc(cert, skip_content=self.options.no_content,
+               skip_products=self.options.no_products)
+
+
+class StatCertCommand(RCTCertCommand):
+
+    def __init__(self):
+        RCTCliCommand.__init__(self, name="stat-cert", aliases=['sc'],
+                               shortdesc=_("Print certificate statistics and sizes"),
+                               primary=True)
+
+    def _do_command(self):
+        cert = self._create_cert()
+        pem = self._get_pem(self._get_file_from_args())
+        print _("Type: %s" % type_to_string(cert))
+        print _("Version: %s" % cert.version)
+        print _("DER size: %db" % self._get_der_size(pem))
+
+        subject_key_id = self._get_subject_key_id(pem)
+        if subject_key_id is not None:
+            print _("Subject Key ID size: %db" % len(subject_key_id))
+
+        if isinstance(cert, EntitlementCertificate):
+            print _("Content sets: %s" % len(cert.content))
+
+    def _get_pem(self, filename):
+        return open(filename, 'r',).read()
+
+    def _get_der_size(self, pem):
+        parts = pem.split("-----BEGIN CERTIFICATE-----\n")
+        cert = parts[1].split("-----END CERTIFICATE-----")[0]
+        return len(base64.b64decode(cert))
+
+    def _get_subject_key_id(self, pem):
+        cert = _certificate.load(pem=pem)
+        subject_key_id = cert.get_extension(oid="2.5.29.14")
+        return subject_key_id

--- a/src/rct/cli.py
+++ b/src/rct/cli.py
@@ -14,11 +14,21 @@
 #
 
 from subscription_manager.cli import CLI
-from rct.commands import CatCertCommand, StatCertCommand
+from rct.cert_commands import CatCertCommand, StatCertCommand
+from rct.manifest_commands import CatManifestCommand, DumpManifestCommand
 
 
 class RctCLI(CLI):
 
     def __init__(self):
-        commands = [CatCertCommand, StatCertCommand]
+        commands = [CatCertCommand, CatManifestCommand, StatCertCommand, DumpManifestCommand]
         CLI.__init__(self, commands)
+
+
+def xstr(value):
+    if value is None:
+        return ''
+    elif isinstance(value, unicode):
+        return value.encode('utf-8')
+    else:
+        return str(value)

--- a/src/rct/commands.py
+++ b/src/rct/commands.py
@@ -13,15 +13,10 @@
 # in this software or its documentation.
 #
 
-import base64
-import os
 import sys
-from rhsm import certificate, _certificate
-from rhsm.certificate2 import EntitlementCertificate
-from rct.printing import printc, type_to_string
 
 import gettext
-from subscription_manager.cli import AbstractCLICommand, InvalidCLIOptionError
+from subscription_manager.cli import AbstractCLICommand
 _ = gettext.gettext
 
 
@@ -45,83 +40,7 @@ class RCTCliCommand(AbstractCLICommand):
         if return_code is not None:
             return return_code
 
-    def _validate_options(self):
-        cert_file = self._get_file_from_args()
-        if not cert_file:
-            raise InvalidCLIOptionError(_("You must specify a certificate file."))
-
-        if not os.path.isfile(cert_file):
-            raise InvalidCLIOptionError(_("The specified certificate file does not exist."))
-
-    def _create_cert(self):
-        cert_file = self._get_file_from_args()
-        try:
-            return certificate.create_from_file(cert_file)
-        except certificate.CertificateException, ce:
-            raise InvalidCLIOptionError(
-                    _("Unable to read certificate file '%s': %s") % (cert_file,
-                        ce))
-
-    def _get_usage(self):
-        return _("%%prog %s [OPTIONS] CERT_FILE") % self.name
-
     def _get_file_from_args(self):
         if not len(self.args) > self.FILE_ARG_IDX:
             return ''
         return self.args[self.FILE_ARG_IDX]
-
-
-class CatCertCommand(RCTCliCommand):
-
-    def __init__(self):
-        RCTCliCommand.__init__(self, name="cat-cert", aliases=['cc'],
-                               shortdesc=_("Print certificate information"),
-                               primary=True)
-
-        self.parser.add_option("--no-products", dest="no_products", action="store_true",
-                               help=_("do not show the cert's product information"))
-        self.parser.add_option("--no-content", dest="no_content", action="store_true",
-                               help=_("do not show the cert's content info"))
-
-    def _do_command(self):
-        """
-        Does the work that this command intends.
-        """
-        cert = self._create_cert()
-        printc(cert, skip_content=self.options.no_content,
-               skip_products=self.options.no_products)
-
-
-class StatCertCommand(RCTCliCommand):
-
-    def __init__(self):
-        RCTCliCommand.__init__(self, name="stat-cert", aliases=['sc'],
-                               shortdesc=_("Print certificate statistics and sizes"),
-                               primary=True)
-
-    def _do_command(self):
-        cert = self._create_cert()
-        pem = self._get_pem(self._get_file_from_args())
-        print _("Type: %s" % type_to_string(cert))
-        print _("Version: %s" % cert.version)
-        print _("DER size: %db" % self._get_der_size(pem))
-
-        subject_key_id = self._get_subject_key_id(pem)
-        if subject_key_id is not None:
-            print _("Subject Key ID size: %db" % len(subject_key_id))
-
-        if isinstance(cert, EntitlementCertificate):
-            print _("Content sets: %s" % len(cert.content))
-
-    def _get_pem(self, filename):
-        return open(filename, 'r',).read()
-
-    def _get_der_size(self, pem):
-        parts = pem.split("-----BEGIN CERTIFICATE-----\n")
-        cert = parts[1].split("-----END CERTIFICATE-----")[0]
-        return len(base64.b64decode(cert))
-
-    def _get_subject_key_id(self, pem):
-        cert = _certificate.load(pem=pem)
-        subject_key_id = cert.get_extension(oid="2.5.29.14")
-        return subject_key_id

--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -1,0 +1,209 @@
+#
+# Copyright (c) 2010 - 2012 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+import os
+import simplejson as json
+import shutil
+import tempfile
+from zipfile import ZipFile
+from rhsm import certificate
+from rct.commands import RCTCliCommand
+from rct.printing import xstr
+
+
+import gettext
+from subscription_manager.cli import InvalidCLIOptionError
+_ = gettext.gettext
+
+
+class RCTManifestCommand(RCTCliCommand):
+
+    INNER_FILE = "consumer_export.zip"
+
+    def __init__(self, name="cli", aliases=[], shortdesc=None, primary=False):
+        RCTCliCommand.__init__(self, name=name, aliases=aliases,
+                shortdesc=shortdesc, primary=primary)
+
+    def _get_usage(self):
+        return _("%%prog %s [OPTIONS] MANIFEST_FILE") % self.name
+
+    def _validate_options(self):
+        manifest_file = self._get_file_from_args()
+        if not manifest_file:
+            raise InvalidCLIOptionError(_("You must specify a manifest file."))
+
+        if not os.path.isfile(manifest_file):
+            raise InvalidCLIOptionError(_("The specified manifest file does not exist."))
+
+    def _extract_manifest(self, location):
+        # Extract the outer file
+        archive = ZipFile(self._get_file_from_args(), 'r')
+        archive.extractall(location)
+
+        # now extract the inner file
+        if location:
+            inner_file = os.path.join(location, self.INNER_FILE)
+        else:
+            inner_file = self.INNER_FILE
+
+        archive = ZipFile(inner_file, 'r')
+        archive.extractall(location)
+
+        # Delete the intermediate file
+        os.remove(inner_file)
+
+
+class CatManifestCommand(RCTManifestCommand):
+
+    def __init__(self):
+        RCTManifestCommand.__init__(self, name="cat-manifest", aliases=['cm'],
+                               shortdesc=_("Print manifest information"),
+                               primary=True)
+
+    def _print_section(self, title, items, indent=1, whitespace=True):
+        # Allow a bit of customization of the tabbing
+        pad = ""
+        for x in range(0, indent - 1):
+            pad = pad + "\t"
+        print(pad + title)
+        pad = pad + "\t"
+        for item in items:
+            if len(item) == 2:
+                print("%s%s: %s" % (pad, item[0], xstr(item[1])))
+            else:
+                print("%s%s" % (pad, item[0]))
+        if whitespace:
+            print ""
+
+    def _print_general(self, location):
+        # Print out general data
+        part = open(os.path.join(location, "export", "meta.json"))
+        data = json.loads(part.read())
+        to_print = []
+        to_print.append((_("Server"), data["webAppPrefix"]))
+        to_print.append((_("Server Version"), data["version"]))
+        to_print.append((_("Date Created"), data["created"]))
+        to_print.append((_("Creator"), data["principalName"]))
+        self._print_section(_("General:"), to_print)
+        part.close()
+
+    def _print_consumer(self, location):
+        # Print out the consumer data
+        part = open(os.path.join(location, "export", "consumer.json"))
+        data = json.loads(part.read())
+        to_print = []
+        to_print.append((_("Name"), data["name"]))
+        to_print.append((_("UUID"), data["uuid"]))
+        to_print.append((_("Type"), data["type"]["label"]))
+        self._print_section(_("Consumer:"), to_print)
+        part.close()
+
+    def _get_product_attribute(self, name, data):
+        return_value = None
+        for attr in data["pool"]["productAttributes"]:
+            if attr["name"] == name:
+                return_value = attr["value"]
+                break
+
+        return return_value
+
+    def _print_products(self, location):
+        ent_dir = os.path.join(location, "export", "entitlements")
+        for ent_file in os.listdir(ent_dir):
+            part = open(os.path.join(ent_dir, ent_file))
+            data = json.loads(part.read())
+            to_print = []
+            to_print.append((_("Name"), data["pool"]["productName"]))
+            to_print.append((_("Quantity"), data["quantity"]))
+            to_print.append((_("Created"), data["created"]))
+            to_print.append((_("Start Date"), data["startDate"]))
+            to_print.append((_("End Date"), data["endDate"]))
+            to_print.append((_("Suport Level"), self._get_product_attribute("support_level", data)))
+            to_print.append((_("Suport Type"), self._get_product_attribute("support_type", data)))
+            to_print.append((_("Architectures"), self._get_product_attribute("arch", data)))
+            to_print.append((_("Product Id"), data["pool"]["productId"]))
+            to_print.append((_("Contract"), data["pool"]["contractNumber"]))
+            to_print.append((_("Subscription Id"), data["pool"]["subscriptionId"]))
+
+            entitlement_file = os.path.join("export", "entitlements", "%s.json" % data["id"])
+            to_print.append((_("Entitlement File"), entitlement_file))
+            #Get the certificate to get the version
+            serial = data["certificates"][0]["serial"]["id"]
+
+            cert_file = os.path.join("export", "entitlement_certificates", "%s.pem" % serial)
+            to_print.append((_("Certificate File"), cert_file))
+            cert_file = os.path.join(location, cert_file)
+
+            try:
+                cert = certificate.create_from_file(cert_file)
+            except certificate.CertificateException, ce:
+                raise certificate.CertificateException(
+                        _("Unable to read certificate file '%s': %s") % (cert_file,
+                        ce))
+            to_print.append((_("Certificate Version"), cert.version))
+
+            self._print_section(_("Subscription:"), to_print, 1, False)
+
+            # Get the provided Products
+            to_print = []
+            for pp in data["pool"]["providedProducts"]:
+                to_print.append((int(pp["productId"]), pp["productName"]))
+
+            self._print_section(_("Provided Products:"), sorted(to_print), 2, False)
+
+            # Get the Content Sets
+            to_print = []
+            for item in cert.content:
+                to_print.append([item.url])
+            self._print_section(_("Content Sets:"), sorted(to_print), 2, True)
+            part.close()
+
+    def _do_command(self):
+        """
+        Does the work that this command intends.
+        """
+        temp = tempfile.mkdtemp()
+        self._extract_manifest(temp)
+        # Print out the header
+        print("\n+-------------------------------------------+")
+        print(_("\tManifest"))
+        print("+-------------------------------------------+\n")
+
+        self._print_general(temp)
+        self._print_consumer(temp)
+        self._print_products(temp)
+
+        shutil.rmtree(temp)
+
+
+class DumpManifestCommand(RCTManifestCommand):
+
+    def __init__(self):
+        RCTManifestCommand.__init__(self, name="dump-manifest", aliases=['dm'],
+                               shortdesc=_("Dump the contents of a manifest"),
+                               primary=True)
+
+        self.parser.add_option("--destination", dest="destination",
+                               help=_("directory to extract the manifest to"))
+
+    def _do_command(self):
+        """
+        Does the work that this command intends.
+        """
+        self._extract_manifest(self.options.destination)
+        if self.options.destination:
+            print _("The manifest has been dumped to the %s directory" % self.options.destination)
+        else:
+            print _("The manifest has been dumped to the current directory")

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -233,7 +233,7 @@ rm -rf %{buildroot}
 %dir %{_datadir}/rhsm/rct
 %{_datadir}/rhsm/rct/__init__.py*
 %{_datadir}/rhsm/rct/cli.py*
-%{_datadir}/rhsm/rct/commands.py*
+%{_datadir}/rhsm/rct/*commands.py*
 %{_datadir}/rhsm/rct/printing.py*
 %attr(755,root,root) %{_bindir}/rct
 

--- a/test/test_catcert_command.py
+++ b/test/test_catcert_command.py
@@ -16,7 +16,7 @@ import sys
 import unittest
 import certdata
 from rhsm.certificate import create_from_pem
-from rct.commands import CatCertCommand
+from rct.cert_commands import CatCertCommand
 from rct.printing import xstr
 
 from stubs import MockStdout, MockStderr

--- a/test/test_rct_cert_command.py
+++ b/test/test_rct_cert_command.py
@@ -17,14 +17,14 @@ import unittest
 
 from mock import patch
 from rhsm.certificate import CertificateException
-from rct.commands import RCTCliCommand
+from rct.cert_commands import RCTCertCommand
 from subscription_manager.cli import InvalidCLIOptionError
 
 
-class RCTCliCommandTests(unittest.TestCase):
+class RCTCertCommandTests(unittest.TestCase):
 
     def test_file_arg_required(self):
-        command = RCTCliCommand()
+        command = RCTCertCommand()
         try:
             command.main([])
             self.fail("Expected InvalidCLIOptionError since no file arg.")
@@ -33,7 +33,7 @@ class RCTCliCommandTests(unittest.TestCase):
                              str(e))
 
     def test_invalid_file_arg(self):
-        command = RCTCliCommand()
+        command = RCTCertCommand()
         try:
             command.main(["this_file_does_not_exist.crt"])
             self.fail("Expected InvalidCLIOptionError since no file does not exist.")
@@ -45,7 +45,7 @@ class RCTCliCommandTests(unittest.TestCase):
     def test_valid_x509_required(self, mock_create, mock_isfile):
         mock_create.side_effect = CertificateException("error!")
         mock_isfile.return_value = True
-        command = RCTCliCommand()
+        command = RCTCertCommand()
 
         command._do_command = lambda: command._create_cert()
         try:

--- a/test/test_statcert_command.py
+++ b/test/test_statcert_command.py
@@ -17,7 +17,7 @@ import sys
 import unittest
 import certdata
 from rhsm.certificate import create_from_pem
-from rct.commands import StatCertCommand
+from rct.cert_commands import StatCertCommand
 
 from stubs import MockStdout, MockStderr
 


### PR DESCRIPTION
dump-man will export the data from the manifest into a directory so that it can be accessed via the file system.
cat-man will output to the screen interesting summary data about the manifest

As part of this work, the commands are broken into 2 files. One is for certificates, and one is for manifests.
