### PR TITLE
1122530: Improved grammar and abbreviation usage.

### DIFF
--- a/man/rhn-migrate-classic-to-rhsm.8
+++ b/man/rhn-migrate-classic-to-rhsm.8
@@ -21,7 +21,7 @@
 rhn-migrate-classic-to-rhsm \- Migrates a system profile from Red Hat Network Classic Hosted to Customer Portal Subscription Management (hosted) or Subscription Asset Manager (on-premise).
 
 .SH SYNOPSIS
-rhn-migrate-classic-to-rhsm [--force] | [--gui] | [--no-auto] | [--servicelevel=SERVICE_LEVEL] | [--serverurl=URL] | [--org=ORG] | [--environment=ENVIRONMEN] | [--no-proxy] | [--help]
+rhn-migrate-classic-to-rhsm [--force] | [--no-auto] | [--service-level=SERVICE_LEVEL] | [--destination-url=URL] | [--legacy-user=LEGACY_USER] | [--legacy-password=LEGACY_PASSWORD] | [-destination-user=DESTINATION_USER] | [--destination-password=DESTINATION_PASSWORD] | [--org=ORG] | [--environment=ENVIRONMENT] | [--no-proxy] | [--help]
 
 .SH DESCRIPTION
 \fBrhn-migrate-classic-to-rhsm\fP migrates a system profile which is registered with Red Hat Network Classic to Customer Portal Subscription Management. This is intended for migrating from the host service, not for migrating from a Satellite system.
