### PR TITLE
1132919: Repo dialog information is updated without the need for a gui r...

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -221,6 +221,8 @@ class MainWindow(widgets.GladeWidget):
             self.my_subs_tab.update_subscriptions()
             # Update main window
             self.refresh()
+            # Reset repos dialog, see bz 1132919
+            self.repos_dialog = RepositoriesDialog(self.backend, self._get_window())
 
         self.backend.cs.add_callback(on_cert_change)
 


### PR DESCRIPTION
...estart.

Recreates the repos_dialog object on cert change to ensure the information is displayed properly.
