### PR TITLE
1180395: Added "Provides Management" to subman list output

### DIFF
--- a/src/subscription_manager/jsonwrapper.py
+++ b/src/subscription_manager/jsonwrapper.py
@@ -40,6 +40,9 @@ class PoolWrapper(object):
 
         return virt_only
 
+    def management_enabled(self):
+        return is_true_value(self._get_attribute_value('productAttributes', 'management_enabled'))
+
     def get_stacking_id(self):
         return self._get_attribute_value('productAttributes', 'stacking_id')
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -94,6 +94,7 @@ AVAILABLE_SUBS_LIST = [
     _("SKU:"),
     _("Contract:"),
     _("Pool ID:"),
+    _("Provides Management:"),
     _("Available:"),
     _("Suggested:"),
     _("Service Level:"),
@@ -133,6 +134,7 @@ CONSUMED_LIST = [
     _("Account:"),
     _("Serial:"),
     _("Pool ID:"),
+    _("Provides Management:"),
     _("Active:"),
     _("Quantity Used:"),
     _("Service Level:"),
@@ -2223,12 +2225,18 @@ class ListCommand(CliCommand):
                         else:
                             machine_type = _("Physical")
 
+                        if 'management_enabled' in data and data['management_enabled']:
+                            data['management_enabled'] = _("Yes")
+                        else:
+                            data['management_enabled'] = _("No")
+
                         print columnize(AVAILABLE_SUBS_LIST, _none_wrap,
                                 data['productName'],
                                 data['providedProducts'],
                                 data['productId'],
                                 data['contractNumber'] or "",
                                 data['id'],
+                                data['management_enabled'],
                                 data['quantity'],
                                 data['suggested'],
                                 data['service_level'] or "",
@@ -2306,6 +2314,7 @@ class ListCommand(CliCommand):
                         service_level = ""
                         service_type = ""
                         system_type = ""
+                        provides_management = "No"
 
                         order = cert.order
 
@@ -2321,6 +2330,11 @@ class ListCommand(CliCommand):
                                 system_type = _("Virtual")
                             else:
                                 system_type = _("Physical")
+
+                            if order.provides_management:
+                                provides_management = _("Yes")
+                            else:
+                                provides_management = _("No")
 
                         pool_id = _("Not Available")
                         if hasattr(cert.pool, "id"):
@@ -2344,6 +2358,7 @@ class ListCommand(CliCommand):
                             account,
                             cert.serial,
                             pool_id,
+                            provides_management,
                             cert.is_valid(),
                             quantity_used,
                             service_level,

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -290,9 +290,22 @@ def get_available_entitlements(facts, get_all=False, active_on=None,
     The 'all' setting can be used to return all pools, even if the rules do
     not pass. (i.e. show pools that are incompatible for your hardware)
     """
-    columns = ['id', 'quantity', 'consumed', 'endDate', 'productName',
-            'providedProducts', 'productId', 'attributes', 'pool_type',
-            'service_level', 'service_type', 'suggested', 'contractNumber']
+    columns = [
+        'id',
+        'quantity',
+        'consumed',
+        'endDate',
+        'productName',
+        'providedProducts',
+        'productId',
+        'attributes',
+        'pool_type',
+        'service_level',
+        'service_type',
+        'suggested',
+        'contractNumber',
+        'management_enabled'
+    ]
 
     pool_stash = PoolStash(Facts(require(ENT_DIR), require(PROD_DIR)))
     dlist = pool_stash.get_filtered_pools_list(active_on, not get_all,
@@ -312,6 +325,7 @@ def get_available_entitlements(facts, get_all=False, active_on=None,
         pool['service_type'] = support_attrs['support_type']
         pool['suggested'] = pool_wrapper.get_suggested_quantity()
         pool['pool_type'] = pool_wrapper.get_pool_type()
+        pool['management_enabled'] = pool_wrapper.management_enabled()
 
         if pool['suggested'] is None:
             pool['suggested'] = ""

--- a/test/test_jsonwrapper.py
+++ b/test/test_jsonwrapper.py
@@ -20,7 +20,8 @@ from subscription_manager.jsonwrapper import PoolWrapper
 class TestPoolWrapper(unittest.TestCase):
 
     def _create_wrapper(self, add_is_virt_only=False, is_virt_only_value="true",
-                        add_stacking_id=False, stacking_id=None, pool_type=None):
+                        add_stacking_id=False, stacking_id=None, pool_type=None,
+                        add_management_enabled=False, management_enabled_value="true"):
         attrs = {}
         if add_is_virt_only:
             attrs['virt_only'] = is_virt_only_value
@@ -28,6 +29,9 @@ class TestPoolWrapper(unittest.TestCase):
         prod_attrs = {}
         if add_stacking_id:
             prod_attrs['stacking_id'] = stacking_id
+
+        if add_management_enabled:
+            prod_attrs['management_enabled'] = management_enabled_value
 
         calculatedAttributes = None
         if pool_type:
@@ -76,3 +80,23 @@ class TestPoolWrapper(unittest.TestCase):
     def test_no_compliance_type(self):
         wrapper = self._create_wrapper()
         self.assertEquals('', wrapper.get_pool_type())
+
+    def test_management_enabled_when_attribute_is_false(self):
+        wrapper = self._create_wrapper(add_management_enabled=True, management_enabled_value="false")
+        self.assertFalse(wrapper.management_enabled())
+
+    def test_management_enabled_when_attribute_is_true(self):
+        wrapper = self._create_wrapper(add_management_enabled=True, management_enabled_value="true")
+        self.assertTrue(wrapper.management_enabled())
+
+    def test_management_enabled_when_attribute_is_1(self):
+        wrapper = self._create_wrapper(add_management_enabled=True, management_enabled_value="1")
+        self.assertTrue(wrapper.management_enabled())
+
+    def test_management_enabled_when_attribute_is_0(self):
+        wrapper = self._create_wrapper(add_management_enabled=True, management_enabled_value="0")
+        self.assertFalse(wrapper.management_enabled())
+
+    def test_management_enabled_when_attribute_is_not_set(self):
+        wrapper = self._create_wrapper()
+        self.assertFalse(wrapper.management_enabled())

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -427,6 +427,7 @@ class TestListCommand(TestCliProxyCommand):
                      'productId': 'dummy-id',
                      'providedProducts': [],
                      'id': '888888888888',
+                     'management_enabled': True,
                      'attributes': [{'name': 'is_virt_only',
                                      'value': 'false'}],
                      'pool_type': 'Some Type',


### PR DESCRIPTION
subscription-manager list --available and --consumed will now
display the "Provides Management" row in its output to match the
information available from the GUI.