### PR TITLE
Add 'smurl' for CLI API access with certs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ RCT_CODE_DIR := $(PREFIX)/$(INSTALL_DIR)/$(INSTALL_MODULE)/rct
 RCT_SRC_DIR := $(BASE_SRC_DIR)/rct
 RD_CODE_DIR := $(PREFIX)/$(INSTALL_DIR)/$(INSTALL_MODULE)/rhsm_debug
 RD_SRC_DIR := $(BASE_SRC_DIR)/rhsm_debug
+SMURL_CODE_DIR := $(PREFIX)/$(INSTALL_DIR)/$(INSTALL_MODULE)/smurl
+SMURL_SRC_DIR := $(BASE_SRC_DIR)/smurl
 RHSM_ICON_SRC_DIR := $(BASE_SRC_DIR)/rhsm_icon
 DAEMONS_SRC_DIR := $(BASE_SRC_DIR)/daemons
 EXAMPLE_PLUGINS_SRC_DIR := example-plugins/
@@ -35,7 +37,7 @@ CONTENT_PLUGINS_SRC_DIR := $(BASE_SRC_DIR)/content_plugins/
 INSTALL_OSTREE_PLUGIN ?= true
 
 YUM_PLUGINS_SRC_DIR := $(BASE_SRC_DIR)/plugins
-ALL_SRC_DIRS := $(SRC_DIR) $(RCT_SRC_DIR) $(RD_SRC_DIR) $(DAEMONS_SRC_DIR) $(CONTENT_PLUGINS_SRC_DIR) $(EXAMPLE_PLUGINS_SRC_DIR) $(YUM_PLUGINS_SRC_DIR)
+ALL_SRC_DIRS := $(SRC_DIR) $(RCT_SRC_DIR) $(RD_SRC_DIR) $(DAEMONS_SRC_DIR) $(SMURL_SRC_DIR) $(CONTENT_PLUGINS_SRC_DIR) $(EXAMPLE_PLUGINS_SRC_DIR) $(YUM_PLUGINS_SRC_DIR)
 
 # sets a version that is more or less latest tag plus commit sha
 VERSION ?= $(shell git describe | awk ' { sub(/subscription-manager-/,"")};1' )
@@ -106,6 +108,7 @@ install-conf:
 	install -m 644 etc-conf/rhn-migrate-classic-to-rhsm.completion.sh $(PREFIX)/etc/bash_completion.d/rhn-migrate-classic-to-rhsm
 	install -m 644 etc-conf/rhsm-icon.completion.sh $(PREFIX)/etc/bash_completion.d/rhsm-icon
 	install -m 644 etc-conf/rhsmcertd.completion.sh $(PREFIX)/etc/bash_completion.d/rhsmcertd
+	install -m 644 etc-conf/smurl.completion.sh $(PREFIX)/etc/bash_completion.d/smurl
 	install -m 644 etc-conf/subscription-manager-gui.appdata.xml $(PREFIX)/$(INSTALL_DIR)/appdata/subscription-manager-gui.appdata.xml
 
 install-help-files:
@@ -324,6 +327,7 @@ install-files: set-versions dbus-service-install compile-po desktop-files instal
 	install -m 644 man/subscription-manager-gui.8 $(PREFIX)/$(INSTALL_DIR)/man/man8/
 	install -m 644 man/rct.8 $(PREFIX)/$(INSTALL_DIR)/man/man8/
 	install -m 644 man/rhsm-debug.8 $(PREFIX)/$(INSTALL_DIR)/man/man8/
+	install -m 644 man/smurl.8 $(PREFIX)/$(INSTALL_DIR)/man/man8/
 	install -m 644 man/rhsm.conf.5 $(PREFIX)/$(INSTALL_DIR)/man/man5/
 
 	install -m 644 etc-conf/rhsm-icon.desktop \
