### PR TITLE
1076359; Removes the extra l from --remove-all

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -542,7 +542,7 @@ Removes a named override from the repos specified with the
 option
 
 .TP
-.B --remove-alll
+.B --remove-all
 Removes all overrides from repos specified with the
 .B --repo
 option


### PR DESCRIPTION
This fixes the typo by removing the extra l in the subscription manager man page at --remove-all
https://bugzilla.redhat.com/show_bug.cgi?id=1076359
