### PR TITLE
1096777: Bad URI for remove by serial

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1543,7 +1543,7 @@ class RemoveCommand(CliCommand):
                     failure = []
                     for serial in self.options.serials:
                         try:
-                            self.cp.unbindBySerial(identity.consumer, serial)
+                            self.cp.unbindBySerial(identity.uuid, serial)
                             success.append(serial)
                         except connection.RestlibException, re:
                             if re.code == 410:


### PR DESCRIPTION
The URI should be built using the consumer UUID. A change elsewhere caused
the identity information dictionary to be used in total. This made the resulting
URI for the command unusable.
