### PR TITLE
968364: show the issuer for certs in rct.

### DIFF
--- a/src/rct/printing.py
+++ b/src/rct/printing.py
@@ -107,7 +107,7 @@ class CertificatePrinter(object):
         s.append("\t%s: %s" % (_("End Date"), xstr(cert.end)))
         self._append_to_cert_section(cert, s)
         s.append("\n%s" % xstr(self._get_subject(cert)))
-        s.append("\n%s" % xstr(self._get_issuer(cert)))
+        s.append("%s" % xstr(self._get_issuer(cert)))
         return "%s" % '\n'.join(s)
 
     def printc(self, cert):

--- a/test/certdata.py
+++ b/test/certdata.py
@@ -203,6 +203,11 @@ Certificate:
 Subject:
 	CN: ff80808139affbb50139b5841809706e
 
+Issuer:
+	C: US
+	CN: boogady
+	L: Raleigh
+
 Product:
 	ID: 37060
 	Name: Awesome OS Server Bits
@@ -354,6 +359,11 @@ Certificate:
 Subject:
 	CN: ff80808139d9e26c0139da23489a0066
 
+Issuer:
+	C: US
+	CN: pipboy
+	L: Raleigh
+
 Product:
 	ID: 100000000000002
 	Name: Awesome OS for x86_64 Bits
@@ -445,6 +455,11 @@ Certificate:
 Subject:
 	CN: 100000000000002
 
+Issuer:
+	C: US
+	CN: localhost
+	L: Raleigh
+
 Product:
 	ID: 100000000000002
 	Name: Awesome OS for x86_64 Bits
@@ -469,6 +484,11 @@ Certificate:
 
 Subject:
 	CN: eaadd6ea-852d-4430-94a7-73d5887d48e8
+
+Issuer:
+	C: US
+	CN: 192.168.1.25
+	L: Raleigh
 
 """
 


### PR DESCRIPTION
The main driver for this is answering "where did this cert come from".
The CA information is a good proxy for this question.
