### PR TITLE
994997: Fix unknown virt status in firstboot.

### DIFF
--- a/src/subscription_manager/hwprobe.py
+++ b/src/subscription_manager/hwprobe.py
@@ -24,9 +24,7 @@ import logging
 import os
 import platform
 import re
-import signal
 import socket
-from subprocess import PIPE, Popen
 import sys
 
 _ = gettext.gettext
@@ -729,20 +727,10 @@ class Hardware:
         return virt_dict
 
     def _get_output(self, cmd):
-        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-
-        process = Popen([cmd], stdout=PIPE)
-        output = process.communicate()[0].strip()
-
-        signal.signal(signal.SIGPIPE, signal.SIG_IGN)
-
-        returncode = process.poll()
-        if returncode:
-            raise CalledProcessError(returncode,
-                                     cmd,
-                                     output=output)
-
-        return output
+        (status, output) = commands.getstatusoutput(cmd)
+        if status:
+            raise CalledProcessError(status, cmd, output=output)
+        return output.strip()
 
     def get_platform_specific_info(self):
         """

--- a/test/test_hw.py
+++ b/test/test_hw.py
@@ -122,50 +122,45 @@ class TestGatherEntries(unittest.TestCase):
 
 class HardwareProbeTests(fixture.SubManFixture):
 
-    @patch('subprocess.Popen')
-    def test_command_error(self, MockPopen):
-        MockPopen.return_value.communicate.return_value = ['', None]
-        MockPopen.return_value.poll.return_value = 2
+    @patch('commands.getstatusoutput')
+    def test_command_error(self, MockCommands):
+        MockCommands.return_value = (2, '')
 
         # Pick up the mocked class
         reload(hwprobe)
         hw = hwprobe.Hardware()
         self.assertRaises(hwprobe.CalledProcessError, hw._get_output, 'test')
 
-    @patch('subprocess.Popen')
-    def test_command_valid(self, MockPopen):
-        MockPopen.return_value.communicate.return_value = ['this is valid', None]
-        MockPopen.return_value.poll.return_value = 0
+    @patch('commands.getstatusoutput')
+    def test_command_valid(self, MockCommands):
+        MockCommands.return_value = [0, 'this is valid']
 
         # Pick up the mocked class
         reload(hwprobe)
         hw = hwprobe.Hardware()
         self.assertEquals('this is valid', hw._get_output('testing'))
 
-    @patch('subprocess.Popen')
-    def test_virt_guest(self, MockPopen):
-        MockPopen.return_value.communicate.return_value = ['kvm', None]
-        MockPopen.return_value.poll.return_value = 0
+    @patch('commands.getstatusoutput')
+    def test_virt_guest(self, MockCommands):
+        MockCommands.return_value = [0, 'kvm']
 
         reload(hwprobe)
         hw = hwprobe.Hardware()
         expected = {'virt.is_guest': True, 'virt.host_type': 'kvm'}
         self.assertEquals(expected, hw.get_virt_info())
 
-    @patch('subprocess.Popen')
-    def test_virt_bare_metal(self, MockPopen):
-        MockPopen.return_value.communicate.return_value = ['', None]
-        MockPopen.return_value.poll.return_value = 0
+    @patch('commands.getstatusoutput')
+    def test_virt_bare_metal(self, MockCommands):
+        MockCommands.return_value = [0, '']
 
         reload(hwprobe)
         hw = hwprobe.Hardware()
         expected = {'virt.is_guest': False, 'virt.host_type': 'Not Applicable'}
         self.assertEquals(expected, hw.get_virt_info())
 
-    @patch('subprocess.Popen')
-    def test_virt_error(self, MockPopen):
-        MockPopen.return_value.communicate.return_value = ['', None]
-        MockPopen.return_value.poll.return_value = 255
+    @patch('commands.getstatusoutput')
+    def test_virt_error(self, MockCommands):
+        MockCommands.return_value = [255, '']
 
         reload(hwprobe)
         hw = hwprobe.Hardware()


### PR DESCRIPTION
Second time we've seen this code cause a bug, as it is not possible to
use this signal code outside of the main thread. This time we'll try to
replace it so the issue no longer occurs by using another method for
running the command.

Popen had issues with:
https://bugzilla.redhat.com/show_bug.cgi?id=681925

The signal code was added as a result of that bug.

Instead we will now use a different method for running virt-what
entirely, which is already in use elsewhere in the facts module.
