### PR TITLE
Adjusted markup removal

### DIFF
--- a/src/subscription_manager/gui/messageWindow.py
+++ b/src/subscription_manager/gui/messageWindow.py
@@ -56,11 +56,6 @@ class MessageWindow(gobject.GObject):
         gobject.GObject.__init__(self)
         self.rc = None
 
-        # escape product strings see rh bz#982286
-        # NOTE: fixes whatever the fix below (bz#633438)
-        #       did not fix
-        text = gobject.markup_escape_text(text)
-
         # this seems to be wordwrapping text passed to
         # it, which is making for ugly error messages
         self.dialog = gtk.MessageDialog(parent, 0, self.STYLE, self.BUTTONS)

--- a/src/subscription_manager/gui/mysubstab.py
+++ b/src/subscription_manager/gui/mysubstab.py
@@ -145,7 +145,10 @@ class MySubscriptionsTab(widgets.SubscriptionManagerTab):
         if not selection.is_valid():
             return
 
-        prompt = messageWindow.YesNoDialog(_("Are you sure you want to remove %s?") % selection['subscription'],
+        # remove all markup, see rh bz#982286
+        subscription_text = gobject.markup_escape_text(selection['subscription'])
+
+        prompt = messageWindow.YesNoDialog(_("Are you sure you want to remove %s?") % subscription_text,
                 self.content.get_toplevel())
         prompt.connect('response', self._on_unsubscribe_prompt_response, selection)
 


### PR DESCRIPTION
Fixed bug 982286, but also broke the markup of many other MessageWindows in the process. This is a fix for that. See fix for 982286 here: https://github.com/candlepin/subscription-manager/pull/688
