### PR TITLE
1176219: Connection errors will now print a message to stderr.

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -24,6 +24,7 @@ import logging
 import os
 import socket
 import threading
+import sys
 from M2Crypto import SSL
 
 from rhsm.config import initConfig
@@ -169,7 +170,7 @@ class StatusCache(CacheManager):
         """
         Load status from wherever is appropriate.
 
-        If server is reachable, return it's response
+        If server is reachable, return its response
         and cache the results to disk.
 
         If the server is not reachable, return the latest cache if
@@ -216,6 +217,8 @@ class StatusCache(CacheManager):
                 return None
 
             log.warn("Unable to reach server, using cached status.")
+            sys.stderr.write(_("Unable to reach server, using cached status.\n"))
+
             return self._read_cache()
 
     def to_dict(self):

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -24,7 +24,6 @@ import logging
 import os
 import socket
 import threading
-import sys
 from M2Crypto import SSL
 
 from rhsm.config import initConfig
@@ -182,26 +181,32 @@ class StatusCache(CacheManager):
             self._sync_with_server(uep, uuid)
             self.write_cache()
             self.last_error = False
+
+            StatusCache._notify_load_status_callbacks(self, True, False)
             return self.server_status
         except SSL.SSLError, ex:
             log.exception(ex)
             self.last_error = ex
             log.error("Consumer certificate is invalid")
+            StatusCache._notify_load_status_callbacks(self, False, False)
             return None
         except connection.RestlibException, ex:
             # Indicates we may be talking to a very old candlepin server
             # which does not have the necessary API call.
             self.last_error = ex
+            StatusCache._notify_load_status_callbacks(self, False, False)
             return None
         except connection.AuthenticationException, ex:
             log.error("Could not authenticate with server, check registration status.")
             log.exception(ex)
             self.last_error = ex
+            StatusCache._notify_load_status_callbacks(self, False, False)
             return None
         except connection.ExpiredIdentityCertException, ex:
             log.exception(ex)
             self.last_error = ex
             log.error("Bad identity, unable to connect to server")
+            StatusCache._notify_load_status_callbacks(self, False, False)
             return None
         except connection.GoneException:
             raise
@@ -214,10 +219,11 @@ class StatusCache(CacheManager):
             self.last_error = ex
             if not self._cache_exists():
                 log.error("Server unreachable, registered, but no cache exists.")
+                StatusCache._notify_load_status_callbacks(self, False, False)
                 return None
 
             log.warn("Unable to reach server, using cached status.")
-            sys.stderr.write(_("Unable to reach server, using cached status.\n"))
+            StatusCache._notify_load_status_callbacks(self, True, True)
 
             return self._read_cache()
 
@@ -278,6 +284,58 @@ class StatusCache(CacheManager):
     def delete_cache(self):
         super(StatusCache, self).delete_cache()
         self.server_status = None
+
+    @staticmethod
+    def register_load_status_callback(callback):
+        """
+        Registers the specified callback with this class. If the callback has already been
+        registered with this class, this method does nothing.
+
+        The callback will be called each time the load_status method is invoked. For each
+        invocation, the callback will receive the StatusCache instance on which the load_status
+        method was invoked, if operation completed successfully and whether or not the result was
+        returned from cache.
+
+        Returns true if the callback was registered succesfully; false otherwise.
+        """
+        try:
+            if callback not in StatusCache._ls_callbacks:
+                StatusCache._ls_callbacks.append(callback)
+                return True
+
+        except AttributeError:
+            StatusCache._ls_callbacks = [callback]
+            return True
+
+        return False
+
+    @staticmethod
+    def remove_load_status_callback(callback):
+        """
+        Removes the specified callback from this class. If the callback had not been previously
+        registered with this class, this method does nothing.
+
+        Returns true if the callback was removed successfully; false otherwise.
+        """
+        try:
+            StatusCache._ls_callbacks.remove(callback)
+            return True
+
+        except ValueError:
+            pass
+
+        except AttributeError:
+            pass
+
+        return False
+
+    @staticmethod
+    def _notify_load_status_callbacks(instance, success, exception):
+        try:
+            for callback in StatusCache._ls_callbacks:
+                callback(instance, success, exception)
+        except AttributeError:
+            pass
 
 
 class EntitlementStatusCache(StatusCache):

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -23,7 +23,7 @@ from mock import Mock
 # used to get a user readable cfg class for test cases
 from stubs import StubProduct, StubProductCertificate, StubCertificateDirectory, \
         StubEntitlementCertificate, StubPool, StubEntitlementDirectory
-from fixture import SubManFixture
+from fixture import SubManFixture, Capture
 
 from rhsm import ourjson as json
 from subscription_manager.cache import ProfileManager, \
@@ -294,7 +294,11 @@ class TestReleaseStatusCache(SubManFixture):
         dummy_release = {'releaseVer': 'MockServer'}
         self.release_cache._read_cache = Mock(return_value=dummy_release)
         self.release_cache._cache_exists = Mock(return_value=True)
-        self.assertEquals(dummy_release, self.release_cache.read_status(uep, "SOMEUUID"))
+
+        with Capture(True):
+            status = self.release_cache.read_status(uep, "SOMEUUID")
+
+        self.assertEquals(dummy_release, status)
 
     def test_server_network_works_with_cache(self):
         uep = Mock()
@@ -357,7 +361,10 @@ class TestEntitlementStatusCache(SubManFixture):
         uep.getCompliance = Mock(side_effect=socket.error("boom"))
         self.status_cache._cache_exists = Mock(return_value=True)
         self.status_cache._read_cache = Mock(return_value=dummy_status)
-        status = self.status_cache.load_status(uep, "SOMEUUID")
+
+        with Capture(True):
+            status = self.status_cache.load_status(uep, "SOMEUUID")
+
         self.assertEquals(dummy_status, status)
         self.assertEquals(1, self.status_cache._read_cache.call_count)
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -23,12 +23,12 @@ from mock import Mock
 # used to get a user readable cfg class for test cases
 from stubs import StubProduct, StubProductCertificate, StubCertificateDirectory, \
         StubEntitlementCertificate, StubPool, StubEntitlementDirectory
-from fixture import SubManFixture, Capture
+from fixture import SubManFixture
 
 from rhsm import ourjson as json
 from subscription_manager.cache import ProfileManager, \
         InstalledProductsManager, EntitlementStatusCache, \
-        PoolTypeCache, ReleaseStatusCache
+        PoolTypeCache, ReleaseStatusCache, StatusCache
 
 from rhsm.profile import Package, RPMProfile
 
@@ -166,6 +166,76 @@ class TestProfileManager(unittest.TestCase):
         return mock_profile
 
 
+class TestStatusCache(unittest.TestCase):
+    def test_register_and_remove_load_status_callback(self):
+        def test_callback_one(a, b, c):
+            pass
+
+        def test_callback_two(a, b, c):
+            pass
+
+        result = StatusCache.remove_load_status_callback(test_callback_one)
+        self.assertFalse(result)
+
+        result = StatusCache.register_load_status_callback(test_callback_one)
+        self.assertTrue(result)
+
+        result = StatusCache.register_load_status_callback(test_callback_two)
+        self.assertTrue(result)
+
+        result = StatusCache.register_load_status_callback(test_callback_one)
+        self.assertFalse(result)
+
+        result = StatusCache.register_load_status_callback(test_callback_two)
+        self.assertFalse(result)
+
+        result = StatusCache.remove_load_status_callback(test_callback_one)
+        self.assertTrue(result)
+
+        result = StatusCache.remove_load_status_callback(test_callback_one)
+        self.assertFalse(result)
+
+        result = StatusCache.remove_load_status_callback(test_callback_two)
+        self.assertTrue(result)
+
+        result = StatusCache.remove_load_status_callback(test_callback_two)
+        self.assertFalse(result)
+
+    def test_execute_callbacks(self):
+        call_count = [0, 0]
+
+        def test_callback_one(a, b, c):
+            self.assertEquals((a, b, c), ('a', 'b', 'c'))
+            call_count[0] += 1
+
+        def test_callback_two(a, b, c):
+            self.assertEquals((a, b, c), ('a', 'b', 'c'))
+            call_count[1] += 1
+
+        StatusCache._notify_load_status_callbacks('a', 'b', 'c')
+        self.assertEquals(call_count, [0, 0])
+
+        StatusCache.register_load_status_callback(test_callback_one)
+
+        StatusCache._notify_load_status_callbacks('a', 'b', 'c')
+        self.assertEquals(call_count, [1, 0])
+
+        StatusCache.register_load_status_callback(test_callback_two)
+
+        StatusCache._notify_load_status_callbacks('a', 'b', 'c')
+        self.assertEquals(call_count, [2, 1])
+
+        StatusCache.remove_load_status_callback(test_callback_one)
+
+        StatusCache._notify_load_status_callbacks('a', 'b', 'c')
+        self.assertEquals(call_count, [2, 2])
+
+        StatusCache.remove_load_status_callback(test_callback_two)
+
+        StatusCache._notify_load_status_callbacks('a', 'b', 'c')
+        self.assertEquals(call_count, [2, 2])
+
+
 class TestInstalledProductsCache(SubManFixture):
 
     def setUp(self):
@@ -295,9 +365,7 @@ class TestReleaseStatusCache(SubManFixture):
         self.release_cache._read_cache = Mock(return_value=dummy_release)
         self.release_cache._cache_exists = Mock(return_value=True)
 
-        with Capture(True):
-            status = self.release_cache.read_status(uep, "SOMEUUID")
-
+        status = self.release_cache.read_status(uep, "SOMEUUID")
         self.assertEquals(dummy_release, status)
 
     def test_server_network_works_with_cache(self):
@@ -362,9 +430,7 @@ class TestEntitlementStatusCache(SubManFixture):
         self.status_cache._cache_exists = Mock(return_value=True)
         self.status_cache._read_cache = Mock(return_value=dummy_status)
 
-        with Capture(True):
-            status = self.status_cache.load_status(uep, "SOMEUUID")
-
+        status = self.status_cache.load_status(uep, "SOMEUUID")
         self.assertEquals(dummy_status, status)
         self.assertEquals(1, self.status_cache._read_cache.call_count)
 


### PR DESCRIPTION
- The StatusCache object will now print a warning to stderr if it
  is unable to connect to the server, but will continue with cached
  status instead.