### PR TITLE
1149286: Removed obsolete CLI options from auto-completion

### DIFF
--- a/etc-conf/rhn-migrate-classic-to-rhsm.completion.sh
+++ b/etc-conf/rhn-migrate-classic-to-rhsm.completion.sh
@@ -11,7 +11,7 @@ _rhn-migrate-classic-to-rhsm()
 	first="${COMP_WORDS[1]}"
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	opts="-h --help --environment -f --force -g --gui -n --no-auto --no-proxy --org -s --servicelevel --legacy-user --legacy-password --destination-url --destination-user --destination-password"
+	opts="-h --help --environment -f --force -n --no-auto --no-proxy --org -s --servicelevel --legacy-user --legacy-password --destination-url --destination-user --destination-password"
 
 	case "${cur}" in
 		-*)


### PR DESCRIPTION
- The -g and -gui options have been removed from the migration tool's
  auto-completion script.
