### PR TITLE
914833: rct cat-cert output reports an Order: Subscription: field.

### DIFF
--- a/src/rct/printing.py
+++ b/src/rct/printing.py
@@ -74,7 +74,6 @@ class OrderPrinter(object):
         s.append("\t%s: %s" % (_("RAM Limit"), xstr(order.ram_limit)))
         s.append("\t%s: %s" % (_("Core Limit"), xstr(order.core_limit)))
         s.append("\t%s: %s" % (_("Virt Only"), xstr(order.virt_only)))
-        s.append("\t%s: %s" % (_("Subscription"), xstr(order.subscription)))
         s.append("\t%s: %s" % (_("Stacking ID"), xstr(order.stacking_id)))
         s.append("\t%s: %s" % (_("Warning Period"), xstr(order.warning_period)))
         s.append("\t%s: %s" % (_("Provides Management"), xstr(order.provides_management)))

--- a/test/certdata.py
+++ b/test/certdata.py
@@ -297,7 +297,6 @@ Order:
 	RAM Limit: 
 	Core Limit: 
 	Virt Only: False
-	Subscription: 
 	Stacking ID: 
 	Warning Period: 30
 	Provides Management: 1
@@ -418,7 +417,6 @@ Order:
 	RAM Limit: 
 	Core Limit: 
 	Virt Only: False
-	Subscription: 
 	Stacking ID: 1
 	Warning Period: 30
 	Provides Management: False


### PR DESCRIPTION
What value is actually reported here? As it turns out, that value
is no longer relevant. It has been removed.
