### PR TITLE
857147: Auto-subscribe window has a confusing name

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -184,8 +184,8 @@ class RegisterScreen(widgets.GladeWidget):
             self.register_dialog.set_title(_("System Registration"))
             self.progress_label.set_markup(_("<b>Registering</b>"))
         elif get_state() == SUBSCRIBING:
-            self.register_dialog.set_title(_("System Subscription"))
-            self.progress_label.set_markup(_("<b>Subscribing</b>"))
+            self.register_dialog.set_title(_("Subscription Attachment"))
+            self.progress_label.set_markup(_("<b>Attaching</b>"))
 
     def _set_register_label(self, screen):
         button_label = self._screens[screen].button_label


### PR DESCRIPTION
Pulled out the old finite state machine.
The window and progress bar titles change based on working task.
