### PR TITLE
prod and ent dir are lazily loaded singletons

### DIFF
--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -23,9 +23,10 @@ sys.path.append('/usr/share/rhsm')
 
 from subscription_manager.injectioninit import init_dep_injection
 init_dep_injection()
+import subscription_manager.injection as inj
 
 from subscription_manager import logutil
-from subscription_manager.repolib import RepoLib, EntitlementDirectory
+from subscription_manager.repolib import RepoLib
 from rhsm import connection
 
 requires_api_version = '2.5'
@@ -83,7 +84,7 @@ def update(conduit):
 
 def warnExpired(conduit):
     """ display warning for expired entitlements """
-    entdir = EntitlementDirectory()
+    entdir = inj.require(inj.ENT_DIR)
     products = set()
     for cert in entdir.list_expired():
         for p in cert.products:
@@ -107,7 +108,7 @@ def warnOrGiveUsageMessage(conduit):
     try:
         try:
             ConsumerIdentity.read().getConsumerId()
-            entdir = EntitlementDirectory()
+            entdir = inj.require(inj.ENT_DIR)
             if len(entdir.list_valid()) == 0:
                 msg = no_subs_warning
             else:

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -29,8 +29,8 @@ from M2Crypto import SSL
 from rhsm.config import initConfig
 import rhsm.connection as connection
 from rhsm.profile import get_profile, RPMProfile
-from subscription_manager.certdirectory import ProductDirectory
 from subscription_manager.certlib import ConsumerIdentity, DataLib
+import subscription_manager.injection as inj
 
 _ = gettext.gettext
 log = logging.getLogger('rhsm-app.' + __name__)
@@ -337,7 +337,7 @@ class InstalledProductsManager(CacheManager):
     def __init__(self, product_dir=None):
 
         if not product_dir:
-            product_dir = ProductDirectory()
+            product_dir = inj.require(inj.PROD_DIR)
 
         self.installed = {}
         for prod_cert in product_dir.list():

--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -22,6 +22,7 @@ import os
 from rhsm.certificate import Key, create_from_file
 from rhsm.config import initConfig
 from subscription_manager.injection import require, ENT_DIR
+from subscription_manager.lazyloader import LazyLoader
 
 log = logging.getLogger('rhsm-app.' + __name__)
 
@@ -157,12 +158,14 @@ class CertificateDirectory(Directory):
         return None
 
 
-class ProductDirectory(CertificateDirectory):
+class ProductDirectory(LazyLoader, CertificateDirectory):
 
     PATH = cfg.get('rhsm', 'productCertDir')
+    path = 'Product Directory'  # Place holder until path is set
 
-    def __init__(self):
-        super(ProductDirectory, self).__init__(self.PATH)
+    def load(self):
+        super(ProductDirectory, self).load()
+        CertificateDirectory.__init__(self, self.PATH)
 
     def get_provided_tags(self):
         """
@@ -186,17 +189,19 @@ class ProductDirectory(CertificateDirectory):
         return installed_products
 
 
-class EntitlementDirectory(CertificateDirectory):
+class EntitlementDirectory(LazyLoader, CertificateDirectory):
 
     PATH = cfg.get('rhsm', 'entitlementCertDir')
     PRODUCT = 'product'
+    path = 'Entitlement Directory'  # Place holder until path is set
 
     @classmethod
     def productpath(cls):
         return cls.PATH
 
-    def __init__(self):
-        super(EntitlementDirectory, self).__init__(self.productpath())
+    def load(self):
+        super(EntitlementDirectory, self).load()
+        CertificateDirectory.__init__(self, self.productpath())
 
     def _check_key(self, cert):
         """

--- a/src/subscription_manager/certlib.py
+++ b/src/subscription_manager/certlib.py
@@ -25,10 +25,11 @@ from rhsm.config import initConfig
 from rhsm.certificate import Key, create_from_pem, GMT
 
 from subscription_manager import plugins
