### PR TITLE
987579: Re-arranged preferences dialog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ find-missing-signals:
 # also remove unneeded 'orientation' property for vbox's
 # since it causes warnings on RHEL5
 fix-glade:
-	perl -pi -e 's/(swapped=\"no\")//' $(GLADEFILES)
+	perl -pi -e 's/(swapped=\".*?\")//' $(GLADEFILES)
 	perl -pi -e 's/^.*property\s*name=\"orientation\">vertical.*$$//' $(GLADEFILES)
 
 

--- a/src/subscription_manager/gui/data/preferences.glade
+++ b/src/subscription_manager/gui/data/preferences.glade
@@ -31,19 +31,6 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <widget class="GtkLabel" id="label_autoheal">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xalign">0.15999999642372131</property>
-                        <property name="label" translatable="yes">Auto-attach preference:</property>
-                      </widget>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
                       <widget class="GtkHBox" id="hbox1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -64,40 +51,38 @@
                             <signal name="toggled" handler="on_autoheal_checkbox_toggled" />
                           </widget>
                           <packing>
-                            <property name="expand">False</property>
+                            <property name="expand">True</property>
                             <property name="fill">False</property>
                             <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <widget class="GtkEventBox" id="autoheal_event">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="visible_window">False</property>
-                            <property name="above_child">True</property>
-                            <signal name="button_press_event" handler="on_autoheal_label_press_event" />
-                            <child>
-                              <widget class="GtkLabel" id="label_preference">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="xalign">0</property>
-                                <property name="xpad">1</property>
-                                <property name="label" translatable="yes">Enabled</property>
-                                <property name="justify">right</property>
-                                <property name="width_chars">8</property>
-                              </widget>
-                            </child>
-                          </widget>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
                           </packing>
                         </child>
                       </widget>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <widget class="GtkEventBox" id="autoheal_event">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="visible_window">False</property>
+                        <property name="above_child">True</property>
+                        <signal name="button_press_event" handler="on_autoheal_label_press_event" />
+                        <child>
+                          <widget class="GtkLabel" id="label_autoheal">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="xalign">0.029999999329447746</property>
+                            <property name="yalign">0.51999998092651367</property>
+                            <property name="label" translatable="yes">Enable auto-attach preference</property>
+                          </widget>
+                        </child>
+                      </widget>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>

--- a/src/subscription_manager/gui/preferences.py
+++ b/src/subscription_manager/gui/preferences.py
@@ -56,8 +56,8 @@ class PreferencesDialog(object):
         self.release_combobox = GLADE_XML.get_widget('release_combobox')
         self.sla_combobox = GLADE_XML.get_widget('sla_combobox')
         self.autoheal_checkbox = GLADE_XML.get_widget('autoheal_checkbox')
-        self.autoheal_preference = GLADE_XML.get_widget('label_preference')
         self.autoheal_event = GLADE_XML.get_widget('autoheal_event')
+        self.autoheal_label = GLADE_XML.get_widget('label_autoheal')
 
         # The first string is the displayed service level; the second is
         # the value sent to Candlepin.
@@ -72,7 +72,7 @@ class PreferencesDialog(object):
             "on_sla_combobox_changed": self._sla_changed,
             "on_release_combobox_changed": self._release_changed,
             "on_autoheal_checkbox_toggled": self._on_autoheal_checkbox_toggled,
-            "on_autoheal_label_press_event": self._on_autoheal_preference_press,
+            "on_autoheal_label_press_event": self._on_autoheal_label_press,
         })
 
         # Handle the dialog's delete event when ESC key is pressed.
@@ -91,7 +91,7 @@ class PreferencesDialog(object):
             self.sla_combobox.set_sensitive(False)
             self.release_combobox.set_sensitive(False)
             self.autoheal_checkbox.set_sensitive(False)
-            self.autoheal_preference.set_sensitive(False)
+            self.autoheal_label.set_sensitive(False)
             return
 
         self.allow_callbacks = False
