### PR TITLE
1128061: Stop logging expected exceptions on unreg

### DIFF
--- a/src/subscription_manager/identity.py
+++ b/src/subscription_manager/identity.py
@@ -139,9 +139,8 @@ class Identity(object):
         # XXX shouldn't catch the global exception here, but that's what
         # existsAndValid did, so this is better.
         except Exception, e:
-            # FIXME: can probably remove this exception logging
-            log.exception(e)
-            log.info("Error reading consumer identity cert")
+            log.debug("Reload of consumer identity cert %s raised an exception with msg: %s",
+                      ConsumerIdentity.certpath(), e)
             self.consumer = None
             self.name = None
             self.uuid = None

--- a/test/test_entcertlib.py
+++ b/test/test_entcertlib.py
@@ -25,6 +25,14 @@ from subscription_manager import entcertlib
 from subscription_manager import injection as inj
 
 
+class TestDisconnected(SubManFixture):
+    def test_repr(self):
+        # no err_msg, so empty repr
+        discon = entcertlib.Disconnected()
+        err_msg = "%s" % discon
+        self.assertEquals("", err_msg)
+
+
 class TestingUpdateAction(entcertlib.EntCertUpdateAction):
 
     def __init__(self):


### PR DESCRIPTION
This log.exception() is information, but also unneeded.
On a reload, a missing cert is a valid case, so stop
cluttering the logs.