-from subscription_manager.certdirectory import EntitlementDirectory, \
-    ProductDirectory, Writer
+from subscription_manager.certdirectory import Writer
 from subscription_manager.identity import ConsumerIdentity
 from subscription_manager.injection import CERT_SORTER, require
+import subscription_manager.injection as inj
+
 from subscription_manager.lock import Lock
 
 log = logging.getLogger('rhsm-app.' + __name__)
@@ -106,7 +107,7 @@ class HealingLib(DataLib):
     def __init__(self, lock=ActionLock(), uep=None, product_dir=None):
         DataLib.__init__(self, lock, uep)
 
-        self._product_dir = product_dir or ProductDirectory()
+        self._product_dir = product_dir or inj.require(inj.PROD_DIR)
         self.plugin_manager = plugins.get_plugin_manager()
 
     def _do_update(self):
@@ -200,7 +201,7 @@ class IdentityCertLib(DataLib):
 class Action:
 
     def __init__(self, uep=None, entdir=None):
-        self.entdir = entdir or EntitlementDirectory()
+        self.entdir = entdir or inj.require(inj.ENT_DIR)
         self.uep = uep
 
     def build(self, bundle):

--- a/src/subscription_manager/facts.py
+++ b/src/subscription_manager/facts.py
@@ -21,8 +21,8 @@ import simplejson as json
 import rhsm.config
 
 from subscription_manager.cache import CacheManager
-from subscription_manager import certdirectory
 from subscription_manager import plugins
+import subscription_manager.injection as inj
 
 _ = gettext.gettext
 
@@ -46,8 +46,8 @@ class Facts(CacheManager):
     def __init__(self, ent_dir=None, prod_dir=None):
         self.facts = {}
 
-        self.entitlement_dir = ent_dir or certdirectory.EntitlementDirectory()
-        self.product_dir = prod_dir or certdirectory.ProductDirectory()
+        self.entitlement_dir = ent_dir or inj.require(inj.ENT_DIR)
+        self.product_dir = prod_dir or inj.require(inj.PROD_DIR)
         # see bz #627962
         # we would like to have this info, but for now, since it
         # can change constantly on laptops, it makes for a lot of

--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -18,6 +18,7 @@
 #
 
 from subscription_manager.injection import require, IDENTITY, CERT_SORTER, CP_PROVIDER
+import subscription_manager.injection as inj
 
 import gettext
 import locale
@@ -33,7 +34,6 @@ import rhsm.config as config
 import rhsm.connection as connection
 
 from subscription_manager.branding import get_branding
-from subscription_manager.certdirectory import EntitlementDirectory, ProductDirectory
 from subscription_manager.certlib import CertLib
 from subscription_manager.facts import Facts
 from subscription_manager.hwprobe import ClassicCheck
@@ -91,8 +91,8 @@ class Backend(object):
 
         self.create_content_connection()
 
-        self.product_dir = ProductDirectory()
-        self.entitlement_dir = EntitlementDirectory()
+        self.product_dir = inj.require(inj.PROD_DIR)
+        self.entitlement_dir = inj.require(inj.ENT_DIR)
         self.certlib = CertLib(uep=self.cp_provider.get_consumer_auth_cp())
 
         self.product_monitor = file_monitor.Monitor(self.product_dir.path)

--- a/src/subscription_manager/injectioninit.py
+++ b/src/subscription_manager/injectioninit.py
@@ -37,8 +37,8 @@ def init_dep_injection():
             ValidProductDateRangeCalculator)
 
     # TODO: singletons possible?
-    inj.provide(inj.ENT_DIR, EntitlementDirectory)
-    inj.provide(inj.PROD_DIR, ProductDirectory)
+    inj.provide(inj.ENT_DIR, EntitlementDirectory(lazy_load=True))
+    inj.provide(inj.PROD_DIR, ProductDirectory(lazy_load=True))
 
     inj.provide(inj.STATUS_CACHE, StatusCache)
     inj.provide(inj.PROD_STATUS_CACHE, ProductStatusCache)

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -36,7 +36,6 @@ import rhsm.connection as connection
 
 from subscription_manager.branding import get_branding
 from subscription_manager.cache import InstalledProductsManager, ProfileManager
