### PR TITLE
1050850: re-evaluate system facts when checking for updates

### DIFF
--- a/src/subscription_manager/facts.py
+++ b/src/subscription_manager/facts.py
@@ -53,7 +53,7 @@ class Facts(CacheManager):
         # can change constantly on laptops, it makes for a lot of
         # fact churn, so we report it, but ignore it as an indicator
         # that we need to update
-        self.graylist = ['cpu.cpu_mhz']
+        self.graylist = ['cpu.cpu_mhz', 'lscpu.cpu_mhz']
 
         # plugin manager so we can add custom facst via plugin
         self.plugin_manager = require(PLUGIN_MANAGER)
@@ -74,7 +74,8 @@ class Facts(CacheManager):
             return True
 
         cached_facts = self._read_cache() or {}
-        self.facts = self.get_facts()
+        # In order to accurately check for changes, we must refresh local data
+        self.facts = self.get_facts(True)
 
         for key in (set(self.facts) | set(cached_facts)) - set(self.graylist):
             if self.facts.get(key) != cached_facts.get(key):


### PR DESCRIPTION
Checking for updates would be a noop after the first time because
we assumed that system facts would not change very quickly. Now
we check every time has_changed is called to more accurately
determine whether the facts have changed.

Added cpu speed from lscpu to the graylist because it is the
same data we're already graylisting from another source.
