### PR TITLE
respect http(s)_proxy env variable for proxy information

### DIFF
--- a/src/subscription_manager/cp_provider.py
+++ b/src/subscription_manager/cp_provider.py
@@ -13,7 +13,7 @@
 #
 
 from subscription_manager.certlib import ConsumerIdentity
-from subscription_manager.utils import remove_scheme
+from subscription_manager.utils import remove_scheme, get_env_proxy_info
 import rhsm.connection as connection
 import rhsm.config
 
@@ -57,13 +57,17 @@ class CPProvider(object):
         self.cert_file = ConsumerIdentity.certpath()
         self.key_file = ConsumerIdentity.keypath()
 
+        # get the proxy information from the environment variable
+        # if available
+        info = get_env_proxy_info()
+
         self.server_hostname = host or cfg.get('server', 'hostname')
         self.server_port = ssl_port or cfg.get_int('server', 'port')
         self.server_prefix = handler or cfg.get('server', 'prefix')
-        self.proxy_hostname = proxy_hostname_arg or remove_scheme(cfg.get('server', 'proxy_hostname'))
-        self.proxy_port = proxy_port_arg or cfg.get_int('server', 'proxy_port')
-        self.proxy_user = proxy_user_arg or cfg.get('server', 'proxy_user')
-        self.proxy_password = proxy_password_arg or cfg.get('server', 'proxy_password')
+        self.proxy_hostname = proxy_hostname_arg or remove_scheme(cfg.get('server', 'proxy_hostname')) or info['proxy_hostname']
+        self.proxy_port = proxy_port_arg or cfg.get_int('server', 'proxy_port') or info['proxy_port']
+        self.proxy_user = proxy_user_arg or cfg.get('server', 'proxy_user') or info['proxy_username']
+        self.proxy_password = proxy_password_arg or cfg.get('server', 'proxy_password') or info['proxy_password']
         self.clean()
 
     # Set username and password used for basic_auth without

--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -38,7 +38,7 @@ from subscription_manager.certlib import CertLib
 from subscription_manager.facts import Facts
 from subscription_manager.hwprobe import ClassicCheck
 from subscription_manager import managerlib
-from subscription_manager.utils import get_client_versions, get_server_versions, parse_baseurl_info, restart_virt_who
+from subscription_manager.utils import get_client_versions, get_server_versions, parse_baseurl_info, restart_virt_who, get_env_proxy_info
 
 from subscription_manager.gui import factsgui
 from subscription_manager.gui import messageWindow
@@ -113,12 +113,15 @@ class Backend(object):
 
     def _create_content_connection(self):
         (cdn_hostname, cdn_port, cdn_prefix) = parse_baseurl_info(cfg.get('rhsm', 'baseurl'))
+        # get the proxy info from the env if available
+        info = get_env_proxy_info()
+
         return connection.ContentConnection(host=cdn_hostname,
-                                            ssl_port=cdn_port,
-                                            proxy_hostname=cfg.get('server', 'proxy_hostname'),
-                                            proxy_port=cfg.get_int('server', 'proxy_port'),
-                                            proxy_user=cfg.get('server', 'proxy_user'),
-                                            proxy_password=cfg.get('server', 'proxy_password'))
+                ssl_port=cdn_port,
+                proxy_hostname=cfg.get('server', 'proxy_hostname') or info['proxy_hostname'],
+                proxy_port=cfg.get_int('server', 'proxy_port') or info['proxy_port'],
+                proxy_user=cfg.get('server', 'proxy_user') or info['proxy_username'],
+                proxy_password=cfg.get('server', 'proxy_password') or info['proxy_password'])
 
 
 class MainWindow(widgets.GladeWidget):

--- a/src/subscription_manager/gui/networkConfig.py
+++ b/src/subscription_manager/gui/networkConfig.py
@@ -25,7 +25,7 @@ import rhsm.config
 import rhsm.connection as connection
 
 from subscription_manager.gui.utils import show_error_window
-from subscription_manager.utils import remove_scheme
+from subscription_manager.utils import remove_scheme, get_env_proxy_info
 import subscription_manager.injection as inj
 
 _ = gettext.gettext
@@ -104,9 +104,12 @@ class NetworkConfigDialog:
         self.enable_action(self.xml.get_widget("enableProxyAuthButton"))
         self.enable_action(self.xml.get_widget("enableProxyButton"))
 
+        # get proxy information from env variable if available
+        info = get_env_proxy_info()
+
         # the extra or "" are to make sure we don't str None
-        self.xml.get_widget("proxyUserEntry").set_text(str(self.cfg.get("server", "proxy_user") or ""))
-        self.xml.get_widget("proxyPasswordEntry").set_text(str(self.cfg.get("server", "proxy_password") or ""))
+        self.xml.get_widget("proxyUserEntry").set_text(str(self.cfg.get("server", "proxy_user") or str(info["proxy_username"]) or ""))
+        self.xml.get_widget("proxyPasswordEntry").set_text(str(self.cfg.get("server", "proxy_password") or str(info["proxy_password"]) or ""))
         self.xml.get_widget("connectionStatusLabel").set_label("")
         # If there is no proxy information, disable the proxy test
         # button.

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -52,7 +52,7 @@ from subscription_manager.repolib import RepoLib, RepoFile
 from subscription_manager.utils import remove_scheme, parse_server_info, \
         ServerUrlParseError, parse_baseurl_info, format_baseurl, is_valid_server_info, \
         MissingCaCertException, get_client_versions, get_server_versions, \