@@ -356,6 +360,10 @@ install-files: set-versions dbus-service-install compile-po desktop-files instal
 	install -m 644 -p $(RD_SRC_DIR)/*.py $(RD_CODE_DIR)
 	install bin/rhsm-debug $(PREFIX)/usr/bin
 
+	install -d $(SMURL_CODE_DIR)
+	install -m 644 -p $(SMURL_SRC_DIR)/*.py $(SMURL_CODE_DIR)
+	install bin/smurl $(PREFIX)/usr/bin
+
 
 desktop-files: etc-conf/rhsm-icon.desktop \
 				etc-conf/subscription-manager-gui.desktop
@@ -384,7 +392,7 @@ coverage-jenkins:
 po/POTFILES.in:
 	# generate the POTFILES.in file expected by intltool. it wants one
 	# file per line, but we're lazy.
-	find $(SRC_DIR)/ $(RCT_SRC_DIR) $(RD_SRC_DIR) $(DAEMONS_SRC_DIR) $(YUM_PLUGINS_SRC_DIR) -name "*.py" > po/POTFILES.in
+	find $(SRC_DIR)/ $(RCT_SRC_DIR) $(RD_SRC_DIR) $(SMURL_SRC_DIR) $(DAEMONS_SRC_DIR) $(YUM_PLUGINS_SRC_DIR) -name "*.py" > po/POTFILES.in
 	find $(SRC_DIR)/gui/data/ -name "*.glade" >> po/POTFILES.in
 	find $(BIN_DIR) -name "*-to-rhsm" >> po/POTFILES.in
 	find $(BIN_DIR) -name "subscription-manager*" >> po/POTFILES.in
@@ -394,6 +402,7 @@ po/POTFILES.in:
 	find etc-conf/ -name "*.desktop.in" >> po/POTFILES.in
 	find $(RCT_SRC_DIR)/ -name "*.py" >> po/POTFILES.in
 	find $(RD_SRC_DIR)/ -name "*.py" >> po/POTFILES.in
+	find $(SMURL_SRC_DIR)/ -name "*.py" >> po/POTFILES.in
 	echo $$(echo `pwd`|rev | sed -r 's|[^/]+|..|g') | sed 's|$$|$(shell find /usr/lib*/python2* -name "optparse.py")|' >> po/POTFILES.in
 
 .PHONY: po/POTFILES.in %.desktop

--- a/bin/smurl
+++ b/bin/smurl
@@ -1,0 +1,82 @@
+#!/usr/bin/python -S
+#
+# wrapper for subscription Manager commandline tool.
+#
+# Copyright (c) 2010 Red Hat, Inc.
+#
+# Authors: Pradeep Kilambi
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+if __name__ != '__main__':
+    raise ImportError("module cannot be imported")
+
+import sys
+sys.setdefaultencoding('utf-8')
+import site
+import os
+
+
+def system_exit(code, msgs=None):
+    "Exit with a code and optional message(s). Saved a few lines of code."
+
+    if msgs:
+        if type(msgs) not in [type([]), type(())]:
+            msgs = (msgs, )
+        for msg in msgs:
+            sys.stderr.write(str(msg) + '\n')
+    sys.exit(code)
+
+_LIBPATH = "/usr/share/rhsm"
+# add to the path if need be
+if _LIBPATH not in sys.path:
+    sys.path.append(_LIBPATH)
+
+
+# this has to be done first thing due to module level translated vars.
+from subscription_manager.i18n import configure_i18n
+configure_i18n()
+
+from subscription_manager import logutil
+logutil.init_logger()
+
+from dbus.mainloop.glib import DBusGMainLoop
+DBusGMainLoop(set_as_default=True)
+
+from subscription_manager.injectioninit import init_dep_injection
+init_dep_injection()
+
+from subscription_manager import managercli
+
+from smurl import cli
+
+
+def main():
+    # execute
+    try:
+        return cli.SmurlCLI().main()
+    except KeyboardInterrupt:
+        system_exit(0, "\nUser interrupted process.")
+
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(abs(main() or 0))
+    except SystemExit, e:
+        #this is a non-exceptional exception thrown by Python 2.4, just
+        #re-raise, bypassing handle_exception
+        raise e
+    except KeyboardInterrupt:
+        system_exit(0, "\nUser interrupted process.")

