### PR TITLE
Fix builds on Fedora 18.

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1,7 +1,7 @@
 # Prefer systemd over sysv on Fedora 17+ and RHEL 7+
 %define use_systemd (0%{?fedora} && 0%{?fedora} >= 17) || (0%{?rhel} && 0%{?rhel} >= 7)
 %define use_dateutil (0%{?fedora} && 0%{?fedora} >= 17) || (0%{?rhel} && 0%{?rhel} >= 6)
-%define use_old_firstboot (0%{?fedora} && 0%{?fedora} <= 18) || (0%{?rhel} && 0%{?rhel} <= 6)
+%define use_old_firstboot (0%{?rhel} && 0%{?rhel} <= 6)
 
 
 %define rhsm_plugins_dir   /usr/share/rhsm-plugins


### PR DESCRIPTION
Makefile discrepancy with the spec file if on Fedora 18, should have
been <= Fedora 19 not 18, but lets do what we do in the Makefile instead
and just fork logic if we're specifically on RHEL 6.
