### PR TITLE
987071: specify arch of librsvg dep

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -95,7 +95,8 @@ Obsoletes: %{name}-gnome < 1.0.3-1
 Provides: %{name}-gnome = %{version}-%{release}
 
 # Fedora can figure this out automatically, but RHEL cannot:
-Requires: librsvg2
+# See #987071
+Requires: librsvg2%{?_isa}
 
 %description -n subscription-manager-gui
 This package contains a GTK+ graphical interface for configuring and


### PR DESCRIPTION
On ppc64, we are installed as a .ppc package, and
gtk2 is installed as ppc/ppc64. The plain require
on librsvg2 can be satisified by the librsvg2.ppc64
package, which only provides svg loaders for the
64bit gtk2, which causes us to fail to load our
svg icons. Specify the arch of the librsvg2
dependcy needed.
