### PR TITLE
1030604: print to stdout instead of stderr for consistency

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2294,7 +2294,8 @@ class OverrideCommand(CliCommand):
                 if ex.code == 400:
                     # black listed overrides specified.
                     # Print message and return a less severe code.
-                    system_exit(1, ex)
+                    print str(ex)
+                    sys.exit(1)
                 else:
                     raise ex
 


### PR DESCRIPTION
An exit code of 1 should not go to stderr as it is a less
severe error. An attempt to modify a blacklisted override
is not a severe exception, so print the message to stdout
and exit with code 1.
