### PR TITLE
1175185: Removed extra slash from rhsm-debug output

### DIFF
--- a/src/rhsm_debug/debug_commands.py
+++ b/src/rhsm_debug/debug_commands.py
@@ -176,7 +176,7 @@ class SystemCommand(CliCommand):
                 # rename only works on the same filesystem, but it is atomic.
                 os.rename(content_path, dest_dir_name)
 
-                print _("Wrote: %s/%s") % (self.options.destination, archive_name)
+                print _("Wrote: %s") % dest_dir_name
 
         except Exception, e:
             managercli.handle_exception(_("Unable to create zip file of system information: %s") % e, e)


### PR DESCRIPTION
- The extra slash will no longer be printed when using the
  rhsm-debug command "system" with a destination directory
  containing a trailing slash and the no-archive flag set.
