### PR TITLE
1183122: Fix KeyErrors building dbus ent status

### DIFF
--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -880,3 +880,46 @@ def allows_multi_entitlement(pool):
             utils.is_true_value(attribute['value']):
             return True
     return False
+
+
+def refresh_compliance_status(default_dbus_properties):
+    sorter = require(CERT_SORTER)
+    installed_products = require(PROD_DIR)
+    status = sorter.get_compliance_status()
+
+    dbus_properties = {}
+    dbus_properties.update(default_dbus_properties)
+
+    dbus_properties["Status"] = _("System is not registered.")
+    if not status:
+        return dbus_properties
+
+    dbus_properties["Status"] = status['status']
+
+    entitlements = {}
+
+    compliant_products = status.get('compliantProducts') or []
+    for prod in compliant_products:
+        if prod:
+            state = sorter.get_status(prod)
+            installed_product = installed_products.find_by_product(prod).products[0]
+        if installed_product and state:
+            entitlements[prod] = (installed_product.name, state, _("Subscribed"))
+
+    reasons = status.get('reasons') or []
+    for reason in reasons:
+        attrs = reason.get('attributes') or {}
+        product_id = attrs.get('product_id')
+        label = product_id or 'Unknown label'
+        name = attrs.get('name') or 'Unknown name'
+        message = reason.get('message') or 'Unknown message'
+
+        if product_id:
+            state = sorter.get_status(label)
+
+        entitlements[label] = (name, state, message)
+
+    if entitlements:
+        dbus_properties["Entitlements"] = entitlements
+
+    return dbus_properties

--- a/test/test_managerlib.py
+++ b/test/test_managerlib.py
@@ -22,9 +22,10 @@ from stubs import StubCertificateDirectory, StubProductCertificate, \
 from fixture import SubManFixture
 from subscription_manager.managerlib import merge_pools, PoolFilter, \
         MergedPoolsStackingGroupSorter, MergedPools, \
-        PoolStash, allows_multi_entitlement, valid_quantity
+        PoolStash, allows_multi_entitlement, valid_quantity, \
+        refresh_compliance_status
 from subscription_manager.injection import provide, \
-        PROD_DIR
+        PROD_DIR, CERT_SORTER
 from modelhelpers import create_pool
 from subscription_manager import managerlib
 import rhsm
@@ -1159,3 +1160,72 @@ class TestGetAvailableEntitlements(SubManFixture):
             'productAttributes': [{'name': 'foo',
                 'value': 'blip'}]
             }
+
+
+class TestRefreshComplianceStatus(SubManFixture):
+    def setUp(self):
+        super(TestRefreshComplianceStatus, self).setUp()
+        # default_dbus_properties
+        self._dbus_properties = {"Version": "1.0",
+                                 "Status": "System not registered."}
+        self.ddp = self._dbus_properties
+
+    def test(self):
+        dbus_compliance = refresh_compliance_status(self.ddp)
+
+        self.assertTrue('Status' in dbus_compliance)
+        self.assertEquals(dbus_compliance['Status'], 'System is not registered.')
+
+    def _stub_sorter(self, compliance_status):
+        self.sorter = StubCertSorter()
+
+        def get_compliance_status():
+            return compliance_status
+
+        self.sorter.get_compliance_status = get_compliance_status
+        provide(CERT_SORTER, self.sorter)
+
+    def _create_cert(self, product_id, label, version, provided_tags):
+        cert = StubProductCertificate(StubProduct(product_id, label, version=version,
+                                   provided_tags=provided_tags))
+        cert.delete = Mock()
+        cert.write = Mock()
+        return cert
+
+    def test_emtpty_status(self):
+        self._stub_sorter({})
+
+        dbus_compliance = refresh_compliance_status(self.ddp)
+        self.assertTrue('Status' in dbus_compliance)
+        self.assertEquals(dbus_compliance['Status'], 'System is not registered.')
+
+    def test_valid_no_reason(self):
+        status = {'compliantProducts': {},
+                  'reasons': [],
+                  'status': 'valid'
+                      }
+
+        self._stub_sorter(status)
+
+        dbus_compliance = refresh_compliance_status(self.ddp)
+        self.assertTrue('Status' in dbus_compliance)
+        self.assertEquals(dbus_compliance['Status'], 'valid')
+
+    def test_valid(self):
+        status = {'compliantProducts': {'37060': []},
+                  'reasons': [{'attributes': {'product_id': '37060',
+                                              'name': 'awesomeos'},
+                                'message': 'this is a reason message'}],
+                  'status': 'valid'
+                      }
+
+        self._stub_sorter(status)
+        self.sorter.valid_products = ['37060']
+
+        prod_cert = self._create_cert('37060', 'awesomeos-server', '7.0', 'rhel-7,rhel-7-server')
+        self.prod_dir.certs.append(prod_cert)
+        dbus_compliance = refresh_compliance_status(self.ddp)
+        self.assertTrue('Status' in dbus_compliance)
+        self.assertTrue('Entitlements' in dbus_compliance)
+        self.assertTrue('37060' in dbus_compliance['Entitlements'])
+        self.assertTrue('awesomeos' in dbus_compliance['Entitlements']['37060'])


### PR DESCRIPTION
If the info returned from a cert_sorter.get_compliance_status
didn't have keys we expected, we broke.

Attempt to be more lenient about the structure of compliance
status. Ignore missing keys, empty lists, etc.

Move refresh_compliance_status to managerlib, and add tests
to test_managerlib.