### PR TITLE
978466: fix missing socket info s390x/ppc64

### DIFF
--- a/scripts/test_hwprobe.sh
+++ b/scripts/test_hwprobe.sh
@@ -21,6 +21,6 @@ SYS_DUMPS=$(find "${SYS_DUMPS_PATH}" -mindepth 1 -maxdepth 1 -type d)
 for sys_dump in ${SYS_DUMPS}
 do
     echo "sys_dump: ${sys_dump}"
-    python ../src/subscription_manager/hwprobe.py "${sys_dump}"
+    python src/subscription_manager/hwprobe.py "${sys_dump}"
     echo
 done


### PR DESCRIPTION
Try to better handle system with no topology info

s390/ppc sometimes have pretty limited cpu topology
info available, especially on rhel5. Try to handle
those cases.

On s390x systems, that have a "cpu topology" info in
/proc/sysinfo and populated
/sys/devivces/system/cpu/cpu*/topology, we defer to
the latter. This is the scenario for s390x on zvm
running RHEL6.

Systems running RHEL5 will not have the /sys info
populated, so fall back to the /proc/sysinfo in
those cases.

For RHEL5 ppc64 systems with no /sys cpu topology
exposed, attempt to check cpu/cpuN/physical_id
for topology info.

If that doesn't have useful info, fallback
to 1 thread = 1 cpu = 1 core = 1 socket

Added cpu_t.topology_source fact to track how
client determined cpu topology info.
