### PR TITLE
987626: Remove PUTS while opening preferences dialog

### DIFF
--- a/test/test_preferences.py
+++ b/test/test_preferences.py
@@ -148,9 +148,9 @@ class TestPreferencesDialog(SubManFixture):
 
         self.preferences_dialog.release_backend.get_releases = get_releases
         self.preferences_dialog.show()
-        self.preferences_dialog.release_combobox.set_active(1)
+        self.preferences_dialog.release_combobox.set_active(5)
         identity = require(IDENTITY)
-        MockUep.assert_called_with(identity.uuid, release="123123")
+        MockUep.assert_called_with(identity.uuid, release="blippy")
 
     def testReleaseUnset(self):
         self._getPrefDialog()


### PR DESCRIPTION
Use handler_block_by_func instead of handler_block if handler_block is not doing what it should be.
