### PR TITLE
995121: require gnome-icon-theme for calendar icon

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -86,6 +86,7 @@ Requires: %{name} = %{version}-%{release}
 Requires: pygtk2 pygtk2-libglade gnome-python2 gnome-python2-canvas
 Requires: usermode-gtk
 Requires: dbus-x11
+Requires: gnome-icon-theme
 Requires(post): scrollkeeper
 Requires(postun): scrollkeeper
 


### PR DESCRIPTION
The icon used for the calendar widget is part of
gnome-icon-theme, which was not a package dep.
