### PR TITLE
1157761: Fixed incorrect option usage in migration tool.

### DIFF
--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -638,7 +638,7 @@ class MigrationEngine(object):
         print _("Attempting to register system to destination server...")
         cmd = ['subscription-manager', 'register', '--username=' + credentials.username, '--password=' + credentials.password]
         if self.options.destination_url:
-            cmd.append('--server-url=' + self.options.destination_url)
+            cmd.append('--serverurl=' + self.options.destination_url)
 
         if org:
             cmd.append('--org=' + org)
@@ -647,14 +647,14 @@ class MigrationEngine(object):
 
         if self.options.five_to_six:
             if self.consumer_exists(self.consumer_id):
-                cmd.append('--consumer-id=' + self.consumer_id)
+                cmd.append('--consumerid=' + self.consumer_id)
 
         if self.options.auto:
             cmd.append('--auto-attach')
 
         if self.options.service_level:
             servicelevel = self.select_service_level(org, self.options.service_level)
-            cmd.append('--service-level=' + servicelevel)
+            cmd.append('--servicelevel=' + servicelevel)
 
         subprocess.call(cmd)
 

--- a/test/test_migration.py
+++ b/test/test_migration.py
@@ -1054,12 +1054,12 @@ class TestMigration(SubManFixture):
             'register',
             '--username=foo',
             '--password=bar',
-            '--server-url=http://example.com',
+            '--serverurl=http://example.com',
             '--org=org',
             '--environment=env',
-            '--consumer-id=id',
+            '--consumerid=id',
             '--auto-attach',
-            '--service-level=y',
+            '--servicelevel=y',
             ]
 
         self.engine.consumer_exists.assert_called_once_with(self.engine.consumer_id)
@@ -1104,7 +1104,7 @@ class TestMigration(SubManFixture):
             'register',
             '--username=foo',
             '--password=bar',
-            '--server-url=foobar',
+            '--serverurl=foobar',
             '--org=org',
             '--environment=env',
             '--auto-attach',


### PR DESCRIPTION
- The migration tool no longer uses hyphenated options when
  issuing commands to Subscription Manager.
