### PR TITLE
968820: raise timeout exceptions for cli calls

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -315,7 +315,7 @@ class CliCommand(AbstractCLICommand):
 
         # get_server_versions needs to handle any exceptions
         # and return the server dict
-        self.server_versions = get_server_versions(self.no_auth_cp)
+        self.server_versions = get_server_versions(self.no_auth_cp, exception_on_timeout=True)
         log.info("Server Versions: %s" % self.server_versions)
 
     def main(self, args=None):


### PR DESCRIPTION
If we get a socket.timeout doing the initial
server resource check from the cli, assume all
network connections are going to fail on a
timeout, so to prevent waiting minutes for that
to finish, raise the exception so we exit
quicker.
