### PR TITLE
921222: Fixed tab completion

### DIFF
--- a/etc-conf/rct.completion.sh
+++ b/etc-conf/rct.completion.sh
@@ -13,19 +13,19 @@ _rct()
 
   case "${first}" in
     cat-cert)
-        COMPREPLY=( $( compgen -W "-h --help --no-products --no-content" -- "$cur" ) )
+        COMPREPLY=( $( compgen -W -o filenames "-h --help --no-products --no-content" -- "$cur" ) )
         return 0
         ;;
     stat-cert)
-        COMPREPLY=( $( compgen -W "-h --help" -- "${cur}" ) )
+        COMPREPLY=( $( compgen -W -o filenames "-h --help" -- "${cur}" ) )
         return 0
         ;;
     cat-manifest)
-        COMPREPLY=( $( compgen -W "-h --help" -- "${cur}" ) )
+        COMPREPLY=( $( compgen -W -o filenames "-h --help" -- "${cur}" ) )
         return 0
         ;;
     dump-manifest)
-        COMPREPLY=( $( compgen -W "-h --help --force" -- "${cur}" ) )
+        COMPREPLY=( $( compgen -W -o filenames "-h --help --force" -- "${cur}" ) )
         return 0
         ;;
   esac

--- a/etc-conf/rhn-migrate-classic-to-rhsm.completion.sh
+++ b/etc-conf/rhn-migrate-classic-to-rhsm.completion.sh
@@ -19,6 +19,9 @@ _rhn-migrate-classic-to-rhsm()
 			return 0
 			;;
 	esac
+
+	COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+	return 0
 }
 
 complete -F _rhn-migrate-classic-to-rhsm rhn-migrate-classic-to-rhsm

--- a/etc-conf/rhsm-icon.completion.sh
+++ b/etc-conf/rhsm-icon.completion.sh
@@ -20,6 +20,9 @@ _rhsm-icon()
 			return 0
 			;;
 	esac
+
+	COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+	return 0
 }
 
 complete -F _rhsm-icon rhsm-icon

--- a/etc-conf/rhsmcertd.completion.sh
+++ b/etc-conf/rhsmcertd.completion.sh
@@ -19,6 +19,9 @@ _rhsmcertd()
 			return 0
 			;;
 	esac
+
+	COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+	return 0
 }
 
 complete -F _rhsmcertd rhsmcertd


### PR DESCRIPTION
Updated the rct command to default to showing filenames and updated the rhsm-icon, rhsmcertd, and rhn-migrate-classic-to-rhsm scripts to tab-complete the "-" at the beginning of the command.
