### PR TITLE
919700: Reload consumer identity after force subscribing.

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1067,6 +1067,10 @@ class RegisterCommand(UserPassCommand):
         # get a new UEP as the consumer
         self.cp = self._get_UEP(cert_file=cert_file, key_file=key_file)
 
+        # Reload the consumer identity:
+        self.identity = inj.FEATURES.require(inj.IDENTITY)
+        self.identity.reload()
+
         # log the version of the server we registered to
         self.log_server_version()
 


### PR DESCRIPTION
New dependency injection has an identity singleton being used. In the
case of a register with --force, the identity was not being reloaded so
an autosubscribe would attempt as the previously registered consumer.
