### PR TITLE
1086377: Next system check-in not displaying in RHEL 5.11

### DIFF
--- a/src/subscription_manager/gui/about.py
+++ b/src/subscription_manager/gui/about.py
@@ -104,9 +104,12 @@ class AboutDialog(object):
             next_update_label.hide()
 
     def _rhsmcertd_on(self):
+        fnull = open(os.devnull, "w")
         try:
-            # if exists [method call returns pid] then true
-            return bool(subprocess.check_output(['pidof', 'rhsmcertd']))
-        except subprocess.CalledProcessError:
-            # if does not exist, returns CalledProcessError
-            return False
+            # if status == 0 then true
+
+            return not subprocess.call(['pidof', 'rhsmcertd'],
+                                       stdout=fnull,
+                                       stderr=fnull)
+        finally:
+            fnull.close()


### PR DESCRIPTION
Call used to determine if rhsmcertd is on worked for RHEL 6 and 7,
but not RHEL 5. Subprocess in Python 2.4 did not have the check_output
method. Subprocess.call gives a consistent answer in all versions. 0 if pidof
has a process number returned and 1 if it does not.
