### PR TITLE
Give users the ability to disable package reporting

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -48,6 +48,10 @@ consumerCertDir = /etc/pki/consumer
 # Manage generation of yum repositories for subscribed content:
 manage_repos = 1
 
+# If set to zero, the client will not report the package profile to
+# the subscription management service.
+report_package_profile = 1
+
 [rhsmcertd]
 # Frequency of certificate refresh (in minutes):
 certFrequency = 240

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -78,6 +78,20 @@ class TestProfileManager(unittest.TestCase):
         uep.supports_resource.assert_called_with('packages')
         self.assertEquals(0, self.profile_mgr.write_cache.call_count)
 
+    def test_update_check_packages_disabled(self):
+        uuid = 'FAKEUUID'
+        uep = Mock()
+        self.profile_mgr._set_report_package_profile(0)
+        uep.updatePackageProfile = Mock()
+        self.profile_mgr.has_changed = Mock(return_value=True)
+        self.profile_mgr.write_cache = Mock()
+
+        self.profile_mgr.update_check(uep, uuid)
+
+        self.assertEquals(0, uep.updatePackageProfile.call_count)
+        uep.supports_resource.assert_called_with('packages')
+        self.assertEquals(0, self.profile_mgr.write_cache.call_count)
+
     def test_update_check_error_uploading(self):
         uuid = 'FAKEUUID'
         uep = Mock()


### PR DESCRIPTION
Provide a setting which allows users to disable the uploading of the package manifest. This pull request is dependent upon https://github.com/candlepin/python-rhsm/pull/53.
