### PR TITLE
Add content/product tag matching for content plugins.

### DIFF
--- a/src/subscription_manager/model/__init__.py
+++ b/src/subscription_manager/model/__init__.py
@@ -27,12 +27,13 @@ class Content(object):
     A generic representation of entitled content.
     """
     def __init__(self, content_type, name, label, url=None,
-        gpg=None, cert=None):
+        gpg=None, tags=None, cert=None):
         self.content_type = content_type
         self.name = name
         self.label = label
         self.url = url
         self.gpg = gpg
+        self.tags = tags or []
         self.cert = cert
 
 
@@ -57,6 +58,7 @@ class EntitlementSource(object):
     """
     def __init__(self):
         self._entitlements = []
+        self.product_tags = []
 
     def __iter__(self):
         return iter(self._entitlements)
@@ -79,8 +81,25 @@ def find_content(ent_source, content_type=None):
     log.debug("Searching for content of type: %s" % content_type)
     for entitlement in ent_source:
         for content in entitlement.contents:
-            if content.content_type.lower() == content_type.lower():
+            # this is basically matching_content from repolib
+            if content.content_type.lower() == content_type.lower() and \
+                    content_tag_match(content, ent_source):
                 log.debug("found content: %s" % content.label)
                 # no unique constraint atm
                 entitled_content.append(content)
     return entitled_content
+
+
+def content_tag_match(content, ent_source):
+    """See if content required tags are provided by installed products.
+
+    Note: this is skipped if the content does not have any required tags.
+    """
+
+    all_tags_found = True
+    for content_tag in content.tags:
+        log.debug("content_tag %s product_tags: %s",
+                  content_tag, ent_source.product_tags)
+        if content_tag not in ent_source.product_tags:
+            all_tags_found = False
+    return all_tags_found

--- a/src/subscription_manager/model/ent_cert.py
+++ b/src/subscription_manager/model/ent_cert.py
@@ -31,7 +31,7 @@ class EntitlementCertContent(Content):
         return cls(content_type=ent_cert_content.content_type,
             name=ent_cert_content.name, label=ent_cert_content.label,
             url=ent_cert_content.url, gpg=ent_cert_content.gpg,
-            cert=cert)
+            tags=ent_cert_content.required_tags, cert=cert)
 
 
 class EntitlementCertEntitlement(Entitlement):
@@ -59,6 +59,9 @@ class EntitlementDirEntitlementSource(EntitlementSource):
 
     def __init__(self):
         ent_dir = inj.require(inj.ENT_DIR)
+        prod_dir = inj.require(inj.PROD_DIR)
+
+        self.product_tags = prod_dir.get_provided_tags()
 
         # populate from ent certs
         self._entitlements = []

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -6,16 +6,34 @@ import fixture
 from subscription_manager import model
 
 
-def mock_content(name, content_type="yum"):
-    """name also has to work as a label."""
+def create_mock_content(name=None, url=None, gpg=None, enabled=None, content_type=None, tags=None):
     mock_content = mock.Mock()
-    mock_content.name = name
-    mock_content.url = "http://mock.example.com/%s/" % name
-    mock_content.gpg = "path/to/gpg"
-    mock_content.enabled = True
+    mock_content.name = name or "mock_content"
     mock_content.label = name
-    mock_content.content_type = content_type
+    mock_content.url = url or "http://mock.example.com/%s/" % name
+    mock_content.gpg = gpg or "path/to/gpg"
+    mock_content.enabled = enabled or True
+    mock_content.content_type = content_type or "yum"
+    mock_content.tags = tags or []
     return mock_content
+
+
+class TestContent(fixture.SubManFixture):
+    def test_init(self):
+        content = model.Content("content-label",
+                                "content name",
+                                "http://contenturl.example.com",
+                                "/path/to/gpg",
+                                ["product-content-tag"],
+                                cert=None)
+
+        self._check_attrs(content)
+        self.assertTrue(isinstance(content.tags, list))
+
+    def _check_attrs(self, content):
+        attrs = ['content_type', 'name', 'label', 'url', 'gpg', 'tags', 'cert']
+        for attr in attrs:
+            self.assertTrue(hasattr(content, attr))
 
 
 class TestEntitlement(fixture.SubManFixture):
