### PR TITLE
1131213: rhn-migrate-classic-to-rhsm now prefers --serverurl input over ...

### DIFF
--- a/src/subscription_manager/cp_provider.py
+++ b/src/subscription_manager/cp_provider.py
@@ -88,6 +88,9 @@ class CPProvider(object):
     def get_consumer_auth_cp(self):
         if not self.consumer_auth_cp:
             self.consumer_auth_cp = connection.UEPConnection(
+                    host=self.server_hostname,
+                    ssl_port=self.server_port,
+                    handler=self.server_prefix,
                     proxy_hostname=self.proxy_hostname,
                     proxy_port=self.proxy_port,
                     proxy_user=self.proxy_user,
@@ -98,6 +101,9 @@ class CPProvider(object):
     def get_basic_auth_cp(self):
         if not self.basic_auth_cp:
             self.basic_auth_cp = connection.UEPConnection(
+                    host=self.server_hostname,
+                    ssl_port=self.server_port,
+                    handler=self.server_prefix,
                     proxy_hostname=self.proxy_hostname,
                     proxy_port=self.proxy_port,
                     proxy_user=self.proxy_user,
@@ -109,6 +115,9 @@ class CPProvider(object):
     def get_no_auth_cp(self):
         if not self.no_auth_cp:
             self.no_auth_cp = connection.UEPConnection(
+                    host=self.server_hostname,
+                    ssl_port=self.server_port,
+                    handler=self.server_prefix,
                     proxy_hostname=self.proxy_hostname,
                     proxy_port=self.proxy_port,
                     proxy_user=self.proxy_user,

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -343,7 +343,6 @@ class CliCommand(AbstractCLICommand):
             except ServerUrlParseError, e:
                 print _("Error parsing serverurl:")
                 handle_exception("Error parsing serverurl:", e)
-
             # this trys to actually connect to the server and ping it
             try:
                 if not is_valid_server_info(self.server_hostname,
@@ -361,7 +360,8 @@ class CliCommand(AbstractCLICommand):
             cfg.set("server", "hostname", self.server_hostname)
             cfg.set("server", "port", self.server_port)
             cfg.set("server", "prefix", self.server_prefix)
-
+            if self.server_port:
+                self.server_port = int(self.server_port)
             config_changed = True
 
         if hasattr(self.options, "base_url") and self.options.base_url:


### PR DESCRIPTION
...subman config files.

With these changes I was able to migrate a RHRL6.6 box from rhn classic to rhsm as dscribed by jsefler at the link below.

bz: https://bugzilla.redhat.com/show_bug.cgi?id=1131213
