### PR TITLE
1157387: Fix incorrect no installed products detected status in GUI.

### DIFF
--- a/src/subscription_manager/gui/installedtab.py
+++ b/src/subscription_manager/gui/installedtab.py
@@ -21,11 +21,13 @@ from subscription_manager.gui import widgets
 from subscription_manager.hwprobe import ClassicCheck
 from subscription_manager.utils import friendly_join
 
+import logging
 import gettext
 import gobject
 import gtk
 import os
 
+log = logging.getLogger('rhsm-app.' + __name__)
 
 _ = gettext.gettext
 
@@ -296,18 +298,20 @@ class InstalledProductsTab(widgets.SubscriptionManagerTab):
 
         if self.backend.cs.system_status == 'valid':
             self._set_status_icons(VALID_STATUS)
-            if self.backend.cs.compliant_until:
+            if len(self.backend.cs.installed_products.keys()) == 0:
+                # No product certs installed, thus no compliant until date:
+                self.subscription_status_label.set_text(
+                        # I18N: Please add newlines if translation is longer:
+                        _("No installed products detected."))
+            elif self.backend.cs.compliant_until:
                 self.subscription_status_label.set_markup(
                         # I18N: Please add newlines if translation is longer:
                         _("System is properly subscribed through %s.") %
                         managerlib.format_date(self.backend.cs.compliant_until))
             else:
-                # No product certs installed, no first invalid date, and
-                # the subscription assistant can't do anything, so we'll disable
-                # the button to launch it:
+                log.warn("Server did not provide a compliant until date.")
                 self.subscription_status_label.set_text(
-                        # I18N: Please add newlines if translation is longer:
-                        _("No installed products detected."))
+                    _("System is properly subscribed."))
         elif self.backend.cs.system_status == 'partial':
             self._set_status_icons(PARTIAL_STATUS)
             self.subscription_status_label.set_markup(


### PR DESCRIPTION
Against SAM 1.4, it seems quite easy to end up with a compliance report that
has no compliant until date. This appears to be a separate bug already fixed in
master and hosted.

The client was incorrectly assuming that if status was valid, and we have no
compliant until date, we must not have any installed products. (normally this
would be a safe assumption)

Instead explicitly check if we have no installed products, and if not we'll
display a less precise message that omits the compliant until date. A warning
is logged as well.
