### PR TITLE
Use rhsm.baseurl for ostree urls as well.

### DIFF
--- a/src/subscription_manager/plugin/ostree/config.py
+++ b/src/subscription_manager/plugin/ostree/config.py
@@ -17,8 +17,11 @@ import logging
 import re
 
 from rhsm import config
+from subscription_manager import utils
 
 log = logging.getLogger("rhsm-app." + __name__)
+
+CFG = config.initConfig()
 
 """Ostree has two config files, both based on the freedesktop.org
 Desktop Entry spec. This defines a file format based on "ini" style
@@ -174,7 +177,13 @@ class RepoFile(BaseOstreeConfigFile):
         # format section name
         section_name = 'remote ' + '"%s"' % ostree_remote.name
 
-        self.set(section_name, 'url', ostree_remote.url)
+        # Assume all remotes will share the same baseurl
+        baseurl = CFG.get('rhsm', 'baseurl')
+
+        full_url = utils.url_base_join(baseurl, ostree_remote.url)
+        log.debug("full_url: %s" % full_url)
+
+        self.set(section_name, 'url', full_url)
 
         if ostree_remote.gpg_verify:
             gpg_verify_string = 'true' if ostree_remote.gpg_verify else 'false'

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -22,7 +22,7 @@ import os
 import string
 import subscription_manager.injection as inj
 from subscription_manager.cache import OverrideStatusCache, WrittenOverrideCache
-from urllib import basejoin
+from subscription_manager import utils
 
 from rhsm.config import initConfig
 from rhsm.connection import RemoteServerException, RestlibException
@@ -261,7 +261,8 @@ class RepoUpdateActionCommand(object):
                 repo['enabled'] = "1"
             else:
                 repo['enabled'] = "0"
-            repo['baseurl'] = self.join(baseurl, self._use_release_for_releasever(content.url))
+            repo['baseurl'] = utils.url_base_join(baseurl,
+                                                  self._use_release_for_releasever(content.url))
 
             # Extract the variables from thr url
             repo_parts = repo['baseurl'].split("/")
@@ -275,7 +276,7 @@ class RepoUpdateActionCommand(object):
                 repo['gpgkey'] = ""
                 repo['gpgcheck'] = '0'
             else:
-                repo['gpgkey'] = self.join(baseurl, gpg_url)
+                repo['gpgkey'] = utils.url_base_join(baseurl, gpg_url)
                 # Leave gpgcheck as the default of 1
 
             repo['sslclientkey'] = ent_cert.key_path()
@@ -327,18 +328,6 @@ class RepoUpdateActionCommand(object):
         repo['proxy'] = proxy
         repo['proxy_username'] = CFG.get('server', 'proxy_user')
         repo['proxy_password'] = CFG.get('server', 'proxy_password')
-
-    def join(self, base, url):
-        if len(url) == 0:
-            return url
-        elif '://' in url:
-            return url
-        else:
-            if (base and (not base.endswith('/'))):
-                base = base + '/'
-            if (url and (url.startswith('/'))):
-                url = url.lstrip('/')
-            return basejoin(base, url)
 
     def _build_props(self, old_repo, new_repo):
         result = {}

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -22,6 +22,7 @@ import pprint
 import signal
 import socket
 import syslog
+import urllib
 
 from M2Crypto.SSL import SSLError
 
@@ -89,6 +90,26 @@ def format_baseurl(hostname, port, prefix):
     return "https://%s:%s%s" % (hostname,
                                  port,
                                  prefix)
+
+
+def url_base_join(base, url):
+    """Join a baseurl (hostname) and url (full or relpath).
+
+    If url is a full url, just return it. Otherwise combine
+    it with base, skipping redundant seperators if needed."""
+
+    # I don't really understand this. Why does joining something
+    # potentially non-empty and "" return ""? -akl
+    if len(url) == 0:
+        return url
+    elif '://' in url:
+        return url
+    else:
+        if (base and (not base.endswith('/'))):
+            base = base + '/'
+        if (url and (url.startswith('/'))):
+            url = url.lstrip('/')
+        return urllib.basejoin(base, url)
 
 
 class MissingCaCertException(Exception):

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -206,29 +206,6 @@ class RepoUpdateActionTests(SubManFixture):
         content = update_action.get_unique_content()
         self.assertEquals(3, len(content))
 
-    def test_join(self):
-        base = "http://foo/bar"
-        update_action = RepoUpdateActionCommand()
-        # File urls should be preserved
-        self.assertEquals("file://this/is/a/file",
-            update_action.join(base, "file://this/is/a/file"))
-        # Http locations should be preserved
-        self.assertEquals("http://this/is/a/url",
-            update_action.join(base, "http://this/is/a/url"))
-        # Blank should remain blank
-        self.assertEquals("",
-            update_action.join(base, ""))
-        # Url Fragments should work
-        self.assertEquals("http://foo/bar/baz",
-            update_action.join(base, "baz"))
-        self.assertEquals("http://foo/bar/baz",
-            update_action.join(base, "/baz"))
-        base = base + "/"
-        self.assertEquals("http://foo/bar/baz",
-            update_action.join(base, "baz"))
-        self.assertEquals("http://foo/bar/baz",
-            update_action.join(base, "/baz"))
-
     def test_only_allow_content_of_type_yum(self):
         update_action = RepoUpdateActionCommand()
         content = update_action.get_content(self.stub_ent_cert,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -7,7 +7,7 @@ from rhsm.utils import ServerUrlParseErrorEmpty, \
 from subscription_manager.utils import parse_server_info, \
     parse_baseurl_info, format_baseurl, \
     get_version, get_client_versions, \
-    get_server_versions, Versions, friendly_join, is_true_value
+    get_server_versions, Versions, friendly_join, is_true_value, url_base_join
 
 from rhsm.config import DEFAULT_PORT, DEFAULT_PREFIX, DEFAULT_HOSTNAME, \
     DEFAULT_CDN_HOSTNAME, DEFAULT_CDN_PORT, DEFAULT_CDN_PREFIX
@@ -248,6 +248,81 @@ class TestParseBaseUrlInfo(fixture.SubManFixture):
         self.assertEquals(prefix, DEFAULT_CDN_PREFIX)
         self.assertEquals("https://foo-bar:8088", format_baseurl(hostname, port, prefix))
 
+
+class TestUrlBaseJoinEmptyBase(fixture.SubManFixture):
+
+    def test_blank_base_blank_url(self):
+        self.assertEquals("",
+                          url_base_join("", ""))
+
+    def test_blank_base_url(self):
+        url = "http://foo.notreal/"
+        self.assertEquals(url,
+                          url_base_join("", url))
+
+    def test_blank_base_url_fragment(self):
+        url = "baz"
+        self.assertEquals(url,
+                          url_base_join("", url))
+
+# Not sure this makes sense.
+#    def test_blank_base_url_fragment_slash(self):
+#        url = "/baz"
+#        self.assertEquals(url,
+#                          url_base_join("", url))
+
+
+class TestUrlBaseJoin(fixture.SubManFixture):
+    base = "http://foo/bar"
+
+    def test_file_url(self):
+        # File urls should be preserved
+        self.assertEquals("file://this/is/a/file",
+            url_base_join(self.base, "file://this/is/a/file"))
+
+    def test_http_url(self):
+        # Http locations should be preserved
+        self.assertEquals("http://this/is/a/url",
+            url_base_join(self.base, "http://this/is/a/url"))
+
+    def test_blank_url(self):
+        # Blank should remain blank
+        self.assertEquals("",
+            url_base_join(self.base, ""))
+
+    def test_url_fragments(self):
+        # Url Fragments should work
+        self.assertEquals(self.base + "/baz",
+            url_base_join(self.base, "baz"))
+        self.assertEquals(self.base + "/baz",
+            url_base_join(self.base, "/baz"))
+
+    def test_base_slash(self):
+        base = self.base + '/'
+        self.assertEquals(self.base + "/baz",
+            url_base_join(base, "baz"))
+        self.assertEquals(self.base + "/baz",
+            url_base_join(base, "/baz"))
+
+
+class TestUrlBaseJoinFileUrl(TestUrlBaseJoin):
+    base = "file:///etc"
+
+
+class TestUrlBaseJoinJustHttpScheme(TestUrlBaseJoin):
+    base = "http://"
+
+
+class TestUrlBaseJoinHttps(TestUrlBaseJoin):
+    base = "https://somesecure.cdn.example.notreal"
+
+
+class TestUrlBaseJoinHostname(TestUrlBaseJoin):
+    base = "cdn.redhat.com"
+
+
+class TestUrlBaseJoinDefaultCdn(TestUrlBaseJoin):
+    base = "https://cdn.redhat.com"
 
 NOT_COLLECTED = "non-collected-package"
 


### PR DESCRIPTION
Extract the url join used by repolib into
utils.url_base_join. Add some tests.

Update repolib and ostree/config.py to use.

Note this waits till the last minute to right out
the repo urls as full urls.
