### PR TITLE
912882: Fix xmlrpc connection class issue for Python 2.7.

### DIFF
--- a/test/test_migration.py
+++ b/test/test_migration.py
@@ -15,6 +15,7 @@
 
 from mock import patch, MagicMock, call
 from M2Crypto import SSL
+import httplib
 import re
 import sys
 import StringIO
@@ -74,8 +75,13 @@ class TestProxiedTransport(unittest.TestCase):
     def test_make_connection(self):
         self.transport.proxy = "proxy"
         http = self.transport.make_connection("host")
+        # On Python 2.7, we will return an HTTPConnection object which doesn't
+        # have a _conn attribute.  See BZ 912882 and BZ 619276.
+        if isinstance(http, httplib.HTTPConnection):
+            self.assertEquals(http.host, "proxy")
+        else:
+            self.assertEquals(http._conn.host, "proxy")
         self.assertEquals(self.transport.realhost, "host")
-        self.assertEquals(http._conn.host, "proxy")
 
 
 class TestMigration(unittest.TestCase):


### PR DESCRIPTION
(Without breaking earlier versions of Python)

This bug is closely related to BZ #619276.

To paraphrase David Malcolm in comment 11 of that bug:

The xmlrpclib Transport.request() (in Python 2.7 request() delegates calls to single_request()) method calls make_connection() which returns a connection object (httplib.HTTP prior to 2.7 and httplib.HTTPConnection in 2.7)

Eventually a call is made on the object returned from make_connection().  Python's xmlrpclib has changed from calling getreply() to getresponse() in r73638 [1] [2].

httplib.HTTP does not have a getresponse() method.  It does have a getreply() method (which delegates to an underlying connection instance's getresponse(), with some wrapper logic).

Since we were overriding make_connection() and returning an httplib.HTTP object, we broke when xmlrpclib in 2.7 tried to call getresponse().

The fix is to discriminate between 2.7 and earlier versions.  I have elected to do that by looking for the single_request() method which doesn't exist in pre-2.7.  This technique is the same as the one used by koji in commit 7876bc06 [3].

[1] http://svn.python.org/view?view=rev&revision=73638
[2] http://svn.python.org/view/python/trunk/Lib/xmlrpclib.py?r1=73638&r2=73637&pathrev=73638
[3] http://git.fedorahosted.org/cgit/koji/commit/?id=7876bc06fe9151fb521409c2e8f6a3535e1eacfe
