### PR TITLE
994997: Fix Unknown is_guest during firstboot.

### DIFF
--- a/src/subscription_manager/hwprobe.py
+++ b/src/subscription_manager/hwprobe.py
@@ -24,7 +24,6 @@ import logging
 import os
 import platform
 import re
-import signal
 import socket
 from subprocess import PIPE, Popen
 import sys
@@ -729,12 +728,8 @@ class Hardware:
         return virt_dict
 
     def _get_output(self, cmd):
-        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-
         process = Popen([cmd], stdout=PIPE)
         output = process.communicate()[0].strip()
-
-        signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 
         returncode = process.poll()
         if returncode:


### PR DESCRIPTION
Signal cannot be used outside of the main thread, depending on when
facts are loaded this can happen in subman, this would be the second
time we've seen it occur.

Possibly re-introduces an old bug but this is preferable to the current
situation:

https://bugzilla.redhat.com/show_bug.cgi?id=681925
