### PR TITLE
Make 'attach' auto unless otherwise specified.

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -261,22 +261,22 @@ The
 command applies a specific subscription to the system.
 
 .TP
-.B --pool=POOLID
-Gives the ID for the subscriptions pool (collection of products) to attach to the system. This option is required, unless
 .B --auto
+Automatically attaches the best-matched compatible subscription or subscriptions to the system. This is the default unless
+.B --pool
 or
 .B --file
 are used.
 
 .TP
+.B --pool=POOLID
+Gives the ID for the subscriptions pool (collection of products) to attach to the system. This overrides the default of --auto.
+
+.TP
 .B --file=FILE
-Specifies a file from which to read whitespace-delimited pool IDs. If FILE is "-", the pool IDs will be read from stdin.
-.br
-This option is required unless
-.B --auto
-or
-.B --pool
-are used.
+Specifies a file from which to read whitespace-delimited pool IDs. If FILE is "-", the pool IDs will be read from stdin. This overrides the default of
+.B
+--auto.
 
 .TP
 .B --quantity=NUMBER
@@ -284,9 +284,6 @@ Attaches a specified number of subscriptions to the system. Subscriptions may ha
 .I stacking
 subscriptions) to cover the number of sockets, guests, or other characteristics.
 
-.TP
-.B --auto
-Automatically attaches the best-matched compatible subscription or subscriptions to the system.
 
 .TP
 .B --servicelevel=LEVEL
@@ -1022,13 +1019,13 @@ subscription-manager attach
 .pp
 As with the
 .B register
-command, the system can be auto-attached to the best-fitting subscriptions using the
+command, the system can be auto-attached to the best-fitting subscriptions. This is the default action and is equilivent to  using the
 .B --auto
 option:
 
 .RS
 .nf
-subscription-manager attach --auto
+subscription-manager attach
 .fi
 .RE
 
@@ -1042,7 +1039,7 @@ option sets a preference that helps the auto-attach process select appropriate s
 
 .RS
 .nf
-subscription-manager attach --auto --servicelevel=premium
+subscription-manager attach --servicelevel=premium
 .fi
 .RE
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1382,12 +1382,13 @@ class AttachCommand(CliCommand):
 
         self.product = None
         self.substoken = None
+        self.auto_attach = True
         self.parser.add_option("--pool", dest="pool", action='append',
                                help=_("the ID of the pool to attach (can be specified more than once)"))
         self.parser.add_option("--quantity", dest="quantity",
-                               help=_("number of subscriptions to attach"))
+            help=_("number of subscriptions to attach"))
         self.parser.add_option("--auto", action='store_true',
-            help=_("automatically attach compatible subscriptions to this system"))
+            help=_("Automatically attach compatible subscriptions to this system. This is the default action."))
         self.parser.add_option("--servicelevel", dest="service_level",
                                help=_("service level to apply to this system, requires --auto"))
         self.parser.add_option("--file", dest="file",
@@ -1414,21 +1415,20 @@ class AttachCommand(CliCommand):
         return True
 
     def _validate_options(self):
-        if not (self.options.pool or self.options.auto or self.options.file):
-            system_exit(os.EX_USAGE, _("Error: This command requires that you specify a pool with --pool or --file, or use --auto."))
-        if self.options.pool and self.options.auto:
-            system_exit(os.EX_USAGE, _("Error: --auto may not be used when specifying pools."))
+        if self.options.pool:
+            if self.options.auto:
+                system_exit(os.EX_USAGE, _("Error: --auto may not be used when specifying pools."))
+            if self.options.service_level:
+                system_exit(os.EX_USAGE, _("Error: Servicelevel is unused with --pool"))
 
         # Quantity must be a positive integer
+        # TODO: simplify with a optparse type="int"
         quantity = self.options.quantity
         if self.options.quantity:
             if not valid_quantity(quantity):
                 system_exit(os.EX_USAGE, _("Error: Quantity must be a positive integer."))
             else:
                 self.options.quantity = int(self.options.quantity)
-
-        if (self.options.service_level and not self.options.auto):
-            system_exit(os.EX_USAGE, _("Error: Must use --auto with --servicelevel."))
 
         # If a pools file was specified, process its contents and append it to options.pool
         if self.options.file:
@@ -1450,6 +1450,11 @@ class AttachCommand(CliCommand):
         self.assert_should_be_registered()
         self._validate_options()
 
+        # --pool or --file turns off default auto attach
+        if self.options.pool or self.options.file:
+            self.auto_attach = False
+
+        # TODO: change to if self.auto_attach: else: pool/file stuff
         try:
             cert_action_client = ActionClient()
             cert_action_client.update()
@@ -1521,7 +1526,7 @@ class AttachCommand(CliCommand):
                 print _('Entitlement Certificate(s) update failed due to the following reasons:')
                 for e in report.exceptions():
                     print '\t-', str(e)
-            elif self.options.auto:
+            elif self.auto_attach:
                 if not products_installed:
                     return_code = 1
                 else:

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1044,6 +1044,32 @@ class TestAttachCommand(TestCliProxyCommand):
 
         self.assertEquals(expected, self.cc.options.pool)
 
+    def test_pool_option_or_auto_option(self):
+        self.cc.main(["--auto", "--pool", "1234"])
+        self.assertRaises(SystemExit, self.cc._validate_options)
+
+    def test_servicelevel_option_but_no_auto_option(self):
+        with self.mock_stdin(open(self.tempfiles[1][1])):
+            self.cc.main(["--servicelevel", "Super", "--file", "-"])
+            self.cc._validate_options()
+
+    def test_servicelevel_option_with_pool_option(self):
+        self.cc.main(["--servicelevel", "Super", "--pool", "1232342342313"])
+        # need a assertRaises that checks a SystemsExit code and message
+        self.assertRaises(SystemExit, self.cc._validate_options)
+
+    def test_just_pools_option(self):
+        self.cc.main(["--pool", "1234"])
+        self.cc._validate_options()
+
+    def test_just_auto_option(self):
+        self.cc.main(["--auto"])
+        self.cc._validate_options()
+
+    def test_no_options_defaults_to_auto(self):
+        self.cc.main([])
+        self.cc._validate_options()
+
     @contextlib.contextmanager
     def mock_stdin(self, fileobj):
         org_stdin = sys.stdin


### PR DESCRIPTION
ie, 'subscription-manager attach' is now the same as
'subscription-manager attach --auto'. Using --pool or
--file turns off the default 'auto' mode.

'--auto' still works as well, though redundant now.