### PR TITLE
Remove unused WARNING_DAYS variable

### DIFF
--- a/src/subscription_manager/gui/widgets.py
+++ b/src/subscription_manager/gui/widgets.py
@@ -34,8 +34,6 @@ _ = gettext.gettext
 
 GLADE_DIR = os.path.join(os.path.dirname(__file__), "data")
 
-WARNING_DAYS = 6 * 7   # 6 weeks * 7 days / week
-
 WARNING_COLOR = '#FFFB82'
 EXPIRED_COLOR = '#FFAF99'
 


### PR DESCRIPTION
This variable isn't referenced anywhere, and shouldn't be used.  QA was grepping for it after we stopped using hardcoded warning time.

No need to put this in 5.10