@@ -30,19 +30,19 @@ rhn-migrate-classic-to-rhsm [--force] | [--gui] | [--no-auto] | [--servicelevel=
 This script migrates configuration, from a channel-based subscription framework to a certificate-based subscription framework. While the \fBrhn-migrate-classic-to-rhsm\fP script performs the migration operation, the data used to map the channels to the corresponding product certificates is defined in the \fBsubscription-manager-migration-data\fP package. The \fBsubscription-manager-migration-data\fP package must be installed before the \fBrhn-migrate-classic-to-rhsm\fP script can be run successfully.
 
 .SH BACKGROUND
-Access to support and updates for products is determined through 
+Access to support and updates for products is determined through
 .I subscriptions.
-Subscriptions are attached to a system, which means that the system has the right to install and update a product with full support. Subscriptions for an entire account are tracked through a 
+Subscriptions are attached to a system, which means that the system has the right to install and update a product with full support. Subscriptions for an entire account are tracked through a
 .I subscription management service.
 
 .PP
 With the channel-based framework, a subscription management service was either an on-premise Satellite or hosted Red Hat Network Classic. With the new certificate-based subscriptions, the subscription management service is either Customer Portal Subscription Management or Subscription Asset Manager. The differences between the two types of subscription management services are described in this Knowledgebase article: <https://access.redhat.com/knowledge/articles/63269>
 
 .PP
-The system registers with the subscription management service and receives an inventory ID number. When subscriptions are attached to a system, that association is noted in the subscription management service. 
+The system registers with the subscription management service and receives an inventory ID number. When subscriptions are attached to a system, that association is noted in the subscription management service.
 
 .PP
-Registering with a subscription management service is exclusive. If a system is registered with Red Hat Network Classic, it cannot simultaneously be registered with Customer Portal Subscription Management. The 
+Registering with a subscription management service is exclusive. If a system is registered with Red Hat Network Classic, it cannot simultaneously be registered with Customer Portal Subscription Management. The
 .B rhn-migrate-classic-to-rhsm
 tool is provided specifically so that there is a way to transition from the deprecated Red Hat Network Classic to Customer Portal Subscription Management or an on-premise Subscription Asset Manager.
 
@@ -56,21 +56,12 @@ Prints the specific help information for the given command.
 Ignore channels not available through Customer Portal Subscription Management (or Subscription Asset Manager). The channels in Red Hat Network Classic are mapped to the product certificates used by the Customer Portal Subscription Management. However, not every channel has a certificate mapping, which can cause errors during migration. Using this option skips any channels which are not mapped to Customer Portal Subscription Management.
 
 .TP
-.B -g, --gui
-Opens the Subscription Manager UI so that administrators can manually select which subscriptions to apply to the 
-system rather than automatically applying best-matched subscriptions based on the existing channel subscriptions.
-
-.TP
 .B -n, --no-auto
 Deletes the system from Red Hat Network Classic and registers it to Customer Portal Subscription Management, but does not attach any subscriptions to the system.
 
 .TP
-.B -s SERVICE_LEVEL, --servicelevel=SERVICE_LEVEL
-Sets a preferred service level for the system, such as premium or standard. This service level preference is then used as one of the criteria for autoattaching subscriptions to the system.
-
-.TP
-.B --serverurl=URL
-Gives the URL of the subscription management service to which to register the system. This is used for environments which have an on-premise subscription management service such as Subscription Asset Manager. If no URL is given, the migration tool uses the Customer Portal Subscription Management Service. 
+.B -s SERVICE_LEVEL, --service-level=SERVICE_LEVEL
+Sets a preferred service level for the system, such as premium or standard. This service level preference is then used as one of the criteria for auto-attaching subscriptions to the system.
 
 .TP
 .B --org=ORG
@@ -83,6 +74,26 @@ Sets which environment within the organization the system belongs to. Every acco
 .TP
 .B --no-proxy
 Disables or ignores any previous RHN proxy settings when migrating to the new subscription management service.
+
+.TP
+.B --legacy-user=LEGACY_USER
+Specifies the user name on the legacy server.
+
+.TP
+.B --legacy-password=LEGACY_PASSWORD
+Specifies the password for the user on the legacy server.
+
+.TP
+.B --destination-url=URL
+Specifies the URL of the subscription management service to which to register the system. This is used for environments which have an on-premise subscription management service such as Subscription Asset Manager. If no URL is given, the migration tool uses the Customer Portal Subscription Management Service.
+
+.TP
+.B --destination-user=DESTINATION_USER
+Specifies the user name on the destination server.
+
+.TP
+.B --destination-password=DESTINATION_PASSWORD
+Specifies the password for the user on the destination server.
 
 .SH USAGE
 The migration process moves the system from the inventory in one subscription management service (Red Hat Network Classic) to the new subscription management service (Customer Portal Subscription Management), and then re-applies the subscriptions to the system. The script runs through these steps:
@@ -103,12 +114,10 @@ The migration process moves the system from the inventory in one subscription ma
 5. Unregister from Red Hat Network Classic.
 
 .IP
-6. Register with Customer Portal Subscription Management and autoattach the best-matched subscriptions. (Alternatively, the 
-.B --gui
-option can be used to launch the Subscription Manager UI to attach subscriptions manually.)
+6. Register with Customer Portal Subscription Management and auto-attach the best-matched subscriptions.
 
 .PP
-After migration, the system facts maintained by Subscription Manager display what script was used for migration and what the previous system ID was. 
+After migration, the system facts maintained by Subscription Manager display what script was used for migration and what the previous system ID was.
 .nf
 [root@server ~]# subscription-manager facts --list | grep migr
 migration.classic_system_id: 09876
@@ -118,7 +127,7 @@ migration.migration_date: 2012-09-14T14:55:29.280519
 .fi
 
 .SS MIGRATION AND AUTOSUBSCRIBE
-The \fBrhn-migrate-classic-to-rhsm\fP tool, by default, autoattaches the best-matching subscriptions to the system. This allows migrations to be automated.
+The \fBrhn-migrate-classic-to-rhsm\fP tool, by default, auto-attaches the best-matching subscriptions to the system. This allows migrations to be automated.
 .nf
 [root@server ~]# rhn-migrate-classic-to-rhsm
 Red Hat account: jsmith@example.com
@@ -156,10 +165,10 @@ Please visit https://access.redhat.com/management/consumers/abcd1234 to view the
 The script prompts for a username and password to use to register the system; this same account is used to authenticate with both Red Hat Network Classic and Customer Portal Subscription Management.
 
 .PP
-Optionally, the \fB--servicelevel\fP argument sets an SLA preference to use with the system. The SLA associated with a subscription is then evaluated when determining what subscriptions to autoattach to the system, along with other factors like installed products, existing channel assignments, and architecture.
+Optionally, the \fB--service-level\fP argument sets an SLA preference to use with the system. The SLA associated with a subscription is then evaluated when determining what subscriptions to auto-attach to the system, along with other factors like installed products, existing channel assignments, and architecture.
 
 .nf
-[root@server ~]# rhn-migrate-classic-to-rhsm --servicelevel=premium
+[root@server ~]# rhn-migrate-classic-to-rhsm --service-level=premium
 Red Hat account: jsmith@example.com
 Password:
 .fi
@@ -168,50 +177,18 @@ Password:
 The \fBrhn-migrate-classic-to-rhsm\fP tool migrates the system to Customer Portal Subscription Management (hosted) services by default. This uses the default configuration for Subscription Manager, which points to the subscription management services for the Customer Portal. For infrastructures which have an on-premise subscription management service such as Subscription Asset Manager, this configuration can be changed so that the migration process registers the systems to the on-premise subscription management service and attaches the appropriate subscriptions.
 
 .PP
-This is done by using the \fB--serverurl\fP option, which specifies the URL of the on-premise service. In this case, the authorization credentials must also be given for the on-premise subscription management service account (which is independent of the RHN account).
+This is done by using the \fB--destination-url\fP option, which specifies the URL of the on-premise service. In this case, the authorization credentials must also be given for the on-premise subscription management service account (which is independent of the RHN account).
 
 .nf
-[root@server ~]# rhn-migrate-classic-to-rhsm --serverurl=sam.example.com
+[root@server ~]# rhn-migrate-classic-to-rhsm --destination-url=sam.example.com
 Red Hat account: jsmith@example.com
 Password:
-.fi
-
-.SS MIGRATION AND MANUALLY SELECTING SUBSCRIPTIONS
-The \fB--no-auto\fP option prevents the autoattach step from running. The \fB--gui\fP option not only prevents autoattach from running, it automatically opens the Subscription Manager GUI so that administrators can attach subscriptions to the system.
-
-.PP
-As with the autoattach process, the script prompts for the RHN username and password for the user.
-
-.nf
-[root@server ~]# rhn-migrate-classic-to-rhsm --gui 
-Red Hat account: jsmith@example.com
-Password:
-
-Retrieving existing RHN Classic subscription information ...
-+----------------------------------+
-System is currently subscribed to:
-+----------------------------------+
-rhel-i386-client-5
-
-List of channels for which certs are being copied
-rhel-i386-client-5
-
-Product Certificates copied successfully to /etc/pki/product !!
-
-Preparing to unregister system from RHN Classic ...
-System successfully unregistered from RHN Classic.
-
-Attempting to register system to RHN ...
-The system has been registered with id: abcd1234
-System server.example.com successfully registered to RHN.
-
-Launching the GUI tool to manually subscribe the system ...
 .fi
 
 .SH FILES
 
 .IP \fI/etc/sysconfig/rhn/systemid\fP
-The digital server ID for this machine if the system has been registered with Red Hat Network Classic. 
+The digital server ID for this machine if the system has been registered with Red Hat Network Classic.
 This file does not exist otherwise.
 
 .IP \fI/etc/sysconfig/rhn/up2date\fP
@@ -241,5 +218,5 @@ This script is part of the Red Hat Subscription Manager tool. Report bugs to <ht
 Copyright \(co 2012 Red Hat, Inc.
 
 .PP
-This is free software; see the source for copying conditions.  There is 
+This is free software; see the source for copying conditions.  There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/man/sat5to6.8
+++ b/man/sat5to6.8
@@ -21,11 +21,11 @@
 sat5to6 \- Migrates a system profile from Red Hat Satellite v.5 to Red Hat Satellite v.6 as part of the Satellite Transition process.
 
 .SH SYNOPSIS
-sat5to6 [--destination-user=DESTINATION_USER] | [--destination-password=DESTINATION_PASSWORD] | [--destination-url=URL] | [--legacy-user=LEGACY_USER] | [--legacy-password=LEGACY_PASSWORD] | [--no-auto] | [--no-proxy] | [--registration-state=STATE] | [--servicelevel=SERVICE_LEVEL] | [--help]
+sat5to6 [--destination-user=DESTINATION_USER] | [--destination-password=DESTINATION_PASSWORD] | [--destination-url=URL] | [--legacy-user=LEGACY_USER] | [--legacy-password=LEGACY_PASSWORD] | [--no-auto] | [--no-proxy] | [--registration-state=STATE] | [--service-level=SERVICE_LEVEL] | [--help]
 
 .SH DESCRIPTION
 \fBsat5to6\fP migrates a system profile which is registered to a Red Hat Satellite v.5 instance to a Red Hat Satellite v.6 instance.
-The tool assumes that the command \fBhammer import content-host\fP has run successfully on the Satellite v.6 installation, that a content-host for the client where \fBsat5to6\fP is to be executed has been created, and that the resulting RPM has been built and installed on the Satellite v.5 host that the client is subscribed to.
+The tool assumes that the command \fBhammer import content-host\fP has run successfully on the Satellite v.6 installation, that a content-host for the client where \fBsat5to6\fP is to be executed has been created, and that the resulting RPM has been built and installed on the Satellite v.5 host to which the client is subscribed.
 
 .PP
 This script queries the Satellite v.5 instance to which it is registered for information about the channels to which it is subscribed, and the content-host UUID to which it should re-attach in Satellite v.6.
@@ -61,7 +61,7 @@ Print the specific help information for the command.
 Do not attempt to automatically attach subscriptions to the associated content-host in the Satellite v.6 instance.
 
 .TP
-.B -s SERVICE_LEVEL, --servicelevel=SERVICE_LEVEL
+.B -s SERVICE_LEVEL, --service-level=SERVICE_LEVEL
 Set a preferred service level for the system, such as premium or standard.
 This service level preference is then used as one of the criteria for autoattaching subscriptions to the system.
 
@@ -230,7 +230,7 @@ System 'URI:CN=system-fqdn' successfully registered.
 \fBsat5to6\fP prompts for usernames and passwords if not provided on the command-line.
 
 .PP
-Optionally, the \fB--servicelevel\fP argument sets an SLA preference to use with the system.
+Optionally, the \fB--service-level\fP argument sets an SLA preference to use with the system.
 The SLA associated with a subscription is then evaluated when determining what subscriptions to autoattach to the system, along with other factors like installed products, existing channel assignments, and architecture.
 
 .SH FILES

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -13,7 +13,7 @@ is a client program that registers a system with a subscription management servi
 .PP
 Red Hat provides content updates and support by issuing
 .I subscriptions
-for its products. These subscriptions are applied to systems; once a subscription for a product is attached to a system, that system allowed to install, update, and receive support for that software product. IT administrators need to track these subscriptions and how they are attached. This subscription management is a feature available for Red Hat platforms version 5.7 (and later) and version 6.1 (and later).
+for its products. These subscriptions are applied to systems; once a subscription for a product is attached to a system, that system is allowed to install, update, and receive support for that software product. IT administrators need to track these subscriptions and how they are attached. This subscription management is a feature available for Red Hat platforms version 5.7 (and later) and version 6.1 (and later).
 
 .PP
 For RHEL systems, content is delivered through the Red Hat Customer Portal. Subscriptions and systems are managed globally through the Red Hat subscription management service, which is integrated with the Customer Portal. Subscriptions are managed for the local system by using the Red Hat Subscription Manager tool. Subscription Manager is a local client which connects a system with the subscription management service.
@@ -164,7 +164,7 @@ Gives the user account password.
 
 .TP
 .B --serverurl=SERVER_HOSTNAME
-Passes the name of the subscription service to register the system with. The default value, if this is not given, is the Customer Portal Subscription Management service,
+Passes the name of the subscription service with which to register the system. The default value, if this is not given, is the Customer Portal Subscription Management service,
 .B subscription.rhn.redhat.com.
 If there is an on-premise subscription service such as Subscription Asset Manager, this parameter can be used to submit the hostname of the subscription service. For Subscription Asset Manager, if the Subscription Manager tool is configured with the Subscription Asset Manager RPM, then the default value for the
 .B --serverurl
@@ -539,25 +539,25 @@ The repository to modify (can be specified more than once)
 
 .TP
 .B --add=NAME:VALUE
-Adds a named override with the provided value to repos specified with the
+Adds a named override with the provided value to repositories specified with the
 .B --repo
 option
 
 .TP
 .B --remove=NAME
-Removes a named override from the repos specified with the
+Removes a named override from the repositories specified with the
 .B --repo
 option
 
 .TP
 .B --remove-all
-Removes all overrides from repos specified with the
+Removes all overrides from repositories specified with the
 .B --repo
 option
 
 .TP
 .B --list
-Lists all overrides from repos specified with the
+Lists all overrides from repositories specified with the
 .B --repo
 option
 
@@ -763,7 +763,7 @@ makes it easier for network administrators to maintain parity between software s
 .SS REGISTERING AND UNREGISTERING MACHINES
 A system is either
 .I registered
-to a subscription management service -- which makes all of the subscriptions available to the system -- or it is not registered. Unregistered systems necessarily lack valid software subscriptions because there is no way to record that the subscriptions have been used or to renew them.
+to a subscription management service -- which makes all of the subscriptions available to the system -- or it is not registered. Unregistered systems necessarily lack valid software subscriptions because there is no way to record that the subscriptions have been used nor any way to renew them.
 
 .PP
 The default subscription management service in the Subscription Manager configuration is the Customer Portal Subscription Management service. The configuration file can be edited before the system is registered to point to an on-premise subscription management service like Subscription Asset Manager.

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1840,19 +1840,19 @@ class ReposCommand(CliCommand):
 
         self.parser.add_option("--list",
                                action="callback", callback=list_callback, dest="list", default=False,
-                               help=_("list all known repos for this system"))
+                               help=_("list all known repositories for this system"))
         self.parser.add_option("--list-enabled",
                                action="callback", callback=list_callback, dest="list_enabled", default=False,
-                               help=_("list known, enabled repos for this system"))
+                               help=_("list known, enabled repositories for this system"))
         self.parser.add_option("--list-disabled",
                                action="callback", callback=list_callback, dest="list_disabled", default=False,
-                               help=_("list known, disabled repos for this system"))
+                               help=_("list known, disabled repositories for this system"))
         self.parser.add_option("--enable", dest="enable", type="str",
                                action='callback', callback=repo_callback, metavar="REPOID",
-                               help=_("repo to enable (can be specified more than once). Wildcards (* and ?) are supported."))
+                               help=_("repository to enable (can be specified more than once). Wildcards (* and ?) are supported."))
         self.parser.add_option("--disable", dest="disable", type="str",
                                action='callback', callback=repo_callback, metavar="REPOID",
-                               help=_("repo to disable (can be specified more than once). Wildcards (* and ?) are supported."))
+                               help=_("repository to disable (can be specified more than once). Wildcards (* and ?) are supported."))
 
     def _validate_options(self):
         if not (self.options.list or hasattr(self.options, 'repo_actions')):
