### PR TITLE
955142: Display core limit in rct cat-cert tool

### DIFF
--- a/src/rct/printing.py
+++ b/src/rct/printing.py
@@ -61,6 +61,7 @@ class OrderPrinter(object):
         s.append("\t%s: %s" % (_("Quantity Used"), xstr(order.quantity_used)))
         s.append("\t%s: %s" % (_("Socket Limit"), xstr(order.socket_limit)))
         s.append("\t%s: %s" % (_("RAM Limit"), xstr(order.ram_limit)))
+        s.append("\t%s: %s" % (_("Core Limit"), xstr(order.core_limit)))
         s.append("\t%s: %s" % (_("Virt Limit"), xstr(order.virt_limit)))
         s.append("\t%s: %s" % (_("Virt Only"), xstr(order.virt_only)))
         s.append("\t%s: %s" % (_("Subscription"), xstr(order.subscription)))

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -31,7 +31,7 @@ Requires:  python-simplejson
 Requires:  python-iniparse
 Requires:  pygobject2
 Requires:  virt-what
-Requires:  python-rhsm >= 1.8.7
+Requires:  python-rhsm >= 1.8.10
 Requires:  dbus-python
 Requires:  yum >= 3.2.19-15
 Requires:  usermode

--- a/test/certdata.py
+++ b/test/certdata.py
@@ -257,6 +257,7 @@ Order:
 	Quantity Used: 1
 	Socket Limit: 2
 	RAM Limit: 
+	Core Limit: 
 	Virt Limit: 
 	Virt Only: False
 	Subscription: 
@@ -366,6 +367,7 @@ Order:
 	Quantity Used: 2
 	Socket Limit: 1
 	RAM Limit: 
+	Core Limit: 
 	Virt Limit: 
 	Virt Only: False
 	Subscription: 


### PR DESCRIPTION
***NOTE: This requires an update to python-rhsm

Cores limit was not getting captured by python-rhsm
and the rct cat-cert tool was not printing it.
