### PR TITLE
959570: Subscription names were being mangled in the installed products ...

### DIFF
--- a/src/subscription_manager/gui/installedtab.py
+++ b/src/subscription_manager/gui/installedtab.py
@@ -19,6 +19,7 @@ from subscription_manager.cert_sorter import FUTURE_SUBSCRIBED, \
 from subscription_manager.branding import get_branding
 from subscription_manager.gui import widgets
 from subscription_manager.hwprobe import ClassicCheck
+from subscription_manager.utils import friendly_join
 
 import gettext
 import gobject
@@ -178,10 +179,8 @@ class InstalledProductsTab(widgets.SubscriptionManagerTab):
 
                     contract_ids, sub_names = self._calc_subs_providing(
                             product_id, compliant_range)
-                    name = self.rreplace((", ").join(sub_names),
-                                         ',', _(' and'), 1)
-                    contract = self.rreplace((", ").join(contract_ids),
-                                             ',', _(' and'), 1)
+                    name = friendly_join(sub_names)
+                    contract = friendly_join(contract_ids)
                     num_of_contracts = len(contract_ids)
 
                     entry['subscription'] = name

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -398,3 +398,17 @@ def restart_virt_who():
     except ValueError:
         # The file has non numeric data in it
         log.error("The virt-who pid file contains non numeric data")
+
+
+def friendly_join(items):
+    if (not items or len(items) == 0):
+        return ""
+
+    items = list(items)
+    if len(items) == 1:
+        return items[0]
+
+    first = items[0:-1]
+    last = items[-1]
+    first_string = ", ".join(first)
+    return first_string + _(" and ") + last

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,7 +5,7 @@ from subscription_manager.utils import remove_scheme, parse_server_info, \
     parse_baseurl_info, format_baseurl, ServerUrlParseErrorEmpty, \
     ServerUrlParseErrorNone, ServerUrlParseErrorPort, ServerUrlParseErrorScheme, \
     ServerUrlParseErrorJustScheme, get_version, get_client_versions, \
-    get_server_versions, Versions
+    get_server_versions, Versions, friendly_join
 from subscription_manager import certlib
 from rhsm.config import DEFAULT_PORT, DEFAULT_PREFIX, DEFAULT_HOSTNAME, \
     DEFAULT_CDN_HOSTNAME, DEFAULT_CDN_PORT, DEFAULT_CDN_PREFIX
@@ -442,3 +442,14 @@ class TestGetVersion(unittest.TestCase):
         versions.get_release.return_value = ""
         result = get_version(versions, "foobar")
         self.assertEquals("1.0", result)
+
+
+class TestFriendlyJoin(unittest.TestCase):
+
+    def test_join(self):
+        self.assertEquals("One", friendly_join(["One"]))
+        self.assertEquals("One and Two", friendly_join(["One", "Two"]))
+        self.assertEquals("One, Two and Three", friendly_join(["One", "Two", "Three"]))
+        self.assertEquals("Three, Two and One", friendly_join(set(["One", "Two", "Three"])))
+        self.assertEquals("", friendly_join([]))
+        self.assertEquals("", friendly_join(None))


### PR DESCRIPTION
...page.

This was due to the name concatination logic which replaced he last comma
with the word "and". This worked fine unless the subscription as a comma in it.
