### PR TITLE
1114132: subman-gui and other tools are disabled in container mode.

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -29,6 +29,7 @@ import webbrowser
 
 import gtk
 import gtk.glade
+import sys
 
 import rhsm.config as config
 
@@ -135,6 +136,11 @@ class MainWindow(widgets.GladeWidget):
                  ent_dir=None, prod_dir=None,
                  auto_launch_registration=False):
         super(MainWindow, self).__init__('mainwindow.glade')
+
+        # Essentially same solution as in the managercli.
+        if config.in_container():
+            sys.stderr.write(_("subscription-manager is disabled when running inside a container. Please refer to your host system for subscription management.\n"))
+            sys.exit(-1)
 
         self.backend = backend or Backend()
         self.identity = require(IDENTITY)

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -136,6 +136,11 @@ class UserCredentials(object):
 
 class MigrationEngine(object):
     def __init__(self):
+
+        # Essentially same solution as in the managercli.
+        if rhsm.config.in_container():
+            sys.stderr.write(_("rhn-migrate-classic-to-rhsm is disabled when running inside a container. Please refer to your host system for subscription management.\n"))
+            sys.exit(-1)
         self.rhncfg = initUp2dateConfig()
         self.rhsmcfg = rhsm.config.initConfig()
 

--- a/test/test_managergui.py
+++ b/test/test_managergui.py
@@ -2,6 +2,8 @@ import unittest
 
 from fixture import SubManFixture
 import mock
+from mock import patch
+import sys
 
 import stubs
 from subscription_manager.gui import managergui, registergui
@@ -29,6 +31,19 @@ class TestManagerGuiMainWindow(SubManFixture):
         managergui.MainWindow(backend=stubs.StubBackend(), facts=stubs.StubFacts(),
                               ent_dir=stubs.StubCertificateDirectory([]),
                               prod_dir=stubs.StubProductDirectory([]))
+
+    @patch('subscription_manager.gui.managergui.config.in_container')
+    def test_gui_in_container_error_message(self, mock_in_container):
+        sys.stderr = stubs.MockStderr()
+        mock_in_container.return_value = True
+        err_msg = 'subscription-manager is disabled when running inside a container.'\
+                  ' Please refer to your host system for subscription management.\n'
+        try:
+            managergui.MainWindow()
+        except SystemExit, e:
+            self.assertEquals(-1, e.code)
+        self.assertEquals(err_msg, sys.stderr.buffer)
+        sys.stderr = sys.__stderr__
 
 
 class TestRegisterScreen(unittest.TestCase):

--- a/test/test_migration.py
+++ b/test/test_migration.py
@@ -114,6 +114,19 @@ class TestMigration(fixture.SubManFixture):
         patch.stopall()
         sys.stderr = sys.__stderr__
 
+    @patch('subscription_manager.migrate.migrate.rhsm.config.in_container')
+    def test_migrate_in_container_error_message(self, mock_in_container):
+        sys.stderr = stubs.MockStderr()
+        mock_in_container.return_value = True
+        err_msg = 'rhn-migrate-classic-to-rhsm is disabled when running inside a container.' \
+        ' Please refer to your host system for subscription management.\n'
+        try:
+            migrate.MigrationEngine().main()
+        except SystemExit, e:
+            self.assertEquals(-1, e.code)
+        self.assertEquals(err_msg, sys.stderr.buffer)
+        sys.stderr = sys.__stderr__
+
     def test_mutually_exclusive_options(self):
         try:
             self.engine.main(["--no-auto", "--servicelevel", "foo"])


### PR DESCRIPTION
The following list of tools have been made to write "[tool name] is disabled when running inside a container. Please refer to your host system for subscription management.\n" to stderr and exit(-1):
- subscription-manager-gui
- rhsmcertd
- rhn-migrate-classic-to-rhsm

bz: https://bugzilla.redhat.com/show_bug.cgi?id=1114132
