### PR TITLE
1120576: Added additional testing of version parsing

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -392,6 +392,34 @@ class TestGetServerVersions(fixture.SubManFixture):
 
     @patch('rhsm.connection.UEPConnection')
     @patch('subscription_manager.utils.ClassicCheck')
+    def test_get_server_versions_cp_with_status_bad_data(self, mock_classic, MockUep):
+        instance = mock_classic.return_value
+        instance.is_registered_with_classic.return_value = False
+        self._inject_mock_valid_consumer()
+        MockUep.supports_resource.return_value = True
+
+        dataset = [
+            {'version': None, 'release': '123'},
+            {'version': 123, 'release': '123'},
+
+            {'version': '123', 'release': None},
+            {'version': '123', 'release': 123},
+
+            {'version': None, 'release': None},
+            {'version': None, 'release': 123},
+            {'version': 123, 'release': None},
+            {'version': 123, 'release': 123},
+        ]
+
+        for value in dataset:
+            MockUep.getStatus.return_value = value
+            sv = get_server_versions(MockUep)
+            self.assertEquals(sv['server-type'], 'Red Hat Subscription Management')
+            self.assertEquals(sv['candlepin'], 'Unknown')
+            self.assertEquals(sv['rules-version'], 'Unknown')
+
+    @patch('rhsm.connection.UEPConnection')
+    @patch('subscription_manager.utils.ClassicCheck')
     def test_get_server_versions_cp_with_status_and_classic(self, mock_classic, MockUep):
         instance = mock_classic.return_value
         instance.is_registered_with_classic.return_value = True


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1120576

It looks like the root problem exists outside the scope of SM and/or has been handled by a prior update. From what I can tell, the version info is just passed through as it is received from the server. That said, aside from doing things which don't seem very "pythonic" (ie: type checking), there's not a whole lot more we can do to catch bad data being sent by the server.

In any event, I've added additional tests which should test any type reasonable to see in a JSON blob. The version concatenation will still throw an exception, but it's already being explicitly handled/expected and logged and is doing so by design.