@@ -160,18 +160,17 @@ class PreferencesDialog(object):
         if 'autoheal' not in consumer_json:
             log.warn("Disabling auto-attach checkbox, server does not support autoheal/auto-attach.")
             self.autoheal_checkbox.set_sensitive(False)
-            self.autoheal_preference.set_sensitive(False)
+            self.autoheal_label.set_sensitive(False)
             return
 
+        self.autoheal_label.set_sensitive(True)
         self.autoheal_checkbox.set_sensitive(True)
-        self.autoheal_preference.set_sensitive(True)
         current_autoheal = consumer_json['autoheal']
         self.autoheal_checkbox.set_active(current_autoheal)
-
         if current_autoheal:
-            self.autoheal_preference.set_label(_("Enabled"))
+            self.autoheal_label.set_label(_("Enabled"))
         else:
-            self.autoheal_preference.set_label(_("Disabled"))
+            self.autoheal_label.set_label(_("Disabled"))
 
     def _close_button_clicked(self, widget):
         self._close_dialog()
@@ -220,13 +219,13 @@ class PreferencesDialog(object):
                                     autoheal=checkbox.get_active())
 
             if (checkbox.get_active()):
-                self.autoheal_preference.set_label(_("Enabled"))
+                self.autoheal_label.set_label(_("Enabled"))
             else:
-                self.autoheal_preference.set_label(_("Disabled"))
+                self.autoheal_label.set_label(_("Disabled"))
 
         return True
 
-    def _on_autoheal_preference_press(self, widget, event):
+    def _on_autoheal_label_press(self, widget, event):
         # NOTE: We have this function/event so the textbox label
         #       next to the checkbox can be clicked, then trigger
         #       the checkbox

--- a/test/test_preferences.py
+++ b/test/test_preferences.py
@@ -57,26 +57,19 @@ class TestPreferencesDialog(SubManFixture):
     def testAutohealChanged(self, MockUep):
         self._getPrefDialog()
         self.preferences_dialog.show()
-        self.preferences_dialog.autoheal_checkbox.set_active(0)
-        display_text = self.preferences_dialog.autoheal_preference.get_label()
-        self.assertEquals("Disabled", display_text)
         identity = require(IDENTITY)
+        event = gtk.gdk.Event(gtk.gdk.BUTTON_PRESS)
+
+        self.preferences_dialog.autoheal_event.emit("button-press-event", event)
+        MockUep.assert_called_with(identity.uuid, autoheal=False)
+
+        self.preferences_dialog.autoheal_event.emit("button-press-event", event)
+        MockUep.assert_called_with(identity.uuid, autoheal=True)
+
+        self.preferences_dialog.autoheal_checkbox.set_active(0)
         MockUep.assert_called_with(identity.uuid, autoheal=False)
 
         self.preferences_dialog.autoheal_checkbox.set_active(1)
-        display_text = self.preferences_dialog.autoheal_preference.get_label()
-        self.assertEquals("Enabled", display_text)
-        MockUep.assert_called_with(identity.uuid, autoheal=True)
-
-        event = gtk.gdk.Event(gtk.gdk.BUTTON_PRESS)
-        self.preferences_dialog.autoheal_event.emit("button-press-event", event)
-        display_text = self.preferences_dialog.autoheal_preference.get_label()
-        self.assertEquals("Disabled", display_text)
-        MockUep.assert_called_with(identity.uuid, autoheal=False)
-
-        self.preferences_dialog.autoheal_event.emit("button-press-event", event)
-        display_text = self.preferences_dialog.autoheal_preference.get_label()
-        self.assertEquals("Enabled", display_text)
         MockUep.assert_called_with(identity.uuid, autoheal=True)
 
     def _getPrefDialog(self):


### PR DESCRIPTION
It was decided the behavior of the auto-attach checkbox must change once again, and so it happened. See the original addition of this feature here: https://github.com/candlepin/subscription-manager/pull/661