--- a/etc-conf/smurl.completion.sh
+++ b/etc-conf/smurl.completion.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+METHODS="
+/activation_keys
+/activation_keys/{activation_key_id}
+/activation_keys/{activation_key_id}/pools
+/activation_keys/{activation_key_id}/pools/{pool_id}
+/admin/init
+/atom
+/serials/{serial_id}
+/serials
+/cdn
+/consumers
+/consumers/{consumer_uuid}
+/consumers/{consumer_uuid}/entitlements/dry-run
+/consumers/{consumer_uuid}/certificates
+/consumers/{consumer_uuid}/export
+/consumers/{consumer_uuid}/compliance
+/consumers/{consumer_uuid}/content_overrides
+/consumers/compliance
+/consumers/{consumer_uuid}
+/consumers/{consumer_uuid}/events
+/consumers/{consumer_uuid}/certificates/serials
+/consumers/{consumer_uuid}/certificates
+/consumers/{consumer_uuid}/guests
+/consumers/{consumer_uuid}/guestids
+/consumers/{consumer_uuid}/host
+/consumers/{consumer_uuid}/owner
+/consumers/{consumer_uuid}/release
+/consumers/{consumer_uuid}/entitlements
+/consumers/{consumer_uuid}/certificates
+/consumers/{consumer_uuid}/deletionrecord
+/consumers/{consumer_uuid}/entitlements/{dbid}
+/consumers/{consumer_uuid}/entitlements
+/consumers/{consumer_uuid}/certificates/{serial}
+/consumers/{consumer_uuid}
+/consumertypes
+/consumertypes/{id}
+/content
+/content/{content_id}
+/crl
+/deleted_consumers
+/distributor_versions
+/distributor_versions/{id}
+/distributor_versions
+/distributor_versions/{id}
+/entitlements/{dbid}
+/entitlements/{dbid}/upstream_cert
+/entitlements/consumer/{consumer_uuid}/product/{product_id}
+/entitlements
+/entitlements/product/{product_id}
+/entitlements/{dbid}
+/entitlements/{entitlement_id}
+/environments/{env_id}/consumers
+/environments/{env_id}
+/environments/{env_id}/content
+/events/{uuid}
+/events
+/hypervisors
+/jobs/scheduler
+/jobs/{job_id}
+/jobs
+/jobs/scheduler
+/migrations
+/owners/{owner_key}/activation_keys
+/owners/{owner_key}/environments
+/owners
+/owners/{owner_key}
+/owners/{owner_key}/subscriptions
+/owners/{owner_key}/uebercert
+/owners/{owner_key}/consumers/{consumer_uuid}/atom
+/owners/{owner_key}/events
+/owners/{owner_key}/imports
+/owners/{owner_key}/atom
+/owners/{owner_key}/info
+/owners/{owner_key}/pools
+/owners/{owner_key}/statistics/{qtype}/{vtype}
+/owners/{owner_key}/subscriptions
+/owners/{owner_key}/uebercert
+/owners/{owner_key}/upstream_consumers
+/owners/{owner_key}/entitlements
+/owners/{owner_key}/imports
+/owners
+/owners/{owner_key}/environments
+/owners/{owner_key}/activation_keys
+/owners/{owner_key}/consumers
+/owners/{owner_key}/entitlements
+/owners/{owner_key}/servicelevels
+/owners/{owner_key}/subscriptions
+/owners/{owner_key}/imports
+/owners/subscriptions
+/pools/{pool_id}
+/pools/{pool_id}/entitlements
+/pools/{pool_id}/statistics/{vtype}
+/pools
+/products
+/products/owners
+/products/{product_uuid}/content/{content_id}
+/products/{product_uuid}/reliance/{rely_product_id}
+/products/{product_uuid}
+/products/{product_uuid}/certificate
+/products/{prod_id}/statistics
+/products/{product_uuid}/subscriptions
+/products/{product_uuid}/content/{content_id}
+/products/{product_uuid}/reliance/{rely_product_uuid}
+/roles/{role_id}/permissions
+/roles/{role_id}/users/{username}
+/roles/{role_id}/users/{username}
+/roles
+/roles/{role_id}/permissions/{perm_id}
+/roles/{role_id}
+/rules
+/serials
+/statistics/generate
+/status
+/subscriptions
+/subscriptions/{subscription_id}/cert
+/subscriptions/{subscription_id}
+/users
+/users/{username}
+/users/{username}/roles
+/users/{username}/owners
+/users/{username}"
+
+
+_smurl_api()
+{
+    local opts="--method --auth -d -X --request --username --password --org"
+    local all_comp="${opts} ${METHODS}"
+    COMPREPLY=($(compgen -W "${all_comp}" -- ${1}))
+}
+
+_smurl()
+{
+  local first cur prev opts base
+  COMPREPLY=()
+
+  first=${COMP_WORDS[1]}
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  opts="api
+        get post put delete head patch
+        --method --auth -d -X --request --username --password --org"
+
+  case "${prev}" in
+     -X|--request)
+        local REQUEST_TYPES="GET POST PUT DELETE HEAD"
+        COMPREPLY=($(compgen -W "${REQUEST_TYPES}" -- ${cur}))
+        return 0
+        ;;
+    --auth)
+        local AUTH_TYPES="consumer user none"
+        COMPREPLY=( $(compgen -W "${AUTH_TYPES}" -- ${cur}) )
+        return 0
+        ;;
+    -d)
+        local filename="${1#@}"
+        COMPREPLY=( $( compgen -W -o filenames "@- " -- "${filename}" ) )
+        return 0
+        ;;
+    api|--method)
+         "_smurl_api" "${cur}" "${prev}"
+         return 0
+         ;;
+   esac
+
+  case "${cur}" in
+      --*)
+          local OPTIONS="--method --auth -d -X --request --username --password --org"
+          COMPREPLY=($(compgen -W "${OPTIONS}" -- ${cur}))
+          # expand options
+          return 0
+          ;;
+          # also need to complete get, etc, and handle get something_to_expand
+          # if not a subcommand or option, try to expand method paths\
+      *get|put|post|head|delete|patch)
+          "_smurl_api" "${cur}" "${prev}"
+          return 0
+          ;;
+      *)
+         "_smurl_api" "${cur}" "${prev}"
+         return 0
+         ;;
+   esac
+
+  method_and_opts="${opts} ${METHODS}"
+  COMPREPLY=($(compgen -W "${method_and_opts}" -- ${cur}))
+  return 0
+
+}
+
+complete -F _smurl -o default smurl

