### PR TITLE
1031008: Reload identity cert on entitlement/product dir changes

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -249,6 +249,11 @@ class StatusCache(CacheManager):
             self.last_error = ex
             log.error("Bad identity, unable to connect to server")
             return None
+        except connection.AuthenticationException, ex:
+            log.error("Could not authenticate with server, check registration status.")
+            log.exception(ex)
+            self.last_error = ex
+            return None
 
     def to_dict(self):
         return self.server_status

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -28,7 +28,7 @@ from rhsm import ourjson as json
 from subscription_manager.cache import ProfileManager, \
         InstalledProductsManager, EntitlementStatusCache
 from rhsm.profile import Package, RPMProfile
-from rhsm.connection import RestlibException
+from rhsm.connection import RestlibException, UnauthorizedException
 
 
 class _FACT_MATCHER(object):
@@ -316,3 +316,8 @@ class TestEntitlementStatusCache(SubManFixture):
             self.assertEquals(new_status, mock_server_status)
         finally:
             shutil.rmtree(cache_dir)
+
+    def test_unauthorized_exception_handled(self):
+        uep = Mock()
+        uep.getCompliance = Mock(side_effect=UnauthorizedException(401, "GET"))
+        self.assertEquals(None, self.status_cache.load_status(uep, "aaa"))


### PR DESCRIPTION
There seems to be a race condition b/w which directory change
events are fired, so we need to make sure that the identity
is refreshed on each event in cert_sorter.

In the case of this BZ, the GUI heard about the entitlement
directory change before the consumer cert directory change,
and did not have the identity refreshed in time causing the
error.
