### PR TITLE
Ckozak/scrolling allsubs

### DIFF
--- a/src/subscription_manager/gui/allsubs.py
+++ b/src/subscription_manager/gui/allsubs.py
@@ -42,12 +42,18 @@ class AllSubscriptionsTab(widgets.SubscriptionManagerTab):
                        ['details_box', 'date_picker_hbox',
                         'month_entry', 'day_entry', 'year_entry',
                         'active_on_checkbutton', 'subscribe_button',
-                        'edit_quantity_label', 'no_subs_label',
+                        'edit_quantity_label', 'scrolledwindow',
                         'filter_options_button', 'applied_filters_label']
 
     def __init__(self, backend, facts, parent_win):
 
         super(AllSubscriptionsTab, self).__init__('allsubs.glade')
+
+        # Set up dynamic elements
+        self.no_subs_label, self.no_subs_label_viewport = widgets.get_scrollable_label()
+        self.widget_switcher = widgets.WidgetSwitcher(self.scrolledwindow,
+                self.no_subs_label_viewport, self.top_view)
+        self.widget_switcher.set_active(0)
 
         self.parent_win = parent_win
         self.backend = backend
@@ -170,9 +176,8 @@ class AllSubscriptionsTab(widgets.SubscriptionManagerTab):
         """
         Show a message in situations where we have no subscriptions to show.
         """
-        self.top_view.hide()
         self.no_subs_label.set_markup("<b><big>%s</big></b>" % message)
-        self.no_subs_label.show()
+        self.widget_switcher.set_active(0)
 
     def display_pools(self):
         """
@@ -210,8 +215,7 @@ class AllSubscriptionsTab(widgets.SubscriptionManagerTab):
             return
 
         # Hide the no subscriptions label and show the pools list:
-        self.top_view.show()
-        self.no_subs_label.hide()
+        self.widget_switcher.set_active(1)
 
         sorter = managerlib.MergedPoolsStackingGroupSorter(merged_pools.values())
         for group in sorter.groups:

--- a/src/subscription_manager/gui/data/allsubs.glade
+++ b/src/subscription_manager/gui/data/allsubs.glade
@@ -149,7 +149,7 @@
             <property name="position">2</property>
             <property name="position_set">True</property>
             <child>
-              <widget class="GtkScrolledWindow" id="scrolledwindow1">
+              <widget class="GtkScrolledWindow" id="scrolledwindow">
                 <property name="height_request">125</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -157,48 +157,6 @@
                 <property name="hscrollbar_policy">automatic</property>
                 <property name="vscrollbar_policy">automatic</property>
                 <property name="shadow_type">etched-in</property>
-                <child>
-                  <widget class="GtkViewport" id="viewport1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="shadow_type">none</property>
-                    <child>
-                      <widget class="GtkVBox" id="vbox4">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <widget class="GtkTreeView" id="top_view">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <accessibility>
-                              <atkproperty name="AtkObject::accessible-name" translatable="yes">All Subscriptions View</atkproperty>
-                            </accessibility>
-                          </widget>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <widget class="GtkLabel" id="no_subs_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_markup">True</property>
-                            <accessibility>
-                              <atkproperty name="AtkObject::accessible-name" translatable="yes">no_subs_label</atkproperty>
-                            </accessibility>
-                          </widget>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </widget>
-                    </child>
-                  </widget>
-                </child>
               </widget>
               <packing>
                 <property name="resize">True</property>

--- a/src/subscription_manager/gui/data/repositories.glade
+++ b/src/subscription_manager/gui/data/repositories.glade
@@ -92,58 +92,11 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkScrolledWindow" id="scrolledwindow1">
+              <widget class="GtkScrolledWindow" id="scrolledwindow">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="hscrollbar_policy">automatic</property>
                 <property name="vscrollbar_policy">automatic</property>
-                <child>
-                  <widget class="GtkViewport" id="viewport1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <widget class="GtkVBox" id="treeview_label_container">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <widget class="GtkTreeView" id="overrides_treeview">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <accessibility>
-                              <atkproperty name="AtkObject::accessible-name" translatable="yes">repository_listview</atkproperty>
-                            </accessibility>
-                          </widget>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <widget class="GtkEventBox" id="no_repos_label_container">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <widget class="GtkLabel" id="no_repos_label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">&lt;b&gt;&lt;big&gt;Attached subscriptions do not provide any repositories.&lt;/big&gt;&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
-                                <property name="wrap">True</property>
-                                <property name="wrap_mode">word-char</property>
-                              </widget>
-                            </child>
-                          </widget>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </widget>
-                    </child>
-                  </widget>
-                </child>
               </widget>
               <packing>
                 <property name="expand">True</property>

--- a/src/subscription_manager/gui/widgets.py
+++ b/src/subscription_manager/gui/widgets.py
@@ -139,6 +139,10 @@ class SubscriptionManagerTab(GladeWidget, HasSortableWidget):
         super(SubscriptionManagerTab, self).__init__(glade_file)
         self.content.unparent()
 
+        # In the allsubs tab, we don't show the treeview until it is populated
+        if self.top_view is None:
+            self.top_view = gtk.TreeView()
+
         # grid lines seem busted in rhel5, so we disable
         # in glade and turn on here for unbroken versions
         if gtk.check_version(self.MIN_GTK_MAJOR_GRID,
@@ -859,6 +863,22 @@ class TextTreeViewColumn(gtk.TreeViewColumn):
                                 store['background'])
 
 
+class WidgetSwitcher(object):
+
+    def __init__(self, parent, *widgets):
+        self.container = parent
+        self.widgets = widgets
+
+    def set_active(self, activate_index=0):
+        current_children = self.container.get_children()
+        to_add = self.widgets[activate_index]
+        if to_add not in current_children:
+            for widget in current_children:
+                self.container.remove(widget)
+            self.container.add(to_add)
+        self.container.show_all()
+
+
 def expand_collapse_on_row_activated_callback(treeview, path, view_column):
     """
     A gtk.TreeView callback allowing row expand/collapse on double-click or key
@@ -870,3 +890,14 @@ def expand_collapse_on_row_activated_callback(treeview, path, view_column):
         treeview.expand_row(path, True)
 
     return True
+
+
+def get_scrollable_label():
+    label = gtk.Label()
+    label.set_use_markup(True)
+    label.set_line_wrap(True)
+    label.set_line_wrap_mode(pango.WRAP_WORD)
+    viewport = gtk.Viewport()
+    viewport.add(label)
+    viewport.show_all()
+    return label, viewport


### PR DESCRIPTION
1058383: widgets are added and removed dynamically

This is better than using nested containers and using show/hide
because we allow the GtkTreeView to handle its own scrolling,
while the GtkLabel is handled by a GtkViewPort

With a container housing multiple widgets, one could move the
selected subscription row (with arrow keys) beyond the top or
bottom of the scrollable pane.
