### PR TITLE
Ckozak/status module

### DIFF
--- a/src/subscription_manager/cli.py
+++ b/src/subscription_manager/cli.py
@@ -84,6 +84,9 @@ class CLI:
     def _add_command(self, cmd):
         self.cli_commands[cmd.name] = cmd
 
+    def _default_command(self):
+        self._usage()
+
     def _usage(self):
         print _("Usage: %s MODULE-NAME [MODULE-OPTIONS] [--help]") % os.path.basename(sys.argv[0])
         print "\r"
@@ -148,7 +151,10 @@ class CLI:
 
     def main(self):
         cmd = self._find_best_match(sys.argv)
-        if len(sys.argv) < 2 or not cmd:
+        if len(sys.argv) < 2:
+            self._default_command()
+            sys.exit(0)
+        if not cmd:
             self._usage()
             # Allow for a 0 return code if just calling --help
             return_code = 1

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2213,6 +2213,9 @@ class ManagerCLI(CLI):
         managerlib.check_identity_cert_perms()
         return CLI.main(self)
 
+    def _default_command(self):
+        StatusCommand().main()
+
 
 def width(in_str):
     if not isinstance(in_str, unicode):


### PR DESCRIPTION
Added "subscription-manager status"
When "subscription-manager" is run with no arguments, status is the default command
status is a primary module
