### PR TITLE
Fix yum subman plugin RepoActionInvoker error.

### DIFF
--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -65,14 +65,14 @@ def update(conduit, cache_only):
         return
 
     try:
-        uep = connection.UEPConnection(cert_file=cert_file, key_file=key_file)
+        connection.UEPConnection(cert_file=cert_file, key_file=key_file)
     #FIXME: catchall exception
     except Exception:
         # log
         conduit.info(2, "Unable to connect to Subscription Management Service")
         return
 
-    rl = RepoActionInvoker(uep=uep, cache_only=cache_only)
+    rl = RepoActionInvoker(cache_only=cache_only)
     rl.update()
 
 


### PR DESCRIPTION
RepoActionInvoker uses a injected uep, we don't
need to pass it as an arg. Leave the try/except
wrapped creation of one here to determine
if we have connection issues.
