### PR TITLE
1075167: Avoid using injected values in migrate-classic-to-rhsm

### DIFF
--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -42,6 +42,7 @@ if _LIBPATH not in sys.path:
 
 from subscription_manager.certdirectory import ProductDirectory
 from subscription_manager.certlib import ConsumerIdentity
+from subscription_manager.identity import Identity
 from subscription_manager.cli import system_exit
 from subscription_manager.i18n_optparse import OptionParser, \
         USAGE, WrappedIndentedHelpFormatter
@@ -709,7 +710,8 @@ class MigrationEngine(object):
             return
 
         # create and populate the redhat.repo file
-        repolib.RepoLib(uep=self.cp).update()
+        identity = Identity()
+        repolib.RepoLib(uep=self.cp, identity=identity).update()
 
         # read in the redhat.repo file
         repofile = repolib.RepoFile()


### PR DESCRIPTION
I don't think it would be a bad idea to use the injector here (especially because most things are loaded lazily now), but it would be a pretty big code change, and I'd prefer that if we use the injector, we use it for everything it can inject.  I'll probably do that after rhel7.
