### PR TITLE
Remove unnecessary network calls after clean command

### DIFF
--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -856,6 +856,8 @@ def clean_all_data(backup=True):
     else:
         shutil.rmtree(consumer_dir, ignore_errors=True)
 
+    require(IDENTITY).reload()
+
     shutil.rmtree(cfg.get('rhsm', 'entitlementCertDir'), ignore_errors=True)
 
     cache.ProfileManager.delete_cache()


### PR DESCRIPTION
The cached identity value was not properly updated when the
clean command was run.  It is being manually reloaded now in
order to stop the compliance manager (CertSorter) from attempting
any network activity.
