### PR TITLE
Use optparse to enforce --quantity is an int.

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1384,8 +1384,8 @@ class AttachCommand(CliCommand):
         self.substoken = None
         self.parser.add_option("--pool", dest="pool", action='append',
                                help=_("the ID of the pool to attach (can be specified more than once)"))
-        self.parser.add_option("--quantity", dest="quantity",
-                               help=_("number of subscriptions to attach"))
+        self.parser.add_option("--quantity", dest="quantity", type="int",
+            help=_("number of subscriptions to attach"))
         self.parser.add_option("--auto", action='store_true',
             help=_("automatically attach compatible subscriptions to this system"))
         self.parser.add_option("--servicelevel", dest="service_level",
@@ -1420,15 +1420,8 @@ class AttachCommand(CliCommand):
             system_exit(os.EX_USAGE, _("Error: --auto may not be used when specifying pools."))
 
         # Quantity must be a positive integer
-        quantity = self.options.quantity
-        if self.options.quantity:
-            if not valid_quantity(quantity):
-                system_exit(os.EX_USAGE, _("Error: Quantity must be a positive integer."))
-            else:
-                self.options.quantity = int(self.options.quantity)
-
-        if (self.options.service_level and not self.options.auto):
-            system_exit(os.EX_USAGE, _("Error: Must use --auto with --servicelevel."))
+        if self.options.quantity is not None and not valid_quantity(self.options.quantity):
+            system_exit(os.EX_DATAERR, _("Error: Quantity must be a positive integer."))
 
         # If a pools file was specified, process its contents and append it to options.pool
         if self.options.file:

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -847,7 +847,7 @@ def clean_all_data(backup=True):
 
 
 def valid_quantity(quantity):
-    if not quantity:
+    if quantity is None:
         return False
 
     try:

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1014,7 +1014,8 @@ class TestAttachCommand(TestCliProxyCommand):
             self.cc.main(["--auto", "--quantity", arg])
             self.cc._validate_options()
         except SystemExit, e:
-            self.assertEquals(e.code, os.EX_USAGE)
+            self.assertTrue(e.code in [2, os.EX_DATAERR])
+            #self.assertEquals(e.code, os.EX_DATAERR)
         else:
             self.fail("No Exception Raised")
 
@@ -1092,8 +1093,9 @@ class TestAttachCommand(TestCliProxyCommand):
             self.fail("No Exception Raised")
 
 
-# Test Attach and Subscribe are the same
-class TestSubscribeCommand(TestAttachCommand):
+# AttachCommand and SubscribeCommand are the same, only need
+# to test it works as an alias, so just basic tests.
+class TestSubscribeCommand(TestCliProxyCommand):
     command_class = managercli.SubscribeCommand
 
 
@@ -1118,7 +1120,7 @@ class TestRemoveCommand(TestCliProxyCommand):
             self.assertEquals(e.code, 2)
 
 
-class TestUnSubscribeCommand(TestRemoveCommand):
+class TestUnSubscribeCommand(TestCliProxyCommand):
     command_class = managercli.UnSubscribeCommand
 
 


### PR DESCRIPTION
Optparse type errors exit as return code '2' by default,
so update tests. '--quantity foo' returns 2, '--quantity 0'
returns 65 (os.EX_DATAERR).