### PR TITLE
998033: Handle Unauthorized/Forbidden exceptions in CLI/GUI

### DIFF
--- a/src/subscription_manager/gui/utils.py
+++ b/src/subscription_manager/gui/utils.py
@@ -87,6 +87,10 @@ def handle_gui_exception(e, msg, parent, format_msg=True, log_msg=None):
         # NOTE: yes this looks a lot like the socket error, but I think these
         # were actually intended to display slightly different messages:
         show_error_window(_("Network error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information."), parent=parent)
+    elif isinstance(e, connection.UnauthorizedException):
+        show_error_window(_("Unauthorized: Invalid credentials for request."), parent=parent)
+    elif isinstance(e, connection.ForbiddenException):
+        show_error_window(_("Forbidden: Invalid credentials for request."), parent=parent)
     elif isinstance(e, connection.RemoteServerException):
         # This is what happens when there's an issue with the server on the other side of the wire
         show_error_window(_("Remote server error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information."), parent=parent)

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -154,6 +154,7 @@ def handle_exception(msg, ex):
 
     log.error(msg)
     log.exception(ex)
+
     if isinstance(ex, socket.error) or isinstance(ex, Disconnected):
         print _("Network error, unable to connect to server.")
         print _("Please see /var/log/rhsm/rhsm.log for more information.")
@@ -162,6 +163,12 @@ def handle_exception(msg, ex):
         # NOTE: yes this looks a lot like the socket error, but I think these
         # were actually intended to display slightly different messages:
         print _("Network error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information.")
+        sys.exit(-1)
+    elif isinstance(ex, connection.UnauthorizedException):
+        print _("Unauthorized: Invalid credentials for request.")
+        sys.exit(-1)
+    elif isinstance(ex, connection.ForbiddenException):
+        print _("Forbidden: Invalid credentials for request.")
         sys.exit(-1)
     elif isinstance(ex, connection.RemoteServerException):
         # This is what happens when there's an issue with the server on the other side of the wire


### PR DESCRIPTION
- translate and print messages when caught in CLI
- translate and show messages when caught in GUI

This bug fix was required as we are now handling
AuthenticationException directly in CLI/GUI which
is the base exception for Authentication/Forbidden
exceptions, which would result in a generic message
instead of custom messages per exception type.

Exception handling in CLI/GUI could use some work
to remove the duplication, but that will be left
for another commit.
