### PR TITLE
958016: use rpm %{optflags} and _hardended_build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ EXAMPLE_PLUGINS_SRC_DIR := example-plugins/
 YUM_PLUGINS_SRC_DIR := $(BASE_SRC_DIR)/plugins
 ALL_SRC_DIRS := $(SRC_DIR) $(RCT_SRC_DIR) $(RD_SRC_DIR) $(DAEMONS_SRC_DIR) $(EXAMPLE_PLUGINS_SRC_DIR) $(YUM_PLUGINS_SRC_DIR)
 
-CFLAGS = -Wall -g
+CFLAGS ?= -g -Wall
 
 %.pyc: %.py
 	python -c "import py_compile; py_compile.compile('$<')"

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -6,6 +6,9 @@
 
 %define rhsm_plugins_dir   /usr/share/rhsm-plugins
 
+
+%global _hardened_build 1
+
 # A couple files are for RHEL 5 only:
 %if 0%{?rhel} == 5
 %define el5 1
@@ -140,7 +143,7 @@ subscriptions
 %setup -q
 
 %build
-make -f Makefile
+make -f Makefile CFLAGS="%{optflags}"
 
 %install
 rm -rf %{buildroot}


### PR DESCRIPTION
Use our CFLAGS only if not set in the env, so we default
to the CFLAGS rpm sets.
