### PR TITLE
1058231: Adjusted "last update" label positioning

### DIFF
--- a/src/subscription_manager/gui/data/factsdialog.glade
+++ b/src/subscription_manager/gui/data/factsdialog.glade
@@ -176,14 +176,14 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <widget class="GtkHBox" id="hbox3">
+              <widget class="GtkVBox" id="vbox3">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
                   <widget class="GtkLabel" id="last_update_title">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="xalign">0</property>
                     <property name="xpad">10</property>
                     <property name="label" translatable="yes">Last Update:</property>
                   </widget>
@@ -198,6 +198,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
+                    <property name="xpad">10</property>
                     <accessibility>
                       <atkproperty name="AtkObject::accessible-name" translatable="yes">Update Time</atkproperty>
                     </accessibility>


### PR DESCRIPTION
- Moved the "Last Update" label on the SubMan GUI "view facts"
  dialog such that it now sits on a line above the actual date.
  This should provide extra space for displaying the date in
  certain languages without significantly changing the layout.
