### PR TITLE
rm creation of InstalledProductManager in reg cli

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -955,7 +955,6 @@ class RegisterCommand(UserPassCommand):
 
         self.facts = Facts(ent_dir=self.entitlement_dir,
                            prod_dir=self.product_dir)
-        self.installed_mgr = InstalledProductsManager()
 
     def _validate_options(self):
         self.autoattach = self.options.autosubscribe or self.options.autoattach
@@ -1007,6 +1006,9 @@ class RegisterCommand(UserPassCommand):
             print(get_branding().REGISTERED_TO_OTHER_WARNING)
 
         self._validate_options()
+
+        # gather installed products info
+        self.installed_mgr = InstalledProductsManager()
 
         # Set consumer's name to hostname by default:
         consumername = self.options.consumername

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -26,8 +26,9 @@ class CliRegistrationTests(SubManFixture):
         self.persisted_consumer = consumer
         return self.persisted_consumer
 
+    @patch('subscription_manager.managercli.InstalledProductsManager.write_cache')
     @patch('subscription_manager.certlib.ConsumerIdentity.exists')
-    def test_register_persists_consumer_cert(self, mock_exists):
+    def test_register_persists_consumer_cert(self, mock_exists, mock_ipm_wc):
         connection.UEPConnection = StubUEP
 
         # When
@@ -37,15 +38,15 @@ class CliRegistrationTests(SubManFixture):
         cmd._persist_identity_cert = self.stub_persist
         cmd.facts.get_facts = Mock(return_value={'fact1': 'val1', 'fact2': 'val2'})
         cmd.facts.write_cache = Mock()
-        cmd.installed_mgr.write_cache = Mock()
 
         cmd.main(['register', '--username=testuser1', '--password=password'])
 
         # Then
         self.assertEqual('dummy-consumer-uuid', self.persisted_consumer["uuid"])
 
+    @patch('subscription_manager.managercli.InstalledProductsManager.write_cache')
     @patch('subscription_manager.certlib.ConsumerIdentity.exists')
-    def test_installed_products_cache_written(self, mock_exists):
+    def test_installed_products_cache_written(self, mock_exists, mock_ipm_wc):
         connection.UEPConnection = StubUEP
 
         cmd = RegisterCommand()
@@ -55,8 +56,7 @@ class CliRegistrationTests(SubManFixture):
         # Mock out facts and installed products:
         cmd.facts.get_facts = Mock(return_value={'fact1': 'val1', 'fact2': 'val2'})
         cmd.facts.write_cache = Mock()
-        cmd.installed_mgr.write_cache = Mock()
 
         cmd.main(['register', '--username=testuser1', '--password=password'])
 
-        self.assertTrue(cmd.installed_mgr.write_cache.call_count > 0)
+        self.assertTrue(mock_ipm_wc.call_count > 0)


### PR DESCRIPTION
A InstalledProductManager was being created in the
**init** for RegisterCommand, so all cli invocations
were creating at least one extra inst of
InstalledProductManager (which has EntitlementDirectory
and ProductDirectory) which was causing an extra
load/parse of all product and entitlement certs.
