### PR TITLE
Fix ta_IN translation problem.

### DIFF
--- a/po/ta_IN.po
+++ b/po/ta_IN.po
@@ -4178,7 +4178,7 @@ msgstr "<b>நிலை:</b>"
 
 #: ../src/subscription_manager/gui/data/installed.glade.h:3
 msgid "Overall Status"
-msgstr "ஒட்டுமொத்த நிலை: %s\n"
+msgstr "ஒட்டுமொத்த நிலை"
 
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys
 #: ../src/subscription_manager/gui/data/installed.glade.h:5


### PR DESCRIPTION
Looks like "Overall Status" translation was copied from a previous one which was "Overall Status: %s\n". Removed the trailing portion for just the text manually.
