### PR TITLE
Removing Error part of message

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -714,7 +714,7 @@ class EnvironmentsCommand(OrgCommand):
                         print columnize(ENVIRONMENT_LIST, _echo, env['name'],
                                 env['description']) + "\n"
                 else:
-                    print _("Error: This org does not have environments.")
+                    print _("This org does not have any environments.")
             else:
                 print _("Error: Server does not support environments.")
 


### PR DESCRIPTION
The return of an empty list of enviroments does not constitute an error.
