### PR TITLE
913187: Allow older manifests to print out correctly.

### DIFF
--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -28,6 +28,17 @@ from subscription_manager.cli import InvalidCLIOptionError
 _ = gettext.gettext
 
 
+def get_value(json_dict, path):
+    current = json_dict
+    for item in path.split("."):
+        if item in current:
+            current = current[item]
+        else:
+            return ""
+
+    return current
+
+
 class RCTManifestCommand(RCTCliCommand):
 
     INNER_FILE = "consumer_export.zip"
@@ -92,10 +103,10 @@ class CatManifestCommand(RCTManifestCommand):
         part = open(os.path.join(location, "export", "meta.json"))
         data = json.loads(part.read())
         to_print = []
-        to_print.append((_("Server"), data["webAppPrefix"]))
-        to_print.append((_("Server Version"), data["version"]))
-        to_print.append((_("Date Created"), data["created"]))
-        to_print.append((_("Creator"), data["principalName"]))
+        to_print.append((_("Server"), get_value(data, "webAppPrefix")))
+        to_print.append((_("Server Version"), get_value(data, "version")))
+        to_print.append((_("Date Created"), get_value(data, "created")))
+        to_print.append((_("Creator"), get_value(data, "principalName")))
         self._print_section(_("General:"), to_print)
         part.close()
 
@@ -104,15 +115,15 @@ class CatManifestCommand(RCTManifestCommand):
         part = open(os.path.join(location, "export", "consumer.json"))
         data = json.loads(part.read())
         to_print = []
-        to_print.append((_("Name"), data["name"]))
-        to_print.append((_("UUID"), data["uuid"]))
-        to_print.append((_("Type"), data["type"]["label"]))
+        to_print.append((_("Name"), get_value(data, "name")))
+        to_print.append((_("UUID"), get_value(data, "uuid")))
+        to_print.append((_("Type"), get_value(data, "type.label")))
         self._print_section(_("Consumer:"), to_print)
         part.close()
 
     def _get_product_attribute(self, name, data):
         return_value = None
-        for attr in data["pool"]["productAttributes"]:
+        for attr in get_value(data, "pool.productAttributes"):
             if attr["name"] == name:
                 return_value = attr["value"]
                 break
@@ -125,17 +136,17 @@ class CatManifestCommand(RCTManifestCommand):
             part = open(os.path.join(ent_dir, ent_file))
             data = json.loads(part.read())
             to_print = []
-            to_print.append((_("Name"), data["pool"]["productName"]))
-            to_print.append((_("Quantity"), data["quantity"]))
-            to_print.append((_("Created"), data["created"]))
-            to_print.append((_("Start Date"), data["startDate"]))
-            to_print.append((_("End Date"), data["endDate"]))
+            to_print.append((_("Name"), get_value(data, "pool.productName")))
+            to_print.append((_("Quantity"), get_value(data, "quantity")))
+            to_print.append((_("Created"), get_value(data, "created")))
+            to_print.append((_("Start Date"), get_value(data, "startDate")))
+            to_print.append((_("End Date"), get_value(data, "endDate")))
             to_print.append((_("Suport Level"), self._get_product_attribute("support_level", data)))
             to_print.append((_("Suport Type"), self._get_product_attribute("support_type", data)))
             to_print.append((_("Architectures"), self._get_product_attribute("arch", data)))
-            to_print.append((_("Product Id"), data["pool"]["productId"]))
-            to_print.append((_("Contract"), data["pool"]["contractNumber"]))
-            to_print.append((_("Subscription Id"), data["pool"]["subscriptionId"]))
+            to_print.append((_("Product Id"), get_value(data, "pool.productId")))
+            to_print.append((_("Contract"), get_value(data, "pool.contractNumber")))
+            to_print.append((_("Subscription Id"), get_value(data, "pool.subscriptionId")))
 
             entitlement_file = os.path.join("export", "entitlements", "%s.json" % data["id"])
             to_print.append((_("Entitlement File"), entitlement_file))

--- a/test/test_rct_manifest_command.py
+++ b/test/test_rct_manifest_command.py
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2012 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+import unittest
+
+from rct.manifest_commands import get_value
+
+
+class RCTManifestCommandTests(unittest.TestCase):
+
+    def test_get_value(self):
+        data = {"test": "value", "test2": {"key2": "value2", "key3": []}}
+        self.assertEquals("", get_value(data, "some.test"))
+        self.assertEquals("", get_value(data, ""))
+        self.assertEquals("", get_value(data, "test2.key4"))
+        self.assertEquals("", get_value(data, "test2.key2.fred"))
+        self.assertEquals("value", get_value(data, "test"))
+        self.assertEquals("value2", get_value(data, "test2.key2"))
+        self.assertEquals([], get_value(data, "test2.key3"))


### PR DESCRIPTION
The code was using a dictionary to store json data. If data is missing, then it will throw an exception. This patch ensures that a empty string is returned if no key is present.
