### PR TITLE
Add content/product tag matching for content plugins. [dont merge yet, rebase coming]

### DIFF
--- a/playpen/noserc.ci
+++ b/playpen/noserc.ci
@@ -1,9 +1,6 @@
 [nosetests]
 with-xvfb=True
-with-id=True
-with-xtraceback=True
 with-coverage=True
 cover-html=True
 cover-xml=True
 cover-erase=True
-with-xunit=True

--- a/src/subscription_manager/model/ent_cert.py
+++ b/src/subscription_manager/model/ent_cert.py
@@ -31,7 +31,7 @@ class EntitlementCertContent(Content):
         return cls(content_type=ent_cert_content.content_type,
             name=ent_cert_content.name, label=ent_cert_content.label,
             url=ent_cert_content.url, gpg=ent_cert_content.gpg,
-            cert=cert)
+            tags=ent_cert_content.required_tags, cert=cert)
 
 
 class EntitlementCertEntitlement(Entitlement):
@@ -59,6 +59,9 @@ class EntitlementDirEntitlementSource(EntitlementSource):
 
     def __init__(self):
         ent_dir = inj.require(inj.ENT_DIR)
+        prod_dir = inj.require(inj.PROD_DIR)
+
+        self.prod_tags = prod_dir.get_provided_tags()
 
         # populate from ent certs
         self._entitlements = []

--- a/test/test_model_ent_cert.py
+++ b/test/test_model_ent_cert.py
@@ -1,0 +1,135 @@
+
+import mock
+
+import fixture
+
+import test_model
+
+from rhsm import certificate2
+from subscription_manager import model
+from subscription_manager.model import ent_cert
+from subscription_manager import injection as inj
+
+
+class TestEntitlement(fixture.SubManFixture):
+    def test_empty_init(self):
+        e = model.Entitlement()
+        self.assertTrue(hasattr(e, 'contents'))
+
+    def test_init_empty_contents(self):
+        e = model.Entitlement(contents=[])
+        self.assertTrue(hasattr(e, 'contents'))
+        self.assertEquals(e.contents, [])
+
+    def test_contents(self):
+        contents = [mock.Mock(), mock.Mock()]
+        e = model.Entitlement(contents=contents)
+        self.assertTrue(hasattr(e, 'contents'))
+        self.assertEquals(len(e.contents), 2)
+
+        for a_content in e.contents:
+            self.assertTrue(isinstance(a_content, mock.Mock))
+
+        self.assertTrue(isinstance(e.contents[0], mock.Mock))
+
+
+def create_mock_content(name=None, url=None, gpg=None, enabled=None, content_type=None, tags=None):
+    mock_content = mock.Mock()
+    mock_content.name = name or "mock_content"
+    mock_content.url = url or "http://mock.example.com"
+    mock_content.gpg = gpg or "path/to/gpg"
+    mock_content.enabled = enabled or True
+    mock_content.content_type = content_type or "yum"
+    mock_content.tags = tags or []
+    return mock_content
+
+
+class TestEntitlementCertContent(test_model.TestContent):
+    def test_from_cert_content_yum(self):
+        mock_content = create_mock_content()
+
+        ent_cert_content = ent_cert.EntitlementCertContent.from_cert_content(mock_content)
+        self._check_attrs(ent_cert_content)
+
+    def test_from_cert_content_ostree(self):
+        mock_content = create_mock_content(content_type="ostree")
+
+        ent_cert_content = ent_cert.EntitlementCertContent.from_cert_content(mock_content)
+        self._check_attrs(ent_cert_content)
+
+    def test_from_cert_content_ostree_tags(self):
+        mock_content = create_mock_content(content_type="ostree", tags=["rhel-7-atomic"])
+
+        ent_cert_content = ent_cert.EntitlementCertContent.from_cert_content(mock_content)
+        self._check_attrs(ent_cert_content)
+
+
+class TestEntitlementCertEntitlement(TestEntitlement):
+    def test_from_ent_cert(self):
+        mock_content = create_mock_content()
+
+        contents = [mock_content]
+
+        mock_ent_cert = mock.Mock()
+        mock_ent_cert.content = contents
+
+        ece = model.ent_cert.EntitlementCertEntitlement.from_ent_cert(mock_ent_cert)
+
+        self.assertEquals(ece.contents[0].name, contents[0].name)
+        self.assertEquals(ece.contents[0].label, contents[0].label)
+        self.assertEquals(ece.contents[0].gpg, contents[0].gpg)
+        self.assertEquals(ece.contents[0].content_type,
+            contents[0].content_type)
+        self.assertEquals(len(ece.contents), 1)
+
+        # for ostree content, gpg is likely to change
+        self.assertEquals(ece.contents[0].gpg, mock_content.gpg)
+
+
+# FIXME: move to stubs/fixture, copied from ent_branding
+# The installed product ids don't have brand_type/brand_name, just the
+# Product from the ent cert
+class DefaultStubInstalledProduct(certificate2.Product):
+    def __init__(self, id=123, name="Awesome OS",
+                 provided_tags=None,
+                 brand_type=None, brand_name=None):
+
+        tags = provided_tags or ["awesomeos-ostree-1"]
+        super(DefaultStubInstalledProduct, self).__init__(id=id, name=name, provided_tags=tags,
+                                                          brand_type=brand_type,
+                                                          brand_name=brand_name)
+
+
+class TestEntitlementDirEntitlementSource(test_model.TestEntitlementSource):
+    def setUp(self):
+        super(TestEntitlementDirEntitlementSource, self).setUp()
+        self._inj_mock_dirs()
+
+    def _inj_mock_dirs(self, stub_product=None):
+
+        stub_product = stub_product or DefaultStubInstalledProduct()
+        mock_prod_dir = mock.NonCallableMock(name='MockProductDir')
+        mock_prod_dir.get_installed_products.return_value = [stub_product.id]
+
+        mock_content = create_mock_content(tags=['awesomeos-ostree-1'])
+        mock_cert_contents = [mock_content]
+
+        mock_ent_cert = mock.Mock(name='MockEntCert')
+        mock_ent_cert.products = [stub_product]
+        mock_ent_cert.content = mock_cert_contents
+
+        mock_ent_dir = mock.NonCallableMock(name='MockEntDir')
+        mock_ent_dir.list_valid.return_value = [mock_ent_cert]
+
+        inj.provide(inj.PROD_DIR, mock_prod_dir)
+        inj.provide(inj.ENT_DIR, mock_ent_dir)
+
+    def _stub_product(self):
+        return DefaultStubInstalledProduct
+
+    def test_init_no_matching(self):
+        # add a product that will not match product tags
+        self._inj_mock_dirs(stub_product=DefaultStubInstalledProduct(provided_tags=[]))
+        ecc = ent_cert.EntitlementDirEntitlementSource()
+        # but this isn't filtering on tags yet, so 1 is expect
+        self.assertEquals(len(ecc), 1)

