### PR TITLE
1122001: Reg with --consumerid no longer checks subscription status

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1094,15 +1094,14 @@ class RegisterCommand(UserPassCommand):
             autosubscribe(self.cp, consumer['uuid'],
                     service_level=self.options.service_level)
 
-        subscribed = 0
-        if (self.options.consumerid or self.options.activation_keys or
-                self.autoattach):
-
+        if (self.options.consumerid or self.options.activation_keys or self.autoattach):
             log.info("System registered, updating entitlements if needed")
             # update certs, repos, and caches.
             # FIXME: aside from the overhead, should this be cert_action_client.update?
             self.entcertlib.update()
 
+        subscribed = 0
+        if (self.options.activation_keys or self.autoattach):
             # update with latest cert info
             self.sorter = inj.require(inj.CERT_SORTER)
             self.sorter.force_cert_check()


### PR DESCRIPTION
This also addresses bug 1145835 in which the registration was erroneously
reporting a failure when using --consumerid without --autosubscribe or
--auto-attach.
