### PR TITLE
Make repolib tag matching use model.find_content

### DIFF
--- a/src/subscription_manager/model/__init__.py
+++ b/src/subscription_manager/model/__init__.py
@@ -26,15 +26,19 @@ class Content(object):
     """
     A generic representation of entitled content.
     """
-    def __init__(self, content_type, name, label, url=None,
-        gpg=None, tags=None, cert=None):
+    def __init__(self, content_type, name, label,
+                 url=None, gpg=None, tags=None, cert=None,
+                 enabled=None, metadata_expire=None):
         self.content_type = content_type
         self.name = name
         self.label = label
+
         self.url = url
         self.gpg = gpg
         self.tags = tags or []
         self.cert = cert
+        self.enabled = enabled
+        self.metadata_expire = metadata_expire
 
 
 class Entitlement(object):
@@ -83,23 +87,19 @@ def find_content(ent_source, content_type=None):
         for content in entitlement.contents:
             # this is basically matching_content from repolib
             if content.content_type.lower() == content_type.lower() and \
-                    content_tag_match(content, ent_source):
-                log.debug("found content: %s" % content.label)
-                # no unique constraint atm
+                    content_tag_match(content.tags, ent_source.product_tags):
                 entitled_content.append(content)
     return entitled_content
 
 
-def content_tag_match(content, ent_source):
+def content_tag_match(content_tags, product_tags):
     """See if content required tags are provided by installed products.
 
     Note: this is skipped if the content does not have any required tags.
     """
 
     all_tags_found = True
-    for content_tag in content.tags:
-        log.debug("content_tag %s product_tags: %s",
-                  content_tag, ent_source.product_tags)
-        if content_tag not in ent_source.product_tags:
+    for content_tag in content_tags:
+        if content_tag not in product_tags:
             all_tags_found = False
     return all_tags_found

--- a/src/subscription_manager/model/ent_cert.py
+++ b/src/subscription_manager/model/ent_cert.py
@@ -31,7 +31,9 @@ class EntitlementCertContent(Content):
         return cls(content_type=ent_cert_content.content_type,
             name=ent_cert_content.name, label=ent_cert_content.label,
             url=ent_cert_content.url, gpg=ent_cert_content.gpg,
-            tags=ent_cert_content.required_tags, cert=cert)
+            tags=ent_cert_content.required_tags, cert=cert,
+            enabled=ent_cert_content.enabled,
+            metadata_expire=ent_cert_content.metadata_expire)
 
 
 class EntitlementCertEntitlement(Entitlement):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -79,6 +79,72 @@ class EntitlementSourceBuilder(object):
         return es
 
 
