### PR TITLE
1093325: Prevent rhsm-debug from throwing tbs

### DIFF
--- a/bin/rhsm-debug
+++ b/bin/rhsm-debug
@@ -75,3 +75,9 @@ if __name__ == '__main__':
     except KeyboardInterrupt:
         sys.stderr.write("\n" + _("User interrupted process."))
         sys.exit(0)
+    except Exception, e:
+        # rhsm-debug can be invoked from sosreport/libreport/abrt, so
+        # letting exceptions all the up to the system excepthook
+        # can cause chaos (abrt handler gets called, invokes sosreport, etc)
+        sys.stderr.write("Error collecting rhsm-debug information")
+        sys.exit(-1)


### PR DESCRIPTION
rhsm-debug was not catching all exceptions at the
top level. This is normally okay for really unexpected
exceptions, but rhsm-debug can end up getting invoked
in the process of abrt handling top level exceptions. Or
from running 'sosreport'. Since there isn't much we
can do about these exceptions, catch them all and
warn to stderr.
