### PR TITLE
1113741: Fix rhsmd traceback on 502 errors.

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -192,11 +192,16 @@ class StatusCache(CacheManager):
             # which does not have the necessary API call.
             self.last_error = ex
             return None
-
-        # If we hit a network error, but no cache exists (extremely unlikely)
-        # then we are disconnected
-        except socket.error, ex:
+        except connection.AuthenticationException, ex:
+            log.error("Could not authenticate with server, check registration status.")
             log.exception(ex)
+            self.last_error = ex
+            return None
+        except (connection.RemoteServerException,
+                connection.NetworkException,
+                socket.error), ex:
+
+            log.error(ex)
             self.last_error = ex
             if not self._cache_exists():
                 log.error("Server unreachable, registered, but no cache exists.")
@@ -204,25 +209,10 @@ class StatusCache(CacheManager):
 
             log.warn("Unable to reach server, using cached status.")
             return self._read_cache()
-
-        except connection.NetworkException, ex:
-            log.exception(ex)
-            self.last_error = ex
-            if not self._cache_exists():
-                log.error("Server unreachable, registered, but no cache exists.")
-                raise
-
-            log.warn("Unable to reach server, using cached status.")
-            return self._read_cache()
         except connection.ExpiredIdentityCertException, ex:
             log.exception(ex)
             self.last_error = ex
             log.error("Bad identity, unable to connect to server")
-            return None
-        except connection.AuthenticationException, ex:
-            log.error("Could not authenticate with server, check registration status.")
-            log.exception(ex)
-            self.last_error = ex
             return None
 
     def to_dict(self):


### PR DESCRIPTION
rhsmd invoked from cron with the '-s' option would traceback
if getCompliance encounters a 502 error and raising a
RemoteServerException. The try/except block in cache.py now
handles that exception as well.

Also combine the handler for NetworkException, socket.error,
and RemoteServerException. This also changed the cache
behavior on an empty cache with network errors so that
the network exception isn't propragated up. In some
odd cases, the result will just be a slightly less specific
error message.

The caught exceptions here no longer get the traceback logged,
the exception msg is sufficient.
