### PR TITLE
1128061: Don't raise logged Disconnected on unreg

### DIFF
--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -226,7 +226,10 @@ class EntCertUpdateAction(object):
 
         identity = inj.require(inj.IDENTITY)
         if not identity.is_valid():
-            raise Disconnected()
+            # We can get here on unregister, with no id or ent certs or repos,
+            # but don't want to raise an exception that would be logged. So
+            # empty result set is returned.
+            return results
 
         reply = self.uep.getCertificateSerials(identity.uuid)
         for d in reply:


### PR DESCRIPTION
BaseActionInvoker handles and logs any exceptions
raise from *certlib actions. For unregister, when we
run the UnregisterAction, we have already deleted
id cert, ent certs, repos, so we would always raise
Disconnected, and then it would get logged.

In either cause, entcertlib's actions don't do much,
so just return empty results instead of raising an
exception that gets logged.
