### PR TITLE
919706: Relax rhn-setup-gnome dependency.

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -47,7 +47,7 @@ Requires: PyXML
 %endif
 
 
-%{?el5:Requires: rhn-setup-gnome >= 0.4.20-49}
+%{?el5:Requires: rhn-setup-gnome}
 # There's no dmi to read on these arches, so don't pull in this dep.
 %ifnarch ppc ppc64 s390 s390x
 Requires:  python-dmidecode
@@ -106,8 +106,7 @@ subscriptions.
 Summary: Firstboot screens for subscription manager
 Group: System Environment/Base
 Requires: %{name}-gui = %{version}-%{release}
-%{?el5:Requires: rhn-setup-gnome >= 0.4.20-49}
-%{?el6:Requires: rhn-setup-gnome >= 1.0.0-82}
+Requires: rhn-setup-gnome
 
 # Fedora can figure this out automatically, but RHEL cannot:
 Requires: librsvg2


### PR DESCRIPTION
To allow installation on older RHEL 5 and 6 versions, this relaxes the
requirement on rhn-setup-gnome. This version requirement was added to
address Bug #810399, so by removing it and then installing on some of
those older RHEL versions means this bug may surface again. It is
however an edge case so this has been deemed to be ok.

Relaxing the version requirement should have no impact on RHEL versions
with that newer rhn-setup-gnome, so the bug will not surface anywhere it
isn't currently happening regardless.
