### PR TITLE
Revert "1046132: Makes rhsm-icon slightly less annoying."

### DIFF
--- a/src/rhsm_icon/rhsm_icon.c
+++ b/src/rhsm_icon/rhsm_icon.c
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 #include <libintl.h>
 #include <locale.h>
-#include <time.h>
+
 #include <glib.h>
 #include <gconf/gconf-client.h>
 #include <gtk/gtk.h>
@@ -103,8 +103,6 @@ typedef enum _StatusType {
 	RHSM_REGISTRATION_REQUIRED
 } StatusType;
 
-static StatusType last_status;  // the last status reported through any means
-static time_t last_checked;  // the time the last check was made
 /* prototypes */
 
 static void hide_icon (Context *);
@@ -287,19 +285,9 @@ static void
 alter_icon (Context * context, StatusType status_type)
 {
 	context->show_registration = status_type == RHSM_REGISTRATION_REQUIRED;
-	long time_since_last_check = difftime(time(0), last_checked);
-	// _hide_icon should be true if the status is one we would like to hide the icon for
-	bool _hide_icon = ((status_type == RHN_CLASSIC) || (status_type == RHSM_VALID));
-	// update_icon should be true if the new status differs from the old or its been at least as long as the check_period
-	bool update_icon = time_since_last_check >= check_period || status_type != last_status;
-
-	// since we have used the old values already above, we can update them
-	last_checked = time(0);
-	last_status = status_type;
-	if (update_icon && !_hide_icon) {
-		display_icon (context, last_status);
-	} else if (_hide_icon){
-		// hides icon only if the status is one listed in _hide_icon above
+	if ((status_type != RHN_CLASSIC) && (status_type != RHSM_VALID)) {
+		display_icon (context, status_type);
+	} else {
 		hide_icon (context);
 	}
 }


### PR DESCRIPTION
This reverts commit 7278a031b636d91ff5554e006ccf10365c789f00.

Per comments in bug, QE has requested we go back to the drawing board on this.
