### PR TITLE
don't query envs when actkey is given

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1127,6 +1127,12 @@ class RegisterCommand(UserPassCommand):
     def _get_environment_id(self, cp, owner_key, environment_name):
         # If none specified on CLI and the server doesn't support environments,
         # return None, the registration method will skip environment specification.
+
+        # Activation keys may not be used with environment for registration.
+        # We use a no-auth cp, so we cannot look up environment ids by name
+        if self.options.activation_keys:
+            return None
+
         supports_environments = cp.supports_resource('environments')
         if not environment_name:
             if supports_environments:

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -126,6 +126,8 @@ class CliRegistrationTests(SubManFixture):
         cp.supports_resource = Mock(return_value=True)
 
         rc = RegisterCommand()
+        rc.options = Mock()
+        rc.options.activation_keys = None
         env_id = rc._get_environment_id(cp, 'owner', None)
 
         expected = None
@@ -140,6 +142,8 @@ class CliRegistrationTests(SubManFixture):
         cp.supports_resource = Mock(return_value=True)
 
         rc = RegisterCommand()
+        rc.options = Mock()
+        rc.options.activation_keys = None
         env_id = rc._get_environment_id(cp, 'owner', None)
 
         expected = "1234"
@@ -155,6 +159,8 @@ class CliRegistrationTests(SubManFixture):
         cp.supports_resource = Mock(return_value=True)
 
         rc = RegisterCommand()
+        rc.options = Mock()
+        rc.options.activation_keys = None
         rc._prompt_for_environment = Mock(return_value="othername")
         env_id = rc._get_environment_id(cp, 'owner', None)
 
@@ -174,6 +180,8 @@ class CliRegistrationTests(SubManFixture):
         cp.supports_resource = Mock(return_value=True)
 
         rc = RegisterCommand()
+        rc.options = Mock()
+        rc.options.activation_keys = None
         rc._prompt_for_environment = Mock(return_value="not_an_env")
         try:
             rc._get_environment_id(cp, 'owner', None)


### PR DESCRIPTION
Causes problems with sam/sat.  We can't access environment list with a no-auth connection.
