### PR TITLE
1006748: replace simplejson with 'ourjson'

### DIFF
--- a/bin/install-num-migrate-to-rhsm
+++ b/bin/install-num-migrate-to-rhsm
@@ -20,7 +20,6 @@ import platform
 import sys
 import glob
 import shutil
-import simplejson as json
 import rhsm.config as config
 from instnum import InstallationNumber, InstallationNumberError
 from datetime import datetime
@@ -30,6 +29,7 @@ _LIBPATH = "/usr/share/rhsm"
 if _LIBPATH not in sys.path:
     sys.path.append(_LIBPATH)
 
+from rhsm import ourjson as json
 from subscription_manager.i18n import configure_i18n
 from subscription_manager.i18n_optparse import OptionParser, \
      WrappedIndentedHelpFormatter, USAGE

--- a/example-plugins/facts.py
+++ b/example-plugins/facts.py
@@ -17,7 +17,7 @@ from subscription_manager.base_plugin import SubManPlugin
 requires_api_version = "1.0"
 
 import subprocess
-import simplejson as json
+import json
 
 
 class FactsPlugin(SubManPlugin):

--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -18,7 +18,6 @@ import errno
 import gettext
 import os
 import sys
-import simplejson as json
 from zipfile import ZipFile, BadZipfile
 
 from rhsm import certificate
@@ -26,6 +25,7 @@ from rhsm import certificate
 from rct.commands import RCTCliCommand
 from rct.printing import xstr
 from subscription_manager.cli import InvalidCLIOptionError
+from rhsm import ourjson as json
 
 _ = gettext.gettext
 

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -22,7 +22,6 @@ necessary.
 import gettext
 import logging
 import os
-import simplejson as json
 import socket
 import threading
 from M2Crypto import SSL
@@ -32,6 +31,7 @@ import rhsm.connection as connection
 from rhsm.profile import get_profile, RPMProfile
 from subscription_manager.certlib import ConsumerIdentity, DataLib
 import subscription_manager.injection as inj
+from rhsm import ourjson as json
 
 _ = gettext.gettext
 log = logging.getLogger('rhsm-app.' + __name__)

--- a/src/subscription_manager/facts.py
+++ b/src/subscription_manager/facts.py
@@ -16,13 +16,13 @@ import gettext
 import glob
 import logging
 import os
-import simplejson as json
 
 import rhsm.config
 
 from subscription_manager.injection import PLUGIN_MANAGER, require
 from subscription_manager.cache import CacheManager
 import subscription_manager.injection as inj
+from rhsm import ourjson as json
 
 _ = gettext.gettext
 

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -21,7 +21,6 @@ import logging
 import os
 import re
 import shutil
-import simplejson as json
 import subprocess
 import sys
 import traceback
@@ -48,6 +47,7 @@ from subscription_manager.i18n_optparse import OptionParser, \
 from subscription_manager.productid import ProductDatabase
 from subscription_manager import repolib
 from subscription_manager.utils import parse_server_info, ServerUrlParseError
+from rhsm import ourjson as json
 
 _RHNLIBPATH = "/usr/share/rhn"
 if _RHNLIBPATH not in sys.path:

--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -19,7 +19,6 @@ import gettext
 from gzip import GzipFile
 import logging
 import os
-import simplejson as json
 import types
 import yum
 
@@ -28,6 +27,7 @@ from rhsm.certificate import create_from_pem
 from subscription_manager.certdirectory import Directory
 from subscription_manager.injection import PLUGIN_MANAGER, require
 import subscription_manager.injection as inj
+from rhsm import ourjson as json
 
 _ = gettext.gettext
 log = logging.getLogger('rhsm-app.' + __name__)

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -27,11 +27,10 @@ URL:     https://fedorahosted.org/subscription-manager/
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 Requires:  python-ethtool
-Requires:  python-simplejson
 Requires:  python-iniparse
 Requires:  pygobject2
 Requires:  virt-what
-Requires:  python-rhsm >= 1.9.1-1
+Requires:  python-rhsm >= 1.10.3
 Requires:  dbus-python
 Requires:  yum >= 3.2.19-15
 Requires:  usermode

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -19,12 +19,12 @@ import socket
 import tempfile
 import threading
 from mock import Mock
-import simplejson as json
 
 # used to get a user readable cfg class for test cases
 from stubs import StubProduct, StubProductCertificate, StubCertificateDirectory
 from fixture import SubManFixture
 
+from rhsm import ourjson as json
 from subscription_manager.cache import ProfileManager, \
         InstalledProductsManager, StatusCache
 from rhsm.profile import Package, RPMProfile

--- a/test/test_cert_sorter.py
+++ b/test/test_cert_sorter.py
@@ -23,7 +23,7 @@ from subscription_manager.cert_sorter import CertSorter, UNKNOWN
 from subscription_manager.cache import StatusCache
 from datetime import timedelta, datetime
 from mock import Mock, patch
-import simplejson as json
+from rhsm import ourjson as json
 
 
 def cert_list_has_product(cert_list, product_id):

--- a/test/test_certmgr.py
+++ b/test/test_certmgr.py
@@ -13,12 +13,12 @@
 # in this software or its documentation.
 #
 
-import simplejson as json
 from datetime import datetime, timedelta
 
 import mock
 import stubs
 
+from rhsm import ourjson as json
 from subscription_manager import certmgr
 from subscription_manager import certlib
 from subscription_manager import repolib

--- a/test/test_facts.py
+++ b/test/test_facts.py
@@ -1,11 +1,11 @@
 import tempfile
-import simplejson as json
 import shutil
 from mock import patch
 
 import fixture
 from stubs import StubEntitlementDirectory, StubProductDirectory
 from subscription_manager import facts
+from rhsm import ourjson as json
 
 facts_buf = """
 {

--- a/test/test_validity.py
+++ b/test/test_validity.py
@@ -13,12 +13,12 @@
 # in this software or its documentation.
 #
 
-import simplejson as json
 from mock import Mock, NonCallableMock
 from datetime import datetime
 
 from fixture import SubManFixture
 from subscription_manager.validity import ValidProductDateRangeCalculator
+from rhsm import ourjson as json
 import subscription_manager.injection as inj
 
 from rhsm.certificate import GMT


### PR DESCRIPTION
ourjson is just a compability wrapper from python-rhsm
1.10.3 or higher. It will use simplejson if installed,
our the builtin python json if simplejson is not installed.

On RHEL6, simplejson is much faster than the builtin
json module. This lets us choose which dep we want
from the rpm spec.
