### PR TITLE
Alikins/no rpm version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@ cover/
 po/build
 po/POTFILES.in
 etc-conf/*.desktop
+src/subscription_manager/version.py
+src/rct/version.py
 bin/rhsmcertd
 bin/rhsm-icon

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ EXAMPLE_PLUGINS_SRC_DIR := example-plugins/
 YUM_PLUGINS_SRC_DIR := $(BASE_SRC_DIR)/plugins
 ALL_SRC_DIRS := $(SRC_DIR) $(RCT_SRC_DIR) $(DAEMONS_SRC_DIR) $(EXAMPLE_PLUGINS_SRC_DIR) $(YUM_PLUGINS_SRC_DIR)
 
+# sets a version that is more or less latest tag plus commit sha
+VERSION ?= $(shell git describe | awk ' { sub(/subscription-manager-/,"")};1' )
 CFLAGS = -Wall -g
 
 %.pyc: %.py
@@ -124,7 +126,11 @@ install-example-plugins-conf:
 .PHONY: install
 install: install-files install-conf install-help-files install-plugins-conf
 
-install-files: dbus-service-install compile-po desktop-files install-plugins
+set-versions:
+	sed -e 's/RPM_VERSION/$(VERSION)/g' $(SRC_DIR)/version.py.in > $(SRC_DIR)/version.py
+	sed -e 's/RPM_VERSION/$(VERSION)/g' $(RCT_SRC_DIR)/version.py.in > $(RCT_SRC_DIR)/version.py
+
+install-files: set-versions dbus-service-install compile-po desktop-files install-plugins
 	install -d $(CODE_DIR)/gui/data/icons
 	install -d $(CODE_DIR)/branding
 	install -d $(CODE_DIR)/migrate

--- a/src/rct/version.py.in
+++ b/src/rct/version.py.in
@@ -1,0 +1,1 @@
+rpm_version = "RPM_VERSION"

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -26,10 +26,11 @@ from M2Crypto.SSL import SSLError
 from subscription_manager.branding import get_branding
 from subscription_manager.certlib import ConsumerIdentity
 from subscription_manager.hwprobe import ClassicCheck
+import subscription_manager.version
+import rhsm.version
 from rhsm.connection import UEPConnection, RestlibException, GoneException
 from rhsm.config import DEFAULT_PORT, DEFAULT_PREFIX, DEFAULT_HOSTNAME, \
     DEFAULT_CDN_HOSTNAME, DEFAULT_CDN_PORT, DEFAULT_CDN_PREFIX
-from rhsm.version import Versions
 
 log = logging.getLogger('rhsm-app.' + __name__)
 
@@ -305,15 +306,13 @@ def get_terminal_width():
 def get_client_versions():
     # It's possible (though unlikely, and kind of broken) to have more
     # than one version of python-rhsm/subscription-manager installed.
-    # Versions() will only return one (and I suspect it's not predictable
-    # which it will return).
+    # This will return whatever version we are using.
     sm_version = _("Unknown")
     pr_version = _("Unknown")
 
     try:
-        versions = Versions()
-        sm_version = get_version(versions, Versions.SUBSCRIPTION_MANAGER)
-        pr_version = get_version(versions, Versions.PYTHON_RHSM)
+        pr_version = rhsm.version.rpm_version
+        sm_version = subscription_manager.version.rpm_version
     except Exception, e:
         log.debug("Client Versions: Unable to check client versions")
         log.exception(e)

--- a/src/subscription_manager/version.py.in
+++ b/src/subscription_manager/version.py.in
@@ -1,0 +1,1 @@
+rpm_version = "RPM_VERSION"

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -210,6 +210,7 @@ rm -rf %{buildroot}
 %{_datadir}/rhsm/subscription_manager/dbus_interface.py*
 %{_datadir}/rhsm/subscription_manager/dmiinfo.py*
 %{_datadir}/rhsm/subscription_manager/entbranding.py*
+%{_datadir}/rhsm/subscription_manager/cp_provider.py*
 %{_datadir}/rhsm/subscription_manager/factlib.py*
 %{_datadir}/rhsm/subscription_manager/facts.py*
 %{_datadir}/rhsm/subscription_manager/hwprobe.py*
@@ -228,6 +229,7 @@ rm -rf %{buildroot}
 %{_datadir}/rhsm/subscription_manager/managerlib.py*
 %{_datadir}/rhsm/subscription_manager/plugins.py*
 %{_datadir}/rhsm/subscription_manager/productid.py*
+%{_datadir}/rhsm/subscription_manager/reasons.py*
 %{_datadir}/rhsm/subscription_manager/release.py*
 %{_datadir}/rhsm/subscription_manager/repolib.py*
 %{_datadir}/rhsm/subscription_manager/rhelentbranding.py*
@@ -237,6 +239,7 @@ rm -rf %{buildroot}
 %{_datadir}/rhsm/subscription_manager/cp_provider.py*
 %{_datadir}/rhsm/subscription_manager/file_monitor.py*
 
+%{_datadir}/rhsm/subscription_manager/version.py*
 # subscription-manager plugins
 %dir %{rhsm_plugins_dir}
 %dir %{_sysconfdir}/rhsm/pluginconf.d
@@ -275,6 +278,7 @@ rm -rf %{buildroot}
 %{_datadir}/rhsm/rct/cli.py*
 %{_datadir}/rhsm/rct/*commands.py*
 %{_datadir}/rhsm/rct/printing.py*
+%{_datadir}/rhsm/rct/version.py*
 %attr(755,root,root) %{_bindir}/rct
 
 %doc


### PR DESCRIPTION
Probably some build/test issues to shake out, but it seems to work for me.

This generates version.py files that are populated with either the rpm version-release,
or 'git describe' like output (ie, more or less latest tag, how many commits since that
tag, and sha of HEAD). 

This removes a lot of runtime code, and removes code that was opening the
rpm database and querying it for two package names and versions. That was
taking on average about .5s every time the process started. 
