### PR TITLE
Fix saving ostree remote configs with gpg set.

### DIFF
--- a/src/subscription_manager/plugin/ostree/config.py
+++ b/src/subscription_manager/plugin/ostree/config.py
@@ -177,7 +177,8 @@ class RepoFile(BaseOstreeConfigFile):
         self.set(section_name, 'url', ostree_remote.url)
 
         if ostree_remote.gpg_verify:
-            self.set(section_name, 'gpg-verify', ostree_remote.gpg_verify)
+            gpg_verify_string = 'true' if ostree_remote.gpg_verify else 'false'
+            self.set(section_name, 'gpg-verify', gpg_verify_string)
         if ostree_remote.tls_client_cert_path:
             self.set(section_name, 'tls-client-cert-path', ostree_remote.tls_client_cert_path)
         if ostree_remote.tls_client_key_path:


### PR DESCRIPTION
Unmap 'gpg-verify' back to "true/false" when saving
ostree repo remote config. Config file is "true/false"
and mapped to bool on read. Creating a remote config
from a Content was passing that bool to config.set.
So Content blobs that actually populate gpgUrl were
failing writing remotes.