--- a/man/smurl.8
+++ b/man/smurl.8
@@ -1,0 +1,114 @@
+.TH smurl 8
+.SH NAME
+smurl \- Provides cli access to the RHSM REST API.
+
+.SH SYNOPSIS
+smurl command [options]
+
+.SH DESCRIPTION
+Provides a CLI to use the Red Hat subscription management REST APIS. It supports using the active
+configuration used by subscription-manager. It supports unauthenticated, user/pass authentication, and
+consumer identity certificate based authentication to the API. 
+
+.PP
+
+.SH COMMANDS
+.TP
+.B api
+Makes a call the Red Hat subscription management REST API and prints the results to stdout.
+
+
+.SH THE API COMMAND
+Makes a call the Red Hat subscription management REST API and prints the results to stdout.
+
+.SS OPTIONS
+.TP
+.B --proxy=PROXY
+Uses an HTTP proxy. The
+.I PROXY
+name has the format
+.I hostname:port.
+
+.TP
+.B --proxyuser=PROXYUSERNAME
+Gives the username to use to authenticate to the HTTP proxy.
+
+.TP
+.B --proxypass=PROXYPASSWORD
+Gives the password to use to authenticate to the HTTP proxy.
+
+.TP
+.B --username=USERNAME
+Gives the username for the account for using with username/password basic authentication to the API.
+
+.TP
+.B --password=PASSWORD
+Gives the user account password.
+
+.TP
+.B --org=ORG
+Specify the organization to use when authenticating to the API.
+
+.TP
+.B -X REQUEST_TYPE
+Type of http request: GET, POST, DELETE, etc. The default is GET if 
+.B -X
+is not specified. Analogous to curl's -X option.
+
+.TP
+.B
+-d DATA
+Data to send, @filename, or @- for stdin. Analogous to curl's -d option.
+
+.TP
+.B
+--method=API_METHOD
+The path to the REST resource. This is appended to the default rhsm server hostname, port, and prefix from /etc/rhsm/rhsm.conf. The default if not specified is '/'. The method can include method aliases, see METHOD ALIASES.
+
+.SS EXAMPLES
+.PP
+Query the REST api for it's /status method. The default will be to use the configured server, prefix, and
+to use the consumer identity certificate for authentication (/etc/pki/identity/).
+.RS
+.nf
+[root@server ~]# smurl api --method /status
+{
+    "managerCapabilities": [
+        "cores",
+        "ram",
+        "instance_multiplier",
+        "derived_product",
+        "cert_v3",
+        "guest_limit",
+        "vcpu"
+    ],
+    "release": "1",
+    "result": true,
+    "rulesSource": "DEFAULT",
+    "rulesVersion": "5.13",
+    "standalone": true,
+    "timeUTC": "2015-02-04T16:48:50.579+0000",
+    "version": "0.9.39"
+}
+
+.fi
+.RE
+
+.PP
+Query the API for the current 'release' of the consumer. Note the use of the {c} alias
+to refer to the systems consumer uuid.
+.RS
+.nf
+[root@server ~]# sudo smurl api --method /consumers/{c}/release
+{
+    "releaseVer": '7Server'
+}
+.fi
+.RE
+
+
+.SH BUGS
+This tool is part of Red Hat Subscription Manager. To file bugs against this command-line tool, go to <https://bugzilla.redhat.com>, and select Red Hat > Red Hat Enterprise Linux > subscription-manager.
+
+.SH COPYRIGHT
+Copyright (c) 2015 Red Hat, Inc. This is licensed under the GNU General Public License, version 2 (GPLv2). A copy of this license is available at http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.

