### PR TITLE
1054496: fix url string parsing exception handling on register

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -327,8 +327,8 @@ class CliCommand(AbstractCLICommand):
                  self.server_port,
                  self.server_prefix) = parse_server_info(self.options.server_url)
             except ServerUrlParseError, e:
-                print _("Error parsing serverurl: %s") % e.msg
-                sys.exit(-1)
+                sys.stdout.write(_("Error parsing serverurl: "))
+                handle_exception("Error parsing serverurl: ", e)
 
             # this trys to actually connect to the server and ping it
             try:
@@ -356,8 +356,8 @@ class CliCommand(AbstractCLICommand):
                  baseurl_server_port,
                  baseurl_server_prefix) = parse_baseurl_info(self.options.base_url)
             except ServerUrlParseError, e:
-                print _("Error parsing baseurl: %s") % e.msg
-                sys.exit(-1)
+                sys.stdout.write(_("Error parsing baseurl: "))
+                handle_exception("Error parsing baseurl: ", e)
 
             cfg.set("rhsm", "baseurl", format_baseurl(baseurl_server_hostname,
                                                       baseurl_server_port,


### PR DESCRIPTION
Reproduce with:
(thanks to jsefler)

```
Steps to Reproduce:
[root@jsefler-7 ~]# subscription-manager register --username=testuser1 --password=password --org=admin --baseurl=http//hostname/prefix --force
Error parsing baseurl: None
Expected results:
Error parsing baseurl: Server URL has an invalid scheme. http:// and https:// are supported

[root@jsefler-7 ~]# subscription-manager register --username=testuser1 --password=password --org=admin --baseurl=https:// --force
Error parsing baseurl: None
Expected results:
Error parsing baseurl: Server URL is just a schema. Should include hostname, and/or port and path


[root@jsefler-7 ~]# subscription-manager register --username=testuser1 --password=password --org=admin --baseurl=https://hostname:PORT/prefix --force
Error parsing baseurl: None
Expected results:
Error parsing baseurl: Server URL port should be numeric


[root@jsefler-7 ~]# subscription-manager register --username=testuser1 --password=password --org=admin --serverurl=https:// --force
Error parsing serverurl: None
Expected results:
Error parsing serverurl: Server URL is just a schema. Should include hostname, and/or port and path


[root@jsefler-7 ~]# subscription-manager register --username=testuser1 --password=password --org=admin --serverurl=https://jsefler-f14-7candlepin.usersys.redhat.com:PORT/candlepin --force
Error parsing serverurl: None
Expected results:
Error parsing serverurl: Server URL port should be numeric


[root@jsefler-7 ~]# subscription-manager register --username=testuser1 --password=password --org=admin --serverurl=https:hostname/prefix --force
Error parsing serverurl: None
Expected results:
Error parsing serverurl: Server URL has an invalid scheme. http:// and https:// are supported
```
