### PR TITLE
1035115: Update product id certs

### DIFF
--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -300,6 +300,20 @@ class ProductConduit(BaseConduit):
         self.product_list = product_list
 
 
+class ProductUpdateConduit(BaseConduit):
+    """Conduit for use with plugins that handle product id update functions."""
+    slots = ['pre_product_id_update', 'post_product_id_update']
+
+    def __init__(self, clazz, product_list):
+        """init for ProductUpdateConduit
+
+        Args:
+            product_list: A list of ProductCertificate objects
+        """
+        super(ProductUpdateConduit, self).__init__(clazz)
+        self.product_list = product_list
+
+
 class FactsConduit(BaseConduit):
     """Conduit for collecting facts."""
     slots = ['post_facts_collection']
@@ -815,7 +829,7 @@ class PluginManager(BasePluginManager):
     def _get_conduits(self):
         """get subscription-manager specific plugin conduits."""
         # we should be able to collect this from the sub classes of BaseConduit
-        return [BaseConduit, ProductConduit,
+        return [BaseConduit, ProductConduit, ProductUpdateConduit,
                 RegistrationConduit, PostRegistrationConduit,
                 FactsConduit, SubscriptionConduit,
                 PostSubscriptionConduit,

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -23,6 +23,7 @@ from subscription_manager.cache import EntitlementStatusCache, ProductStatusCach
         OverrideStatusCache
 from rhsm.certificate import GMT
 from subscription_manager.gui.utils import AsyncWidgetUpdater, handle_gui_exception
+from rhsm.certificate2 import Version
 
 # config file is root only, so just fill in a stringbuffer
 cfg_buf = """
@@ -166,7 +167,9 @@ class StubProductCertificate(ProductCertificate):
             products = products + provided_products
 
         self.name = product.name
-        version = product.version
+
+        # product certs are all version 1.0
+        version = Version("1.0")
 
         # TODO: product should be a StubProduct, check for strings coming in and error out
         self.product = product

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -798,6 +798,12 @@ class TestProductConduit(unittest.TestCase):
         self.assertEquals([], conduit.product_list)
 
 
+class TestProductUpdateConduit(unittest.TestCase):
+    def test_product_update_conduit(self):
+        conduit = plugins.ProductUpdateConduit(StubPluginClass, product_list=[])
+        self.assertEquals([], conduit.product_list)
+
+
 class TestFactsConduit(unittest.TestCase):
     def test_facts_conduit(self):
         conduit = plugins.FactsConduit(StubPluginClass, facts={})


### PR DESCRIPTION
Add support for updating the install product id
certs to newer versions.

productid.py now checks available versions against
installed versions, and compares the certs with
ComparableProductCert and ComparableProduct classes.

Versions newer than installed systems are updated.

Add a "pre_product_id_update" and "post_product_id_update"
plugin slots, and corresponding plugin conduit.

Split installing of new product certs, and updating
old ones so we can have seperate plugins.
wip: add comparable Productid class
