### PR TITLE
957218: Bump system.certificate_version for cores support

### DIFF
--- a/src/subscription_manager/facts.py
+++ b/src/subscription_manager/facts.py
@@ -28,7 +28,7 @@ log = logging.getLogger('rhsm-app.' + __name__)
 
 # Hardcoded value for the version of certificates this version of the client
 # prefers:
-CERT_VERSION = "3.1"
+CERT_VERSION = "3.2"
 
 
 class Facts(CacheManager):


### PR DESCRIPTION
Support for cores subscriptions require v3.2 certificates. Bumped the certificate version so that the latest client can consume the subscriptions.
