### PR TITLE
1134963: Fix 'release --list' on some systems.

### DIFF
--- a/src/subscription_manager/release.py
+++ b/src/subscription_manager/release.py
@@ -148,9 +148,12 @@ class CdnReleaseVersionProvider(object):
     def _build_listing_path(self, content_url):
         listing_parts = content_url.split('$releasever', 1)
         listing_base = listing_parts[0]
-        listing_path = "%s/listing" % listing_base
+        listing_path = u"%s/listing" % listing_base
         # FIXME: cleanup paths ("//"'s, etc)
-        return listing_path
+
+        # Make sure content URLS are encoded to the default utf8
+        # as unicode strings aren't valid. See rhbz#1134963
+        return listing_path.encode()
 
     # require tags provided by installed products?
 

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -17,7 +17,6 @@ import StringIO
 from rhsm import config
 import random
 import mock
-import simplejson as json
 import tempfile
 
 from subscription_manager.cert_sorter import CertSorter
@@ -28,6 +27,8 @@ from subscription_manager.lock import ActionLock
 from rhsm.certificate import GMT
 from subscription_manager.gui.utils import AsyncWidgetUpdater, handle_gui_exception
 from rhsm.certificate2 import Version
+
+from rhsm import ourjson as json
 
 # config file is root only, so just fill in a stringbuffer
 cfg_buf = """


### PR DESCRIPTION
Encode the url path we request the release 'listing'
file from unicode. Depending if 'python-simplejson'
is installed, the Content.url str could be a 'str' or
a 'unicode'. The unicode string is not valid for
inclusion in an URL. This was causing failed GET
requests to the CDN, resulting in 'release --list'
return no results after a 20s timeout.

The exception from the timeout was causing a
httplib.BadStatusLine exception to be logged.

python-simplejson defaults to decoding any
json strings that can be represented as 'str'
to 'str' vs 'unicode'. The default 'json' decoder
always returns unicode strings.

For performance reasons, we attempt to use
python-simplejson if installed, but it is
not a package dep. If it's not installed, the
'release --list' command would fail.
