### PR TITLE
cleanup and fix gui pool reselection on refresh

### DIFF
--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -174,11 +174,9 @@ class CatManifestCommand(RCTManifestCommand):
 
     def _print_section(self, title, items, indent=1, whitespace=True):
         # Allow a bit of customization of the tabbing
-        pad = ""
-        for x in range(0, indent - 1):
-            pad = pad + "\t"
+        pad = "\t" * (indent - 1)
         print(pad + title)
-        pad = pad + "\t"
+        pad += "\t"
         for item in items:
             if len(item) == 2:
                 print("%s%s: %s" % (pad, item[0], xstr(item[1])))

--- a/src/subscription_manager/gui/storage.py
+++ b/src/subscription_manager/gui/storage.py
@@ -30,14 +30,14 @@ class MappedStore(object):
         specify all keys, and a 'None' value is inserted by default into
         positions that are omitted
         """
-        entry = [None for i in range(self.get_n_columns())]
+        entry = [None] * self.get_n_columns()
 
         for key, value in item_map.iteritems():
             entry[self[key]] = value
         return entry
 
     def __contains__(self, item):
-        return item in self.type_index.keys()
+        return item in self.type_index
 
 
 class MappedListStore(MappedStore, gtk.ListStore):


### PR DESCRIPTION
When the pool list was refreshed in the gui, we did not re-select
the old pool if it was part of a stack (child row)