@@ -40,40 +58,37 @@ class TestEntitlement(fixture.SubManFixture):
         self.assertTrue(isinstance(e.contents[0], mock.Mock))
 
 
-class TestEntitlementCertEntitlement(fixture.SubManFixture):
-    def test_from_ent_cert(self):
-        c = mock_content('mock_content')
-        contents = [c]
-
-        mock_ent_cert = mock.Mock()
-        mock_ent_cert.content = contents
-
-        ece = model.ent_cert.EntitlementCertEntitlement.from_ent_cert(mock_ent_cert)
-
-        self.assertEquals(ece.contents[0].name, contents[0].name)
-        self.assertEquals(ece.contents[0].label, contents[0].label)
-        self.assertEquals(ece.contents[0].gpg, contents[0].gpg)
-        self.assertEquals(ece.contents[0].content_type,
-            contents[0].content_type)
-        self.assertEquals(len(ece.contents), 1)
-
-        # for ostree content, gpg is likely to change
-        self.assertEquals(ece.contents[0].gpg, c.gpg)
-
-
-class TestEntitlementSource(fixture.SubManFixture):
-
+class EntitlementSourceBuilder(object):
     def contents_list(self, name):
-        return [mock_content(name), mock_content(name)]
+        return [self.mock_content(name), self.mock_content(name)]
 
-    def test(self):
+    def mock_content(self, name):
+        """name also has to work as a label."""
+        mock_content = create_mock_content(name=name)
+        return mock_content
+
+    def ent_source(self):
         cl1 = self.contents_list('content1')
         cl2 = self.contents_list('content2')
+
         ent1 = model.Entitlement(contents=cl1)
         ent2 = model.Entitlement(contents=cl2)
 
         es = model.EntitlementSource()
         es._entitlements = [ent1, ent2]
+        return es
+
+
+class TestEntitlementSource(fixture.SubManFixture):
+    def test_empty_init(self):
+        es = model.EntitlementSource()
+        # NOTE: this is just for testing this impl, the api
+        # itself should never reference self.entitlements
+        self.assertTrue(hasattr(es, '_entitlements'))
+
+    def test(self):
+        esb = EntitlementSourceBuilder()
+        es = esb.ent_source()
 
         self.assertEquals(len(es), 2)
 
@@ -83,20 +98,245 @@ class TestEntitlementSource(fixture.SubManFixture):
 
         self.assertTrue(isinstance(es[0], model.Entitlement))
 
-    def test_find_container_content(self):
-        yum_content = mock_content("yum_content", content_type="yum")
-        container_content = mock_content("container_content",
-            content_type="containerImage")
 
