### PR TITLE
1142918: Fixed proxy config button labels

### DIFF
--- a/src/subscription_manager/gui/data/networkConfig.glade
+++ b/src/subscription_manager/gui/data/networkConfig.glade
@@ -276,7 +276,7 @@
                 <property name="receives_default">True</property>
                 <property name="use_underline">True</property>
                 <accessibility>
-                  <atkproperty name="AtkObject::accessible-name" translatable="yes">Test Connection Button</atkproperty>
+                  <atkproperty name="AtkObject::accessible-name" translatable="yes">Cancel Button</atkproperty>
                 </accessibility>
               </widget>
               <packing>


### PR DESCRIPTION
- The "cancel" button on the proxy configuration window no longer
  has the same accessibility label as the "test connection" button.
