### PR TITLE
Correct at-spi name for subscription type text

### DIFF
--- a/src/subscription_manager/gui/data/subdetailscontract.glade
+++ b/src/subscription_manager/gui/data/subdetailscontract.glade
@@ -148,7 +148,7 @@
                                 <property name="left_margin">10</property>
                                 <property name="cursor_visible">False</property>
                                 <accessibility>
-                                  <atkproperty name="AtkObject::accessible-name" translatable="yes">Subscription Text</atkproperty>
+                                  <atkproperty name="AtkObject::accessible-name" translatable="yes">Subscription Type Text</atkproperty>
                                 </accessibility>
                               </widget>
                               <packing>


### PR DESCRIPTION
It was originally "Subscription Text" which is a duplicate of an
existing field.