-        ent1 = model.Entitlement(contents=[yum_content])
-        ent2 = model.Entitlement(contents=[container_content])
+class TestFindContent(fixture.SubManFixture):
+    def test(self):
+        esb = EntitlementSourceBuilder()
+        es = esb.ent_source()
+
+        res = model.find_content(es, content_type="yum")
+        self.assertEquals(len(res), 4)
+
+    def test_product_tags(self):
+        esb = EntitlementSourceBuilder()
+        es = esb.ent_source()
+        es.product_tags = []
+
+        res = model.find_content(es, content_type="yum")
+        self.assertEquals(len(res), 4)
+
+    def test_product_tags_one_non_match(self):
+        esb = EntitlementSourceBuilder()
+        es = esb.ent_source()
+        es.product_tags = ['something-random-tag']
+
+        res = model.find_content(es, content_type="yum")
+        self.assertEquals(len(res), 4)
+
+    def test_product_tags_and_content_tags_match(self):
+        content = create_mock_content(tags=['awesomeos-ostree-1'],
+                                      content_type="ostree")
+        content_list = [content]
+
+        entitlement = model.Entitlement(contents=content_list)
+        es = model.EntitlementSource()
+        es._entitlements = [entitlement]
+        es.product_tags = ['awesomeos-ostree-1']
+
+        res = model.find_content(es, content_type="ostree")
+
+        self.assertEquals(len(res), 1)
+        self.assertEquals(res[0], content)
+
+    def test_product_tags_and_content_tags_no_match(self):
+        content1 = create_mock_content(tags=['awesomeos-ostree-23'],
+                                      content_type="ostree")
+        content2 = create_mock_content(name="more-test-content",
+                                       tags=['awesomeos-ostree-24'],
+                                       content_type="ostree")
+        content_list = [content1, content2]
+
+        entitlement = model.Entitlement(contents=content_list)
+        es = model.EntitlementSource()
+        es._entitlements = [entitlement]
+        es.product_tags = ['awesomeos-ostree-1']
+
+        res = model.find_content(es, content_type="ostree")
+
+        self.assertEquals(len(res), 0)
+
+    def test_product_tags_and_content_tags_no_match_no_product_tags(self):
+        content1 = create_mock_content(tags=['awesomeos-ostree-23'],
+                                      content_type="ostree")
+        content2 = create_mock_content(name="more-test-content",
+                                       tags=['awesomeos-ostree-24'],
+                                       content_type="ostree")
+        content_list = [content1, content2]
+
+        entitlement = model.Entitlement(contents=content_list)
+        es = model.EntitlementSource()
+        es._entitlements = [entitlement]
+
+        res = model.find_content(es, content_type="ostree")
+
+        self.assertEquals(len(res), 0)
+
+    def test_product_tags_and_content_tags_no_match_empty_product_tags(self):
+        content1 = create_mock_content(tags=['awesomeos-ostree-23'],
+                                      content_type="ostree")
+        content2 = create_mock_content(name="more-test-content",
+                                       tags=['awesomeos-ostree-24'],
+                                       content_type="ostree")
+        content_list = [content1, content2]
+
+        entitlement = model.Entitlement(contents=content_list)
+        es = model.EntitlementSource()
+        es._entitlements = [entitlement]
+        es.product_tags = []
+
+        res = model.find_content(es, content_type="ostree")
+
+        self.assertEquals(len(res), 0)
+
+    def test_product_tags_and_content_tags_multiple_content_one_match(self):
+        content1 = create_mock_content(tags=['awesomeos-ostree-23'],
+                                      content_type="ostree")
+        content2 = create_mock_content(name="more-test-content",
+                                       tags=['awesomeos-ostree-1'],
+                                       content_type="ostree")
+        content_list = [content1, content2]
+
+        entitlement = model.Entitlement(contents=content_list)
+        es = model.EntitlementSource()
+        es._entitlements = [entitlement]
+        es.product_tags = ['awesomeos-ostree-1']
+
+        res = model.find_content(es, content_type="ostree")
+
+        self.assertEquals(len(res), 1)
+        self.assertEquals(res[0], content2)
+
+    def test_no_content_tags(self):
+        content = create_mock_content(content_type="ostree")
+        content_list = [content]
+
+        entitlement = model.Entitlement(contents=content_list)
+        es = model.EntitlementSource()
+        es._entitlements = [entitlement]
+        es.product_tags = ['awesomeos-ostree-1']
+
+        res = model.find_content(es, content_type="ostree")
+        self.assertEquals(len(res), 1)
+        self.assertEquals(res[0], content)
+
+    def test_find_container_content(self):
+        container_content = create_mock_content(name="container_content",
+                                                tags=["awesomeos-1"],
+                                                content_type="containerImage")
+
+        ent1 = model.Entitlement(contents=[container_content])
 
         ent_src = model.EntitlementSource()
-        ent_src._entitlements = [ent1, ent2]
-        yum_list = model.find_content(ent_src, content_type='yum')
-        self.assertEquals(1, len(yum_list))
-        self.assertEquals('yum_content', yum_list[0].name)
+        ent_src._entitlements = [ent1]
+        ent_src.product_tags = ["awesomeos-1"]
+
         cont_list = model.find_content(ent_src,
             content_type='containerImage')
         self.assertEquals(1, len(cont_list))
         self.assertEquals('container_content', cont_list[0].name)
