### PR TITLE
963579: Stop hiding the Library environment.

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -58,9 +58,6 @@ log = logging.getLogger('rhsm-app.' + __name__)
 
 CFG = config.initConfig()
 
-# An implied Katello environment which we can't actual register to.
-LIBRARY_ENV_NAME = "library"
-
 DONT_CHANGE = -2
 PROGRESS_PAGE = -1
 CHOOSE_SERVER_PAGE = 0
@@ -978,10 +975,7 @@ class AsyncBackend(object):
                          "environment to register with.")
                 retval = []
                 for env in self.backend.cp_provider.get_basic_auth_cp().getEnvironmentList(owner_key):
-                    # We need to ignore the "locker" environment, you can't
-                    # register to it:
-                    if env['name'].lower() != LIBRARY_ENV_NAME.lower():
-                        retval.append(env)
+                    retval.append(env)
                 if len(retval) == 0:
                     raise Exception(_("Server supports environments, but "
                         "none are available."))

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -62,7 +62,6 @@ cfg = rhsm.config.initConfig()
 
 
 NOT_REGISTERED = _("This system is not yet registered. Try 'subscription-manager register --help' for more information.")
-LIBRARY_ENV_NAME = "library"
 
 # Translates the cert sorter status constants:
 STATUS_MAP = {
@@ -690,13 +689,7 @@ class EnvironmentsCommand(OrgCommand):
         self._add_url_options()
 
     def _get_enviornments(self, org):
-        raw_environments = self.cp.getEnvironmentList(org)
-        environments = []
-        # Remove the library environemnt
-        for env in raw_environments:
-            if env['name'].lower() != LIBRARY_ENV_NAME.lower():
-                environments.append(env)
-        return environments
+        return self.cp.getEnvironmentList(org)
 
     def _do_command(self):
         self._validate_options()

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -206,7 +206,7 @@ class TestEnvironmentsCommand(TestCliProxyCommand):
     def test_insecure(self):
         self.cc.main(["--insecure"])
 
-    def test_no_library(self):
+    def test_library_no_longer_filtered(self):
         self.cc.cp = StubUEP()
         environments = []
         environments.append({'name': 'JarJar'})
@@ -215,9 +215,7 @@ class TestEnvironmentsCommand(TestCliProxyCommand):
         environments.append({'name': 'Binks'})
         self.cc.cp.setEnvironmentList(environments)
         results = self.cc._get_enviornments("Anikan")
-        self.assertTrue(len(results) == 2)
-        self.assertTrue(results[0]['name'] == 'JarJar')
-        self.assertTrue(results[1]['name'] == 'Binks')
+        self.assertTrue(len(results) == 4)
 
 
 class TestRegisterCommand(TestCliProxyCommand):


### PR DESCRIPTION
This is no longer desired for Katello/Satellite.
