### PR TITLE
973938: correctly handle SIGPIPE in rct

### DIFF
--- a/src/rct/printing.py
+++ b/src/rct/printing.py
@@ -18,6 +18,10 @@ _ = gettext.gettext
 
 from rhsm.certificate2 import EntitlementCertificate, ProductCertificate, IdentityCertificate
 
+# BZ 973938 python doesn't correctly handle SIGPIPE
+import signal
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
 
 # TODO: to be extra paranoid, we could ask to print
 #       the attribute of the object, and handle it


### PR DESCRIPTION
I think this is only a problem in rct cat-cert because we're building a giant string and printing it out at once, it doesn't seem to break lots of separate prints.
