### PR TITLE
1114117: Stop collecting subs info by default.

### DIFF
--- a/etc-conf/rhsm-debug.completion.sh
+++ b/etc-conf/rhsm-debug.completion.sh
@@ -17,7 +17,9 @@ _rhsm-debug()
     system)
         case "${cur}" in
             -*)
-                local opts="--destination --no-archive --no-subscriptions --sos ${_rhsm_debug_common_opts}"
+                local opts="--destination --no-archive
+                            --no-subscriptions --subscriptions
+                            --sos ${_rhsm_debug_common_opts}"
                 COMPREPLY=( $( compgen -W "${opts}" -- "$cur" ) )
                 return 0
                 ;;

--- a/man/rhsm-debug.8
+++ b/man/rhsm-debug.8
@@ -61,8 +61,11 @@ Excludes data files that are also collected by the sosreport tool.
 
 .TP
 .B --no-subscriptions
-Excludes the gathering of subscription information.
+Excludes the gathering of subscription information. This is the default.
 
+.TP
+.B --subscriptions
+Includes the gathering of subscription information. This includes subscriptions available for this system and organization.
 
 .SH BUGS
 This tool is part of Red Hat Subscription Manager. To file bugs against this command-line tool, go to <https://bugzilla.redhat.com>, and select Red Hat > Red Hat Enterprise Linux > subscription-manager.

--- a/src/rhsm_debug/debug_commands.py
+++ b/src/rhsm_debug/debug_commands.py
@@ -61,9 +61,16 @@ class SystemCommand(CliCommand):
         self.parser.add_option("--sos", action='store_true',
                                default=False, dest="sos",
                                help=_("only data not already included in sos report will be collected"))
-        self.parser.add_option("--no-subscriptions", action='store_true',
-                               default=False, dest="nosubs",
-                               help=_("exclude subscription data"))
+        # The default is to not collect org level subscriptions info. The
+        # --subscriptions option can be used to include that.
+        # "--no-subscriptions" is now the default, but keep it for
+        # cli backwards compatibility.
+        self.parser.add_option("--no-subscriptions", action='store_false',
+                               dest="include_subs",
+                               help=_("exclude subscription data (default)"))
+        self.parser.add_option("--subscriptions", action='store_true',
+                               default=False, dest="include_subs",
+                               help=_("include subscription data"))
         self.assemble_path = ASSEMBLE_DIR
 
     def _get_usage(self):
@@ -103,7 +110,7 @@ class SystemCommand(CliCommand):
             self._makedir(content_path)
 
             owner = self.cp.getOwner(consumer.uuid)
-            if not self.options.nosubs:
+            if self.options.include_subs:
                 try:
                     self._write_flat_file(content_path, "subscriptions.json",
                                       self.cp.getSubscriptionList(owner['key']))

--- a/test/test_rhsm_debug_command.py
+++ b/test/test_rhsm_debug_command.py
@@ -82,7 +82,7 @@ class TestCompileCommand(TestCliCommand):
     # permissions. It will make those dirs in tar.
     def test_command_tar(self):
         try:
-            self.cc.main(["--destination", self.path])
+            self.cc.main(["--subscriptions", "--destination", self.path])
         except SystemExit:
             self.fail("Exception Raised")
 
@@ -110,7 +110,7 @@ class TestCompileCommand(TestCliCommand):
     # permissions. It will make those dirs in tree.
     def test_command_tree(self):
         try:
-            self.cc.main(["--destination", self.path, "--no-archive"])
+            self.cc.main(["--subscriptions", "--destination", self.path, "--no-archive"])
         except SystemExit:
             self.fail("Exception Raised")
 
@@ -136,7 +136,7 @@ class TestCompileCommand(TestCliCommand):
     # sos flag limits included data
     def test_command_sos(self):
         try:
-            self.cc.main(["--destination", self.path, "--no-archive", "--sos"])
+            self.cc.main(["--subscriptions", "--destination", self.path, "--no-archive", "--sos"])
         except SystemExit:
             self.fail("Exception Raised")
 
@@ -167,6 +167,17 @@ class TestCompileCommand(TestCliCommand):
         except SystemExit:
             self.fail("Exception Raised")
 
+        self._assert_no_subs()
+
+    def test_command_no_subs_default(self):
+        try:
+            self.cc.main(["--destination", self.path, "--no-archive"])
+        except SystemExit:
+            self.fail("Exception Raised")
+
+        self._assert_no_subs()
+
+    def _assert_no_subs(self):
         try:
             tree_path = path_join(self.path, self.code)
             self.assertTrue(os.path.exists(path_join(tree_path, "consumer.json")))


### PR DESCRIPTION
Add a '--subscriptions' cli option now, and make '--no-subscriptions'
the default behaviour. For orgs with lots of subscriptions
available, the candlepin api request getSubscriptionsList can
be very slow.