### PR TITLE
1159266: rhsm-icon -i fails with "TypeError: 'NoneType' object has no at...

### DIFF
--- a/src/daemons/rhsm_d.py
+++ b/src/daemons/rhsm_d.py
@@ -22,6 +22,7 @@ import dbus
 import dbus.service
 import dbus.glib
 import logging
+import gettext
 
 import sys
 sys.path.append("/usr/share/rhsm")
@@ -35,7 +36,7 @@ from subscription_manager.injectioninit import init_dep_injection
 init_dep_injection()
 
 from subscription_manager.branding import get_branding
-from subscription_manager.injection import require, IDENTITY, CERT_SORTER
+from subscription_manager.injection import require, IDENTITY, CERT_SORTER, PROD_DIR
 from subscription_manager.hwprobe import ClassicCheck
 from subscription_manager.i18n_optparse import OptionParser, \
     WrappedIndentedHelpFormatter, USAGE
@@ -45,6 +46,8 @@ from subscription_manager.cert_sorter import RHSM_VALID, \
 
 import rhsm.config
 CFG = rhsm.config.initConfig()
+
+_ = gettext.gettext
 
 enable_debug = False
 
@@ -86,22 +89,31 @@ def check_status(force_signal):
         return pre_result
 
     sorter = require(CERT_SORTER)
-
     return sorter.get_status_for_icon()
 
 
-def get_compliance_status():
+def refresh_compliance_status(dbus_properties):
     sorter = require(CERT_SORTER)
+    installed_products = require(PROD_DIR)
     status = sorter.get_compliance_status()
-    result = dbus.Dictionary({})
-    result.update({"system_status": (status['status'], "")})
 
-    for reason in status['reasons']:
-        label = reason['attributes']['product_id']
-        name = reason['attributes']['name']
-        message = reason['message']
-        result.update({label:(name, message)})
-    return result
+    dbus_properties["Status"] = _("System is not registered.")
+    if status:
+        dbus_properties["Status"] = status['status']
+        dbus_properties["Entitlements"] = {}
+        for prod in status['compliantProducts']:
+            state = sorter.get_status(prod)
+            installed_product = installed_products.find_by_product(prod).products[0]
+            dbus_properties["Entitlements"][prod] = (installed_product.name, state, _("Subscribed"))
+        for reason in status['reasons']:
+            label = reason['attributes']['product_id']
+            name = reason['attributes']['name']
+            message = reason['message']
+            state = sorter.get_status(label)
+            dbus_properties["Entitlements"][label] = (name, state, message)
+    else:
+        dbus_properties.pop("Entitlements", None)
+
 
 def check_if_ran_once(checker, loop):
     if checker.has_run:
@@ -112,9 +124,10 @@ def check_if_ran_once(checker, loop):
 
 
 class StatusChecker(dbus.service.Object):
+    INTERFACE_NAME = "com.redhat.SubscriptionManager"
 
     def __init__(self, bus, keep_alive, force_signal, loop):
-        name = dbus.service.BusName("com.redhat.SubscriptionManager", bus)
+        name = dbus.service.BusName(self.INTERFACE_NAME, bus)
         dbus.service.Object.__init__(self, name, "/EntitlementStatus")
         self.has_run = False
         #this will get set after first invocation
@@ -122,6 +135,12 @@ class StatusChecker(dbus.service.Object):
         self.keep_alive = keep_alive
         self.force_signal = force_signal
         self.loop = loop
