### PR TITLE
1119648: Added additional functionality to repo listing.

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -164,7 +164,7 @@ _subscription_manager_release()
 
 _subscription_manager_repos()
 {
-  local opts="--disable --enable --list
+  local opts="--disable --enable --list --list-enabled --list-disabled
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -1,4 +1,4 @@
-.TH subscription-manager 8 "January 29, 2014" "version 2.8" "Subscription Management"  Deon Lackey 
+.TH subscription-manager 8 "January 29, 2014" "version 2.8" "Subscription Management"  Deon Lackey
 .SH NAME
 subscription-manager \- Registers systems to a subscription management service and then attaches and manages subscriptions for software products.
 
@@ -467,6 +467,14 @@ command lists all of the repositories that are available to a system. This comma
 .TP
 .B --list
 Lists all of the repositories that are provided by the content service used by the system.
+
+.TP
+.B --list-enabled
+Lists all of the enabled repositories that are provided by the content service used by the system.
+
+.TP
+.B --list-disabled
+Lists all of the disabled repositories that are provided by the content service used by the system.
 
 .TP
 .B --enable=REPO_ID


### PR DESCRIPTION
Added the --list-enabled and --list-disabled options for explicitly
specifying only enabled or disabled repos. --list now acts as a
shorthand for specifying both.