+class TestContentTagMatch(fixture.SubManFixture):
+    def test_empty_content_empty_product(self):
+        content_tags = []
+        product_tags = []
+        matched = model.content_tag_match(content_tags, product_tags)
+        # no requires means no missing requires
+        self.assertTrue(matched)
+
+    def test_content_empty_product(self):
+        content_tags = ["awesomeos-1"]
+        product_tags = []
+        matched = model.content_tag_match(content_tags, product_tags)
+        # content requires 'awesomeos-1" but products do not provide
+        self.assertFalse(matched)
+
+    def test_empty_content_product_awesome(self):
+        content_tags = []
+        product_tags = ["awesomeos-1"]
+        matched = model.content_tag_match(content_tags, product_tags)
+        # no content requires, so anything matches
+        self.assertTrue(matched)
+
+    def test_content_awesome_product_awesome(self):
+        content_tags = ["awesomeos-1"]
+        product_tags = ["awesomeos-1"]
+        matched = model.content_tag_match(content_tags, product_tags)
+        # require awesomeos-1, have awesomeos-1
+        self.assertTrue(matched)
+
+    def test_content_awesome_product_meh(self):
+        content_tags = ["awesomeos-1"]
+        product_tags = ["mehos-1"]
+        matched = model.content_tag_match(content_tags, product_tags)
+        # The requires awesomeos-1 is not provided
+        self.assertFalse(matched)
+
+    def test_content_multiple_product_multiple(self):
+        content_tags = ["awesomeos-1", "awesomeos-server-1"]
+        product_tags = ["awesomeos-1", "awesomeos-server-1"]
+        matched = model.content_tag_match(content_tags, product_tags)
+        # content requires awesomeos-1 and awesomeos-server-1, and they are
+        # provided
+        self.assertTrue(matched)
+
+    def test_content_multiple_missing_product_multiple(self):
+        content_tags = ["awesomeos-server-1", "awesomeos-1"]
+        product_tags = ["awesomeos-1"]
+        matched = model.content_tag_match(content_tags, product_tags)
+        # content requires os and server, but only server is provided
+        self.assertFalse(matched)
+
+    def test_content_all_missing_product_multiple(self):
+        content_tags = ["mehos-1", "mehos-doorstop-1"]
+        product_tags = ["awesomeos-1", "awesomeos-server-1"]
+        matched = model.content_tag_match(content_tags, product_tags)
+        # none of the content required tags are provided
+        self.assertFalse(matched)
+
+    def test_content_dupes_product_dupes(self):
+        content_tags = ["awesomeos-1", "awesomeos-1", "awesomeos-1"]
+        product_tags = ["awesomeos-1", "awesomeos-1", "awesomeos-1"]
+        matched = model.content_tag_match(content_tags, product_tags)
+        # requires met multiple times
+        self.assertTrue(matched)
+
+
 class TestEntitlementSource(fixture.SubManFixture):
     def test_empty_init(self):
         es = model.EntitlementSource()

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -173,8 +173,8 @@ class RepoUpdateActionTests(SubManFixture):
     def test_no_gpg_key(self):
 
         update_action = RepoUpdateActionCommand()
-        content = update_action.get_content(self.stub_ent_cert,
-                                            "http://example.com", None)
+        content = update_action.get_all_content(baseurl="http://example.com",
+                                                ca_cert=None)
         c1 = self._find_content(content, 'c1')
         self.assertEquals('', c1['gpgkey'])
         self.assertEquals('0', c1['gpgcheck'])
@@ -186,16 +186,16 @@ class RepoUpdateActionTests(SubManFixture):
     def test_gpg_key(self):
 
         update_action = RepoUpdateActionCommand()
-        content = update_action.get_content(self.stub_ent_cert,
-                                            "http://example.com", None)
+        content = update_action.get_all_content(baseurl="http://example.com",
+                                                ca_cert=None)
         c4 = self._find_content(content, 'c4')
         self.assertEquals('http://example.com/gpg.key', c4['gpgkey'])
         self.assertEquals('1', c4['gpgcheck'])
 
     def test_ui_repoid_vars(self):
         update_action = RepoUpdateActionCommand()
-        content = update_action.get_content(self.stub_ent_cert,
-                                            "http://example.com", None)
+        content = update_action.get_all_content(baseurl="http://example.com",
+                                            ca_cert=None)
         c4 = self._find_content(content, 'c4')
         self.assertEquals('some path', c4['ui_repoid_vars'])
         c2 = self._find_content(content, 'c2')
@@ -208,8 +208,8 @@ class RepoUpdateActionTests(SubManFixture):
 
     def test_only_allow_content_of_type_yum(self):
         update_action = RepoUpdateActionCommand()
-        content = update_action.get_content(self.stub_ent_cert,
-                                            "http://example.com", None)
+        content = update_action.get_all_content(baseurl="http://example.com",
+                                                ca_cert=None)
         self.assertTrue(self._find_content(content, "c1") is not None)
         self.assertTrue(self._find_content(content, "c5") is None)
         self.assertTrue(self._find_content(content, "c6") is None)


### PR DESCRIPTION
repolib now uses model.find_content to match content
required tags and product provided tags. repolib and the
ostree and container plugins now use the same code for
this.

This also removes some of the verbose debug logging that
repolib previously had.
