### PR TITLE
1107810: Updates help message for identity --force.

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -575,7 +575,7 @@ class IdentityCommand(UserPassCommand):
         self.parser.add_option("--regenerate", action='store_true',
                                help=_("request a new certificate be generated"))
         self.parser.add_option("--force", action='store_true',
-                               help=_("force certificate regeneration (requires username and password)"))
+                               help=_("force certificate regeneration (requires username and password); Only used with --regenerate"))
 
     def _validate_options(self):
         self.assert_should_be_registered()


### PR DESCRIPTION
Changes help message for subscription manager identity --force to reflect that it is only used with --regenerate.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1107810