-from subscription_manager.certdirectory import EntitlementDirectory, ProductDirectory
 from subscription_manager.certlib import CertLib, ConsumerIdentity, Disconnected
 from subscription_manager.certmgr import CertManager
 from subscription_manager.cert_sorter import FUTURE_SUBSCRIBED, SUBSCRIBED, \
@@ -200,8 +199,8 @@ def autosubscribe(cp, consumer_uuid, service_level=None):
 
 
 def show_autosubscribe_output(uep):
-    installed_status = managerlib.get_installed_product_status(ProductDirectory(),
-            EntitlementDirectory(), uep)
+    installed_status = managerlib.get_installed_product_status(inj.require(inj.PROD_DIR),
+            inj.require(inj.ENT_DIR), uep)
     if not installed_status:
         print _("No products installed.")
         return 1

--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -25,8 +25,9 @@ import yum
 
 from rhsm.certificate import create_from_pem
 
-from subscription_manager.certdirectory import Directory, ProductDirectory
+from subscription_manager.certdirectory import Directory
 from subscription_manager import plugins
+import subscription_manager.injection as inj
 
 _ = gettext.gettext
 log = logging.getLogger('rhsm-app.' + __name__)
@@ -128,7 +129,7 @@ class ProductManager:
 
         self.pdir = product_dir
         if not product_dir:
-            self.pdir = ProductDirectory()
+            self.pdir = inj.require(inj.PROD_DIR)
 
         self.db = product_db
         if not product_db:

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -25,7 +25,8 @@ from rhsm.config import initConfig
 from rhsm.connection import RemoteServerException, RestlibException
 
 from certlib import ActionLock, DataLib, ConsumerIdentity
-from certdirectory import Path, EntitlementDirectory, ProductDirectory
+from certdirectory import Path
+import subscription_manager.injection as inj
 
 log = logging.getLogger('rhsm-app.' + __name__)
 
@@ -81,12 +82,12 @@ class UpdateAction:
         if ent_dir:
             self.ent_dir = ent_dir
         else:
-            self.ent_dir = EntitlementDirectory()
+            self.ent_dir = inj.require(inj.ENT_DIR)
 
         if prod_dir:
             self.prod_dir = prod_dir
         else:
-            self.prod_dir = ProductDirectory()
+            self.prod_dir = inj.require(inj.PROD_DIR)
 
         self.uep = uep
         self.manage_repos = 1

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -19,6 +19,7 @@ import random
 import tempfile
 
 from subscription_manager.cert_sorter import CertSorter
+from subscription_manager.lazyloader import LazyLoader
 
 # config file is root only, so just fill in a stringbuffer
 cfg_buf = """
@@ -280,11 +281,16 @@ class StubCertificateDirectory(EntitlementDirectory):
     def getCerts(self):
         return self.certs
 
+
 # so we can use a less confusing name when we use this stub
-StubEntitlementDirectory = StubCertificateDirectory
+class StubEntitlementDirectory(StubCertificateDirectory, LazyLoader):
+
+    def __init__(self, certificates=None):
+        super(StubEntitlementDirectory, self).__init__(certificates)
+        LazyLoader.__init__(self)
 
 
-class StubProductDirectory(StubCertificateDirectory, ProductDirectory):
+class StubProductDirectory(StubCertificateDirectory, ProductDirectory, LazyLoader):
     """
     Stub for mimicing behavior of an on-disk certificate directory.
     Can be used for both entitlement and product directories as needed.
@@ -302,6 +308,7 @@ class StubProductDirectory(StubCertificateDirectory, ProductDirectory):
             for pid in pids:
                 certificates.append(StubProductCertificate(StubProduct(pid)))
         super(StubProductDirectory, self).__init__(certificates)
+        LazyLoader.__init__(self)
 
 
 class StubConsumerIdentity(object):


### PR DESCRIPTION
Prevents a fair amount of disk IO and certificate loading by creating ProductDirectory and EntitlementDirectory only once.
