### PR TITLE
918746: multiple specifications of --disable does not throw error when r...

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1791,9 +1791,9 @@ class ReposCommand(CliCommand):
             return rc
 
         if self.options.enable:
-            rc = rc or self._set_repo_status(repos, self.options.enable, True)
+            rc = self._set_repo_status(repos, self.options.enable, True) or rc
         if self.options.disable:
-            rc = rc or self._set_repo_status(repos, self.options.disable, False)
+            rc = self._set_repo_status(repos, self.options.disable, False) or rc
 
         if self.options.list:
             if len(repos) > 0:


### PR DESCRIPTION
...epo id is invalid

Corrected logic error that short-circuited disable if enable had error.
