### PR TITLE
Bumping the python-rhsm required version

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -31,7 +31,7 @@ Requires:  python-ethtool
 Requires:  python-iniparse
 Requires:  pygobject2
 Requires:  virt-what
-Requires:  python-rhsm >= 1.10.4
+Requires:  python-rhsm >= 1.10.6
 Requires:  dbus-python
 Requires:  yum >= 3.2.19-15
 Requires:  usermode


### PR DESCRIPTION
Override support is required for the new content
overrides code.
