### PR TITLE
1128658: do not contact RHN if unregistered

### DIFF
--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -118,7 +118,7 @@ class RepoUpdateActionCommand(object):
 
         self.release = None
         self.overrides = {}
-        self.override_supported = bool(self.uep and self.uep.supports_resource('content_overrides'))
+        self.override_supported = bool(self.identity.is_valid() and self.uep and self.uep.supports_resource('content_overrides'))
         self.written_overrides = WrittenOverrideCache()
 
         # FIXME: empty report at the moment, should be changed to include


### PR DESCRIPTION
when running 'yum --disablerepo=* makecache' we shouldn't attempt to contact
RHN. We were always making a call to get overrides which doesn't make sense if
we are not registered.
## TEST
- install this patched version of subsription-manager on RHEL 6.6
- install `wireshark`
- open 2 terminals 
- in one terminal run wireshark: `tshark -f 'dst host subscription.rhn.redhat.com'`
- in the other run `yum --disablerepo=\* makecache`
- There should be NO traffic in the wireshark terminal.
