### PR TITLE
Use the unknown icon when it is appropriate.

### DIFF
--- a/src/subscription_manager/gui/installedtab.py
+++ b/src/subscription_manager/gui/installedtab.py
@@ -48,6 +48,7 @@ INVALID_STATUS = 1
 VALID_STATUS = 2
 UNKNOWN_STATUS = 3
 
+
 class InstalledProductsTab(widgets.SubscriptionManagerTab):
     widget_names = widgets.SubscriptionManagerTab.widget_names + \
                 ['product_text', 'product_arch_text', 'validity_text',


### PR DESCRIPTION
When the system is not registered, it shows up as unknown. If,
however, the machine is registered with RHN classic the machine
shows green and the products show unknown.
