### PR TITLE
873967: Move choose server tooltips closer to the elements they assist w...

### DIFF
--- a/src/subscription_manager/gui/data/choose_server.glade
+++ b/src/subscription_manager/gui/data/choose_server.glade
@@ -149,6 +149,7 @@
                 <property name="right_attach">3</property>
                 <property name="top_attach">1</property>
                 <property name="bottom_attach">2</property>
+                <property name="x_options"/>
               </packing>
             </child>
             <child>
@@ -202,8 +203,8 @@
             </child>
           </widget>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="position">1</property>
           </packing>
         </child>
@@ -244,8 +245,8 @@
                         <property name="wrap">True</property>
                       </widget>
                       <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -279,8 +280,8 @@
             </child>
           </widget>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="padding">1</property>
             <property name="position">2</property>
           </packing>


### PR DESCRIPTION
...ith.

Tooltip for the subscription management service text is now closer to the text
itself. Similarly the activation key checkbox tooltip is now _much_ closer,
which hopefully is more clear. The checkbox itself is now centered beneath the
server URI textbox.
