### PR TITLE
Bumping required python-rhsm version

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -31,7 +31,7 @@ Requires:  python-simplejson
 Requires:  python-iniparse
 Requires:  pygobject2
 Requires:  virt-what
-Requires:  python-rhsm >= 1.8.11
+Requires:  python-rhsm >= 1.8.12
 Requires:  dbus-python
 Requires:  yum >= 3.2.19-15
 Requires:  usermode


### PR DESCRIPTION
This is required by rct as it is now expecting the
issuer on the ProductCertificate.
