### PR TITLE
1094617: Status line reporting for installed products uses incorrect dat...

### DIFF
--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -13,7 +13,7 @@
 #
 
 from copy import copy
-from datetime import datetime, timedelta
+from datetime import datetime
 import logging
 
 from rhsm.certificate import GMT
@@ -100,10 +100,6 @@ class ComplianceManager(object):
         # Maps product ID to future entitlements.
         self.future_products = {}
 
-        # The first date we're completely invalid from midnight to midnight:
-        # Will be None if we're not currently valid for the date requested.
-        self.first_invalid_date = None
-
         # Reasons that products aren't fully compliant
         self.reasons = Reasons([], self)
         self.supports_reasons = False
@@ -168,8 +164,6 @@ class ComplianceManager(object):
 
         if status['compliantUntil'] is not None:
             self.compliant_until = parse_date(status['compliantUntil'])
-            self.first_invalid_date = self.compliant_until + \
-                    timedelta(seconds=60 * 60 * 24 - 1)
 
         # Lookup product certs for each unentitled product returned by
         # the server:

--- a/src/subscription_manager/gui/installedtab.py
+++ b/src/subscription_manager/gui/installedtab.py
@@ -296,11 +296,11 @@ class InstalledProductsTab(widgets.SubscriptionManagerTab):
 
         if self.backend.cs.system_status == 'valid':
             self._set_status_icons(VALID_STATUS)
-            if self.backend.cs.first_invalid_date:
+            if self.backend.cs.compliant_until:
                 self.subscription_status_label.set_markup(
                         # I18N: Please add newlines if translation is longer:
                         _("System is properly subscribed through %s.") %
-                        managerlib.format_date(self.backend.cs.first_invalid_date))
+                        managerlib.format_date(self.backend.cs.compliant_until))
             else:
                 # No product certs installed, no first invalid date, and
                 # the subscription assistant can't do anything, so we'll disable

--- a/test/test_cert_sorter.py
+++ b/test/test_cert_sorter.py
@@ -198,7 +198,6 @@ class CertSorterTests(SubManFixture):
         self.sorter = CertSorter()
         self.sorter.is_registered = Mock(return_value=True)
         self.assertTrue(self.sorter.compliant_until is None)
-        self.assertTrue(self.sorter.first_invalid_date is None)
 
     def test_compliant_until(self):
         compliant_until = self.sorter.compliant_until
@@ -208,12 +207,6 @@ class CertSorterTests(SubManFixture):
         self.assertEquals(13, compliant_until.hour)
         self.assertEquals(43, compliant_until.minute)
         self.assertEquals(12, compliant_until.second)
-
-    def test_first_invalid_date(self):
-        first_invalid = self.sorter.first_invalid_date
-        self.assertEquals(2013, first_invalid.year)
-        self.assertEquals(4, first_invalid.month)
-        self.assertEquals(27, first_invalid.day)
 
     def test_scan_for_expired_or_future_products(self):
         prod_dir = StubProductDirectory(pids=["a", "b", "c", "d", "e"])


### PR DESCRIPTION
...e

Field first_invalid_date was only used for this field. It was not the
correct date. Removed field altogether.
