### PR TITLE
make python-dateutil optional for rhel5

### DIFF
--- a/src/subscription_manager/gui/contract_selection.py
+++ b/src/subscription_manager/gui/contract_selection.py
@@ -26,7 +26,7 @@ _ = gettext.gettext
 
 from subscription_manager.gui import widgets
 from subscription_manager.quantity import allows_multi_entitlement
-from subscription_manager import managerlib
+from subscription_manager import isodate
 
 prefix = os.path.dirname(__file__)
 CONTRACT_SELECTION_GLADE = os.path.join(prefix, "data/contract_selection.glade")
@@ -137,8 +137,8 @@ class ContractSelectionWindow(object):
 
         row = [pool['contractNumber'],
                 "%s / %s" % (pool['consumed'], quantity),
-               managerlib.parseDate(pool['startDate']),
-               managerlib.parseDate(pool['endDate']),
+               isodate.parse_date(pool['startDate']),
+               isodate.parse_date(pool['endDate']),
                default_quantity_value,
                pool['productName'], pool,
                PoolWrapper(pool).is_virt_only(),

--- a/src/subscription_manager/isodate.py
+++ b/src/subscription_manager/isodate.py
@@ -1,0 +1,108 @@
+#
+# find a reasonable iso8601 date parser
+#
+# Copyright (c) 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+
+# try to find a reasonable iso8601 date format parser
+
+import datetime
+import logging
+
+log = logging.getLogger('rhsm-app.' + __name__)
+
+# 2038-01-01, used as the default when we hit an date overflow on
+# 32-bit systems:
+OVERFLOW_DATE = 2145916800.0
+
+
+class ServerTz(datetime.tzinfo):
+    """
+    tzinfo object for the tz offset of the entitlement server
+    """
+
+    def __init__(self, offset):
+        self.__offset = datetime.timedelta(seconds=offset)
+
+    def utcoffset(self, dt):
+        return self.__offset
+
+    def dst(self, dt):
+        return datetime.timedelta(seconds=0)
+
+
+# we want parse_date to just work. Assume we have dateutil,
+# if we can't  import that, try PyXML. RHEL6+ have dateutil,
+# RHEL5 has pyxml (and pyxml is likely going away for rhel6+,
+# at least in base install)
+def _parse_date_pyxml(date):
+    # so this get's a little ugly. We want to know the
+    # tz/utc offset of the time, so we can make the datetime
+    # object be not "naive". In theory, we will always get
+    # these timestamps in UTC, but if we can figure it out,
+    # might as well
+    matches = xml.utils.iso8601.__datetime_rx.match(date)
+
+    # parse out the timezone offset
+    offset = xml.utils.iso8601.__extract_tzd(matches)
+
+    # create a new tzinfo using that offset
+    server_tz = ServerTz(offset)
+
+    # create a new datetime this time using the timezone
+    # so we aren't "naive"
+    try:
+        posix_time = xml.utils.iso8601.parse(date)
+    except OverflowError:
+        # Handle dates above 2038 on 32-bit systems by swapping it out with
+        # 2038-01-01. (which should be ok) Such a system is quite clearly
+        # in big trouble come that date, we just want to make sure they
+        # can still list such subscription now.
+        log.warning("Date overflow: %s, using Jan 1 2038 instead." % date)
+        posix_time = OVERFLOW_DATE
+
+    dt = datetime.datetime.fromtimestamp(posix_time, tz=server_tz)
+    return dt
+
+
+def _parse_date_dateutil(date):
+    # see comment for _parse_date_pyxml
+    try:
+        dt = dateutil.parser.parse(date)
+    except ValueError:
+        log.warning("Date overflow: %s, using 9999-09-06 instead." % date)
+        return dateutil.parser.parse("9999-09-06T00:00:00.000+0000")
+
+    return dt
+
+try:
+    import dateutil.parser
+    parse_date = _parse_date_dateutil
+    parse_date_impl_name = 'dateutil'
+except ImportError:
+    log.warning("dateutil module not found, trying pyxml")
+
+    # now try pyxml
+    try:
+        import xml.utils.iso8601
+        parse_date = _parse_date_pyxml
+        parse_date_impl_name = 'pyxml'
+    # if we can't import either,
+    # we have broken package deps...
+    except ImportError:
+        log.warning("pyxml xml.utils.iso8601 not imported")
+        # if we found neither raise an ImportError communicating that
+        # we needed one ot the other and found neither
+        raise ImportError("No suitable date parsing module found ('dateutil', nor 'xml.utils.iso8601')")

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1,5 +1,6 @@
 # Prefer systemd over sysv on Fedora 17+ and RHEL 7+
 %define use_systemd (0%{?fedora} && 0%{?fedora} >= 17) || (0%{?rhel} && 0%{?rhel} >= 7)
+%define use_dateutil (0%{?fedora} && 0%{?fedora} >= 17) || (0%{?rhel} && 0%{?rhel} >= 6)
 
 
 %define rhsm_plugins_dir   /usr/share/rhsm-plugins
@@ -29,13 +30,24 @@ Requires:  python-ethtool
 Requires:  python-simplejson
 Requires:  python-iniparse
 Requires:  pygobject2
-Requires:  python-dateutil
 Requires:  virt-what
 Requires:  python-rhsm >= 1.8.6
 Requires:  dbus-python
 Requires:  yum >= 3.2.19-15
 Requires:  usermode
+# dateutil is better than our version
+# built using PyXML utils, but PyXML is
+# deprecated for f17+, and dateutil doesn't
+# exist on rhel5
+%if %use_dateutil
+# we are building for fedora >= 12 or rhel >= 6
+Requires: python-dateutil
+%else
+Requires: PyXML
+%endif
 
+
+%{?el5:Requires: rhn-setup-gnome >= 0.4.20-49}
 # There's no dmi to read on these arches, so don't pull in this dep.
 %ifnarch ppc ppc64 s390 s390x
 Requires:  python-dmidecode
@@ -191,6 +203,7 @@ rm -rf %{buildroot}
 %{_datadir}/rhsm/subscription_manager/factlib.py*
 %{_datadir}/rhsm/subscription_manager/facts.py*
 %{_datadir}/rhsm/subscription_manager/hwprobe.py*
+%{_datadir}/rhsm/subscription_manager/isodate.py*
 %{_datadir}/rhsm/subscription_manager/i18n_optparse.py*
 %{_datadir}/rhsm/subscription_manager/i18n.py*
 %{_datadir}/rhsm/subscription_manager/__init__.py*

--- a/test/test_contract_selection_gui.py
+++ b/test/test_contract_selection_gui.py
@@ -5,7 +5,7 @@ import rhsm_display
 rhsm_display.set_display()
 
 from subscription_manager.gui import contract_selection
-from subscription_manager import managerlib
+from subscription_manager import isodate
 
 
 def stubSelectedCallback(self, pool):
@@ -20,8 +20,8 @@ class ContractSelection(unittest.TestCase):
     pool = {'productName': 'SomeProduct',
             'consumed': '3',
             'quantity': '10',
-            'startDate': datetime.datetime.now(tz=managerlib.ServerTz(0)).isoformat(),
-            'endDate': datetime.datetime.now(tz=managerlib.ServerTz(0)).isoformat(),
+            'startDate': datetime.datetime.now(tz=isodate.ServerTz(0)).isoformat(),
+            'endDate': datetime.datetime.now(tz=isodate.ServerTz(0)).isoformat(),
             'contractNumber': 'contractNumber',
             'attributes': [],
             'productAttributes': []}

--- a/test/test_isodate.py
+++ b/test/test_isodate.py
@@ -1,0 +1,116 @@
+#
+# Copyright (c) 2010-2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+import datetime
+import time
+import unittest
+
+from subscription_manager import isodate
+from subscription_manager.managerlib import LocalTz
+
+
+# two classes for this, one that sets up for dateutil, one for
+# for pyxml
+class TestParseDate(unittest.TestCase):
+
+    def _test_local_tz(self):
+        tz = LocalTz()
+        dt_no_tz = datetime.datetime(year=2000, month=1, day=1, hour=12, minute=34)
+        now_dt = datetime.datetime(year=2000, month=1, day=1, hour=12, minute=34, tzinfo=tz)
+        isodate.parse_date(now_dt.isoformat())
+        # last member is is_dst, which is -1, if there is no tzinfo, which
+        # we expect for dt_no_tz
+        #
+        # see if we get the same times
+        now_dt_tt = now_dt.timetuple()
+        dt_no_tz_tt = dt_no_tz.timetuple()
+
+        # tm_isdst (timpletuple()[8]) is 0 if a tz is set,
+        # but the dst offset is 0
+        # if it is -1, no timezone is set
+        if now_dt_tt[8] == 1 and dt_no_tz_tt == -1:
+            # we are applying DST to now time, but not no_tz time, so
+            # they will be off by an hour. This is kind of weird
+            self.assertEquals(now_dt_tt[:2], dt_no_tz_tt[:2])
+            self.assertEquals(now_dt_tt[4:7], dt_no_tz_tt[4:7])
+
+            # add an hour for comparisons
+            dt_no_tz_dst = dt_no_tz
+            dt_no_tz_dst = dt_no_tz + datetime.timedelta(hours=1)
+            self.assertEquals(now_dt_tt[3], dt_no_tz_dst.timetuple()[3])
+        else:
+            self.assertEquals(now_dt_tt[:7], dt_no_tz_tt[:7])
+
+    def test_local_tz_now(self):
+        self._test_local_tz()
+
+    def test_local_tz_not_dst(self):
+        time.daylight = 0
+        self._test_local_tz()
+
+    def test_local_tz_dst(self):
+        time.daylight = 1
+        self._test_local_tz()
+
+    def test_server_date_utc_timezone(self):
+        # sample date from json response from server
+        server_date = "2012-04-10T00:00:00.000+0000"
+        dt = isodate.parse_date(server_date)
+        # no dst
+        self.assertEquals(datetime.timedelta(seconds=0), dt.tzinfo.dst(dt))
+        # it's a utc date, no offset
+        self.assertEquals(datetime.timedelta(seconds=0), dt.tzinfo.utcoffset(dt))
+
+    def test_server_date_est_timezone(self):
+        est_date = "2012-04-10T00:00:00.000-04:00"
+        dt = isodate.parse_date(est_date)
+        self.assertEquals(datetime.timedelta(hours=-4), dt.tzinfo.utcoffset(dt))
+
+    # just past the 32bit unix epoch
+    def test_2038_bug(self):
+        parsed = isodate.parse_date("2038-11-24T00:00:00.000+0000")
+        # this should be okay with either time parser, even on
+        # 32bit platforms. maybe
+        self.assertEquals(2038, parsed.year)
+        self.assertEquals(11, parsed.month)
+        self.assertEquals(24, parsed.day)
+
+    def test_9999_bug(self):
+        parsed = isodate.parse_date("9999-09-06T00:00:00.000+0000")
+        # depending on what sys modules are available, the different
+        # parser handle overflow slightly differently
+        if isodate.parse_date_impl_name == 'dateutil':
+            self._dateutil_overflow(parsed)
+        else:
+            self._pyxml_overflow(parsed)
+
+    def test_10000_bug(self):
+        # dateutil is okay up to 9999, so we just return
+        # 9999-9-6 after that since that's what datetime/dateutil do
+        parsed = isodate.parse_date("10000-09-06T00:00:00.000+0000")
+        if isodate.parse_date_impl_name == 'dateutil':
+            self._dateutil_overflow(parsed)
+        else:
+            self._pyxml_overflow(parsed)
+
+    def _dateutil_overflow(self, parsed):
+        self.assertEquals(9999, parsed.year)
+
+    # Simulated a 32-bit date overflow, date should have been
+    # replaced by one that does not overflow:
+    def _pyxml_overflow(self, parsed):
+        self.assertEquals(2038, parsed.year)
+        self.assertEquals(1, parsed.month)
+        self.assertEquals(1, parsed.day)

--- a/test/test_managerlib.py
+++ b/test/test_managerlib.py
@@ -22,7 +22,7 @@ from os import linesep as NEW_LINE
 from stubs import StubCertificateDirectory, StubProductCertificate, \
         StubProduct, StubEntitlementCertificate
 from subscription_manager.managerlib import merge_pools, PoolFilter, \
-        getInstalledProductStatus, LocalTz, parseDate, \
+        getInstalledProductStatus, LocalTz, \
         MergedPoolsStackingGroupSorter, MergedPools, PoolStash
 from modelhelpers import create_pool
 from subscription_manager import managerlib
@@ -604,81 +604,6 @@ class InstalledProductStatusTests(unittest.TestCase):
         self.assertEquals("subscribed", product_status[0][4])
         self.assertEquals("product1", product_status[1][0])
         self.assertEquals("subscribed", product_status[1][4])
-
-
-class TestParseDate(unittest.TestCase):
-    def _test_local_tz(self):
-        tz = LocalTz()
-        dt_no_tz = datetime(year=2000, month=1, day=1, hour=12, minute=34)
-        now_dt = datetime(year=2000, month=1, day=1, hour=12, minute=34, tzinfo=tz)
-        parseDate(now_dt.isoformat())
-        # last member is is_dst, which is -1, if there is no tzinfo, which
-        # we expect for dt_no_tz
-        #
-        # see if we get the same times
-        now_dt_tt = now_dt.timetuple()
-        dt_no_tz_tt = dt_no_tz.timetuple()
-
-        # tm_isdst (timpletuple()[8]) is 0 if a tz is set,
-        # but the dst offset is 0
-        # if it is -1, no timezone is set
-        if now_dt_tt[8] == 1 and dt_no_tz_tt == -1:
-            # we are applying DST to now time, but not no_tz time, so
-            # they will be off by an hour. This is kind of weird
-            self.assertEquals(now_dt_tt[:2], dt_no_tz_tt[:2])
-            self.assertEquals(now_dt_tt[4:7], dt_no_tz_tt[4:7])
-
-            # add an hour for comparisons
-            dt_no_tz_dst = dt_no_tz
-            dt_no_tz_dst = dt_no_tz + timedelta(hours=1)
-            self.assertEquals(now_dt_tt[3], dt_no_tz_dst.timetuple()[3])
-        else:
-            self.assertEquals(now_dt_tt[:7], dt_no_tz_tt[:7])
-
-    def test_local_tz_now(self):
-        self._test_local_tz()
-
-    def test_local_tz_not_dst(self):
-        time.daylight = 0
-        self._test_local_tz()
-
-    def test_local_tz_dst(self):
-        time.daylight = 1
-        self._test_local_tz()
-
-    def test_server_date_utc_timezone(self):
-        # sample date from json response from server
-        server_date = "2012-04-10T00:00:00.000+0000"
-        dt = parseDate(server_date)
-        # no dst
-        self.assertEquals(timedelta(seconds=0), dt.tzinfo.dst(dt))
-        # it's a utc date, no offset
-        self.assertEquals(timedelta(seconds=0), dt.tzinfo.utcoffset(dt))
-
-    def test_server_date_est_timezone(self):
-        est_date = "2012-04-10T00:00:00.000-04:00"
-        dt = parseDate(est_date)
-        self.assertEquals(timedelta(hours=-4), dt.tzinfo.utcoffset(dt))
-
-    # verify that we can handle dates past 2038
-    # datetime and dateutil modules seem okay with this
-    # even on 32bit platforms
-    def test_2038_bug(self):
-        parsed = parseDate("9999-09-06T00:00:00.000+0000")
-
-        # Simulated a 32-bit date overflow, date should have been
-        # replaced by one that does not overflow:
-        self.assertEquals(9999, parsed.year)
-        self.assertEquals(9, parsed.month)
-        self.assertEquals(6, parsed.day)
-
-    def test_10000_bug(self):
-        # dateutil is okay up to 9999, so we just return
-        # 9999-9-6 after that since that's what datetime/dateutil do
-        parsed = parseDate("10000-09-06T00:00:00.000+0000")
-        self.assertEquals(9999, parsed.year)
-        self.assertEquals(9, parsed.month)
-        self.assertEquals(6, parsed.day)
 
 
 # http://docs.python.org/library/datetime.html


### PR DESCRIPTION
make python-dateutil optional for rhel5
