### PR TITLE
Added client-side support for --matches on the list command.

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -103,6 +103,7 @@ _subscription_manager_list()
   local opts="--all --available --consumed --installed
               --ondate --servicelevel
               --match-installed --no-overlap
+              --matches
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -430,6 +430,13 @@ Shows only subscriptions matching products that are currently installed; only us
 .B --available
 option.
 
+.TP
+.B --matches=SEARCH
+Limits the output of --installed, --available and --consumed to only subscriptions or products which contain SEARCH in the subscription or product information, varying with the list requested and the server version.
+.br
+SEARCH may contain the wildcards ? or * to match a single character or zero or more characters, respectively. The wildcard characters may be escaped with a backslash to represent a literal
+question mark or asterisk. Likewise, to represent a backslash, it must be escaped with another backslash.
+
 .SS REFRESH OPTIONS
 The
 .B refresh

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -31,7 +31,7 @@ from subscription_manager.cert_sorter import StackingGroupSorter, ComplianceMana
 from subscription_manager import identity
 from subscription_manager.facts import Facts
 from subscription_manager.injection import require, CERT_SORTER, \
-        PRODUCT_DATE_RANGE_CALCULATOR, IDENTITY, ENTITLEMENT_STATUS_CACHE, \
+        IDENTITY, ENTITLEMENT_STATUS_CACHE, \
         PROD_STATUS_CACHE, ENT_DIR, PROD_DIR, CP_PROVIDER, OVERRIDE_STATUS_CACHE, \
         POOLTYPE_CACHE
 from subscription_manager import isodate
@@ -75,39 +75,6 @@ def persist_consumer_cert(consumerinfo):
     log.info("Consumer created: %s" % consumer_info)
     system_log("Registered system with identity: %s" % consumer.getConsumerId())
     return consumer_info
-
-
-def get_installed_product_status(product_directory, entitlement_directory, uep):
-    """
-     Returns the Installed products and their subscription states
-    """
-    product_status = []
-
-    sorter = require(CERT_SORTER)
-
-    calculator = require(PRODUCT_DATE_RANGE_CALCULATOR, uep)
-    for installed_product in sorter.installed_products:
-        product_cert = sorter.installed_products[installed_product]
-        for product in product_cert.products:
-            begin = ""
-            end = ""
-            prod_status_range = calculator.calculate(product.id)
-            if prod_status_range:
-                # Format the date in user's local time as the date
-                # range is returned in GMT.
-                begin = format_date(prod_status_range.begin())
-                end = format_date(prod_status_range.end())
-            data = (product.name,
-                    installed_product,
-                    product.version,
-                    ",".join(product.architectures),
-                    sorter.get_status(product.id),
-                    sorter.reasons.get_product_reasons(product),
-                    begin,
-                    end)
-            product_status.append(data)
-
-    return product_status
 
 
 class CertificateFetchError(Exception):
@@ -290,7 +257,7 @@ class PoolFilter(object):
         return filtered_pools
 
 
-def list_pools(uep, consumer_uuid, facts, list_all=False, active_on=None):
+def list_pools(uep, consumer_uuid, facts, list_all=False, active_on=None, filter_string=None):
     """
     Wrapper around the UEP call to fetch pools, which forces a facts update
     if anything has changed before making the request. This ensures the
@@ -304,15 +271,16 @@ def list_pools(uep, consumer_uuid, facts, list_all=False, active_on=None):
 
     owner = uep.getOwner(consumer_uuid)
     ownerid = owner['key']
+
     return uep.getPoolsList(consumer=consumer_uuid, listAll=list_all,
-            active_on=active_on, owner=ownerid)
+            active_on=active_on, owner=ownerid, filter_string=filter_string)
 
 
 # TODO: This method is morphing the actual pool json and returning a new
 # dict which does not contain all the pool info. Not sure if this is really
 # necessary. Also some "view" specific things going on in here.
 def get_available_entitlements(facts, get_all=False, active_on=None,
-        overlapping=False, uninstalled=False, text=None):
+        overlapping=False, uninstalled=False, text=None, filter_string=None):
     """
     Returns a list of entitlement pools from the server.
 
