### PR TITLE
make sure entitlement has a pool before reading it

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -477,7 +477,8 @@ class PoolTypeCache(object):
             self._do_update()
 
     def requires_update(self):
-        attached_pool_ids = set([ent.pool.id for ent in self.ent_dir.list()])
+        attached_pool_ids = set([ent.pool.id for ent in self.ent_dir.list()
+            if ent.pool and ent.pool.id])
         missing_types = attached_pool_ids - set(self.pooltype_map)
         return bool(missing_types)
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -392,6 +392,15 @@ class TestPoolTypeCache(SubManFixture):
             expected_id = 'poolid' + str(i)
             self.assertEquals('some type', pooltype_cache.get(expected_id))
 
+    def test_requires_update_ents_with_no_pool(self):
+        pooltype_cache = PoolTypeCache()
+        pooltype_cache.ent_dir = self.ent_dir
+        for ent in self.ent_dir.certs:
+            ent.pool = None
+
+        # No ents have pools so there is nothing we can update
+        self.assertFalse(pooltype_cache.requires_update())
+
     def _build_ent_json(self, pool_id, pool_type):
         result = {}
         result['id'] = "1234"


### PR DESCRIPTION
Some v1 certs appear to have a Nonetype pool

```
2014-02-07 17:10:00,323 [DEBUG] subscription-manager-gui @connection.py:450 - Making request: GET /candlepin/status
2014-02-07 17:10:00,333 [DEBUG] subscription-manager-gui @connection.py:473 - Response: status=200, requestUuid=ff8c8dcd-a03e-4f84-bb1e-dd8e210ae779
2014-02-07 17:10:00,333 [DEBUG] subscription-manager-gui @managergui.py:151 - Server Versions: {'candlepin': '0.9.2-1', 'server-type': 'Red Hat Subscription Management'} 
2014-02-07 17:10:00,378 [ERROR] subscription-manager-gui @subscription-manager-gui:205 - 'NoneType' object has no attribute 'id'
Traceback (most recent call last):
  File "/home/ckozak/code/subscription-manager/bin/subscription-manager-gui", line 188, in <module>
    main = managergui.MainWindow(auto_launch_registration=options.register)
  File "/home/ckozak/code/subscription-manager/src/subscription_manager/gui/managergui.py", line 186, in __init__
    prod_dir=self.product_dir)
  File "/home/ckozak/code/subscription-manager/src/subscription_manager/gui/mysubstab.py", line 61, in __init__
    self.pooltype_cache = require(POOLTYPE_CACHE)
  File "/home/ckozak/code/subscription-manager/src/subscription_manager/injection.py", line 98, in require
    return FEATURES.require(feature, *args, **kwargs)
  File "/home/ckozak/code/subscription-manager/src/subscription_manager/injection.py", line 72, in require
    self.providers[feature] = provider()
  File "/home/ckozak/code/subscription-manager/src/subscription_manager/cache.py", line 470, in __init__
    self.update()
  File "/home/ckozak/code/subscription-manager/src/subscription_manager/cache.py", line 476, in update
    if self.requires_update():
  File "/home/ckozak/code/subscription-manager/src/subscription_manager/cache.py", line 485, in requires_update
    attached_pool_ids = set([ent.pool.id for ent in self.ent_dir.list()])
```
