### PR TITLE
Dgoodwin/container mode

### DIFF
--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -74,6 +74,9 @@ def update(conduit, cache_only):
     else:
         conduit.info(3, "Unable to read consumer identity")
 
+    if config.in_container():
+        conduit.info("Subscription Manager is operating in container mode.")
+
     rl = RepoActionInvoker(cache_only=cache_only)
     rl.update()
 

--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -205,7 +205,6 @@ class ProductDirectory(CertificateDirectory):
         return installed_products
 
 
-
 class EntitlementDirectory(CertificateDirectory):
 
     PATH = cfg.get('rhsm', 'entitlementCertDir')


### PR DESCRIPTION
Allow yum plugin to actually generate redhat.repo in a situation where we have no identity cert, but do have entitlement certs. Disable messaging to tell use to register in this scenario.

subscription-manager CLI completely disabled if in container mode. There is an argument to be made that perhaps some commands might be useful (list --consumed and --installed), but given the goal of not having subscription-manager installed at all (we plan to extract a small library for just yum plugin and repo generation bits), it's probably best to shut it down entirely lest anyone get used to it being there.
