### PR TITLE
replace file monitors with a single monitor

### DIFF
--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -356,15 +356,13 @@ class CertSorter(ComplianceManager):
         self.load()
         self.notify()
 
-    def on_cert_changed(self, monitor, *changed):
-        # Functions in order corresponding to monitor boolean order
-        changed_functions = [self.on_identity_changed,
-                self.on_ent_dir_changed, self.on_prod_dir_changed]
-
-        # Call correct corresponding on-change functions
-        for (changed, function) in filter(lambda l: l[0] is True,
-                zip(changed, changed_functions)):
-            function()
+    def on_cert_changed(self, monitor, ident_changed, ent_changed, prod_changed):
+        if ident_changed:
+            self.on_identity_changed()
+        if ent_changed:
+            self.on_ent_dir_changed()
+        if prod_changed:
+            self.on_prod_dir_changed()
 
         # Now that local data has been refreshed, updated compliance
         self.on_change()


### PR DESCRIPTION
This allows us to make sure events are fired in the correct order.  If we switch to inotify, we can revert to something similar to the old implementation.
