### PR TITLE
1149007: Fixed subman command line usage

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -5,8 +5,8 @@
 #
 
 # options common to all subcommands (+ 3rd level opts for simplicity)
-_subscription_manager_common_opts="-h --help --proxy --proxyuser --proxypassword"
-_subscription_manager_common_url_opts="--insecure --serverurl"
+_subscription_manager_common_opts="-h --help --proxy --proxy-user --proxy-password"
+_subscription_manager_common_url_opts="--insecure --server-url"
 # complete functions for subcommands ($1 - current opt, $2 - previous opt)
 
 _subscription_manager_auto_attach()
@@ -27,7 +27,7 @@ _subscription_manager_attach()
           COMPREPLY=($(compgen -W "${POOLS}" -- ${1}))
           return 0
   esac
-  local opts="--auto --pool --quantity --servicelevel
+  local opts="--auto --pool --quantity --service-level
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }
@@ -101,7 +101,7 @@ _subscription_manager_import()
 _subscription_manager_list()
 {
   local opts="--all --available --consumed --installed
-              --ondate --servicelevel
+              --on-date --service-level
               --match-installed --no-overlap
               --matches
               ${_subscription_manager_common_opts}"
@@ -125,7 +125,7 @@ _subscription_manager_repo_override()
 
 _subscription_manager_plugins()
 {
-  local opts="--list --listhooks --listslots --verbose
+  local opts="--list --list-hooks --list-slots --verbose
               -h --help"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }
@@ -146,9 +146,9 @@ _subscription_manager_refresh()
 
 _subscription_manager_register()
 {
-  local opts="--activationkey --auto-attach --autosubscribe --baseurl --consumerid
+  local opts="--activation-key --auto-attach --autosubscribe --baseurl --consumer-id
               --environment --force --name --org --password --release
-              --servicelevel --type --username
+              --service-level --type --username
               ${_subscription_manager_common_url_opts}
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
@@ -181,7 +181,7 @@ _subscription_manager_service_level()
 
 _subscription_manager_status()
 {
-  local opts="${_subscription_manager_common_opts} --ondate"
+  local opts="${_subscription_manager_common_opts} --on-date"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }
 

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -142,11 +142,11 @@ name has the format
 
 
 .TP
-.B --proxyuser=PROXYUSERNAME
+.B --proxy-user=PROXY_USERNAME
 Gives the username to use to authenticate to the HTTP proxy.
 
 .TP
-.B --proxypass=PROXYPASSWORD
+.B --proxy-password=PROXY_PASSWORD
 Gives the password to use to authenticate to the HTTP proxy.
 
 .SS REGISTER OPTIONS
@@ -163,11 +163,11 @@ Gives the username for the account which is registering the system; this user ac
 Gives the user account password.
 
 .TP
-.B --serverurl=SERVER_HOSTNAME
+.B --server-url=SERVER_HOSTNAME
 Passes the name of the subscription service with which to register the system. The default value, if this is not given, is the Customer Portal Subscription Management service,
 .B subscription.rhn.redhat.com.
 If there is an on-premise subscription service such as Subscription Asset Manager, this parameter can be used to submit the hostname of the subscription service. For Subscription Asset Manager, if the Subscription Manager tool is configured with the Subscription Asset Manager RPM, then the default value for the
-.B --serverurl
+.B --server-url
 parameter is for the on-premise Subscription Asset Manager server.
 
 
@@ -185,15 +185,15 @@ Sets the name of the system to register. This defaults to the hostname.
 
 
 .TP
-.B --consumerid=CONSUMERID
+.B --consumer-id=CONSUMERID
 References an existing system inventory ID to resume using a previous registration for this system. The ID is used as an inventory number for the system in the subscription management service database. If the system's identity is lost or corrupted, this option allows it to resume using its previous identity and subscriptions.
 
 .TP
-.B --activationkey=KEYS
+.B --activation-key=KEYS
 Gives a comma-separated list of product keys to use to redeem or apply specific subscriptions to the system. This is used for preconfigured systems which may already have products installed. Activation keys are issued by an on-premise subscription management service, such as Subscription Asset Manager.
 .IP
 When the
-.B --activationkey
+.B --activation-key
 option is used, it is not necessary to use the
 .B --username
 and
@@ -203,7 +203,7 @@ options, because the authentication information is implicit in the activation ke
 For example:
 .RS
 .nf
-subscription-manager register --org="IT Dept" --activationkey=1234abcd
+subscription-manager register --org="IT Dept" --activation-key=1234abcd
 .fi
 .RE
 
@@ -213,7 +213,7 @@ Automatically attaches compatible subscriptions to this system.
 
 
 .TP
-.B --servicelevel=LEVEL
+.B --service-level=LEVEL
 Sets the preferred service level to use with subscriptions added to the system. Service levels are commonly premium, standard, and none, though other levels may be available depending on the product and the contract. This preference can only be used in conjunction with the
 .B --auto-attach
 option, and then it is used as one of the factors for matching subscriptions.
@@ -235,7 +235,7 @@ meaning that there are multiple organizations within one customer unit. A system
 Registers the system to an environment within an organization.
 
 .TP
-.B --type=CONSUMERTYPE
+.B --type=CONSUMER_TYPE
 Sets the type of unit to register. Most units in the inventory will use the default value of
 .B system.
 For development or test systems, this can be
@@ -261,7 +261,7 @@ The
 command applies a specific subscription to the system.
 
 .TP
-.B --pool=POOLID
+.B --pool=POOL_ID
 Gives the ID for the subscriptions pool (collection of products) to attach to the system. This option is required, unless
 .B --auto
 is used.
@@ -277,7 +277,7 @@ subscriptions) to cover the number of sockets, guests, or other characteristics.
 Automatically attaches the best-matched compatible subscription or subscriptions to the system.
 
 .TP
-.B --servicelevel=LEVEL
+.B --service-level=LEVEL
 Sets the preferred service level to use with subscriptions attached to the system. Service levels are commonly premium, standard, and none, though other levels may be available depending on the product and the contract. This preference can only be used in conjunction with the
 .B --auto
 option, and then it is used as one of the factors for matching subscriptions.
@@ -305,7 +305,7 @@ The
 command removes a subscription from the system. (This does not uninstall the associated products.)
 
 .TP
-.B --serial=SERIALNUMBER
+.B --serial=SERIAL_NUMBER
 Gives the serial number of the subscription certificate for the specific product to remove from the system. Subscription certificates attached to a system are in a certificate, in
 .B /etc/pki/entitlement/<serial_number>.pem.
 To remove multiple subscriptions, use the
@@ -413,7 +413,7 @@ Lists all of the subscriptions currently attached to the system.
 Lists products which are currently installed on the system which may (or may not) have subscriptions associated with them, as well as products with attached subscriptions which may (or may not) be installed.
 
 .TP
-.B --ondate=YYYY-MM-DD
+.B --on-date=YYYY-MM-DD
 Sets the date to use to search for active and available subscriptions. The default (if not explicitly passed) is today's date; using a later date looks for subscriptions which will be active then. This is only used with the
 .B --available
 option.
@@ -506,11 +506,11 @@ Gives the username for the account to use to connect to the organization account
 Gives the user account password.
 
 .TP
-.B --serverurl=SERVER_HOSTNAME
+.B --server-url=SERVER_HOSTNAME
 Passes the name of the subscription service to use to list all available organizations. The \fBorgs\fP command will list all organizations for the specified service for which the user account is granted access. The default value, if this is not given, is the Customer Portal Subscription Management service,
 .B https://subscription.rhn.redhat.com:443.
 If there is an on-premise subscription service such as Subscription Asset Manager, this parameter can be used to submit the hostname of the subscription service, in the form \fI[protocol://]servername[:port][/prefix]\fP. For Subscription Asset Manager, if the Subscription Manager tool is configured with the Subscription Asset Manager RPM, then the default value for the
-.B --serverurl
+.B --server-url
 parameter is for the on-premise Subscription Asset Manager server.
 
 
@@ -524,11 +524,11 @@ command lists the available subscription-manager plugins.
 List the available subscription-manager plugins.
 
 .TP
-.B --listslots
+.B --list-slots
 List the available plugin slots
 
 .TP
-.B --listhooks
+.B --list-hooks
 List the available plugin slots and the hooks that handle them.
 
 .TP
@@ -646,7 +646,7 @@ command removes all of the subscription and identity data from the local system
 This means that any of the subscriptions applied to the system are not available for other systems to use. The
 .B clean
 command is useful in cases where the local subscription information is corrupted or lost somehow, and the system will be reregistered using the
-.B register --consumerid=EXISTING_ID
+.B register --consumer-id=EXISTING_ID
 command.
 
 .PP
@@ -726,11 +726,11 @@ Overall Status: Current
 
 
 .TP
-.B --ondate=DATE
+.B --on-date=DATE
 Shows the system status for a specific date \fIin the future\fP. The format of the date is \fIYYYY-MM-DD\fP.
 
 .nf
-[root@server ~]# subscription-manager status --ondate=2014-01-01
+[root@server ~]# subscription-manager status --on-date=2014-01-01
 +-------------------------------------------+
      System Status Details
 +-------------------------------------------+
@@ -798,11 +798,11 @@ subscription-manager register --username=admin --password=secret
 With on-premise subscription services, such as Subscription Asset Manager, the infrastructure is more complex. The local administrator can define independent groups called
 .I organizations
 which represent physical or organizational divisions (\fB--org\fP). Those organizations can be subdivided into \fIenvironments\fP (\fB--environment\fP).
-Optionally, the information about what subscription service (\fB--serverurl\fP) and content delivery network (\fB--baseurl\fP) to use for the system registration can also be passed (which overrides the Red Hat Subscription Manager settings). The server and content URLs are usually configured in the Subscription Manager configuration before registering a system.
+Optionally, the information about what subscription service (\fB--server-url\fP) and content delivery network (\fB--baseurl\fP) to use for the system registration can also be passed (which overrides the Red Hat Subscription Manager settings). The server and content URLs are usually configured in the Subscription Manager configuration before registering a system.
 
 .nf
 subscription-manager register --username=admin --password=secret
---org="IT Dept" --environment="local dev" --serverurl=local-cloudforms.example.com --baseurl=https://local-cloudforms.example.com:8088/cfse
+--org="IT Dept" --environment="local dev" --server-url=local-cloudforms.example.com --baseurl=https://local-cloudforms.example.com:8088/cfse
 .fi
 
 
@@ -828,7 +828,7 @@ If a system is registered and then somehow its subscription information is lost 
 
 .nf
 subscription-manager register --username=admin
---password=secret --consumerid=1234abcd
+--password=secret --consumer-id=1234abcd
 .fi
 
 .PP
@@ -877,15 +877,15 @@ subscription-manager register --username=admin --password=secret
 
 .PP
 Auto-attach also supports an option to set a preferred service level with the selected subscriptions, the
-.B --servicelevel
+.B --service-level
 option. In this case, the
-.B --servicelevel
+.B --service-level
 option sets a preference that helps the auto-attach process select appropriate subscriptions. For example, if the preferred service level for a production server is premium, and there are three matching subscriptions with different service levels (none, standard, and premium), the auto-attach process selects the subscription which offers a premium service level.
 
 .RS
 .nf
 subscription-manager register --username=admin --password=secret
---auto-attach --servicelevel=premium
+--auto-attach --service-level=premium
 .fi
 .RE
 
@@ -901,12 +901,12 @@ that subscription (meaning, it removes that subscription so that another system 
 .PP The
 .B list
 command shows you what subscriptions are available specifically to the system (meaning subscriptions which are active, have available quantities, and match the hardware and architecture) or all subscriptions for the organization. Using the
-.B --ondate
+.B --on-date
 option shows subscriptions that are or will be active at a specific time (otherwise, it shows subscriptions which are active today).
 
 .RS
 .nf
-subscription-manager list --available --ondate=2012-01-31
+subscription-manager list --available --on-date=2012-01-31
 +-------------------------------------------+
     Available Subscriptions
 +-------------------------------------------+
@@ -970,14 +970,14 @@ subscription-manager attach --auto
 
 .PP
 Auto-attach also supports an option to set a preferred service level with the selected subscriptions, the
-.B --servicelevel
+.B --service-level
 option. In this case, the
-.B --servicelevel
+.B --service-level
 option sets a preference that helps the auto-attach process select appropriate subscriptions. For example, if the preferred service level for a production server is premium, and there are three matching subscriptions with different service levels (none, standard, and premium), the auto-attach process selects the subscription which offers a premium subscription.
 
 .RS
 .nf
-subscription-manager attach --auto --servicelevel=premium
+subscription-manager attach --auto --service-level=premium
 .fi
 .RE
 
@@ -1105,7 +1105,7 @@ tool can be run as a post-install script as part of the kickstart installation p
 .RS
 .nf
 %post --log=/root/ks-post.log
-/usr/sbin/subscription-manager register --username admin --password secret --org 'east colo' --auto-attach --servicelevel=premium --force
+/usr/sbin/subscription-manager register --username admin --password secret --org 'east colo' --auto-attach --service-level=premium --force
 .fi
 .RE
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -21,7 +21,7 @@ import fnmatch
 import getpass
 import gettext
 import logging
-from optparse import OptionValueError
+from optparse import OptionValueError, SUPPRESS_HELP
 import os
 import socket
 import sys
@@ -250,6 +250,14 @@ def get_installed_product_status(product_directory, entitlement_directory, uep, 
     return product_status
 
 
+def deprecated_opt_warning(option, opt_str, value, parser, alias):
+    sys.stderr.write(_("Warning: The \"%s\" option is deprecated. Use \"%s\" instead.\n") % (opt_str, alias))
+
+    opt_alias = parser.get_option(alias)
+    if opt_alias is not None:
+        opt_alias.process(alias, value, parser.values, parser)
+
+
 class CliCommand(AbstractCLICommand):
     """ Base class for all sub-commands. """
 
@@ -289,19 +297,19 @@ class CliCommand(AbstractCLICommand):
 
     def _add_url_options(self):
         """ Add options that allow the setting of the server URL."""
-        self.parser.add_option("--serverurl", dest="server_url",
-                               default=None, help=_("server URL in the form of https://hostname:port/prefix"))
-        self.parser.add_option("--insecure", action="store_true",
-                                default=False, help=_("do not check the server SSL certificate against available certificate authorities"))
+        self.parser.add_option("--server-url", dest="server_url", default=None, help=_("server URL in the form of https://hostname:port/prefix"))
+        self.parser.add_option("--insecure", action="store_true", default=False, help=_("do not check the server SSL certificate against available certificate authorities"))
+
+        self.parser.add_option("--serverurl", help=SUPPRESS_HELP, action="callback", callback=deprecated_opt_warning, nargs=1, type="string", callback_kwargs={"alias": "--server-url"})
 
     def _add_proxy_options(self):
         """ Add proxy options that apply to sub-commands that require network connections. """
-        self.parser.add_option("--proxy", dest="proxy_url",
-                               default=None, help=_("proxy URL in the form of proxy_hostname:proxy_port"))
-        self.parser.add_option("--proxyuser", dest="proxy_user",
-                                default=None, help=_("user for HTTP proxy with basic authentication"))
-        self.parser.add_option("--proxypassword", dest="proxy_password",
-                                default=None, help=_("password for HTTP proxy with basic authentication"))
+        self.parser.add_option("--proxy", dest="proxy_url", default=None, help=_("proxy URL in the form of proxy_hostname:proxy_port"))
+        self.parser.add_option("--proxy-user", dest="proxy_user", default=None, help=_("user for HTTP proxy with basic authentication"))
+        self.parser.add_option("--proxy-password", dest="proxy_password", default=None, help=_("password for HTTP proxy with basic authentication"))
+
+        self.parser.add_option("--proxyuser", help=SUPPRESS_HELP, action="callback", callback=deprecated_opt_warning, nargs=1, type="string", callback_kwargs={"alias": "--proxy-user"})
+        self.parser.add_option("--proxypassword", help=SUPPRESS_HELP, action="callback", callback=deprecated_opt_warning, nargs=1, type="string", callback_kwargs={"alias": "--proxy-password"})
 
     def _do_command(self):
         pass
@@ -505,10 +513,8 @@ class UserPassCommand(CliCommand):
         self._username = None
         self._password = None
 
-        self.parser.add_option("--username", dest="username",
-                               help=_("username to use when authorizing against the server"))
-        self.parser.add_option("--password", dest="password",
-                               help=_("password to use when authorizing against the server"))
+        self.parser.add_option("--username", dest="username", help=_("username to use when authorizing against the server"))
+        self.parser.add_option("--password", dest="password", help=_("password to use when authorizing against the server"))
 
     @staticmethod
     def _get_username_and_password(username, password):
@@ -550,8 +556,7 @@ class OrgCommand(UserPassCommand):
         self._org = None
         if not hasattr(self, "_org_help_text"):
             self._org_help_text = _("specify organization")
-        self.parser.add_option("--org", dest="org", metavar="ORG_KEY",
-            help=self._org_help_text)
+        self.parser.add_option("--org", dest="org", metavar="ORG_KEY", help=self._org_help_text)
 
     @staticmethod
     def _get_org(org):
@@ -613,10 +618,8 @@ class IdentityCommand(UserPassCommand):
 
         super(IdentityCommand, self).__init__("identity", shortdesc, False)
 
-        self.parser.add_option("--regenerate", action='store_true',
-                               help=_("request a new certificate be generated"))
-        self.parser.add_option("--force", action='store_true',
-                               help=_("force certificate regeneration (requires username and password); Only used with --regenerate"))
+        self.parser.add_option("--regenerate", action='store_true', help=_("request a new certificate be generated"))
+        self.parser.add_option("--force", action='store_true', help=_("force certificate regeneration (requires username and password); Only used with --regenerate"))
 
     def _validate_options(self):
         self.assert_should_be_registered()
@@ -776,12 +779,9 @@ class AutohealCommand(CliCommand):
         super(AutohealCommand, self).__init__("auto-attach", shortdesc,
                                                 False)
 
-        self.parser.add_option("--enable", dest="enable", action='store_true',
-                help=_("try to attach subscriptions for uncovered products each check-in"))
-        self.parser.add_option("--disable", dest="disable", action='store_true',
-                help=_("do not try to automatically attach subscriptions each check-in"))
-        self.parser.add_option("--show", dest="show", action='store_true',
-                help=_("show the current auto-attach preference"))
+        self.parser.add_option("--enable", dest="enable", action='store_true', help=_("try to attach subscriptions for uncovered products each check-in"))
+        self.parser.add_option("--disable", dest="disable", action='store_true', help=_("do not try to automatically attach subscriptions each check-in"))
+        self.parser.add_option("--show", dest="show", action='store_true', help=_("show the current auto-attach preference"))
 
     def _toggle(self, autoheal):
         self.cp.updateConsumer(self.uuid, autoheal=autoheal)
@@ -812,21 +812,14 @@ class ServiceLevelCommand(OrgCommand):
     def __init__(self):
 
         shortdesc = _("Manage service levels for this system")
-        self._org_help_text = \
-            _("specify an organization when listing available service levels using the organization key, only used with --list")
-        super(ServiceLevelCommand, self).__init__("service-level", shortdesc,
-                                                  False)
+        self._org_help_text = _("specify an organization when listing available service levels using the organization key, only used with --list")
+        super(ServiceLevelCommand, self).__init__("service-level", shortdesc, False)
 
         self._add_url_options()
-        self.parser.add_option("--show", dest="show", action='store_true',
-                help=_("show this system's current service level"))
-        self.parser.add_option("--list", dest="list", action='store_true',
-                help=_("list all service levels available"))
-        self.parser.add_option("--set", dest="service_level",
-                               help=_("service level to apply to this system"))
-        self.parser.add_option("--unset", dest="unset",
-                               action='store_true',
-                               help=_("unset the service level for this system"))
+        self.parser.add_option("--show", dest="show", action='store_true', help=_("show this system's current service level"))
+        self.parser.add_option("--list", dest="list", action='store_true', help=_("list all service levels available"))
+        self.parser.add_option("--set", dest="service_level", help=_("service level to apply to this system"))
+        self.parser.add_option("--unset", dest="unset", action='store_true', help=_("unset the service level for this system"))
 
         self.identity = inj.require(inj.IDENTITY)
 
@@ -962,24 +955,24 @@ class RegisterCommand(UserPassCommand):
                                help=_("the type of unit to register, defaults to system"))
         self.parser.add_option("--name", dest="consumername", metavar="SYSTEMNAME",
                                help=_("name of the system to register, defaults to the hostname"))
-        self.parser.add_option("--consumerid", dest="consumerid", metavar="SYSTEMID",
+        self.parser.add_option("--consumer-id", dest="consumerid", metavar="SYSTEMID",
                                help=_("the existing system data is pulled from the server"))
         self.parser.add_option("--org", dest="org", metavar="ORG_KEY",
                                help=_("register with one of multiple organizations for the user, using organization key"))
         self.parser.add_option("--environment", dest="environment",
                                help=_("register with a specific environment in the destination org"))
-        self.parser.add_option("--release", dest="release",
-                               help=_("set a release version"))
-        self.parser.add_option("--autosubscribe", action='store_true',
-                               help=_("Deprecated, see --auto-attach"))
+        self.parser.add_option("--release", dest="release", help=_("set a release version"))
+        self.parser.add_option("--autosubscribe", action='store_true', help=SUPPRESS_HELP)
         self.parser.add_option("--auto-attach", action='store_true', dest="autoattach",
                                help=_("automatically attach compatible subscriptions to this system"))
         self.parser.add_option("--force", action='store_true',
                                help=_("register the system even if it is already registered"))
-        self.parser.add_option("--activationkey", action='append', dest="activation_keys",
-                               help=_("activation key to use for registration (can be specified more than once)"))
-        self.parser.add_option("--service-level", "--servicelevel", dest="service_level",
-                               help=_("system preference used when subscribing automatically, requires --auto-attach"))
+        self.parser.add_option("--activation-key", action='append', dest="activation_keys", help=_("activation key to use for registration (can be specified more than once)"))
+        self.parser.add_option("--service-level", dest="service_level", help=_("system preference used when subscribing automatically, requires --auto-attach"))
+
+        self.parser.add_option("--activationkey", help=SUPPRESS_HELP, action="callback", callback=deprecated_opt_warning, nargs=1, type="string", callback_kwargs={"alias": "--activation-key"})
+        self.parser.add_option("--consumerid", help=SUPPRESS_HELP, action="callback", callback=deprecated_opt_warning, nargs=1, type="string", callback_kwargs={"alias": "--consumer-id"})
+        self.parser.add_option("--servicelevel", help=SUPPRESS_HELP, action="callback", callback=deprecated_opt_warning, nargs=1, type="string", callback_kwargs={"alias": "--service-level"})
 
     def _validate_options(self):
         self.autoattach = self.options.autosubscribe or self.options.autoattach
@@ -1417,8 +1410,11 @@ class AttachCommand(CliCommand):
                                help=_("number of subscriptions to attach"))
         self.parser.add_option("--auto", action='store_true',
             help=_("automatically attach compatible subscriptions to this system"))
-        self.parser.add_option("--service-level", "--servicelevel", dest="service_level",
-                               help=_("service level to apply to this system, requires --auto"))
+
+        self.parser.add_option("--service-level", dest="service_level", help=_("service level to apply to this system, requires --auto"))
+
+        self.parser.add_option("--servicelevel", help=SUPPRESS_HELP, action="callback", callback=deprecated_opt_warning, nargs=1, type="string", callback_kwargs={"alias": "--service-level"})
+
         # re bz #864207
         _("All installed products are covered by valid entitlements.")
         _("No need to update subscriptions at this time.")
@@ -1560,6 +1556,10 @@ class SubscribeCommand(AttachCommand):
     def _primary(self):
         return False
 
+    def _do_command(self):
+        sys.stderr.write(_("Warning: The \"subscribe\" command is deprecated. Use \"attach\" instead.\n"))
+        return super(SubscribeCommand, self)._do_command()
+
 
 class RemoveCommand(CliCommand):
 
@@ -1685,6 +1685,10 @@ class UnSubscribeCommand(RemoveCommand):
     def _primary(self):
         return False
 
+    def _do_command(self):
+        sys.stderr.write(_("Warning: The \"unsubscribe\" command is deprecated. Use \"remove\" instead.\n"))
+        return super(UnSubscribeCommand, self)._do_command()
+
 
 class FactsCommand(CliCommand):
 
@@ -1800,15 +1804,13 @@ class PluginsCommand(CliCommand):
         super(PluginsCommand, self).__init__("plugins", shortdesc, False)
 
         SM = "subscription-manager"
-        self.parser.add_option("--list", action="store_true",
-                                help=_("list %s plugins") % SM)
-        self.parser.add_option("--listslots", action="store_true",
-                                help=_("list %s plugin slots") % SM)
-        self.parser.add_option("--listhooks", action="store_true",
-                                help=_("list %s plugin hooks") % SM)
-        self.parser.add_option("--verbose", action="store_true",
-                               default=False,
-                               help=_("show verbose plugin info"))
+        self.parser.add_option("--list", action="store_true", help=_("list %s plugins") % SM)
+        self.parser.add_option("--list-slots", action="store_true", dest="listslots", help=_("list %s plugin slots") % SM)
+        self.parser.add_option("--list-hooks", action="store_true", dest="listhooks", help=_("list %s plugin hooks") % SM)
+        self.parser.add_option("--verbose", action="store_true", default=False, help=_("show verbose plugin info"))
+
+        self.parser.add_option("--listslots", help=SUPPRESS_HELP, action="callback", callback=deprecated_opt_warning, callback_kwargs={"alias": "--list-slots"})
+        self.parser.add_option("--listhooks", help=SUPPRESS_HELP, action="callback", callback=deprecated_opt_warning, callback_kwargs={"alias": "--list-hooks"})
 
     def _validate_options(self):
         # default to list
@@ -2136,13 +2138,10 @@ class ListCommand(CliCommand):
                                help=_("show those subscriptions which are available"))
         self.parser.add_option("--all", action='store_true',
                                help=_("used with --available to ensure all subscriptions are returned"))
-        self.parser.add_option("--ondate", dest="on_date",
-                                help=(_("date to search on, defaults to today's date, only used with --available (example: %s)")
-                                      % strftime("%Y-%m-%d", localtime())))
-        self.parser.add_option("--consumed", action='store_true',
-                               help=_("show the subscriptions being consumed by this system"))
-        self.parser.add_option("--service-level", "--servicelevel", dest="service_level",
-                               help=_("shows only subscriptions matching the specified service level; only used with --available and --consumed"))
+
+        self.parser.add_option("--on-date", dest="on_date", help=(_("date to search on, defaults to today's date, only used with --available (example: %s)") % strftime("%Y-%m-%d", localtime())))
+        self.parser.add_option("--consumed", action='store_true', help=_("show the subscriptions being consumed by this system"))
+        self.parser.add_option("--service-level", dest="service_level", help=_("shows only subscriptions matching the specified service level; only used with --available and --consumed"))
         self.parser.add_option("--no-overlap", action='store_true',
                                help=_("shows pools which provide products that are not already covered; only used with --available"))
         self.parser.add_option("--match-installed", action="store_true",
@@ -2150,12 +2149,15 @@ class ListCommand(CliCommand):
         self.parser.add_option("--matches", dest="filter_string",
                                help=_("lists only subscriptions or products containing the specified search string in the subscription or product information, varying with the list requested and the server version (case-insensitive)."))
 
+        self.parser.add_option("--ondate", help=SUPPRESS_HELP, action="callback", callback=deprecated_opt_warning, nargs=1, type="string", callback_kwargs={"alias": "--on-date"})
+        self.parser.add_option("--servicelevel", help=SUPPRESS_HELP, action="callback", callback=deprecated_opt_warning, nargs=1, type="string", callback_kwargs={"alias": "--service-level"})
+
     def _validate_options(self):
         if (self.options.all and not self.options.available):
             print _("Error: --all is only applicable with --available")
             sys.exit(-1)
         if (self.options.on_date and not self.options.available):
-            print _("Error: --ondate is only applicable with --available")
+            print _("Error: --on-date is only applicable with --available")
             sys.exit(-1)
         if self.options.service_level is not None and not (self.options.consumed or self.options.available):
             print _("Error: --service-level is only applicable with --available or --consumed")
@@ -2495,9 +2497,9 @@ class StatusCommand(CliCommand):
     def __init__(self):
         shortdesc = _("Show status information for this system's subscriptions and products")
         super(StatusCommand, self).__init__("status", shortdesc, True)
-        self.parser.add_option("--ondate", dest="on_date",
-                                help=(_("future date to check status on, defaults to today's date (example: %s)")
-                                      % strftime("%Y-%m-%d", localtime())))
+        self.parser.add_option("--on-date", dest="on_date", help=(_("future date to check status on, defaults to today's date (example: %s)") % strftime("%Y-%m-%d", localtime())))
+
+        self.parser.add_option("--ondate", help=SUPPRESS_HELP, action="callback", callback=deprecated_opt_warning, nargs=1, type="string", callback_kwargs={"alias": "--on-date"})
 
     def _do_command(self):
         # list status and all reasons it is not valid

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -85,14 +85,14 @@ run_sm unregister
 
 # activation keys
 run_sm unregister
-run_sm register --activationkey "${ACTIVATION_KEY}" --org "${ORG}" --force
+run_sm register --activation-key "${ACTIVATION_KEY}" --org "${ORG}" --force
 run_sm unregister
-run_sm register --activationkey "${ACTIVATION_KEY}" --org "${ORG}" --force --auto-attach
+run_sm register --activation-key "${ACTIVATION_KEY}" --org "${ORG}" --force --auto-attach
 run_sm unregister
 
 # what to run after the tests, ie, restore configs, etc
 #post () {
-#    
+#
 #}
 
 #post

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -364,22 +364,26 @@ class TestRegisterCommand(TestCliProxyCommand):
             self.fail("Exception Raised")
 
     def test_keys_and_consumerid(self):
-        self._test_exception(["--consumerid", "22", "--activationkey", "key"])
+        self._test_exception(["--consumer-id", "22", "--activation-key", "key"])
+        self._test_exception(["--consumerid", "22", "--activation-key", "key"])
 
     def test_key_and_org(self):
+        self._test_no_exception(["--activation-key", "key", "--org", "org"])
         self._test_no_exception(["--activationkey", "key", "--org", "org"])
 
     def test_key_and_no_org(self):
+        self._test_exception(["--activation-key", "key"])
         self._test_exception(["--activationkey", "key"])
 
     def test_empty_string_key_and_org(self):
+        self._test_exception(["--activation-key=", "--org", "org"])
         self._test_exception(["--activationkey=", "--org", "org"])
 
     def test_keys_and_username(self):
-        self._test_exception(["--username", "bob", "--activationkey", "key"])
+        self._test_exception(["--username", "bob", "--activation-key", "key"])
 
     def test_keys_and_environments(self):
-        self._test_exception(["--environment", "JarJar", "--activationkey", "Binks"])
+        self._test_exception(["--environment", "JarJar", "--activation-key", "Binks"])
 
     def test_env_and_org(self):
         self._test_no_exception(["--env", "env", "--org", "org"])
@@ -1138,6 +1142,10 @@ class TestOverrideCommand(TestCliProxyCommand):
         self.assertTrue(self.cc.options.list)
 
     def test_list_by_default_with_options_from_super_class(self):
+        self.cc.main(["--proxy", "http://www.example.com", "--proxy-user", "foo", "--proxy-password", "bar"])
+        self.cc._validate_options()
+        self.assertTrue(self.cc.options.list)
+
         self.cc.main(["--proxy", "http://www.example.com", "--proxyuser", "foo", "--proxypassword", "bar"])
         self.cc._validate_options()
         self.assertTrue(self.cc.options.list)

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -77,7 +77,7 @@ class CliRegistrationTests(SubManFixture):
         mock_entcertlib_instance = mock_entcertlib.return_value
 
         self._inject_ipm()
-        cmd.main(['register', '--activationkey=test_key', '--org=test_org'])
+        cmd.main(['register', '--activation-key=test_key', '--org=test_org'])
 
 #        self.assertTrue(mock_ipm_wc.call_count > 0)
 
@@ -101,7 +101,7 @@ class CliRegistrationTests(SubManFixture):
         connection.UEPConnection.getConsumer = Mock(return_value={'uuid': '123123'})
 
         self._inject_ipm()
-        cmd.main(['register', '--consumerid=123456', '--username=testuser1', '--password=password', '--org=test_org'])
+        cmd.main(['register', '--consumer-id=123456', '--username=testuser1', '--password=password', '--org=test_org'])
 
         #self.assertTrue(mock_ipm.write_cache.call_count > 0)
 


### PR DESCRIPTION
- The following options have been deprecated and replaced by
  hypenated alternatives:
  - serverurl
  - proxyuser
  - proxypassword
  - activationkey
  - consumerid
  - servicelevel
  - listslots
  - listhooks
  - ondate
  
  The original non-hypenated versions still work and should forward
  to the new versions, but will print a deprecation warning to stderr.
  
  This also addresses bz 1154179 for hypenating all command line
  options.
- Subscribe and unsubscribe now print deprecation warnings to
  stderr when used.
- Tab completion for subscribe, unsubscribe and all deprecated
  CLI options has been removed.
