### PR TITLE
Fix firstboot on Fedora 19.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,9 +154,14 @@ install-files: dbus-service-install compile-po desktop-files install-plugins
 	install -d $(PREFIX)/usr/share/icons/hicolor/32x32/apps
 	install -d $(PREFIX)/usr/share/icons/hicolor/48x48/apps
 	install -d $(PREFIX)/usr/share/icons/hicolor/scalable/apps
-	install -d $(PREFIX)/usr/share/rhn/up2date_client/firstboot/
 	install -d $(PREFIX)/usr/share/rhsm/subscription_manager/gui/firstboot
-	if [ $(OS_VERSION) = 7 ]; then install -d $(PREFIX)/usr/share/firstboot/modules; fi
+
+	# Adjust firstboot screen location for RHEL 6:
+	if [ $(OS_VERSION) = 6 ]; then \
+		install -d $(PREFIX)/usr/share/rhn/up2date_client/firstboot; \
+	else \
+		install -d $(PREFIX)/usr/share/firstboot/modules; \
+	fi; \
 
 	install -d $(PREFIX)/usr/libexec
 	install -m 755 $(DAEMONS_SRC_DIR)/rhsmcertd-worker.py \
@@ -221,11 +226,11 @@ install-files: dbus-service-install compile-po desktop-files install-plugins
 		fi; \
 	fi; \
 
-	# RHEL 7 Customizations:
-	if [ $(OS_VERSION) = 7 ]; then \
-		install -m644 $(SRC_DIR)/gui/firstboot/*.py $(PREFIX)/usr/share/firstboot/modules/;\
-	else \
+	# RHEL 6 Customizations:
+	if [ $(OS_VERSION) = 6 ]; then \
 		install -m644 $(SRC_DIR)/gui/firstboot/*.py $(PREFIX)/usr/share/rhn/up2date_client/firstboot;\
+	else \
+		install -m644 $(SRC_DIR)/gui/firstboot/*.py $(PREFIX)/usr/share/firstboot/modules/;\
 	fi;\
 
 	install -m 644 man/rhn-migrate-classic-to-rhsm.8 $(PREFIX)/$(INSTALL_DIR)/man/man8/

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1,6 +1,7 @@
 # Prefer systemd over sysv on Fedora 17+ and RHEL 7+
 %define use_systemd (0%{?fedora} && 0%{?fedora} >= 17) || (0%{?rhel} && 0%{?rhel} >= 7)
 %define use_dateutil (0%{?fedora} && 0%{?fedora} >= 17) || (0%{?rhel} && 0%{?rhel} >= 6)
+%define use_old_firstboot (0%{?fedora} && 0%{?fedora} <= 18) || (0%{?rhel} && 0%{?rhel} <= 6)
 
 
 %define rhsm_plugins_dir   /usr/share/rhsm-plugins
@@ -105,7 +106,11 @@ subscriptions.
 Summary: Firstboot screens for subscription manager
 Group: System Environment/Base
 Requires: %{name}-gui = %{version}-%{release}
+
+# Required for firstboot before RHEL 7:
+%if %use_old_firstboot
 Requires: rhn-setup-gnome
+%endif
 
 # Fedora can figure this out automatically, but RHEL cannot:
 Requires: librsvg2
@@ -315,11 +320,11 @@ rm -rf %{buildroot}
 
 %files -n subscription-manager-firstboot
 %defattr(-,root,root,-)
-# RHEL7 and beyond:
-%if 0%{?rhel} > 6
-%{_datadir}/firstboot/modules/rhsm_login.py*
-%else
+# RHEL 6 needs a different location for firstboot modules:
+%if %use_old_firstboot
 %{_datadir}/rhn/up2date_client/firstboot/rhsm_login.py*
+%else
+%{_datadir}/firstboot/modules/rhsm_login.py*
 %endif
 
 


### PR DESCRIPTION
Instead of making exceptions for RHEL 7, we switch to this behaviour
being the default going forward, and make exceptions for < RHEL 6 and
Fedora 18.

This is mostly just for developer testing. It may still not work on Fedora 18, though this is unchanged from before.
