### PR TITLE
961124: Allow rct dump-manifest to overwrite earlier manifests.

### DIFF
--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -82,7 +82,7 @@ class ZipExtractAll(ZipFile):
         return results
 
     def _open_excl(self, path):
-        return os.fdopen(os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL), 'w')
+        return os.fdopen(os.open(path, os.O_RDWR | os.O_CREAT), 'w')
 
     def _write_file(self, output_path, archive_path):
         outfile = self._open_excl(output_path)


### PR DESCRIPTION
This may be a bit risky as it could damage a previous export,
but this tool is more of a dev tool so I am not too worried
about it.
