### PR TITLE
Fix odd ostree repo config whitespace issues.

### DIFF
--- a/src/subscription_manager/plugin/ostree/config.py
+++ b/src/subscription_manager/plugin/ostree/config.py
@@ -16,7 +16,14 @@
 import logging
 import re
 
-import iniparse
+# iniparse.utils isn't in old versions
+# but it's always there if ostree is
+iniparse_tidy = None
+try:
+    import iniparse.utils.tidy as iniparse_tidy
+except ImportError:
+    pass
+
 
 from rhsm import config
 from subscription_manager import utils
@@ -93,9 +100,13 @@ class KeyFileConfigParser(config.RhsmConfigParser):
     def has_default(self, section, prop):
         return False
 
-    def save(self, config_file=None):
+    def tidy(self):
         # tidy up config file, rm empty lines, insure newline at eof, etc
-        iniparse.utils.tidy(self)
+        if iniparse_tidy:
+            iniparse_tidy(self)
+
+    def save(self, config_file=None):
+        self.tidy()
 
         self.log_contents()
         log.debug("KeyFile.save %s" % self.config_file)

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -88,6 +88,8 @@ Summary: A plugin for handling OSTree content.
 Group: System Environment/Base
 
 Requires: pygobject3-base
+# plugin needs a slightly newer version of python-iniparse for 'tidy'
+Requires:  python-iniparse >= 0.4
 
 %description -n subscription-manager-plugin-ostree
 Enables handling of content of type 'ostree' in any certificates


### PR DESCRIPTION
Call iniparse's 'tidy' on the config object before
saving it.
