### PR TITLE
Use local ent certs to list attached pools

### DIFF
--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -525,8 +525,7 @@ class PoolStash(object):
         return self._filter_pools(incompatible, overlapping, uninstalled, False, text)
 
     def _get_subscribed_pool_ids(self):
-        cp = require(CP_PROVIDER).get_consumer_auth_cp()
-        return [entitlement['pool']['id'] for entitlement in cp.getEntitlementList(self.identity.uuid)]
+        return [ent.pool.id for ent in require(ENT_DIR).list()]
 
     def _filter_pools(self, incompatible, overlapping, uninstalled, subscribed,
             text):


### PR DESCRIPTION
we were using getEntitlementList(uuid) until now, which downloads
the entire list of attached entitlements along with their
certificate and key, as well as pool data.

It is possible for local certificates to be out of sync with the server, but we should probably take care of that instead of using an extra (large) server call to get a list of pool ids
