### PR TITLE
Include ppc64le in list of archs to skip dmi

### DIFF
--- a/src/subscription_manager/hwprobe.py
+++ b/src/subscription_manager/hwprobe.py
@@ -111,7 +111,7 @@ class Hardware:
         self.prefix = prefix or ''
         self.testing = testing or False
 
-        self.no_dmi_arches = ['s390x', 'ppc64', 'ppc']
+        self.no_dmi_arches = ['s390x', 'ppc64', 'ppc64le', 'ppc']
         # we need this so we can decide which of the
         # arch specific code bases to follow
         self.arch = self.get_arch()


### PR DESCRIPTION
That needs to get flipped to a DMI whitelist.
