### PR TITLE
1147463: Log py.warnings to shutup gobject warning

### DIFF
--- a/bin/subscription-manager-gui
+++ b/bin/subscription-manager-gui
@@ -47,7 +47,12 @@ _ = gettext.gettext
 # get with glib2-2.40
 # See https://bugzilla.gnome.org/show_bug.cgi?id=698614 for why we can
 # ignore this warning (it was reverted in glib2-2.42 and later...)
-logging.captureWarnings(True)
+
+try:
+    # python 2.7+ only
+    logging.captureWarnings(True)
+except AttributeError:
+    pass
 
 try:
     import gtk

--- a/src/subscription_manager/logutil.py
+++ b/src/subscription_manager/logutil.py
@@ -64,7 +64,6 @@ def _get_handler():
     handler.setFormatter(logging.Formatter(LOG_FORMAT))
     handler.setLevel(LOG_LEVEL)
     handler.addFilter(ContextLoggingFilter(name=""))
-    handler.addFilter(PyWarningsLoggingFilter(name="py.warnings"))
 
     return handler
 
@@ -76,7 +75,6 @@ def _get_stdout_handler():
 
     handler = logging.StreamHandler()
     handler.addFilter(ContextLoggingFilter(name=""))
-    handler.addFilter(PyWarningsLoggingFilter(name="py.warnings"))
 
     return handler
 
@@ -96,6 +94,9 @@ class ContextLoggingFilter(object):
         return True
 
 
+# Note: this only does anything for python 2.6+, if the
+# logging module has 'captureWarnings'. Otherwise it will not
+# be triggered.
 class PyWarningsLoggingFilter(object):
     """Add a prefix to the messages from py.warnings.
 
@@ -121,6 +122,7 @@ def init_logger():
 
     # log python and pygtk "warnings" sent here by logging.captureWarnings
     logging.getLogger("py.warnings").setLevel(logging.WARNING)
+    logging.getLogger("py.warnings").addFilter(PyWarningsLoggingFilter(name="py.warnings"))
 
     # FIXME: remove 'rhsm-app' when we rename all the loggers
     logging.getLogger("rhsm-app").setLevel(LOG_LEVEL)

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -7,7 +7,11 @@ import tempfile
 
 # just log py.warnings (and pygtk warnings in particular)
 import logging
-logging.captureWarnings(True)
+try:
+    # 2.7+
+    logging.captureWarnings(True)
+except AttributeError:
+    pass
 
 from mock import Mock, MagicMock, NonCallableMock, patch, mock_open
 from contextlib import contextmanager


### PR DESCRIPTION
On startup, we were always getting a gobject warning like:
  /usr/lib64/python2.7/site-packages/gobject/**init**.py:115: Warning:
  Attempt to add property subscription_manager+gui+widgets+CellRendererDate::date
  after class was initialised
    type_register(cls, namespace.get('**gtype_name**'))

This warning is spurious and has been removed in newer versions
of glib. See https://bugzilla.gnome.org/show_bug.cgi?id=698614

But warnings to stdout/stdout are not useful for a gui app
typically launched from desktop app launchers not a shell.
So use the "logging.captureWarnings" method to send those
warnings to the "py.warnings" log.

Add a PyWarningsLoggingFilter class to add a note about the
source of the log messages to the log msg, without changing the
current logging format.
