### PR TITLE
961124: Allow rct dump-manifest to be called more than once

### DIFF
--- a/etc-conf/rct.completion.sh
+++ b/etc-conf/rct.completion.sh
@@ -25,7 +25,7 @@ _rct()
         return 0
         ;;
     dump-manifest)
-        COMPREPLY=( $( compgen -f -o filenames -- "$cur" ) )
+        COMPREPLY=( $( compgen -f -o filenames -W "--force" -- "$cur" ) )
         return 0
         ;;
   esac

--- a/src/subscription_manager/cli.py
+++ b/src/subscription_manager/cli.py
@@ -160,6 +160,8 @@ class CLI:
             return cmd.main()
         except InvalidCLIOptionError, error:
             print error
+        except Exception, e:
+            systemExit(-1, e)
 
 
 def systemExit(code, msgs=None):

--- a/test/test_rct_manifest_command.py
+++ b/test/test_rct_manifest_command.py
@@ -100,6 +100,7 @@ class RCTManifestCommandTests(fixture.SubManFixture):
         #This makes sure there is a 'None' at 'self.options.destination'
         mancommand.options = mancommand
         mancommand.destination = None
+        mancommand.overwrite_files = False
 
         mancommand._do_command()
         self.assertTrue(os.path.exists(os.path.join(new_directory, "export")))
@@ -114,7 +115,23 @@ class RCTManifestCommandTests(fixture.SubManFixture):
         #This makes sure the temp directory is referenced at 'self.options.destination'
         mancommand.options = mancommand
         mancommand.destination = new_directory
+        mancommand.overwrite_files = False
 
+        mancommand._do_command()
+        self.assertTrue(os.path.exists(os.path.join(new_directory, "export")))
+        shutil.rmtree(new_directory)
+
+    def test_dump_manifest_directory_twice(self):
+        new_directory = tempfile.mkdtemp()
+        mancommand = DumpManifestCommand()
+        mancommand.args = [_build_valid_manifest()]
+
+        #This makes sure the temp directory is referenced at 'self.options.destination'
+        mancommand.options = mancommand
+        mancommand.destination = new_directory
+        mancommand.overwrite_files = True
+
+        mancommand._do_command()
         mancommand._do_command()
         self.assertTrue(os.path.exists(os.path.join(new_directory, "export")))
         shutil.rmtree(new_directory)


### PR DESCRIPTION
Added a --force/-f uption to dump-manifest. If this is used, it will overwrite existing files.
There is no ability to do this per file. The command either fails on the first file, or
overwrites them all.
