### PR TITLE
916666: Displayed 'Next System Check-In' is inaccuarate

### DIFF
--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -131,7 +131,7 @@ r_log (const char *level, const char *message, ...)
 #define error(msg, ...) r_log ("ERROR", msg, ##__VA_ARGS__)
 #define debug(msg, ...) if (show_debug) r_log ("DEBUG", msg, ##__VA_ARGS__)
 
-void
+static gboolean
 log_update (int delay)
 {
 	time_t update = time (NULL);
@@ -149,6 +149,7 @@ log_update (int delay)
 		fprintf (updatefile, "%s", buf);
 		fclose (updatefile);
 	}
+	return TRUE;
 }
 
 /* Handle program signals */

--- a/src/subscription_manager/gui/about.py
+++ b/src/subscription_manager/gui/about.py
@@ -36,6 +36,7 @@ LICENSE = _("\nThis software is licensed to you under the GNU General Public Lic
             "in this software or its documentation.\n")
 
 UPDATE_FILE = '/var/run/rhsm/update'
+LOCK_FILE = '/var/lock/subsys/rhsmcertd'
 
 prefix = os.path.dirname(__file__)
 
@@ -87,7 +88,10 @@ class AboutDialog(object):
 
     def _set_next_update(self, next_update_label):
         try:
-            next_update = long(file(UPDATE_FILE).read())
+            if(os.path.exists(LOCK_FILE)):
+                next_update = long(file(UPDATE_FILE).read())
+            else:
+                next_update = None
         except Exception:
             next_update = None
 


### PR DESCRIPTION
GUI now does not show next checkin time when rhsmcertd is not running
update file is now updated each time the frequency is reached so that the checkin
time in the about pane is correct.