--- a/scripts/gen-api-completions.py
+++ b/scripts/gen-api-completions.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python
+
+# Copyright 2013 Red Hat
+#
+# Generate a txt file of candlepin api method paths (ie,
+# /consumers/{consumer_uuid}) from api docs
+#
+#  ./gen-api-completions.py candlepin_methods.json
+#
+# for example, the data from https://github.com/RoUS/candlepin-api
+# or the candlepin api docs generated with:
+#
+#  cd ~/src/candlepin/server
+#  buildr candlepin:server:apicrawl
+#
+# api info is written to candlepin/server/target/candlepin_methods.json
+#
+
+import simplejson as json
+import sys
+from collections import defaultdict
+
+
+def find_verb(verb, api):
+    return [x for x in api if verb in x['httpVerbs']]
+
+
+def find_verbs(verb_map, api):
+    for method in api:
+        verb_list = method['httpVerbs']
+        for verb in verb_list:
+            verb_map[verb].append(method)
+    return verb_map
+
+
+def method_paths(method_list):
+    return [x['url'] for x in method_list]
+
+
+def write_completions(verb, method_list):
+    completions_filename = "candlepin-api-completions-%s" % verb
+    completions_fp = open(completions_filename, 'w')
+    paths = method_paths(method_list)
+    completions_fp.write('\n'.join(paths))
+    completions_fp.close()
+
+
+def main():
+    api_json_filename = sys.argv[1]
+    api_json_fp = open(api_json_filename, 'r')
+
+    api = json.load(api_json_fp)
+
+    verb_map = defaultdict(list)
+
+    #pprint.pprint([(x['url'], x['verifiedParams']) for x in api])
+
+    verb_map = find_verbs(verb_map, api)
+
+    all_paths = []
+    for verb in verb_map:
+        all_paths += method_paths(verb_map[verb])
+        #write_completions(verb, verb_map[verb])
+
+    completions = sorted(set(all_paths))
+    for completion in completions:
+        print completion
+
+if __name__ == "__main__":
+    main()

--- a/src/smurl/cli.py
+++ b/src/smurl/cli.py
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2010 - 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+from subscription_manager.cli import CLI
+from smurl.commands import ApiCommand
+
+
+class SmurlCLI(CLI):
+
+    def __init__(self):
+        commands = [ApiCommand]
+        CLI.__init__(self, command_classes=commands)
+
+    # default to "api" subcommand
+    def _default_command(self):
+        cmd = self.cli_commands['api']
+        return cmd.main()
+
+    def _find_best_match(self, args):
+        """Like the base _find_best_match, but always match at least the default."""
+        # argh, CLI is old style class
+        cmd = CLI._find_best_match(self, args)
+        if not cmd:
+            cmd = self.cli_commands['api']
+        return cmd

