### PR TITLE
982286: Fixed empty dialog message

### DIFF
--- a/src/subscription_manager/gui/messageWindow.py
+++ b/src/subscription_manager/gui/messageWindow.py
@@ -70,6 +70,7 @@ class MessageWindow(gobject.GObject):
 
         # escape product strings see rh bz#633438
         self.dialog.set_markup(text)
+
         self.dialog.set_default_response(0)
 
         self.dialog.set_position(gtk.WIN_POS_CENTER_ON_PARENT)


### PR DESCRIPTION
Fixed issue where subscription names with ampersands were not being terminated correctly as strings, so Python was trying to parse the strings into entities.
