### PR TITLE
Wottop/884285 lifetime

### DIFF
--- a/bin/subscription-manager
+++ b/bin/subscription-manager
@@ -55,6 +55,9 @@ try:
     from subscription_manager import logutil
     logutil.init_logger()
 
+    from dbus.mainloop.glib import DBusGMainLoop
+    DBusGMainLoop(set_as_default=True)
+
     from subscription_manager.injectioninit import init_dep_injection
     init_dep_injection()
 

--- a/src/subscription_manager/dbus_interface.py
+++ b/src/subscription_manager/dbus_interface.py
@@ -14,7 +14,7 @@
 #
 
 import dbus
-import inspect
+import gobject
 import logging
 import subscription_manager.injection as inj
 
@@ -24,14 +24,15 @@ log = logging.getLogger('rhsm-app.' + __name__)
 class DbusIface(object):
 
     service_name = 'com.redhat.SubscriptionManager'
+    has_main_loop = False
 
     def __init__(self):
         try:
             # Only follow names if there is a default main loop
-            self.has_main_loop = self._get_main_loop() is not None
+            self.has_main_loop = dbus.get_default_main_loop() is not None
 
             self.bus = dbus.SystemBus()
-            validity_obj = self._get_validity_object(self.service_name,
+            validity_obj = self.bus.get_object(self.service_name,
                     '/EntitlementStatus',
                     follow_name_owner_changes=self.has_main_loop)
             self.validity_iface = dbus.Interface(validity_obj,
@@ -49,29 +50,19 @@ class DbusIface(object):
     def update(self):
         pass
 
+    def update_status(self):
+        self.validity_iface.update_status(
+                inj.require(inj.CERT_SORTER).get_status_for_icon(),
+                ignore_reply=self.has_main_loop)
+
+    def emit_status(self):
+        self.validity_iface.emit_status()
+
     def _update(self):
         try:
-            self.validity_iface.update_status(
-                    inj.require(inj.CERT_SORTER).get_status_for_icon(),
-                    ignore_reply=self.has_main_loop)
-            self.validity_iface.emit_status(ignore_reply=self.has_main_loop)
+            gobject.idle_add(self.update_status)
+            gobject.idle_add(self.emit_status)
         except dbus.DBusException, e:
             # Should be unreachable in the gui
             log.debug("Failed to update rhsmd")
             log.exception(e)
-
-    # RHEL5 doesn't support 'follow_name_owner_changes'
-    def _get_validity_object(self, *args, **kwargs):
-        iface_args = inspect.getargspec(self.bus.get_object)[0]
-        if 'follow_name_owner_changes' not in iface_args and \
-                'follow_name_owner_changes' in kwargs:
-            log.debug("installed python-dbus doesn't support 'follow_name_owner_changes'")
-            del kwargs['follow_name_owner_changes']
-        return self.bus.get_object(*args, **kwargs)
-
-    # RHEL5 doesn't support 'get_default_main_loop'
-    def _get_main_loop(self):
-        if not hasattr(dbus, "get_default_main_loop"):
-            log.debug("installed python-dbus doesn't support 'get_default_main_loop'")
-            return None
-        return dbus.get_default_main_loop()

--- a/src/subscription_manager/logutil.py
+++ b/src/subscription_manager/logutil.py
@@ -20,7 +20,7 @@ CERT_LOG = '/var/log/rhsm/rhsmcertd.log'
 handler = None
 stdout_handler = None
 
-LOG_FORMAT = u'%(asctime)s [%(levelname)s] %(cmd_name)s ' \
+LOG_FORMAT = u'%(asctime)s [%(levelname)s] %(cmd_name)s:%(process)d ' \
               '@%(filename)s:%(lineno)d - %(message)s'
 
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -28,6 +28,7 @@ import re
 import socket
 import sys
 from time import localtime, strftime, strptime
+import gobject
 
 from M2Crypto import X509
 
@@ -488,6 +489,13 @@ class CliCommand(AbstractCLICommand):
         except X509.X509Error, e:
             log.error(e)
             print _('System certificates corrupted. Please reregister.')
+        finally:
+            # clear the loop
+            mainloop = gobject.MainLoop()
+            mainctx = mainloop.get_context()
+            while (mainctx.pending()):
+                mainctx.iteration()
+            mainloop.quit()
 
 
 class UserPassCommand(CliCommand):


### PR DESCRIPTION
allows the 2 dbus messages to go out successfully on entitlement update: integer for rhsm-icon, dictionary of compliance reasons for Cockpit.

use dbus-monitor --system --monitor to observe signals. [add "path=/EntitlementStatus" to filter.]

RHEL 7 showed the problems better than Fedora 20. Should confirm on that.
