### PR TITLE
1038242: add anaconda.pid check before chroot

### DIFF
--- a/src/plugins/product-id.py
+++ b/src/plugins/product-id.py
@@ -36,7 +36,10 @@ def chroot():
     within an Anaconda installation.
     """
     sysimage = '/mnt/sysimage'
-    if os.path.exists(sysimage):
+    # See rhbz#1038242, try to be more sure we are running in anaconda
+    # before we chroot
+    anaconda_pid = '/var/run/anaconda.pid'
+    if os.path.exists(sysimage) and os.path.exists(anaconda_pid):
         Path.ROOT = sysimage
 
 


### PR DESCRIPTION
The yum plugin 'productid.py' has to detect if it is
running in anaconda or not, so that it will place the
productid file in the correct chroot.

Previusly, this just checked for existince of '/mnt/sysimage'
but that can exist outside of anaconda (or in the original
bug, left over by anaconda). So add a check that
'/var/run/anaconda.pid' exists as well.
