### PR TITLE
1123029: Use default product certs if present.

### DIFF
--- a/test/stubs.py
+++ b/test/stubs.py
@@ -325,6 +325,11 @@ class StubProductDirectory(StubCertificateDirectory, ProductDirectory):
                 certificates.append(StubProductCertificate(StubProduct(pid)))
         super(StubProductDirectory, self).__init__(certificates)
 
+    # real version just calls refresh on it's set of ProductDirs, that don't
+    # exist here, so this needs to be stubbed.
+    def refresh(self):
+        pass
+
 
 class StubConsumerIdentity(object):
     CONSUMER_NAME = "John Q Consumer"


### PR DESCRIPTION
In addition to the prodCertDir (/etc/pki/product),
we also check for product id cert in
/etc/pki/product-default.

/etc/pki/product-default will include product
certificates installed as part of the
base os install. In contrast to /etc/pki/product
which contains product certs that originate in
the yum repo metadata, and are installed when
rpms from that repo are installed.

For yum repos that do not include the productid
repodata (for example, created from a local
mirror with createrepo), product ids would
not be installed from anaconda, making it difficult
to later attach those systems to the proper
subscriptions. Now, for os installs, the approriate
product id cert will be installed in /etc/pki/product-default
as part of base system rpm installed by anaconda.

certdirectory.ProductDirectory is now a composition of two
ProductCertificateDirectories, one for /etc/pki/product,
one for /etc/pki/product-default

The Directory.list() results for the two are aggregated.

Note the order of the result matters, and if the list()
entries have dupes, the later values "win". Product ids
in "/etc/pki/product" will override those in
"/etc/pki/product-default" if there are duplicates.
