### PR TITLE
Allow tests to run in any TZ

### DIFF
--- a/test/stubs.py
+++ b/test/stubs.py
@@ -229,7 +229,7 @@ class StubEntitlementCertificate(EntitlementCertificate):
             products = products + provided_products
 
         if not start_date:
-            start_date = datetime.now()
+            start_date = datetime.utcnow()
         if not end_date:
             end_date = start_date + timedelta(days=365)
 


### PR DESCRIPTION
### Details

python-rhsm expects entitlement certificate dates to be in UTC
as they are provided from candlepin. Update stub certificates to
use UTC defaults for start/end dates. We should perhaps be
converting our dates to UTC when certs are created (to be
backlogged).

StubEntitlementCertificates were setting the default
start/end dates in localtime which would cause tests
to fail if local TZ was GMT + >= 1 hour.

Certificate.is_valid() compares against UTC now which
fails against a TZ as specified above.
### Notes

Quick reference to change TZ on your test machine.

``` bash
# Make note of current time zone
> ls -al /etc/localtime
lrwxrwxrwx. 1 root root 37 Apr 26  2013 /etc/localtime -> ../usr/share/zoneinfo/America/Halifax

# Change TZ to a broken one
> sudo rm /etc/localtime && sudo ln -s /usr/share/zoneinfo/Europe/Prague /etc/localtime

# Revert to old timezone
> sudo rm /etc/localtime && sudo ln -s <path_to_old_tz> /etc/localtime
```