@@ -1919,8 +1919,8 @@ class ReposCommand(CliCommand):
             matches = set([repo for repo in repos if fnmatch.fnmatch(repo.id, repoid)])
             if not matches:
                 rc = 1
-                print _("Error: %s is not a valid repo ID. "
-                        "Use --list option to see valid repos.") % repoid
+                print _("Error: %s is not a valid repository ID. "
+                        "Use --list option to see valid repositories.") % repoid
 
             # Overwrite repo if it's already in the dict, we want the last
             # match to be the one sent to server.
@@ -1958,9 +1958,9 @@ class ReposCommand(CliCommand):
         for repo in repos_to_modify:
             # Watchout for string comparison here:
             if repos_to_modify[repo] == "1":
-                print _("Repo '%s' is enabled for this system.") % repo.id
+                print _("Repository '%s' is enabled for this system.") % repo.id
             else:
-                print _("Repo '%s' is disabled for this system.") % repo.id
+                print _("Repository '%s' is disabled for this system.") % repo.id
         return rc
 
 

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -787,7 +787,7 @@ def add_parser_options(parser, five_to_six_script=False):
         help=_("don't execute the auto-attach option while registering with subscription manager"))
     parser.add_option("-s", "--service-level",
         help=_("service level to follow when attaching subscriptions, for no service "
-            "level use --servicelevel=\"\""))
+            "level use --service-level=\"\""))
     # See BZ 915847 - some users want to connect to RHN with a proxy but to RHSM without a proxy
     parser.add_option("--no-proxy", action="store_true", dest='noproxy',
         help=_("don't use legacy proxy settings with destination server"))
@@ -820,7 +820,7 @@ def add_parser_options(parser, five_to_six_script=False):
 def validate_options(options):
     if options.service_level and not options.auto:
         # TODO Need to explain why this restriction exists.
-        system_exit(1, _("The --servicelevel and --no-auto options cannot be used together."))
+        system_exit(1, _("The --service-level and --no-auto options cannot be used together."))
 
 
 def is_hosted():


### PR DESCRIPTION
Made some changes to the man pages and some displayed strings to improve
the grammar and reduce the usage of select abbreviations and terms.

Additionally, the man pages for the rhn-migrate-classic-to-rhsm and
sat5to6.8 have been updated to reflect changes to the options and
functionality (bug 1145828).
