### PR TITLE
855050: set default fallback window icon

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -62,6 +62,7 @@ _ = gettext.gettext
 gettext.textdomain("rhsm")
 
 gtk.glade.bindtextdomain("rhsm")
+gtk.window_set_default_icon_name("subscription-manager")
 
 log = logging.getLogger('rhsm-app.' + __name__)
 


### PR DESCRIPTION
On older systems, setting the icon on a GtkAboutWindow didn't also set the icon for the license window.

By setting a default, we shouldn't have to worry about this again, and should save ourselves some trouble when we add new windows.
