### PR TITLE
Dont log exception if a repo doesn't have productid

### DIFF
--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -451,6 +451,9 @@ class ProductManager:
                 if cert is None:
                     continue
                 lst.append((cert, repo.id))
+            except yum.Errors.RepoMDError, e:
+                log.warn("Error loading productid metadata for %s." % repo)
+                self.meta_data_errors.append(repo.id)
             except Exception, e:
                 log.warn("Error loading productid metadata for %s." % repo)
                 log.exception(e)


### PR DESCRIPTION
We were cluttering logs with exception stack traces
for the very common case of a yum repo not having
productid metadata. Log an error, but not an exception.
