### PR TITLE
Fix echo'ing of exit status or exception on exit

### DIFF
--- a/src/subscription_manager/cli.py
+++ b/src/subscription_manager/cli.py
@@ -166,8 +166,6 @@ class CLI:
             return cmd.main()
         except InvalidCLIOptionError, error:
             print error
-        except Exception, e:
-            system_exit(-1, e)
 
 
 def system_exit(code, msgs=None):


### PR DESCRIPTION
cli.py main() had a "try/except Exception, e" added
to it. This exception handlers was not needed except
that code was raising Exceptions() as control flow,
instead of a more specific exception for the case
of trying to write to an already existing file. So
manifest_commands.py was changed to handle
EnvironmentError (base class of IOError/OSError)
itself, and the try/except Exception was removed.

That handler would call system_exit(exit_status,
exception) but system_exit expects (exit_status, msg),
and eventually call sys.exit(). On RHEL5, this was
causing the exit status to get echoed to stderr.

Error handling for dump-manifest was improved
to show a specific error for existing file,
and a generic error for other errors.
