### PR TITLE
973838: refresh redhat.repo after register

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1102,16 +1102,24 @@ class RegisterCommand(UserPassCommand):
                                  "by the server. Did not complete your request."))
             autosubscribe(self.cp, consumer['uuid'],
                     service_level=self.options.service_level)
+
+        subscribed = 0
         if (self.options.consumerid or self.options.activation_keys or
                 self.autoattach):
+
+            log.info("System registered, updating entitlements if needed")
+            # update certs, repos, and caches.
+            # FIXME: aside from the overhead, should this be certmgr.update?
             self.certlib.update()
 
-        # run this after certlib update, so we have the new entitlements
-        subscribed = 0
-        if self.autoattach:
+            rl = RepoLib(uep=self.cp)
+            rl.update()
+
+            # update with latest cert info
             self.sorter = inj.require(inj.CERT_SORTER)
             self.sorter.force_cert_check()
             subscribed = show_autosubscribe_output(self.cp)
+
         self._request_validity_check()
         return subscribed
 

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -21,6 +21,7 @@ BACKUP_DIR="/tmp/sm-smoke/backup"
 USERNAME="${1:-admin}"
 PASSWORD="${2:-admin}"
 ORG="${3:-admin}"
+ACTIVATION_KEY="${4:-default_key}"
 
 #global_args="--help"
 GLOBAL_ARGS=""
@@ -68,6 +69,7 @@ run_sm service-level
 run_sm repos
 run_sm subscribe --auto
 run_sm list --consumed
+run_sm repos
 
 # others...
 run_sm config --list
@@ -79,6 +81,13 @@ run_sm orgs --username "${USERNAME}" --password "${PASSWORD}"
 run_sm release --list
 run_sm remove --all
 run_sm plugins --list
+run_sm unregister
+
+# activation keys
+run_sm unregister
+run_sm register --activationkey "${ACTIVATION_KEY}" --org "${ORG}" --force
+run_sm unregister
+run_sm register --activationkey "${ACTIVATION_KEY}" --org "${ORG}" --force --auto-attach
 run_sm unregister
 
 # what to run after the tests, ie, restore configs, etc


### PR DESCRIPTION
For cases where register potentially attaches pools
(--auto-attach/--activationkey/--consumerid)
run certlib.update and repolib.update so entitlements
certs are pulled, and redhat.repo is refreshed
immediately.

[This may get obsoleted by fix for https://bugzilla.redhat.com/show_bug.cgi?id=1008016, but
hopefully test cases would still be useful]
