### PR TITLE
874169: Fix label alignment in progress UI

### DIFF
--- a/src/subscription_manager/gui/data/registration.glade
+++ b/src/subscription_manager/gui/data/registration.glade
@@ -1,8 +1,9 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glade-interface>
   <!-- interface-requires gtk+ 2.10 -->
   <!-- interface-naming-policy project-wide -->
   <widget class="GtkDialog" id="register_dialog">
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">System Registration</property>
     <property name="resizable">False</property>
@@ -15,97 +16,19 @@
     <accessibility>
       <atkproperty name="AtkObject::accessible-name">register_dialog</atkproperty>
     </accessibility>
-    <signal name="delete_event" handler="on_register_dialog_delete_event"/>
+    <signal name="delete_event" handler="on_register_dialog_delete_event" />
     <child internal-child="vbox">
       <widget class="GtkVBox" id="dialog-vbox6">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="spacing">2</property>
         <accessibility>
           <atkproperty name="AtkObject::accessible-name" translatable="yes">register_dialog_main_vbox</atkproperty>
         </accessibility>
-        <child>
-          <widget class="GtkNotebook" id="register_notebook">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="show_tabs">False</property>
-            <property name="show_border">False</property>
-            <child>
-              <widget class="GtkVBox" id="progressVbox">
-                <property name="visible">True</property>
-                <property name="border_width">25</property>
-                <property name="spacing">7</property>
-                <child>
-                  <widget class="GtkLabel" id="progress_label">
-                    <property name="visible">True</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">&lt;b&gt;Registering&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
-                    <accessibility>
-                      <atkproperty name="AtkObject::accessible-name" translatable="yes">progress_label</atkproperty>
-                    </accessibility>
-                  </widget>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="padding">8</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <widget class="GtkAlignment" id="alignment2">
-                    <property name="visible">True</property>
-                    <property name="xscale">0.75</property>
-                    <child>
-                      <widget class="GtkProgressBar" id="register_progressbar">
-                        <property name="visible">True</property>
-                        <property name="activity_mode">True</property>
-                        <accessibility>
-                          <atkproperty name="AtkObject::accessible-name" translatable="yes">register_progressbar</atkproperty>
-                        </accessibility>
-                      </widget>
-                    </child>
-                  </widget>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <widget class="GtkLabel" id="register_details_label">
-                    <property name="visible">True</property>
-                    <property name="xalign">0.11999999731779099</property>
-                    <property name="use_markup">True</property>
-                    <accessibility>
-                      <atkproperty name="AtkObject::accessible-name" translatable="yes">register_details_label</atkproperty>
-                    </accessibility>
-                  </widget>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-              </widget>
-            </child>
-            <child>
-              <widget class="GtkLabel" id="label2">
-                <property name="visible">True</property>
-                <property name="label" translatable="yes">page 2</property>
-              </widget>
-              <packing>
-                <property name="tab_fill">False</property>
-                <property name="type">tab</property>
-              </packing>
-            </child>
-          </widget>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
           <widget class="GtkHButtonBox" id="dialog-action_area6">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <accessibility>
               <atkproperty name="AtkObject::accessible-name" translatable="yes">registration_dialog_action_area</atkproperty>
@@ -121,7 +44,7 @@
                 <accessibility>
                   <atkproperty name="AtkObject::accessible-name">cancel_button</atkproperty>
                 </accessibility>
-                <signal name="clicked" handler="on_register_cancel_button_clicked"/>
+                <signal name="clicked" handler="on_register_cancel_button_clicked" />
               </widget>
               <packing>
                 <property name="expand">False</property>
@@ -142,7 +65,7 @@
                   <atkproperty name="AtkObject::accessible-name" translatable="yes">register_button</atkproperty>
                   <atkproperty name="AtkObject::accessible-description">register_button</atkproperty>
                 </accessibility>
-                <signal name="clicked" handler="on_register_button_clicked"/>
+                <signal name="clicked" handler="on_register_button_clicked" />
               </widget>
               <packing>
                 <property name="expand">False</property>
@@ -156,6 +79,87 @@
             <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <widget class="GtkNotebook" id="register_notebook">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="show_tabs">False</property>
+            <property name="show_border">False</property>
+            <child>
+              <widget class="GtkVBox" id="progressVbox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">25</property>
+                <property name="spacing">7</property>
+                <child>
+                  <widget class="GtkLabel" id="progress_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">&lt;b&gt;Registering&lt;/b&gt;</property>
+                    <property name="use_markup">True</property>
+                    <accessibility>
+                      <atkproperty name="AtkObject::accessible-name" translatable="yes">progress_label</atkproperty>
+                    </accessibility>
+                  </widget>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="padding">8</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkProgressBar" id="register_progressbar">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="activity_mode">True</property>
+                    <accessibility>
+                      <atkproperty name="AtkObject::accessible-name" translatable="yes">register_progressbar</atkproperty>
+                    </accessibility>
+                  </widget>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkLabel" id="register_details_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="use_markup">True</property>
+                    <accessibility>
+                      <atkproperty name="AtkObject::accessible-name" translatable="yes">register_details_label</atkproperty>
+                    </accessibility>
+                  </widget>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </widget>
+            </child>
+            <child>
+              <widget class="GtkLabel" id="label2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">page 2</property>
+              </widget>
+              <packing>
+                <property name="tab_fill">False</property>
+                <property name="type">tab</property>
+              </packing>
+            </child>
+          </widget>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </widget>


### PR DESCRIPTION
We were doing some funky alignments with the progress
bar widget that were causing different label alignments
as the string length changed.

Removed the glade alignment constraints on the progress
bar and the margin on the label so that everything lines
up as expected.

Previously we had a large left margin on the bar and
label that offset from the bold progess label. I also
removed this so that all 3 widgets align. This looks
a lot better IMO.
