### PR TITLE
977321: update prod status after attach --auto

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1459,6 +1459,7 @@ class AttachCommand(CliCommand):
             result = None
             if cert_update:
                 result = self.certlib.update()
+                self.sorter.load()
 
             if result and result[1]:
                 print 'Entitlement Certificate(s) update failed due to the following reasons:'


### PR DESCRIPTION
This is unnecessary if ckozak/centralize_cert_sorter gets merged