+        self._dbus_properties = {
+            "Version": "1.0",
+            "Status": _("System not registered."),
+            "Entitlements": {}
+        }
+
 
     @dbus.service.signal(
         dbus_interface='com.redhat.SubscriptionManager.EntitlementStatus',
@@ -130,12 +149,6 @@ class StatusChecker(dbus.service.Object):
         log.info("D-Bus signal com.redhat.SubscriptionManager.EntitlementStatus.entitlement_status_changed emitted")
         debug("signal fired! code is " + str(status_code))
 
-    @dbus.service.signal(
-        dbus_interface='com.redhat.SubscriptionManager.EntitlementStatus',
-        signature='a{s(ss)}')
-    def entitlement_status_changed_reason(self, reason):
-        log.info("D-Bus signal com.redhat.SubscriptionManager.EntitlementStatus.entitlement_status_changed_reason emitted")
-        debug("signal fired! reason is status: %s" % (reason['system_status'],))
 
     #this is so we can guarantee exit after the dbus stuff is done, since
     #certain parts of that are async
@@ -157,7 +170,6 @@ class StatusChecker(dbus.service.Object):
             debug("Validity status changed, fire signal")
             #we send the code out, but no one uses it at this time
             self.entitlement_status_changed(ret)
-            self.entitlement_status_changed_reason(get_compliance_status())
         self.last_status = ret
         self.has_run = True
         self.watchdog()
@@ -174,10 +186,55 @@ class StatusChecker(dbus.service.Object):
         if status != self.last_status:
             debug("Validity status changed, fire signal")
             self.entitlement_status_changed(status)
-            self.entitlement_status_changed_reason(get_compliance_status())
         self.last_status = status
         self.has_run = True
         self.watchdog()
+
+    @dbus.service.method(
+            dbus_interface="com.redhat.SubscriptionManager.EntitlementStatus",
+            in_signature='')
+    def emit_status(self):
+        log.info("D-Bus interface com.redhat.SubscriptionManager.EntitlementStatus.emit_status called ")
+        refresh_compliance_status(self._dbus_properties)
+        # this code assumes that all properties change
+        changes = self._dbus_properties
+        log.info("emit_PropertiesChanged called, changed properties: %s", str(changes))
+        self.PropertiesChanged(self.INTERFACE_NAME, changes, [])
+
+    @dbus.service.signal(
+            dbus_interface=dbus.PROPERTIES_IFACE,
+            signature="sa{sv}as")
+    def PropertiesChanged(self, interface_name, changed_properties,
+                          invalidated_properties):
+        log.info("PropertiesChanged called")
+
+    @dbus.service.method(
+            dbus_interface=dbus.PROPERTIES_IFACE,
+            in_signature="ss", out_signature="v")
+    def Get(self, interface_name, property_name):
+        log.info("Get(%s, %s) called", interface_name, property_name)
+        refresh_compliance_status(self._dbus_properties)
+        if self._dbus_properties.has_key(property_name):
+            return self.GetAll(interface_name)[property_name]
+        raise dbus.exceptions.DBusException("Uknown property %s", property_name)
+
+    @dbus.service.method(
+            dbus_interface=dbus.PROPERTIES_IFACE,
+            in_signature="s", out_signature="a{sv}")
+    def GetAll(self, interface_name):
+        log.info("GetAll(%s) called", interface_name)
+        refresh_compliance_status(self._dbus_properties)
+        if interface_name == self.INTERFACE_NAME:
+            return self._dbus_properties
+        else:
+            raise dbus.exceptions.DBusException("SubscriptionManager does not implement %s interface" % interface_name)
+
+    @dbus.service.method(
+            dbus_interface=dbus.PROPERTIES_IFACE,
+            in_signature="ssv")
+    def Set(self, interface_name, property_name, new_value):
+        log.info("Set(%s) called", interface_name)
+        raise dbus.exceptions.DBusException("All SubscriptionManager properties are read-only")
 
 
 def parse_force_signal(cli_arg):

--- a/src/subscription_manager/dbus_interface.py
+++ b/src/subscription_manager/dbus_interface.py
@@ -54,6 +54,7 @@ class DbusIface(object):
             self.validity_iface.update_status(
                     inj.require(inj.CERT_SORTER).get_status_for_icon(),
                     ignore_reply=self.has_main_loop)
+            self.validity_iface.emit_status(ignore_reply=self.has_main_loop)
         except dbus.DBusException, e:
             # Should be unreachable in the gui
             log.debug("Failed to update rhsmd")


### PR DESCRIPTION
...tribute '**getitem**'"

Modified calls to move new status call out of startup process for rhsm-icon. The
poke no longer fires the full status response.
Updated to fit dbus expected standard for Properites