@@ -328,7 +296,7 @@ def get_available_entitlements(facts, get_all=False, active_on=None,
 
     pool_stash = PoolStash(Facts(require(ENT_DIR), require(PROD_DIR)))
     dlist = pool_stash.get_filtered_pools_list(active_on, not get_all,
-           overlapping, uninstalled, text)
+           overlapping, uninstalled, text, filter_string)
 
     for pool in dlist:
         pool_wrapper = PoolWrapper(pool)
@@ -518,7 +486,7 @@ class PoolStash(object):
         log.debug("   %s already subscribed" % len(self.subscribed_pool_ids))
 
     def get_filtered_pools_list(self, active_on, incompatible,
-            overlapping, uninstalled, text):
+            overlapping, uninstalled, text, filter_string):
         """
         Used for CLI --available filtering
         cuts down on api calls
@@ -532,11 +500,11 @@ class PoolStash(object):
 
         if incompatible:
             for pool in list_pools(require(CP_PROVIDER).get_consumer_auth_cp(),
-                    self.identity.uuid, self.facts, active_on=active_on):
+                    self.identity.uuid, self.facts, active_on=active_on, filter_string=filter_string):
                 self.compatible_pools[pool['id']] = pool
         else:  # --all has been used
             for pool in list_pools(require(CP_PROVIDER).get_consumer_auth_cp(),
-                    self.identity.uuid, self.facts, list_all=True, active_on=active_on):
+                    self.identity.uuid, self.facts, list_all=True, active_on=active_on, filter_string=filter_string):
                 self.all_pools[pool['id']] = pool
 
         return self._filter_pools(incompatible, overlapping, uninstalled, False, text)

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -18,6 +18,7 @@ import gettext
 import logging
 import os
 import pprint
+import re
 
 import signal
 import socket
@@ -323,3 +324,157 @@ def chroot(dirname):
     Change root of all paths.
     """
     Path.ROOT = dirname
