### PR TITLE
1175291: Fixed a bug with attaching pools via empty file

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1433,6 +1433,12 @@ class AttachCommand(CliCommand):
         if self.options.file:
             if self.options.file == '-' or os.path.isfile(self.options.file):
                 self._read_pool_ids(self.options.file)
+
+                if len(self.options.pool) < 1:
+                    if self.options.file == '-':
+                        system_exit(os.EX_DATAERR, _("Error: Received data does not contain any pool IDs."))
+                    else:
+                        system_exit(os.EX_DATAERR, _("Error: The file \"%s\" does not contain any pool IDs.") % self.options.file)
             else:
                 system_exit(os.EX_DATAERR, _("Error: The file \"%s\" does not exist or cannot be read.") % self.options.file)
 


### PR DESCRIPTION
- When attaching pools with the --file option, the attach command
  will no longer perform an auto-attach if no pools are specified
  in the given file.