+
+    def test_awesomeos_product_tags(self):
+        product_tags_beta = ["awesomeos-ostree-beta", "awesomeos-ostree-beta-7"]
+        product_tags_htb = ["awesomeos-ostree-htb", "awesomeos-ostree-htb-7"]
+        product_tags_os = ["awesomeos-ostree", "awesomeos-ostree-7"]
+
+        content_tags_beta = ["awesomeos-ostree-beta-7"]
+        content_tags_htb = ["awesomeos-ostree-htb-7"]
+        content_tags_os = ["awesomeos-ostree-7"]
+
+        beta_ostree_content = create_mock_content(name="awesomeos_beta_ostree_content",
+                                                  tags=content_tags_beta,
+                                                  content_type="ostree")
+
+        htb_ostree_content = create_mock_content(name="awesomeos_htb_ostree_content",
+                                                 tags=content_tags_htb,
+                                                 content_type="ostree")
+
+        ostree_content = create_mock_content(name="awesomeos_ostree_content",
+                                             tags=content_tags_os,
+                                             content_type="ostree")
+
+        ent = model.Entitlement(contents=[ostree_content,
+                                          htb_ostree_content,
+                                          beta_ostree_content])
+
+        ent_src = model.EntitlementSource()
+        ent_src._entitlements = [ent]
+
+        # beta product
+        ent_src.product_tags = product_tags_beta
+        ostree_list = model.find_content(ent_src, content_type='ostree')
+        self.assertEquals(1, len(ostree_list))
+        self.assertEquals('awesomeos_beta_ostree_content', ostree_list[0].name)
+
+        # htb products
+        ent_src.product_tags = product_tags_htb
+        ostree_list = model.find_content(ent_src, content_type='ostree')
+        self.assertEquals(1, len(ostree_list))
+        self.assertEquals('awesomeos_htb_ostree_content', ostree_list[0].name)
+
+        ent_src.product_tags = product_tags_os
+        ostree_list = model.find_content(ent_src, content_type='ostree')
+        self.assertEquals(1, len(ostree_list))
+        self.assertEquals('awesomeos_ostree_content', ostree_list[0].name)
+
+        # beta product, no beta content
+        ent = model.Entitlement(contents=[ostree_content])
+        ent_src._entitlements = [ent]
+        ent_src.product_tags = product_tags_beta
+        ostree_list = model.find_content(ent_src, content_type='ostree')
+        self.assertEquals(0, len(ostree_list))
+
+        # awesomeos product, no os content, beta, htb content
+        ent = model.Entitlement(contents=[htb_ostree_content,
+                                          beta_ostree_content])
+        ent_src._entitlements = [ent]
+        ent_src.product_tags = product_tags_os
+        ostree_list = model.find_content(ent_src, content_type='ostree')
+        self.assertEquals(0, len(ostree_list))
+
+        # awesomeos and beta product, all content
+        ent = model.Entitlement(contents=[ostree_content,
+                                          htb_ostree_content,
+                                          beta_ostree_content])
+        ent_src._entitlements = [ent]
+        ent_src.product_tags = product_tags_os + product_tags_beta
+        ostree_list = model.find_content(ent_src, content_type='ostree')
+        # should be os and beta content
+        self.assertEquals(2, len(ostree_list))
+        content_names = [x.name for x in ostree_list]
+        self.assertTrue('awesomeos_ostree_content' in content_names)
+        self.assertTrue('awesomeos_beta_ostree_content' in content_names)
+        self.assertFalse('awesomeos_htb_ostree_content' in content_names)
+
+    def test_find_content_everything(self):
+        yum_content = create_mock_content(name="yum_content",
+                                          tags=["awesomeos-1"],
+                                          content_type="yum")
+        container_content = create_mock_content(name="container_content",
+                                                tags=["awesomeos-1"],
+                                                content_type="containerImage")
+        ostree_content = create_mock_content(name="ostree_content",
+                                             tags=["awesomeos-1"],
+                                             content_type="ostree")
+
+        ent1 = model.Entitlement(contents=[yum_content])
+        ent2 = model.Entitlement(contents=[container_content, ostree_content])
+
+        ent_src = model.EntitlementSource()
+        ent_src._entitlements = [ent1, ent2]
+        ent_src.product_tags = ["awesomeos-1"]
+
+        yum_list = model.find_content(ent_src, content_type='yum')
+        self.assertEquals(1, len(yum_list))
+        self.assertEquals('yum_content', yum_list[0].name)
+
+        cont_list = model.find_content(ent_src,
+            content_type='containerImage')
+        self.assertEquals(1, len(cont_list))
+        self.assertEquals('container_content', cont_list[0].name)
+
+        ostree_list = model.find_content(ent_src,
+                                         content_type="ostree")
+        self.assertEquals(1, len(ostree_list))
+        self.assertEquals('ostree_content', ostree_list[0].name)