--- a/test/test_ostree_content_plugin.py
+++ b/test/test_ostree_content_plugin.py
@@ -967,6 +967,7 @@ class TestOsTreeContents(fixture.SubManFixture):
             name="mock_content_%s" % name,
             label=name,
             enabled=True,
+            required_tags=[],
             gpg="path/to/gpg",
             url="http://mock.example.com/%s/" % name)
         return EntitlementCertContent.from_cert_content(content)
@@ -983,6 +984,48 @@ class TestOsTreeContents(fixture.SubManFixture):
 
         contents = find_content(ent_src,
             content_type=action_invoker.OSTREE_CONTENT_TYPE)
+        self.assertEquals(len(contents), 1)
+
+        for content in contents:
+            self.assertEquals(content.content_type,
+                action_invoker.OSTREE_CONTENT_TYPE)
+
+    def test_ent_source_prod_tags(self):
+        yc = self.create_content("yum", "yum_content")
+        oc = self.create_content("ostree", "ostree_content")
+
+        ent1 = Entitlement(contents=[yc])
+        ent2 = Entitlement(contents=[oc])
+
+        ent_src = EntitlementSource()
+        ent_src._entitlements = [ent1, ent2]
+
+        # faux prod_tags to hit find_content, but no content tags
+        ent_src.prod_tags = ['awesomeos-ostree-1', 'awesomeos-ostree-super']
+
+        contents = find_content(ent_src,
+            content_type=action_invoker.OSTREE_CONTENT_TYPE)
+        self.assertEquals(len(contents), 1)
+
+        for content in contents:
+            self.assertEquals(content.content_type,
+                action_invoker.OSTREE_CONTENT_TYPE)
+
+    def test_ent_source_prod_tags_and_content_tags(self):
+        oc = self.create_content("ostree", "ostree_content")
+        oc.tags = ['awesomeos-ostree-1']
+
+        ent = Entitlement(contents=[oc])
+
+        ent_src = EntitlementSource()
+        ent_src._entitlements = [ent]
+
+        # faux prod_tags to hit find_content, but no content tags
+        ent_src.prod_tags = ['awesomeos-ostree-1', 'awesomeos-ostree-super']
+
+        contents = find_content(ent_src,
+            content_type=action_invoker.OSTREE_CONTENT_TYPE)
+        print "contents", contents
         self.assertEquals(len(contents), 1)
 
         for content in contents:


### PR DESCRIPTION
model.find_content compares the required tags on
products with provided product tags, ala repolib.
