### PR TITLE
Added support for attaching pools from a file/stdin.

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -27,7 +27,7 @@ _subscription_manager_attach()
           COMPREPLY=($(compgen -W "${POOLS}" -- ${1}))
           return 0
   esac
-  local opts="--auto --pool --quantity --servicelevel
+  local opts="--auto --pool --quantity --servicelevel --file
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -264,7 +264,19 @@ command applies a specific subscription to the system.
 .B --pool=POOLID
 Gives the ID for the subscriptions pool (collection of products) to attach to the system. This option is required, unless
 .B --auto
-is used.
+or
+.B --file
+are used.
+
+.TP
+.B --file=FILE
+Specifies a file from which to read whitespace-delimited pool IDs. If FILE is "-", the pool IDs will be read from stdin.
+.br
+This option is required unless
+.B --auto
+or
+.B --pool
+are used.
 
 .TP
 .B --quantity=NUMBER


### PR DESCRIPTION
- Added the --file option to the attach command. If a file is
  provided, pools will be read from the file. If the file is
  given as a single hyphen, pools will be read from stdin.

While it's possible to have done a single dash at the end of the command, it'd have required refactoring how the input validation is performed. Currently, CLICommand checks if there is anything left on the command line after parsing options via optparse. If so, it throws an error. One method to "fix" this would be to move that to its _validate_options(), then call the validation method in place of the hard-coded "fail everything" block. This way, subclasses of the CLICommand could override/precede the check and use leftovers without throwing errors.