--- a/src/smurl/commands.py
+++ b/src/smurl/commands.py
@@ -1,0 +1,185 @@
+import gettext
+import logging
+import sys
+
+log = logging.getLogger('rhsm-app.smurl.' + __name__)
+
+from rhsm import connection
+from rhsm import ourjson as json
+
+from subscription_manager import managercli
+import subscription_manager.injection as inj
+
+_ = gettext.gettext
+
+
+class ApiCommand(managercli.OrgCommand):
+    request_types = ["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"]
+
+    def __init__(self):
+        shortdesc = _("interface to rhsm API")
+
+        self.uuid = inj.require(inj.IDENTITY).uuid
+
+        super(ApiCommand, self).__init__("api", shortdesc, True)
+        self.parser.add_option("--auth", dest="auth_type", default="consumer",
+                               help=(_("auth type to use: consumer, user, none")))
+        self.parser.add_option("-X", dest="request_type", default="GET",
+                               help=(_("Type of http request: GET, POST, etc")))
+        self.parser.add_option("-d", dest="data",
+                               help=(_("Data to send, @filename, or @- for stdin")))
+        self.parser.add_option("--method", dest="api_method",
+                               default="/status",
+                               help=(_("URL to request")))
+        self.parser.add_option("--aliases", dest="list_aliases",
+                               action="store_true", default=False,
+                               help=(_("List the supported method aliases and values")))
+        self._add_url_options()
+
+        # FIXME: we could move RegisterCommand._determine_owner to OrgCommand and
+        # we use it here to find the default org
+        self.aliases = {'{c}': 'uuid',
+                        '{consumer_uuid}': 'uuid',
+                        #'{o}': self.owner,
+                        '{u}': 'username',
+                        '{username}': 'username',
+                        '{owner_key}': 'username',
+                        '{organization}': 'org',
+                        '{org}': 'org'}
+
+        # NOTE: what should we do with command line args?
+        # assume they are url_methods? query params?
+
+    def _validate_options(self):
+        pass
+
+    def _validate_args(self):
+        #self.args = self.args[1:]
+        # ignore anything bogus atm
+        return
+
+    def _parse_args(self):
+        if not self.args:
+            return
+
+        # Various DWIM hackery to make cli 'do what I mean'
+        # pull out things that look like http verbs or methods
+        # and use them.
+        for arg in self.args:
+            # override the default GET if we see 'POST' or 'post'
+            # in the free args on the cli. last one wins.
+            if arg.upper() in self.request_types:
+                self.options.request_type = arg
+
+            # If it looks like a url path/method, try to use it as one
+            if self._is_method(arg):
+                self.options.api_method = arg
+
+    def _is_method(self, method):
+        "Guess if the arg is meant to be a method name."
+        return '/' in method
+
+    def expand_aliases(self, method_string):
+        # ie, {consumer_uuid} for consumer uuid
+        # {owner_key}
+        # FIXME: plenty of other ways to do more powerful formatting
+        full_method = method_string
+
+        for alias, attr in self.aliases.items():
+            if alias in full_method:
+                # NOTE: this may prompt for interactive user/pass/org info
+                attr_value = getattr(self, attr)
+                if attr_value is None:
+                    raise Exception("value of expansion of %s in %s was None" % (attr, full_method))
+
+                full_method = full_method.replace(alias, getattr(self, attr))
+
+        return full_method
+
+    def _get_cp(self):
+        if self.options.auth_type == 'consumer':
+            return self.cp_provider.get_consumer_auth_cp()
+        if self.options.auth_type == 'user':
+            self.cp_provider.set_user_pass(self.username, self.password)
+            return self.cp_provider.get_basic_auth_cp()
+        if self.options.auth_type == "none":
+            return self.cp_provider.get_no_auth_cp()
+
+        print _("Unknown auth type: %s") % self.options.auth_type
+        self._exit(code=1)
+
+    def _exit(self, code=None):
+        status_code = code or 0
+        sys.exit(status_code)
+
+    def _request(self, cp, request_type, method, info=None):
+        return cp.conn._request(request_type, method, info)
+
+    def _do_request(self, cp, request_type, method, info=None):
+        try:
+            result = self._request(cp, request_type, method, info)
+        except connection.RestlibException, e:
+            self._show_error(e)
+            return
+
+        self._show_result(result)
+
+    def _show_error(self, exc):
+        sys.stderr.write("%s\n" % exc)
+
+    def _show_result(self, result):
+        print json.dumps(result, indent=4, sort_keys=True)
+
+    def _read_data(self, data_label):
+        json_str = None
+        if data_label is None:
+            return None
+        # ala curl -d @-
+        elif data_label == '@-':
+            json_str = sys.stdin.read()
+        # ala curl -d @some_file
+        elif data_label.startswith("@"):
+            with open(data_label[1:], "r") as data_file:
+                json_str = data_file.read()
+
+        if json_str:
+            return json.loads(json_str)
+
+        return None
+
+    def _list_aliases(self):
+        interactive_attrs = ['username', 'password', 'org']
+
+        for alias in sorted(self.aliases):
+            attr_name = self.aliases[alias]
+
+            # FIXME: little ugly to avoid being prompted,
+            #        instead just see if the info is specified on cli
+            if attr_name in interactive_attrs:
+                # avoid the properties that will prompt
+                value = getattr(self.options, attr_name)
+            else:
+                value = getattr(self, attr_name)
+
+            expanded = value or 'Unknown'
+            print "%s: %s" % (alias, expanded)
+
+    def _do_command(self):
+        self._parse_args()
+
+        log.debug("smurl request with auth %s: %s %s",
+                  self.options.auth_type, self.options.request_type,
+                  self.options.api_method)
+
+        if self.options.list_aliases:
+            self._list_aliases()
+            self._exit(code=1)
+
+        request_type = self.options.request_type.upper()
+
+        self._do_request(self._get_cp(),
+                         request_type,
+                         self.expand_aliases(self.options.api_method),
+                         info=self._read_data(self.options.data))
+
+        # TODO: exit with a useful status code

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -363,6 +363,15 @@ class CliCommand(AbstractCLICommand):
         self.server_versions = get_server_versions(self.no_auth_cp, exception_on_timeout=True)
         log.info("Server Versions: %s" % self.server_versions)
 
