### PR TITLE
1058495: productid yum errors on yum remove

### DIFF
--- a/src/plugins/product-id.py
+++ b/src/plugins/product-id.py
@@ -49,8 +49,12 @@ def posttrans_hook(conduit):
     if hasattr(conduit, 'registerPackageName'):
         conduit.registerPackageName("subscription-manager")
 
-    from subscription_manager.injectioninit import init_dep_injection
-    init_dep_injection()
+    try:
+        from subscription_manager.injectioninit import init_dep_injection
+        init_dep_injection()
+    except ImportError, e:
+        conduit.error(3, str(e))
+        return
 
     logutil.init_logger_for_yum()
     chroot()


### PR DESCRIPTION
If we yum remove subscription-manager, we also remove
the productid yum plugin, which trys to lazy load
subman code and errors. Catch and handle that case.
