### PR TITLE
919702: utils.parseDate is now isodate.parse_date

### DIFF
--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -18,7 +18,7 @@ import logging
 from rhsm.certificate import GMT
 from rhsm.connection import RestlibException
 
-from subscription_manager.utils import parseDate
+from subscription_manager.isodate import parse_date
 from subscription_manager.injection import FEATURES, IDENTITY
 
 log = logging.getLogger('rhsm-app.' + __name__)
@@ -139,7 +139,7 @@ class CertSorter(object):
         # invalid from midnight to midnight.
         self.compliant_until = None
         if status['compliantUntil'] is not None:
-            self.compliant_until = parseDate(status['compliantUntil'])
+            self.compliant_until = parse_date(status['compliantUntil'])
             self.first_invalid_date = self.compliant_until + \
                     timedelta(seconds=60 * 60 * 24 - 1)
 

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -22,7 +22,6 @@ from subscription_manager.certlib import ConsumerIdentity
 from urlparse import urlparse
 import os
 import signal
-import dateutil.parser
 
 log = logging.getLogger('rhsm-app.' + __name__)
 
@@ -399,12 +398,3 @@ def restart_virt_who():
     except ValueError:
         # The file has non numeric data in it
         log.error("The virt-who pid file contains non numeric data")
-
-
-def parseDate(date):
-    try:
-        dt = dateutil.parser.parse(date)
-    except ValueError:
-        log.warning("Date overflow: %s, using 9999-09-06 instead." % date)
-        return dateutil.parser.parse("9999-09-06T00:00:00.000+0000")
-    return dt

--- a/src/subscription_manager/validity.py
+++ b/src/subscription_manager/validity.py
@@ -15,7 +15,7 @@
 
 import logging
 from subscription_manager.injection import FEATURES, IDENTITY
-from subscription_manager.utils import parseDate
+from subscription_manager.isodate import parse_date
 from rhsm.certificate import DateRange
 
 log = logging.getLogger('rhsm-app.' + __name__)
@@ -62,8 +62,8 @@ class ValidProductDateRangeCalculator(object):
                 if prod['startDate'] is None or prod['endDate'] is None:
                     return None
 
-                return DateRange(parseDate(prod['startDate']),
-                    parseDate(prod['endDate']))
+                return DateRange(parse_date(prod['startDate']),
+                    parse_date(prod['endDate']))
             else:
                 # If startDate / endDate not supported
                 log.warn("Server does not support product date ranges.")


### PR DESCRIPTION
remove utils.parseDate and update refs to it, this
fixes bug requiring dateutil on rhel5
