### PR TITLE
922806: Fix RHEL 5 firstboot issue with backButton.

### DIFF
--- a/src/subscription_manager/gui/firstboot/rhsm_login.py
+++ b/src/subscription_manager/gui/firstboot/rhsm_login.py
@@ -358,9 +358,15 @@ class moduleClass(RhsmFirstbootModule, registergui.RegisterScreen):
         # the standalone gui flow), which is before apply(). So
         # do nothing here if we haven't set a ref to self.interface
         # yet. See bz#863572
-        if self.interface is not None:
-            self.interface.backButton.set_sensitive(sensitive)
-            self.interface.nextButton.set_sensitive(sensitive)
+        # EL5:
+        if self._is_compat:
+            self.parent.backButton.set_sensitive(sensitive)
+            self.parent.nextButton.set_sensitive(sensitive)
+        # EL6:
+        else:
+            if self.interface is not None:
+                self.interface.backButton.set_sensitive(sensitive)
+                self.interface.nextButton.set_sensitive(sensitive)
 
     def _get_credentials_hash(self):
         """


### PR DESCRIPTION
Disabling the next/back buttons implemented in commit 1f70a077 appears
to be RHEL 6 specific.

On RHEL 5, the interface provided is a GtkNotebook which has no
next/back buttons on it. However we do have a reference to a parent
which does, and we can use instead.
