### PR TITLE
Use the new Product.brand_name for brand_name

### DIFF
--- a/src/rct/printing.py
+++ b/src/rct/printing.py
@@ -50,6 +50,13 @@ class ProductPrinter(object):
         if hasattr(product, 'brand_type'):
             brand_type = product.brand_type
         s.append("\t%s: %s" % (_("Brand Type"), xstr(brand_type)))
+
+        brand_name = ""
+        if hasattr(product, 'brand_name'):
+            brand_name = product.brand_name
+
+        s.append("\t%s: %s" % (_("Brand Name"), xstr(brand_name)))
+
         return "%s\n" % '\n'.join(s)
 
 

--- a/src/subscription_manager/entbranding.py
+++ b/src/subscription_manager/entbranding.py
@@ -126,7 +126,7 @@ class ProductBrand(Brand):
 
     @classmethod
     def from_product(cls, product):
-        return cls(product.name)
+        return cls(product.brand_name)
 
     @staticmethod
     def format_brand(brand):

--- a/src/subscription_manager/rhelentbranding.py
+++ b/src/subscription_manager/rhelentbranding.py
@@ -81,7 +81,7 @@ class RHELBrandPicker(entbranding.BrandPicker):
         branded_name_set = set([])
         for cert, product in branded_certs:
             # uniq on product id and product name
-            branded_name_set.add(product.name)
+            branded_name_set.add(product.brand_name)
 
         if len(branded_name_set) == 1:
             # all the ent certs provide the same branding info,
@@ -94,7 +94,7 @@ class RHELBrandPicker(entbranding.BrandPicker):
             for branded_cert in branded_certs:
                 log.debug("Entitlement cert %s (%s) provided branded name information for (%s, %s)" %
                             (branded_cert[0].serial, branded_cert[0].order.name,
-                            branded_cert[1].id, branded_cert[1].name))
+                            branded_cert[1].id, branded_cert[1].brand_name))
             return None
 
     def _get_branded_cert_products(self):
@@ -155,7 +155,10 @@ class RHELBrandPicker(entbranding.BrandPicker):
         elif product.brand_type != 'OS':
             return False
 
-        if not product.name:
+        if not hasattr(product, 'brand_name'):
+            return False
+
+        if not product.brand_name:
             return False
 
         return True

--- a/test/certdata.py
+++ b/test/certdata.py
@@ -242,6 +242,7 @@ Product:
 	Arch: ALL
 	Tags: 
 	Brand Type: 
+	Brand Name: 
 
 Product:
 	ID: 37065
@@ -250,6 +251,7 @@ Product:
 	Arch: ALL
 	Tags: 
 	Brand Type: 
+	Brand Name: 
 
 Product:
 	ID: 37067
@@ -258,6 +260,7 @@ Product:
 	Arch: ALL
 	Tags: 
 	Brand Type: 
+	Brand Name: 
 
 Product:
 	ID: 37068
@@ -266,6 +269,7 @@ Product:
 	Arch: ALL
 	Tags: 
 	Brand Type: 
+	Brand Name: 
 
 Product:
 	ID: 37069
@@ -274,6 +278,7 @@ Product:
 	Arch: ALL
 	Tags: 
 	Brand Type: 
+	Brand Name: 
 
 Product:
 	ID: 37070
@@ -282,6 +287,7 @@ Product:
 	Arch: ALL
 	Tags: 
 	Brand Type: 
+	Brand Name: 
 
 Order:
 	Name: Awesome OS Server Bundled
@@ -402,6 +408,7 @@ Product:
 	Arch: x86_64
 	Tags: 
 	Brand Type: 
+	Brand Name: 
 
 Order:
 	Name: Awesome OS for x86_64
@@ -497,6 +504,7 @@ Product:
 	Arch: x86_64
 	Tags: 
 	Brand Type: 
+	Brand Name: 
 
 """
 
@@ -527,7 +535,7 @@ Product:
 	Arch: ALL
 	Tags: 
 	Brand Type: 
-
+	Brand Name: 
 """
 
 IDENTITY_CERT_OUTPUT = """

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -119,7 +119,7 @@ class StubProduct(Product):
 
     def __init__(self, product_id, name=None, version=None,
                  architectures=None, provided_tags=None,
-                 os=None):
+                 os=None, brand_name=None):
 
         # Initialize some defaults:
         if not name:
@@ -138,7 +138,7 @@ class StubProduct(Product):
         super(StubProduct, self).__init__(id=product_id, name=name, version=version,
                                           architectures=architectures,
                                           provided_tags=provided_tags,
-                                          brand_type=os)
+                                          brand_type=os, brand_name=brand_name)
 
 
 class StubContent(Content):


### PR DESCRIPTION
Instead of overloading the Product.name for the
branded name, look for a brand_name attribute and
use that instead.
