### PR TITLE
988482: fix gtk warnings on gtk-2.10

### DIFF
--- a/src/subscription_manager/gui/data/choose_server.glade
+++ b/src/subscription_manager/gui/data/choose_server.glade
@@ -102,7 +102,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="has_tooltip">True</property>
                 <property name="tooltip" translatable="yes">Reset to register with Customer Portal.</property>
                 <accessibility>
                   <atkproperty name="AtkObject::accessible-name" translatable="yes">default_button</atkproperty>
@@ -118,7 +117,6 @@
             <child>
               <widget class="GtkEventBox" id="eventbox2">
                 <property name="visible">True</property>
-                <property name="has_tooltip">True</property>
                 <property name="tooltip" translatable="yes">Activation Keys are alphanumeric strings that are pre-configured by your system administrators to automatically register your system and attach all necessary subscriptions.</property>
                 <property name="visible_window">False</property>
                 <child>

--- a/src/subscription_manager/gui/data/redeem.glade
+++ b/src/subscription_manager/gui/data/redeem.glade
@@ -126,10 +126,6 @@ when the redemption is complete.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="invisible_char">●</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
-                    <property name="primary_icon_sensitive">True</property>
-                    <property name="secondary_icon_sensitive">True</property>
                     <accessibility>
                       <atkproperty name="AtkObject::accessible-name" translatable="yes">Email Address Text</atkproperty>
                     </accessibility>


### PR DESCRIPTION
Various gtk widget properties included in the
glade files that do not exist in gtk-2.10.