--- a/test/test_model_ent_cert.py
+++ b/test/test_model_ent_cert.py
@@ -1,0 +1,136 @@
+
+import mock
+
+import fixture
+
+import test_model
+
+from rhsm import certificate2
+from subscription_manager import model
+from subscription_manager.model import ent_cert
+from subscription_manager import injection as inj
+
+
+class TestEntitlement(fixture.SubManFixture):
+    def test_empty_init(self):
+        e = model.Entitlement()
+        self.assertTrue(hasattr(e, 'contents'))
+
+    def test_init_empty_contents(self):
+        e = model.Entitlement(contents=[])
+        self.assertTrue(hasattr(e, 'contents'))
+        self.assertEquals(e.contents, [])
+
+    def test_contents(self):
+        contents = [mock.Mock(), mock.Mock()]
+        e = model.Entitlement(contents=contents)
+        self.assertTrue(hasattr(e, 'contents'))
+        self.assertEquals(len(e.contents), 2)
+
+        for a_content in e.contents:
+            self.assertTrue(isinstance(a_content, mock.Mock))
+
+        self.assertTrue(isinstance(e.contents[0], mock.Mock))
+
+
+def create_mock_content(name=None, url=None, gpg=None, enabled=None, content_type=None, tags=None):
+    mock_content = mock.Mock()
+    mock_content.name = name or "mock_content"
+    mock_content.url = url or "http://mock.example.com"
+    mock_content.gpg = gpg or "path/to/gpg"
+    mock_content.enabled = enabled or True
+    mock_content.content_type = content_type or "yum"
+    mock_content.tags = tags or []
+    return mock_content
+
+
+class TestEntitlementCertContent(test_model.TestContent):
+    def test_from_cert_content_yum(self):
+        mock_content = create_mock_content()
+
+        ent_cert_content = ent_cert.EntitlementCertContent.from_cert_content(mock_content)
+        self._check_attrs(ent_cert_content)
+
+    def test_from_cert_content_ostree(self):
+        mock_content = create_mock_content(content_type="ostree")
+
+        ent_cert_content = ent_cert.EntitlementCertContent.from_cert_content(mock_content)
+        self._check_attrs(ent_cert_content)
+
+    def test_from_cert_content_ostree_tags(self):
+        mock_content = create_mock_content(content_type="ostree", tags=["rhel-7-atomic"])
+
+        ent_cert_content = ent_cert.EntitlementCertContent.from_cert_content(mock_content)
+        self._check_attrs(ent_cert_content)
+
+
+class TestEntitlementCertEntitlement(TestEntitlement):
+    def test_from_ent_cert(self):
+        mock_content = create_mock_content()
+
+        contents = [mock_content]
+
+        mock_ent_cert = mock.Mock()
+        mock_ent_cert.content = contents
+
+        ece = model.ent_cert.EntitlementCertEntitlement.from_ent_cert(mock_ent_cert)
+
+        self.assertEquals(ece.contents[0].name, contents[0].name)
+        self.assertEquals(ece.contents[0].label, contents[0].label)
+        self.assertEquals(ece.contents[0].gpg, contents[0].gpg)
+        self.assertEquals(ece.contents[0].content_type,
+            contents[0].content_type)
+        self.assertEquals(len(ece.contents), 1)
+
+        # for ostree content, gpg is likely to change
+        self.assertEquals(ece.contents[0].gpg, mock_content.gpg)
+
+
+# FIXME: move to stubs/fixture, copied from ent_branding
+# The installed product ids don't have brand_type/brand_name, just the
+# Product from the ent cert
+class DefaultStubInstalledProduct(certificate2.Product):
+    def __init__(self, id=123, name="Awesome OS",
+                 provided_tags=None,
+                 brand_type=None, brand_name=None):
+
+        tags = provided_tags or ["awesomeos-ostree-1"]
+        super(DefaultStubInstalledProduct, self).__init__(id=id, name=name, provided_tags=tags,
+                                                          brand_type=brand_type,
+                                                          brand_name=brand_name)
+
+
+class TestEntitlementDirEntitlementSource(test_model.TestEntitlementSource):
+    def setUp(self):
+        super(TestEntitlementDirEntitlementSource, self).setUp()
+        self._inj_mock_dirs()
+
+    def _inj_mock_dirs(self, stub_product=None):
+
+        stub_product = stub_product or DefaultStubInstalledProduct()
+        mock_prod_dir = mock.NonCallableMock(name='MockProductDir')
+        mock_prod_dir.get_installed_products.return_value = [stub_product.id]
+        mock_prod_dir.get_provided_tags.return_value = stub_product.provided_tags
+
+        mock_content = create_mock_content(tags=['awesomeos-ostree-1'])
+        mock_cert_contents = [mock_content]
+
+        mock_ent_cert = mock.Mock(name='MockEntCert')
+        mock_ent_cert.products = [stub_product]
+        mock_ent_cert.content = mock_cert_contents
+
+        mock_ent_dir = mock.NonCallableMock(name='MockEntDir')
+        mock_ent_dir.list_valid.return_value = [mock_ent_cert]
+
+        inj.provide(inj.PROD_DIR, mock_prod_dir)
+        inj.provide(inj.ENT_DIR, mock_ent_dir)
+
+    def _stub_product(self):
+        return DefaultStubInstalledProduct
+
+    def test_init_no_matching(self):
+        # add a product that will not match product tags
+        self._inj_mock_dirs(stub_product=DefaultStubInstalledProduct(provided_tags=[]))
+        ecc = ent_cert.EntitlementDirEntitlementSource()
+        self.assertEquals(len(ecc), 1)
+        self.assertEquals(len(ecc.product_tags), 1)