-        restart_virt_who, get_terminal_width
+        restart_virt_who, get_terminal_width, get_env_proxy_info
 from subscription_manager.overrides import Overrides, Override
 
 from yum.i18n import utf8_width
@@ -334,11 +334,14 @@ class CliCommand(AbstractCLICommand):
                 print _("cannot parse argument: %s") % arg
             sys.exit(-1)
 
+        # get proxy information from env variable if available
+        info = get_env_proxy_info()
+
         # set proxy before we try to connect to server
-        self.proxy_hostname = remove_scheme(cfg.get('server', 'proxy_hostname'))
-        self.proxy_port = cfg.get_int('server', 'proxy_port')
-        self.proxy_user = cfg.get('server', 'proxy_user')
-        self.proxy_password = cfg.get('server', 'proxy_password')
+        self.proxy_hostname = remove_scheme(cfg.get('server', 'proxy_hostname')) or info['proxy_hostname']
+        self.proxy_port = cfg.get_int('server', 'proxy_port') or info['proxy_port']
+        self.proxy_user = cfg.get('server', 'proxy_user') or info['proxy_username']
+        self.proxy_password = cfg.get('server', 'proxy_password') or info['proxy_password']
 
         self.server_hostname = cfg.get("server", "hostname")
         self.server_port = cfg.get("server", "port")

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -27,7 +27,7 @@ from rhsm.connection import RemoteServerException, RestlibException
 
 from certlib import ActionLock, DataLib
 from certdirectory import Path, ProductDirectory, EntitlementDirectory
-from utils import UnsupportedOperationException
+from utils import UnsupportedOperationException, get_env_proxy_info
 
 log = logging.getLogger('rhsm-app.' + __name__)
 
@@ -291,9 +291,12 @@ class UpdateAction:
     def _set_proxy_info(self, repo):
         proxy = ""
 
-        proxy_host = CFG.get('server', 'proxy_hostname')
+        # get proxy info from env variable if available
+        info = get_env_proxy_info()
+
+        proxy_host = CFG.get('server', 'proxy_hostname') or info['proxy_hostname']
         # proxy_port as string is fine here
-        proxy_port = CFG.get('server', 'proxy_port')
+        proxy_port = CFG.get('server', 'proxy_port') or info['proxy_port']
         if proxy_host != "":
             proxy = "https://%s" % proxy_host
             if proxy_port != "":
@@ -302,8 +305,8 @@ class UpdateAction:
         # These could be empty string, in which case they will not be
         # set in the yum repo file:
         repo['proxy'] = proxy
-        repo['proxy_username'] = CFG.get('server', 'proxy_user')
-        repo['proxy_password'] = CFG.get('server', 'proxy_password')
+        repo['proxy_username'] = CFG.get('server', 'proxy_user') or info['proxy_username']
+        repo['proxy_password'] = CFG.get('server', 'proxy_password') or info['proxy_password']
 
     def join(self, base, url):
         if len(url) == 0:

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import unittest
 import re
 import sys
@@ -159,6 +160,33 @@ class TestCliProxyCommand(TestCliCommand):
         self.assertEquals(type(proxy_url), type(self.cc.options.proxy_url))
         self.assertEquals(proxy_host, self.cc.proxy_hostname)
         self.assertEquals(int(proxy_port), self.cc.proxy_port)
+
+    def test_env_proxy_url(self):
+        os.environ["https_proxy"] = "https://user:pass@example.com:1111"
+        self.cc.main()
+        self.assertEquals("user", self.cc.proxy_user)
+        self.assertEquals("pass", self.cc.proxy_password)
+        self.assertEquals("example.com", self.cc.proxy_hostname)
+        self.assertEquals(1111, self.cc.proxy_port)
+        os.environ.pop("https_proxy")
+
+    def test_env_proxy_url_no_port(self):
+        os.environ["https_proxy"] = "https://user:pass@example.com"
+        self.cc.main()
+        self.assertEquals("user", self.cc.proxy_user)
+        self.assertEquals("pass", self.cc.proxy_password)
+        self.assertEquals("example.com", self.cc.proxy_hostname)
+        self.assertEquals(3128, self.cc.proxy_port)
+        os.environ.pop("https_proxy")
+
+    def test_env_proxy_url_nouser_or_pass(self):
+        os.environ["https_proxy"] = "https://example.com"
+        self.cc.main()
+        self.assertEquals(None, self.cc.proxy_user)
+        self.assertEquals(None, self.cc.proxy_password)
+        self.assertEquals("example.com", self.cc.proxy_hostname)
+        self.assertEquals(3128, self.cc.proxy_port)
+        os.environ.pop("https_proxy")
 
     def test_main_proxy_user(self):
         proxy_user = "buster"


### PR DESCRIPTION
The idea behind this is to allow a user to specify the username/password
and other proxy information in an environment variable instead of
the configuration file. Subscription manager will use the values passed in from
the cli or from the configuration file if present otherwise it will try to use
the http(s)_proxy environment variables. The variables are read in the following
order:

HTTPS_PROXY
https_proxy
HTTP_PROXY
http_proxy

Summary of changes:

```
* updated parse_url to handle username/password
* Add unit tests for parse_util
* added get_env_proxy_info utility method to hide details of
  working with the env variables.
* cp_provider, managergui, managercli, repolib use the new
  utility method.
* rhsm_login and migrate were untouched.
```
## TEST
- setup a squid proxy in a guest to use as a proxy for this test
- on your subscription manager machine do the following:
  - export HTTPS_PROXY=https://username:password@proxyhost:port
  - subscription-manager register

Consumer should be registered.

You can also configure squid to deny all requests and watch subscription-manager fail to register.
