### PR TITLE
make default logger include sys.argv[0]

### DIFF
--- a/bin/install-num-migrate-to-rhsm
+++ b/bin/install-num-migrate-to-rhsm
@@ -33,11 +33,14 @@ if _LIBPATH not in sys.path:
 from subscription_manager.i18n import configure_i18n
 from subscription_manager.i18n_optparse import OptionParser, \
      WrappedIndentedHelpFormatter, USAGE
+from subscription_manager import logutil
 
 configure_i18n()
 
 import gettext
 _ = gettext.gettext
+
+logutil.init_logger()
 
 cfg = config.initConfig()
 PRODUCT_CERT_DIR = cfg.get('rhsm', 'productcertdir')

--- a/bin/rct
+++ b/bin/rct
@@ -29,6 +29,9 @@ if _LIBPATH not in sys.path:
 from subscription_manager.i18n import configure_i18n
 configure_i18n()
 
+from subscription_manager import logutil
+logutil.init_logger()
+
 import gettext
 _ = gettext.gettext
 

--- a/bin/rhn-migrate-classic-to-rhsm
+++ b/bin/rhn-migrate-classic-to-rhsm
@@ -46,6 +46,9 @@ try:
     from subscription_manager.i18n import configure_i18n
     configure_i18n()
 
+    from subscription_manager import logutil
+    logutil.init_logger()
+
     from subscription_manager.migrate import migrate
     from subscription_manager.managercli import handle_exception
 except KeyboardInterrupt:
@@ -53,10 +56,6 @@ except KeyboardInterrupt:
 except ImportError, e:
     system_exit(2, "Unable to find Subscription Manager module.\n"
                   "Error: %s" % e)
-
-
-from subscription_manager import logutil
-logutil.init_logger()
 
 
 def main():

--- a/bin/subscription-manager-gui
+++ b/bin/subscription-manager-gui
@@ -111,11 +111,13 @@ try:
     from subscription_manager.i18n import configure_i18n
     configure_i18n(with_glade=True)
 
+    from subscription_manager import logutil
+    logutil.init_logger()
+
     from subscription_manager.injectioninit import init_dep_injection
     init_dep_injection()
 
     from subscription_manager.gui import managergui
-    from subscription_manager import logutil
     from subscription_manager.i18n_optparse import OptionParser, \
         WrappedIndentedHelpFormatter, USAGE
 except ImportError, e:
@@ -154,8 +156,8 @@ if __name__ == '__main__':
                       help=_("launches the registration dialog on startup"))
     options, args = parser.parse_args(args=sys.argv)
 
-    logutil.init_logger()
-    log = logging.getLogger('subscription-manager-gui')
+    log = logging.getLogger("rhsm-app.subscription-manager-gui")
+
     try:
         bus = dbus.SessionBus()
     except dbus.exceptions.DBusException:

--- a/src/daemons/rhsm_d.py
+++ b/src/daemons/rhsm_d.py
@@ -26,9 +26,10 @@ import logging
 import sys
 sys.path.append("/usr/share/rhsm")
 
-from subscription_manager.logutil import init_logger
-init_logger()
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger("rhsm-app.rhsmd")
+
+from subscription_manager import logutil
+logutil.init_logger()
 
 from subscription_manager.injectioninit import init_dep_injection
 init_dep_injection()

--- a/src/daemons/rhsmcertd-worker.py
+++ b/src/daemons/rhsmcertd-worker.py
@@ -19,13 +19,15 @@ sys.path.append("/usr/share/rhsm")
 
 import logging
 
+from subscription_manager import logutil
+logutil.init_logger()
+
 from rhsm import connection
 
 from subscription_manager.injectioninit import init_dep_injection
 init_dep_injection()
 
 from subscription_manager import certmgr
-from subscription_manager import logutil
 from subscription_manager import managerlib
 from subscription_manager.certlib import ConsumerIdentity
 from subscription_manager.i18n_optparse import OptionParser, \

--- a/src/plugins/product-id.py
+++ b/src/plugins/product-id.py
@@ -21,8 +21,6 @@ from yum.plugins import TYPE_CORE
 
 sys.path.append('/usr/share/rhsm')
 
-from subscription_manager.injectioninit import init_dep_injection
-init_dep_injection()
 
 from subscription_manager import logutil
 from subscription_manager.productid import ProductManager
@@ -50,6 +48,9 @@ def posttrans_hook(conduit):
     # yum on 5.7 doesn't have this method, so check for it
     if hasattr(conduit, 'registerPackageName'):
         conduit.registerPackageName("subscription-manager")
+
+    from subscription_manager.injectioninit import init_dep_injection
+    init_dep_injection()
 
     logutil.init_logger_for_yum()
     chroot()

--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -21,11 +21,7 @@ from yum.plugins import TYPE_CORE, TYPE_INTERACTIVE
 
 sys.path.append('/usr/share/rhsm')
 
-from subscription_manager.injectioninit import init_dep_injection
-init_dep_injection()
-import subscription_manager.injection as inj
-
-from subscription_manager import logutil
+from subscription_manager import injection as inj
 from subscription_manager.repolib import RepoLib
 from rhsm import connection
 
@@ -123,9 +119,15 @@ def config_hook(conduit):
     """ update """
     # register rpm name for yum history recording"
     # yum on 5.7 doesn't have this method, so check for it
+
+    from subscription_manager import logutil
+    logutil.init_logger_for_yum()
+
+    from subscription_manager.injectioninit import init_dep_injection
+    init_dep_injection()
+
     if hasattr(conduit, 'registerPackageName'):
         conduit.registerPackageName("subscription-manager")
-    logutil.init_logger_for_yum()
     try:
         update(conduit)
         warnOrGiveUsageMessage(conduit)

--- a/src/subscription_manager/injection.py
+++ b/src/subscription_manager/injection.py
@@ -25,9 +25,7 @@ CP_PROVIDER = "CP_PROVIDER"
 PLUGIN_MANAGER = "PLUGIN_MANAGER"
 DBUS_IFACE = "DBUS_IFACE"
 
-import logging
 import types
-log = logging.getLogger('rhsm-app.' + __name__)
 
 
 class FeatureBroker:


### PR DESCRIPTION
Log the name of the program that is doing things
(ala, subscription-manager, subscription-manager-gui,
rhsmcertd-worker, etc)

Add a logging Filter that subs in the cli info

Make sure init_logger happens in each app, and
happens before injectioninit.
