### PR TITLE
922825: pre_subscribe conduit now contains more data

### DIFF
--- a/example-plugins/dbus_event.py
+++ b/example-plugins/dbus_event.py
@@ -90,3 +90,9 @@ class DbusEventPlugin(SubManPlugin):
 
     def post_subscribe_hook(self, conduit):
         self._dbus_event("post_subscribe", conduit)
+
+    def pre_auto_attach_hook(self, conduit):
+        self._dbus_event("pre_auto_attach", conduit)
+
+    def post_auto_attach_hook(self, conduit):
+        self._dbus_event("post_auto_attach", conduit)

--- a/example-plugins/subscribe.py
+++ b/example-plugins/subscribe.py
@@ -36,3 +36,9 @@ class SubscribePlugin(SubManPlugin):
             conduit: A PostSubscriptionConduit()
         """
         conduit.log.info("post subscribe called")
+
+    def pre_auto_attach_hook(self, conduit):
+        conduit.log.info("pre auto attach called")
+
+    def post_auto_attach_hook(self, conduit):
+        conduit.log.info("post auto attach called")

--- a/src/subscription_manager/certlib.py
+++ b/src/subscription_manager/certlib.py
@@ -133,9 +133,10 @@ class HealingLib(DataLib):
                 if not cs.is_valid():
                     log.warn("Found invalid entitlements for today: %s" %
                             today)
-                    self.plugin_manager.run("pre_subscribe", consumer_uuid=uuid)
+                    self.plugin_manager.run("pre_auto_attach", consumer_uuid=uuid)
                     ents = self.uep.bind(uuid, today)
-                    self.plugin_manager.run("post_subscribe", consumer_uuid=uuid, entitlement_data=ents)
+                    self.plugin_manager.run("post_auto_attach", consumer_uuid=uuid,
+                                            entitlement_data=ents)
                     cert_updater.update()
                 else:
                     log.info("Entitlements are valid for today: %s" %
@@ -149,9 +150,10 @@ class HealingLib(DataLib):
                     elif tomorrow > cs.compliant_until:
                         log.warn("Entitlements will be invalid by tomorrow: %s" %
                                 tomorrow)
-                        self.plugin_manager.run("pre_subscribe", consumer_uuid=uuid)
+                        self.plugin_manager.run("pre_auto_attach", consumer_uuid=uuid)
                         ents = self.uep.bind(uuid, tomorrow)
-                        self.plugin_manager.run("post_subscribe", consumer_uuid=uuid, entitlement_data=ents)
+                        self.plugin_manager.run("post_auto_attach", consumer_uuid=uuid,
+                                                entitlement_data=ents)
                         cert_updater.update()
                     else:
                         log.info("Entitlements are valid for tomorrow: %s" %

--- a/src/subscription_manager/gui/allsubs.py
+++ b/src/subscription_manager/gui/allsubs.py
@@ -369,7 +369,8 @@ class AllSubscriptionsTab(widgets.SubscriptionManagerTab):
 
         self._contract_selection_cancelled()
         try:
-            self.plugin_manager.run("pre_subscribe", consumer_uuid=self.identity.uuid)
+            self.plugin_manager.run("pre_subscribe", consumer_uuid=self.identity.uuid,
+                                    pool_id=pool['id'], quantity=quantity)
             ents = self.backend.uep.bindByEntitlementPool(self.identity.uuid, pool['id'], quantity)
             self.plugin_manager.run("post_subscribe", consumer_uuid=self.identity.uuid, entitlement_data=ents)
             managerlib.fetch_certificates(self.backend)

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -1040,7 +1040,8 @@ class AsyncBackend(object):
                 pool_id = pool_quantity['pool']['id']
                 quantity = pool_quantity['quantity']
                 log.info("  pool %s quantity %s" % (pool_id, quantity))
-                self.plugin_manager.run("pre_subscribe", consumer_uuid=uuid)
+                self.plugin_manager.run("pre_subscribe", consumer_uuid=uuid,
+                                        pool_id=pool_id, quantity=quantity)
                 ents = self.backend.uep.bindByEntitlementPool(uuid, pool_id, quantity)
                 self.plugin_manager.run("post_subscribe", consumer_uuid=uuid, entitlement_data=ents)
             managerlib.fetch_certificates(self.backend)

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -190,9 +190,9 @@ def autosubscribe(cp, consumer_uuid, service_level=None):
 
     plugin_manager = plugins.get_plugin_manager()
     try:
-        plugin_manager.run("pre_subscribe", consumer_uuid=consumer_uuid)
+        plugin_manager.run("pre_auto_attach", consumer_uuid=consumer_uuid)
         ents = cp.bind(consumer_uuid)  # new style
-        plugin_manager.run("post_subscribe", consumer_uuid=consumer_uuid, entitlement_data=ents)
+        plugin_manager.run("post_auto_attach", consumer_uuid=consumer_uuid, entitlement_data=ents)
 
     except Exception, e:
         log.warning("Error during auto-attach.")
@@ -1406,7 +1406,12 @@ class AttachCommand(CliCommand):
                         # odd html strings will cause issues, reject them here.
                         if (pool.find("#") >= 0):
                             system_exit(-1, _("Please enter a valid numeric pool ID."))
-                        self.plugin_manager.run("pre_subscribe", consumer_uuid=consumer_uuid)
+                        # If quantity is None, server will assume 1. pre_subscribe will
+                        # report the same.
+                        self.plugin_manager.run("pre_subscribe",
+                                                consumer_uuid=consumer_uuid,
+                                                pool_id=pool,
+                                                quantity=self.options.quantity or 1)
                         ents = self.cp.bindByEntitlementPool(consumer_uuid, pool, self.options.quantity)
                         self.plugin_manager.run("post_subscribe", consumer_uuid=consumer_uuid, entitlement_data=ents)
                         # Usually just one, but may as well be safe:

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -851,8 +851,12 @@ class TestPostRegistrationConduit(unittest.TestCase):
 class TestSubscriptionConduit(unittest.TestCase):
     def test_subscription_conduit(self):
         conduit = plugins.SubscriptionConduit(StubPluginClass,
-                                              consumer_uuid="123456789")
+                                              consumer_uuid="123456789",
+                                              pool_id="4444",
+                                              quantity=4)
         self.assertEquals("123456789", conduit.consumer_uuid)
+        self.assertEquals(4, conduit.quantity)
+        self.assertEquals("4444", conduit.pool_id)
 
 
 class TestPostSubscriptionConduit(unittest.TestCase):
@@ -861,6 +865,21 @@ class TestPostSubscriptionConduit(unittest.TestCase):
                                                   consumer_uuid="123456789",
                                                   entitlement_data={})
         self.assertEquals("123456789", conduit.consumer_uuid)
+        self.assertEquals({}, conduit.entitlement_data)
+
+
+class TestAutoAttachConduit(unittest.TestCase):
+    def test_auto_attach_conduit(self):
+        conduit = plugins.AutoAttachConduit(StubPluginClass, "a-consumer-uuid")
+        self.assertEquals("a-consumer-uuid", conduit.consumer_uuid)
+
+
+class TestPostAutoAttachConduit(unittest.TestCase):
+    def test_post_auto_attach_conduit(self):
+        conduit = plugins.PostAutoAttachConduit(StubPluginClass,
+                                                "a-consumer-uuid",
+                                                {})
+        self.assertEquals("a-consumer-uuid", conduit.consumer_uuid)
         self.assertEquals({}, conduit.entitlement_data)
 
 


### PR DESCRIPTION
Data added:
- pool_id: the id of the pool from which the entitlement(s) will be consumed
- quantity: the quantity requested to consume

Created seperated slots/conduits for auto-attach
- auto-attach/healing now call pre_auto_attach and post_auto_attach
  hooks.

**Testing Notes**
Be sure to test both command line and GUI. Both manual and auto attach should be tested as well.

Install the example plugins:

```
sudo make install-example-plugins
```

Tail the log for plugin invokations:

```
tail -f /var/log/rhsm/rhsm.log | grep plugins.py
```

Register and subscribe to a single pool and auto subscribe.
