### PR TITLE
make autoheal checkbox do nothing at the moment

### DIFF
--- a/src/subscription_manager/gui/data/preferences.glade
+++ b/src/subscription_manager/gui/data/preferences.glade
@@ -132,7 +132,7 @@
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
                     <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="on_checkbox_toggled"/>
+                    <signal name="toggled" handler="on_autoheal_checkbox_toggled"/>
                   </widget>
                   <packing>
                     <property name="expand">True</property>

--- a/src/subscription_manager/gui/preferences.py
+++ b/src/subscription_manager/gui/preferences.py
@@ -16,7 +16,6 @@
 import gettext
 import logging
 import os
-import threading
 
 import gtk
 import gtk.glade
@@ -70,7 +69,7 @@ class PreferencesDialog(object):
             "on_close_button_clicked": self._close_button_clicked,
             "on_sla_combobox_changed": self._sla_changed,
             "on_release_combobox_changed": self._release_changed,
-            "on_checkbox_toggled": self._on_checkbox_toggled,
+            "on_autoheal_checkbox_toggled": self._on_autoheal_checkbox_toggled,
         })
 
         # Handle the dialog's delete event when ESC key is pressed.
@@ -203,11 +202,8 @@ class PreferencesDialog(object):
         self._close_dialog()
         return True
 
-    def _on_checkbox_toggled(self, checkbox):
+    def _on_autoheal_checkbox_toggled(self, checkbox):
         log.info("Auto-attach (autoheal) changed to: %s" % checkbox.get_active())
-        update_func = self.backend.cp_provider.get_consumer_auth_cp().updateConsumer
-        update_thread = threading.Thread(target=update_func, args=[self.identity.uuid], kwargs={'autoheal':checkbox.get_active()})
-        update_thread.start()
 
         if (checkbox.get_active()):
             checkbox.set_label(_("Enabled"))

--- a/test/test_preferences.py
+++ b/test/test_preferences.py
@@ -123,6 +123,15 @@ class TestPreferencesDialog(SubManFixture):
         identity = require(IDENTITY)
         MockUep.assert_called_with(identity.uuid, release="123123")
 
+    @mock.patch.object(stubs.StubUEP, 'updateConsumer')
+    def testAutohealChanged(self, MockUep):
+        self._getPrefDialog()
+
+        self.preferences_dialog.show()
+        self.preferences_dialog.autoheal_checkbox.set_active(1)
+        # we currently dont actually do anything here, so
+        # not much to test
+
     def testReleaseUnset(self):
         self._getPrefDialog()
 


### PR DESCRIPTION
Needs python-rhsm rev and tests.

Just to keep that from throwing errors with current python-rhsm. If we
want to build a version now, or we could fix it later at once.
