### PR TITLE
921249: Fix Unknown virt status being reported to server.

### DIFF
--- a/src/subscription_manager/certlib.py
+++ b/src/subscription_manager/certlib.py
@@ -52,8 +52,14 @@ class ActionLock(Lock):
 
 class DataLib(object):
 
-    def __init__(self, lock=ActionLock(), uep=None):
+    def __init__(self, lock=None, uep=None):
         self.lock = lock
+
+        # Need to do this here rather than with a default argument to prevent
+        # circular dependency problems:
+        if not self.lock:
+            self.lock = ActionLock()
+
         self.uep = uep
 
     def update(self):

--- a/src/subscription_manager/certmgr.py
+++ b/src/subscription_manager/certmgr.py
@@ -42,12 +42,13 @@ class CertManager:
     @type repolib: L{RepoLib}
     """
 
-    def __init__(self, lock=ActionLock(), uep=None, product_dir=None):
+    def __init__(self, lock=ActionLock(), uep=None, product_dir=None,
+            facts=None):
         self.lock = lock
         self.uep = uep
         self.certlib = CertLib(self.lock, uep=self.uep)
         self.repolib = RepoLib(self.lock, uep=self.uep)
-        self.factlib = FactLib(self.lock, uep=self.uep)
+        self.factlib = FactLib(self.lock, uep=self.uep, facts=facts)
         self.profilelib = PackageProfileLib(self.lock, uep=self.uep)
         self.installedprodlib = InstalledProductsLib(self.lock, uep=self.uep)
         #healinglib requires a fact set in order to get socket count

--- a/src/subscription_manager/factlib.py
+++ b/src/subscription_manager/factlib.py
@@ -33,6 +33,11 @@ class FactLib(DataLib):
 
     Makes use of the facts module as well.
     """
+    def __init__(self, lock=None, uep=None, facts=None):
+        DataLib.__init__(self, lock, uep)
+        self.facts = facts
+        if not self.facts:
+            self.facts = Facts()
 
     def _do_update(self):
         updates = 0
@@ -40,18 +45,14 @@ class FactLib(DataLib):
         # figure out the diff between latest facts and
         # report that as updates
 
-        facts = self._get_facts()
-        if facts.has_changed():
-            updates = len(facts.get_facts())
+        if self.facts.has_changed():
+            updates = len(self.facts.get_facts())
             if not ConsumerIdentity.exists():
                 return updates
             consumer = ConsumerIdentity.read()
             consumer_uuid = consumer.getConsumerId()
 
-            facts.update_check(self.uep, consumer_uuid)
+            self.facts.update_check(self.uep, consumer_uuid)
         else:
             log.info("Facts have not changed, skipping upload.")
         return updates
-
-    def _get_facts(self):
-        return Facts()

--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -180,6 +180,11 @@ class MainWindow(widgets.GladeWidget):
 
         self.facts = facts or Facts(self.backend.entitlement_dir,
                 self.backend.product_dir)
+        # We need to make sure facts are loaded immediately, some GUI operations
+        # are done in separate threads, and if facts try to load in another
+        # thread the virt guest detection code breaks due to hwprobe's use of
+        # signals.
+        self.facts.get_facts()
 
         log.debug("Client Versions: %s " % get_client_versions())
         log.debug("Server Versions: %s " % get_server_versions(self.backend.uep))

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -1092,7 +1092,7 @@ class AsyncBackend(object):
         # Will map service level (string) to the results of the dry-run
         # autobind results for each SLA that covers all installed products:
         suitable_slas = {}
-        certmgr = CertManager(uep=self.backend.uep)
+        certmgr = CertManager(uep=self.backend.uep, facts=facts)
         certmgr.update()
         for sla in available_slas:
             dry_run_json = self.backend.uep.dryRunBind(consumer.uuid, sla)

--- a/test/test_factlib.py
+++ b/test/test_factlib.py
@@ -22,13 +22,9 @@ class TestFactlib(unittest.TestCase):
 
     def setUp(self):
         self.stub_uep = stubs.StubUEP()
-        self.fl = factlib.FactLib(lock=stubs.MockActionLock(), uep=self.stub_uep)
-
         self.expected_facts = {'fact1': 'F1', 'fact2': 'F2'}
-
-        def init_facts():
-            return stubs.StubFacts(self.expected_facts)
-        self.fl._get_facts = init_facts
+        self.fl = factlib.FactLib(lock=stubs.MockActionLock(),
+                uep=self.stub_uep, facts=stubs.StubFacts(self.expected_facts))
 
     def test_factlib_updates_when_identity_does_not_exist(self):
         factlib.ConsumerIdentity = stubs.StubConsumerIdentity


### PR DESCRIPTION
hwprobe.py use of signals is only allowed in a main application thread
now. During GUI registration and auto-attach we were needlessly
re-loading facts which triggered this code and failed as this is an
async operation.

To solve this patch just uses the facts we loaded in the main thread
when the GUI was launched. FactLib should continue to re-load facts if
none were provided.
