### PR TITLE
Wait until exit to write status caches. Not very pretty.

### DIFF
--- a/bin/subscription-manager
+++ b/bin/subscription-manager
@@ -23,6 +23,7 @@ if __name__ != '__main__':
 
 import sys
 import os
+import subscription_manager.injection as inj
 
 
 def system_exit(code, msgs=None):
@@ -75,14 +76,21 @@ def main():
     return 0
 
 
+def cleanup():
+    inj.require(inj.STATUS_CACHE).write_cache()
+    inj.require(inj.PROD_STATUS_CACHE).write_cache()
+
 if __name__ == '__main__':
     try:
         sys.exit(abs(main() or 0))
     except SystemExit, e:
         #this is a non-exceptional exception thrown by Python 2.4, just
         #re-raise, bypassing handle_exception
+        cleanup()
         raise e
     except KeyboardInterrupt:
+        cleanup()
         system_exit(0, "\nUser interrupted process.")
     except Exception, e:
+        cleanup()
         handle_exception("exception caught in subscription-manager", e)

--- a/bin/subscription-manager-gui
+++ b/bin/subscription-manager-gui
@@ -40,6 +40,7 @@ import dbus.exceptions
 import gtk
 import logging
 import gettext
+import subscription_manager.injection as inj
 _ = gettext.gettext
 
 # Since the location of these def's keeps moving, hardcoded them here as per the spec
@@ -142,6 +143,11 @@ def already_running(bus):
         return True
     return False
 
+
+def cleanup():
+    inj.require(inj.STATUS_CACHE).write_cache()
+    inj.require(inj.PROD_STATUS_CACHE).write_cache()
+
 if __name__ == '__main__':
     parser = OptionParser(usage=USAGE,
                           formatter=WrappedIndentedHelpFormatter())
@@ -176,9 +182,12 @@ if __name__ == '__main__':
         except SystemExit, e:
             #this is a non-exceptional exception thrown by Python 2.4, just
             #re-raise, bypassing handle_exception
+            cleanup()
             raise e
         except KeyboardInterrupt:
+            cleanup()
             system_exit(0, "\nUser interrupted process.")
         except Exception, e:
+            cleanup()
             log.exception(e)
             system_exit(1, e)

--- a/src/daemons/rhsm_d.py
+++ b/src/daemons/rhsm_d.py
@@ -31,7 +31,8 @@ init_dep_injection()
 
 from subscription_manager.certlib import ConsumerIdentity
 from subscription_manager.branding import get_branding
-from subscription_manager.injection import require, CERT_SORTER
+import subscription_manager.injection as inj
+from subscription_manager.cert_sorter import CertSorter
 from subscription_manager.hwprobe import ClassicCheck
 from subscription_manager.i18n_optparse import OptionParser, \
     WrappedIndentedHelpFormatter, USAGE
@@ -83,7 +84,9 @@ def check_status(force_signal):
         debug("The system is not currently registered.")
         return RHSM_REGISTRATION_REQUIRED
 
-    sorter = require(CERT_SORTER)
+    sorter = CertSorter()
+    inj.require(inj.STATUS_CACHE).write_cache()
+    inj.require(inj.PROD_STATUS_CACHE).write_cache()
 
     if len(sorter.unentitled_products.keys()) > 0 or len(sorter.expired_products.keys()) > 0:
         debug("System has one or more certificates that are not valid")

--- a/src/subscription_manager/injectioninit.py
+++ b/src/subscription_manager/injectioninit.py
@@ -46,7 +46,6 @@ def init_dep_injection():
 
     inj.provide(inj.CP_PROVIDER, CPProvider())
 
-    # Must come after ent dir, prod dir, conn info, and identity
     inj.provide(inj.CERT_SORTER, CertSorter(lazy_load=True))
 
     # Set up plugin manager as a singleton.


### PR DESCRIPTION
I think this works, but I don't like manually writing caches in the launcher.

Uses a destructor to write out at the end, avoid unnecessary/repetitive disk io