+
+
+class CertificateFilter(object):
+    def match(self, cert):
+        """
+        Checks if the specified certificate matches this filter's restrictions.
+        Returns True if the specified certificate matches this filter's restrictions ; False
+        otherwise.
+        """
+        raise NotImplementedError
+
+
+class ProductCertificateFilter(CertificateFilter):
+    def __init__(self, filter_string=None):
+        super(ProductCertificateFilter, self).__init__()
+
+        self._fs_regex = None
+
+        if filter_string is not None:
+            self.set_filter_string(filter_string)
+
+    def set_filter_string(self, filter_string):
+        """
+        Sets this filter's filter string to the specified string. The filter string may use ? or *
+        for wildcards, representing one or any characters, respectively.
+
+        Returns True if the specified filter string was processed and assigned successfully; False
+        otherwise.
+        """
+        literals = []
+        wildcards = []
+        translated = []
+        output = False
+
+        wildcard_map = {
+            '*': '.*',
+            '?': '.',
+        }
+
+        expression = ur"""
+            ((?:                # A captured, non-capture group :)
+                [^*?\\]*        # Character literals and other uninteresting junk (greedy)
+                (?:\\.?)*       # Anything escaped with a backslash, or just a trailing backslash
+            )*)                 # Repeat the above sequence 0+ times, greedily
+            ([*?]|\Z)           # Any of our wildcards (* or ?) not preceded by a backslash OR end of input
+        """
+
+        if filter_string is not None:
+            try:
+                # Break it up based on our special characters...
+                for match in re.finditer(expression, filter_string, re.VERBOSE):
+                    literals.append(match.group(1))
+
+                    if match.group(2):
+                        wildcards.append(match.group(2))
+
+                # ...and put it all back together.
+                for literal in literals:
+                    # Impl note:
+                    # Unfortunately we need to unescape the literals so they can be safely re-escaped by the
+                    # re.escape method; lest we risk doubly-escaping some stuff and breaking our regex
+                    # horribly.
+                    literal = re.sub(r"\\([*?\\])", r"\1", literal)
+                    literal = re.escape(literal)
+
+                    translated.append(literal)
+                    if len(wildcards):
+                        translated.append(wildcard_map.get(wildcards.pop(0)))
+
+                self._fs_regex = re.compile("^%s$" % ''.join(translated), re.IGNORECASE)
+                output = True
+            except TypeError:
+                # Invalid filter string type. Rethrow with a proper message and backtrace?
+                pass
+        else:
+            self._fs_regex = None
+            output = True
+
+        return output
+
+    def match(self, cert):
+        """
+        Checks if the specified certificate matches this filter's restrictions.
+        Returns True if the specified certificate matches this filter's restrictions ; False
+        otherwise.
+        """
+        # Check filter string (contains-text)
+        if self._fs_regex is not None:
+            # Perhaps we should be validating our input object here...?
+            for product in cert.products:
+                if (product.name and self._fs_regex.match(product.name) is not None) or (product.id and self._fs_regex.match(product.id) is not None):
+                    return True
+
+        return False
+
+
+class EntitlementCertificateFilter(ProductCertificateFilter):
+    def __init__(self, filter_string=None, service_level=None):
+        super(EntitlementCertificateFilter, self).__init__(filter_string=filter_string)
+
+        self._sl_filter = None
+
+        if service_level is not None:
+            self.set_service_level(service_level)
+
+    def set_service_level(self, service_level):
+        """
+        Sets this filter's required service level to the level specified. Service level filters are
+        case insensitive.
+
+        Returns True if the service level filter was set successfully; False otherwise.
+        """
+
+        output = False
+
+        if service_level is not None:
+            try:
+                self._sl_filter = '' + service_level.lower()
+                output = True
+            except:
+                # Likely not a string or otherwise bad input.
+                pass
+
+        else:
+            self._sl_filter = None
+            output = True
+
+        return output
+
+    def match(self, cert):
+        """
+        Checks if the specified certificate matches this filter's restrictions.
+        Returns True if the specified certificate matches this filter's restrictions ; False
+        otherwise.
+        """
+        # Again: perhaps we should be validating our input object here...?
+
+        # Check service level filter
+        sl_check = self._sl_filter is None or (
+            cert.order
+            and cert.order.service_level
+            and cert.order.service_level.lower() == self._sl_filter.lower()
+        )
+
+        # Check filter string (contains-text)
+        fs_check = self._fs_regex is None or (
+            super(EntitlementCertificateFilter, self).match(cert)
+            or (cert.order.name and self._fs_regex.match(cert.order.name) is not None)
+            or (cert.order.sku and self._fs_regex.match(cert.order.sku) is not None)
+            or (cert.order.service_level and self._fs_regex.match(cert.order.service_level) is not None)
+            or (cert.order.contract and self._fs_regex.match(cert.order.contract) is not None)
+        )
+
+        return sl_check and fs_check and (self._sl_filter is not None or self._fs_regex is not None)

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -40,7 +40,7 @@ Requires:  python-ethtool
 Requires:  python-iniparse
 Requires:  pygobject2
 Requires:  virt-what
-Requires:  python-rhsm >= 1.12.3
+Requires:  python-rhsm >= 1.13.5
 Requires:  dbus-python
 Requires:  yum >= 3.2.19-15
 Requires:  usermode


### PR DESCRIPTION
- --contains-text with --installed or --consumed options use a
  client-side filtering implementation, where --available uses
  server-side.
- Fixed an issue which would cause output for --available or
  --consumed to be skipped if --installed or --available had
  zero objects to display.
- Updated the man pages and auto-complete accordingly.
