### PR TITLE
1114117: Allow subscriptions to be excluded from rhsm-debug data collection

### DIFF
--- a/src/rhsm_debug/debug_commands.py
+++ b/src/rhsm_debug/debug_commands.py
@@ -60,6 +60,9 @@ class SystemCommand(CliCommand):
         self.parser.add_option("--sos", action='store_true',
                                default=False, dest="sos",
                                help=_("only data not already included in sos report will be collected"))
+        self.parser.add_option("--no-subscriptions", action='store_true',
+                               default=False, dest="nosubs",
+                               help=_("exclude subscription data"))
 
     def _get_usage(self):
         return _("%%prog %s [OPTIONS] ") % self.name
@@ -90,12 +93,12 @@ class SystemCommand(CliCommand):
             self._makedir(content_path)
 
             owner = self.cp.getOwner(consumer.uuid)
-
-            try:
-                self._write_flat_file(content_path, "subscriptions.json",
+            if not self.options.nosubs:
+                try:
+                    self._write_flat_file(content_path, "subscriptions.json",
                                       self.cp.getSubscriptionList(owner['key']))
-            except Exception, e:
-                log.warning("Server does not allow retrieval of subscriptions by owner.")
+                except Exception, e:
+                    log.warning("Server does not allow retrieval of subscriptions by owner.")
 
             self._write_flat_file(content_path, "consumer.json",
                                   self.cp.getConsumer(consumer.uuid))

--- a/test/test_rhsm_debug_command.py
+++ b/test/test_rhsm_debug_command.py
@@ -150,6 +150,39 @@ class TestCompileCommand(TestCliCommand):
         finally:
             shutil.rmtree(path)
 
+    # Runs the non-tar tree creation.
+    # no-subscriptions flag limits included data
+    def test_command_no_subs(self):
+        try:
+            self.cc._do_command = self._orig_do_command
+            self.cc._make_code = self._make_code
+            self.cc._get_assemble_dir = self._get_assemble_dir
+            self.cc._copy_directory = self._copy_directory
+            self.cc._makedir = self._makedir
+            self.test_dir = os.getcwd()
+            path = path_join(self.test_dir, "testing-dir")
+            self.cc.main(["--destination", path, "--no-archive", "--no-subscriptions"])
+        except SystemExit:
+            self.fail("Exception Raised")
+
+        try:
+            tree_path = path_join(path, self.code)
+            self.assertTrue(os.path.exists(path_join(tree_path, "consumer.json")))
+            self.assertTrue(os.path.exists(path_join(tree_path, "compliance.json")))
+            self.assertTrue(os.path.exists(path_join(tree_path, "entitlements.json")))
+            self.assertTrue(os.path.exists(path_join(tree_path, "pools.json")))
+            self.assertTrue(os.path.exists(path_join(tree_path, "version.json")))
+            self.assertFalse(os.path.exists(path_join(tree_path, "subscriptions.json")))
+            self.assertTrue(os.path.exists(path_join(tree_path, "/etc/rhsm")))
+            self.assertTrue(os.path.exists(path_join(tree_path, "/var/log/rhsm")))
+            self.assertTrue(os.path.exists(path_join(tree_path, "/var/lib/rhsm")))
+            # if cert directories are default, these should not be included
+            self.assertTrue(os.path.exists(path_join(tree_path, cfg.get('rhsm', 'productCertDir'))))
+            self.assertTrue(os.path.exists(path_join(tree_path, cfg.get('rhsm', 'entitlementCertDir'))))
+            self.assertTrue(os.path.exists(path_join(tree_path, cfg.get('rhsm', 'consumerCertDir'))))
+        finally:
+            shutil.rmtree(path)
+
     # Test to see that the filter on copy directory properly skips any -key.pem files
     def test_copy_private_key_filter(self):
         path1 = "./test-key-filter"


### PR DESCRIPTION
It is the most time consuming part of the data set. This allows the
rest of the collection to go on without it when not needed.
