### PR TITLE
1054632: Adds '7.x' to how to launch section of manual.

### DIFF
--- a/docs/subscription-manager.xml
+++ b/docs/subscription-manager.xml
@@ -230,7 +230,7 @@
 		<tertiary>launching Red Hat Subscription Manager</tertiary>
 	</indexterm>
 			<para>
-				Red Hat Subscription Manager is listed as one of the administrative tools in the <guimenu>System =&gt; Administration</guimenu> menu in 6.x and in the <guimenuitem>Applications =&gt; System Tools</guimenuitem> menu in 5.x.
+				Red Hat Subscription Manager is listed as one of the administrative tools in the <guimenu>System =&gt; Administration</guimenu> menu in 6.x and in the <guimenuitem>Applications =&gt; System Tools</guimenuitem> menu in 5.x and 7.x.
 			</para>
 			<para>
 				Alternatively, the Red Hat Subscription Manager GUI can be opened from the command line with a single command:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1054632
