### PR TITLE
Check for RHSM_DISPLAY before loading any modules.

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,2 @@
+import rhsm_display
+rhsm_display.set_display()

--- a/test/test_contract_selection_gui.py
+++ b/test/test_contract_selection_gui.py
@@ -1,9 +1,6 @@
 import unittest
 import datetime
 
-import rhsm_display
-rhsm_display.set_display()
-
 from subscription_manager.gui import contract_selection
 from subscription_manager import isodate
 

--- a/test/test_facts_gui.py
+++ b/test/test_facts_gui.py
@@ -1,8 +1,5 @@
 from fixture import SubManFixture
 
-import rhsm_display
-rhsm_display.set_display()
-
 from subscription_manager.injection import provide, IDENTITY
 from stubs import StubUEP, StubFacts
 from subscription_manager.gui import factsgui

--- a/test/test_gui_utils.py
+++ b/test/test_gui_utils.py
@@ -7,8 +7,6 @@ MIN_GTK_MAJOR = 2
 MIN_GTK_MINOR = 18
 MIN_GTK_MICRO = 0
 
-import rhsm_display
-rhsm_display.set_display()
 
 from subscription_manager.gui import utils
 from subscription_manager.gui import storage

--- a/test/test_handle_gui_exception.py
+++ b/test/test_handle_gui_exception.py
@@ -2,9 +2,6 @@ import unittest
 import socket
 from M2Crypto import SSL
 
-import rhsm_display
-rhsm_display.set_display()
-
 from subscription_manager.gui import utils
 from fixture import FakeException, FakeLogger
 

--- a/test/test_managergui.py
+++ b/test/test_managergui.py
@@ -1,8 +1,5 @@
 import unittest
 
-import rhsm_display
-rhsm_display.set_display()
-
 from fixture import SubManFixture
 import mock
 

--- a/test/test_mysubstab.py
+++ b/test/test_mysubstab.py
@@ -14,9 +14,6 @@
 
 import datetime
 
-import rhsm_display
-rhsm_display.set_display()
-
 from fixture import SubManFixture
 from stubs import StubUEP, StubEntitlementCertificate, \
         StubCertificateDirectory, StubProduct, StubBackend, \

--- a/test/test_network_config_gui.py
+++ b/test/test_network_config_gui.py
@@ -1,8 +1,5 @@
 import unittest
 
-import rhsm_display
-rhsm_display.set_display()
-
 import stubs
 from subscription_manager.gui import networkConfig
 

--- a/test/test_preferences.py
+++ b/test/test_preferences.py
@@ -18,8 +18,6 @@ import mock
 import gtk
 
 import stubs
-import rhsm_display
-rhsm_display.set_display()
 
 from fixture import SubManFixture
 from subscription_manager.injection import require, provide, IDENTITY

--- a/test/test_progress_gui.py
+++ b/test/test_progress_gui.py
@@ -1,8 +1,5 @@
 import unittest
 
-import rhsm_display
-rhsm_display.set_display()
-
 from subscription_manager.gui import progress
 
 

--- a/test/test_registrationgui.py
+++ b/test/test_registrationgui.py
@@ -2,8 +2,6 @@
 from mock import Mock
 
 from fixture import SubManFixture
-import rhsm_display
-rhsm_display.set_display()
 
 from stubs import StubBackend, StubFacts
 from subscription_manager.gui.registergui import RegisterScreen, \

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -14,9 +14,6 @@
 
 import unittest
 
-import rhsm_display
-rhsm_display.set_display()
-
 from subscription_manager.gui.storage import MappedTreeStore, MappedListStore
 
 

--- a/test/test_widgets.py
+++ b/test/test_widgets.py
@@ -17,9 +17,6 @@ import locale
 import gettext
 import unittest
 
-import rhsm_display
-rhsm_display.set_display()
-
 import test_po_files
 
 import gtk


### PR DESCRIPTION
if RHSM_DISPLAY is set to a display number, for example,
and offscreen vncserver, DISPLAY will be set to that
value for the tests, so any windows get displayed
there.