--- a/test/test_ostree_content_plugin.py
+++ b/test/test_ostree_content_plugin.py
@@ -1031,6 +1031,7 @@ class TestOsTreeContents(fixture.SubManFixture):
             name="mock_content_%s" % name,
             label=name,
             enabled=True,
+            required_tags=[],
             gpg="path/to/gpg",
             url="http://mock.example.com/%s/" % name)
         return EntitlementCertContent.from_cert_content(content)
@@ -1047,6 +1048,48 @@ class TestOsTreeContents(fixture.SubManFixture):
 
         contents = find_content(ent_src,
             content_type=action_invoker.OSTREE_CONTENT_TYPE)
+        self.assertEquals(len(contents), 1)
+
+        for content in contents:
+            self.assertEquals(content.content_type,
+                action_invoker.OSTREE_CONTENT_TYPE)
+
+    def test_ent_source_product_tags(self):
+        yc = self.create_content("yum", "yum_content")
+        oc = self.create_content("ostree", "ostree_content")
+
+        ent1 = Entitlement(contents=[yc])
+        ent2 = Entitlement(contents=[oc])
+
+        ent_src = EntitlementSource()
+        ent_src._entitlements = [ent1, ent2]
+
+        # faux product_tags to hit find_content, but no content tags
+        ent_src.product_tags = ['awesomeos-ostree-1', 'awesomeos-ostree-super']
+
+        contents = find_content(ent_src,
+            content_type=action_invoker.OSTREE_CONTENT_TYPE)
+        self.assertEquals(len(contents), 1)
+
+        for content in contents:
+            self.assertEquals(content.content_type,
+                action_invoker.OSTREE_CONTENT_TYPE)
+
+    def test_ent_source_product_tags_and_content_tags(self):
+        oc = self.create_content("ostree", "ostree_content")
+        oc.tags = ['awesomeos-ostree-1']
+
+        ent = Entitlement(contents=[oc])
+
+        ent_src = EntitlementSource()
+        ent_src._entitlements = [ent]
+
+        # faux product_tags to hit find_content, but no content tags
+        ent_src.product_tags = ['awesomeos-ostree-1', 'awesomeos-ostree-super']
+
+        contents = find_content(ent_src,
+            content_type=action_invoker.OSTREE_CONTENT_TYPE)
+        print "contents", contents
         self.assertEquals(len(contents), 1)
 
         for content in contents:


### PR DESCRIPTION
model.find_content compares the required tags on
products with provided product tags, ala repolib.
