### PR TITLE
919584: Fix unicode error in RHEL 5.

### DIFF
--- a/bin/subscription-manager
+++ b/bin/subscription-manager
@@ -23,16 +23,6 @@ if __name__ != '__main__':
 
 import sys
 import os
-import codecs
-
-# Change encoding of output streams when no encoding is forced via
-# $PYTHONIOENCODING or setting in lib/python{version}/site-packages
-if sys.getdefaultencoding() == 'ascii':
-    writer_class = codecs.getwriter('utf-8')
-if sys.stdout.encoding is None:
-    sys.stdout = writer_class(sys.stdout)
-if sys.stderr.encoding is None:
-    sys.stderr = writer_class(sys.stderr)
 
 
 def systemExit(code, msgs=None):


### PR DESCRIPTION
This commit reverts 056e69dc833919709bbf23d8a7b73a5345f77fdf which
was a fix for BZ #800323.
