### PR TITLE
895447: The count of subscriptions removed is zero for certs that have b...

### DIFF
--- a/src/subscription_manager/certlib.py
+++ b/src/subscription_manager/certlib.py
@@ -309,6 +309,7 @@ class UpdateAction(Action):
         # If we just deleted certs, we need to refresh the now stale
         # entitlement directory before we go to delete expired certs.
         if len(report.rogue) > 0:
+            print _("Any local-only certificates have been deleted.")
             self.entdir.refresh()
 
     def getCertificatesBySerialList(self, snList):


### PR DESCRIPTION
...een imported.

The counts returned are from the server. Additional message added to show that local-only entitlement certificates are removed in the process. They were getting removed previously, but the user was not informed.
