### PR TITLE
mock __request_validity_check to speed up tests

### DIFF
--- a/test/fixture.py
+++ b/test/fixture.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mock import Mock, NonCallableMock
+from mock import Mock, NonCallableMock, patch
 import subscription_manager.injection as inj
 import stubs
 
@@ -31,3 +31,9 @@ class SubManFixture(unittest.TestCase):
         inj.provide(inj.ENT_DIR, self.ent_dir)
         self.prod_dir = stubs.StubProductDirectory()
         inj.provide(inj.PROD_DIR, self.prod_dir)
+
+        self.dbus_patcher = patch('subscription_manager.managercli.CliCommand._request_validity_check')
+        self.dbus_patcher.start()
+
+    def tearDown(self):
+        self.dbus_patcher.stop()

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -250,6 +250,7 @@ class TestInstalledProductsCache(unittest.TestCase):
 class TestStatusCache(SubManFixture):
 
     def setUp(self):
+        super(TestStatusCache, self).setUp()
         self.status_cache = StatusCache()
         self.status_cache.write_cache = Mock()
 

--- a/test/test_registrationgui.py
+++ b/test/test_registrationgui.py
@@ -46,6 +46,7 @@ class RegisterScreenTests(SubManFixture):
 class CredentialsScreenTests(SubManFixture):
 
     def setUp(self):
+        super(CredentialsScreenTests, self).setUp()
         self.backend = StubBackend()
         self.parent = Mock()
 
@@ -68,6 +69,7 @@ class CredentialsScreenTests(SubManFixture):
 
 class ActivationKeyScreenTests(SubManFixture):
     def setUp(self):
+        super(ActivationKeyScreenTests, self).setUp()
         self.backend = StubBackend()
         self.parent = Mock()
         self.screen = ActivationKeyScreen(self.backend, self.parent)
@@ -81,6 +83,7 @@ class ActivationKeyScreenTests(SubManFixture):
 
 class ChooseServerScreenTests(SubManFixture):
     def setUp(self):
+        super(ChooseServerScreenTests, self).setUp()
         self.backend = StubBackend()
         self.parent = Mock()
         self.screen = ChooseServerScreen(self.backend, self.parent)

--- a/test/test_unsubscribe.py
+++ b/test/test_unsubscribe.py
@@ -28,6 +28,7 @@ class CliUnSubscribeTests(SubManFixture):
 
     def setUp(self):
         self.oldCI = managercli.ConsumerIdentity
+        super(CliUnSubscribeTests, self).setUp()
 
     def test_unsubscribe_registered(self):
         connection.UEPConnection = StubUEP


### PR DESCRIPTION
managercli.CliCommand._request_validity_check was getting
invoked many times, and making dbus connections. This
is not particularly fast, and not very meaningful for
unit tests, so mock it out in SubManFixture.
