### PR TITLE
1039736: Fix missed reference to CloudForms in tooltip.

### DIFF
--- a/src/subscription_manager/gui/data/choose_server.glade
+++ b/src/subscription_manager/gui/data/choose_server.glade
@@ -50,7 +50,7 @@
                       <widget class="GtkImage" id="image2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="tooltip" translatable="yes">Registering with Customer Portal, Subscription Asset Manager, CloudForms System Engine or Candlepin servers can be used to provide your system with updates and allow management through the selected server's interface.</property>
+                        <property name="tooltip" translatable="yes">Registering with Customer Portal, Subscription Asset Manager, Satellite or Candlepin servers can be used to provide your system with updates and allow management through the selected server's interface.</property>
                         <property name="xalign">1</property>
                         <property name="stock">gtk-info</property>
                       </widget>


### PR DESCRIPTION
Got one in commit 81ec17b88d73425bca79a2911dfa7d1f98282dec, but there was one
more.