+    def _validate_args(self):
+        # we dont need argv[0] in this list...
+        self.args = self.args[1:]
+        # check for unparsed arguments
+        if self.args:
+            for arg in self.args:
+                print _("cannot parse argument: %s") % arg
+            system_exit(os.EX_USAGE)
+
     def main(self, args=None):
 
         # TODO: For now, we disable the CLI entirely. We may want to allow some commands in the future.
@@ -377,13 +386,7 @@ class CliCommand(AbstractCLICommand):
 
         (self.options, self.args) = self.parser.parse_args(args)
 
-        # we dont need argv[0] in this list...
-        self.args = self.args[1:]
-        # check for unparsed arguments
-        if self.args:
-            for arg in self.args:
-                print _("cannot parse argument: %s") % arg
-            system_exit(os.EX_USAGE)
+        self._validate_args()
 
         if hasattr(self.options, "insecure") and self.options.insecure:
             cfg.set("server", "insecure", "1")

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -259,6 +259,7 @@ rm -rf %{buildroot}
 %{_sysconfdir}/bash_completion.d/rhn-migrate-classic-to-rhsm
 %{_sysconfdir}/bash_completion.d/rhsm-icon
 %{_sysconfdir}/bash_completion.d/rhsmcertd
+%{_sysconfdir}/bash_completion.d/smurl
 
 %attr(700,root,root) %{_sysconfdir}/cron.daily/rhsmd
 %{_datadir}/dbus-1/system-services/com.redhat.SubscriptionManager.service
@@ -376,11 +377,19 @@ rm -rf %{buildroot}
 %{_datadir}/rhsm/rhsm_debug/*commands.py*
 %attr(755,root,root) %{_bindir}/rhsm-debug
 
+# Include smurl cli api tool
+%dir %{_datadir}/rhsm/smurl
+%{_datadir}/rhsm/smurl/__init__.py*
+%{_datadir}/rhsm/smurl/cli.py*
+%{_datadir}/rhsm/smurl/commands.py*
+%attr(755,root,root) %{_bindir}/smurl
+
 %doc
 %{_mandir}/man8/subscription-manager.8*
 %{_mandir}/man8/rhsmcertd.8*
 %{_mandir}/man8/rct.8*
 %{_mandir}/man8/rhsm-debug.8*
+%{_mandir}/man8/smurl.8*
 %{_mandir}/man5/rhsm.conf.5*
 %doc LICENSE
 


### PR DESCRIPTION
This is used for making requests to the RHSM REST
API ("candlepin") from the cli.

It uses the systems rhsm configuration, and uses
identity certificate based authentication by
default.

Bash tab completion is included for url method
completion.

A simple alias or macro form is support for url
methods, for referencing the systems consumer uuid,
or user or org. For example, to show the JSON
result of a GET request (the default) to the
current consumer systems compliance info:

  smurl api --method /consumers/{c}/compliance

-X and -d options are support for specifying the
http request type, and any data to use in PUT or
POST request. This commands mirror curl's options.