### PR TITLE
1130637: Correct call to os.path.isfile

### DIFF
--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -546,7 +546,7 @@ class MigrationEngine(object):
         #Hack to address BZ 853233
         product_dir = inj.require(inj.PROD_DIR)
         if os.path.isfile(os.path.join(product_dir.path, "68.pem")) and \
-            os.path.isfile(os.path.join(product_dir.path), "71.pem"):
+            os.path.isfile(os.path.join(product_dir.path, "71.pem")):
             try:
                 os.remove(os.path.join(product_dir.path, "68.pem"))
                 self.db.delete("68")


### PR DESCRIPTION
The unit tests missed this issue because by default Mock does not
verify the method signatures of the calls to the mock object are valid.
The solution to this problem is to use Mock's autospec functionality.
See http://www.voidspace.org.uk/python/mock/helpers.html#auto-speccing
