### PR TITLE
976855: populate a "version.py" at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,7 @@ po/build
 po/POTFILES.in
 po/.zanata-cache
 etc-conf/*.desktop
+src/subscription_manager/version.py
+src/rct/version.py
 bin/rhsmcertd
 bin/rhsm-icon

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ INSTALL_OSTREE_PLUGIN ?= true
 YUM_PLUGINS_SRC_DIR := $(BASE_SRC_DIR)/plugins
 ALL_SRC_DIRS := $(SRC_DIR) $(RCT_SRC_DIR) $(RD_SRC_DIR) $(DAEMONS_SRC_DIR) $(CONTENT_PLUGINS_SRC_DIR) $(EXAMPLE_PLUGINS_SRC_DIR) $(YUM_PLUGINS_SRC_DIR)
 
+# sets a version that is more or less latest tag plus commit sha
+VERSION ?= $(shell git describe | awk ' { sub(/subscription-manager-/,"")};1' )
+
+# inherit from env if set so rpm can override
 CFLAGS ?= -g -Wall
 
 %.pyc: %.py
@@ -178,7 +182,11 @@ install-example-plugins-conf:
 .PHONY: install
 install: install-files install-conf install-help-files install-plugins-conf
 
-install-files: dbus-service-install compile-po desktop-files install-plugins
+set-versions:
+	sed -e 's/RPM_VERSION/$(VERSION)/g' $(SRC_DIR)/version.py.in > $(SRC_DIR)/version.py
+	sed -e 's/RPM_VERSION/$(VERSION)/g' $(RCT_SRC_DIR)/version.py.in > $(RCT_SRC_DIR)/version.py
+
+install-files: set-versions dbus-service-install compile-po desktop-files install-plugins
 	install -d $(CODE_DIR)/gui/data/icons
 	install -d $(CODE_DIR)/branding
 	install -d $(CODE_DIR)/model

--- a/src/rct/version.py.in
+++ b/src/rct/version.py.in
@@ -1,0 +1,1 @@
+rpm_version = "RPM_VERSION"

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -37,10 +37,11 @@ from subscription_manager import injection as inj
 # compatibility.
 from rhsm.utils import parse_url
 
+import subscription_manager.version
+import rhsm.version
 from rhsm.connection import UEPConnection, RestlibException, GoneException
 from rhsm.config import DEFAULT_PORT, DEFAULT_PREFIX, DEFAULT_HOSTNAME, \
     DEFAULT_CDN_HOSTNAME, DEFAULT_CDN_PORT, DEFAULT_CDN_PREFIX
-from rhsm.version import Versions
 
 log = logging.getLogger('rhsm-app.' + __name__)
 
@@ -205,15 +206,13 @@ def get_terminal_width():
 def get_client_versions():
     # It's possible (though unlikely, and kind of broken) to have more
     # than one version of python-rhsm/subscription-manager installed.
-    # Versions() will only return one (and I suspect it's not predictable
-    # which it will return).
+    # This will return whatever version we are using.
     sm_version = _("Unknown")
     pr_version = _("Unknown")
 
     try:
-        versions = Versions()
-        sm_version = get_version(versions, Versions.SUBSCRIPTION_MANAGER)
-        pr_version = get_version(versions, Versions.PYTHON_RHSM)
+        pr_version = rhsm.version.rpm_version
+        sm_version = subscription_manager.version.rpm_version
     except Exception, e:
         log.debug("Client Versions: Unable to check client versions")
         log.exception(e)

--- a/src/subscription_manager/version.py.in
+++ b/src/subscription_manager/version.py.in
@@ -1,0 +1,1 @@
+rpm_version = "RPM_VERSION"

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -287,6 +287,7 @@ rm -rf %{buildroot}
 %{_datadir}/rhsm/subscription_manager/dmiinfo.py*
 %{_datadir}/rhsm/subscription_manager/entcertlib.py*
 %{_datadir}/rhsm/subscription_manager/entbranding.py*
+%{_datadir}/rhsm/subscription_manager/cp_provider.py*
 %{_datadir}/rhsm/subscription_manager/factlib.py*
 %{_datadir}/rhsm/subscription_manager/facts.py*
 %{_datadir}/rhsm/subscription_manager/healinglib.py*
@@ -311,6 +312,7 @@ rm -rf %{buildroot}
 %{_datadir}/rhsm/subscription_manager/packageprofilelib.py*
 %{_datadir}/rhsm/subscription_manager/plugins.py*
 %{_datadir}/rhsm/subscription_manager/productid.py*
+%{_datadir}/rhsm/subscription_manager/reasons.py*
 %{_datadir}/rhsm/subscription_manager/release.py*
 %{_datadir}/rhsm/subscription_manager/repolib.py*
 %{_datadir}/rhsm/subscription_manager/rhelentbranding.py*
@@ -325,6 +327,7 @@ rm -rf %{buildroot}
 %{_datadir}/rhsm/subscription_manager/exceptions.py*
 %{_datadir}/rhsm/subscription_manager/plugin/*.py*
 
+%{_datadir}/rhsm/subscription_manager/version.py*
 # subscription-manager plugins
 %dir %{rhsm_plugins_dir}
 %dir %{_sysconfdir}/rhsm/pluginconf.d
@@ -362,6 +365,7 @@ rm -rf %{buildroot}
 %{_datadir}/rhsm/rct/cli.py*
 %{_datadir}/rhsm/rct/*commands.py*
 %{_datadir}/rhsm/rct/printing.py*
+%{_datadir}/rhsm/rct/version.py*
 %attr(755,root,root) %{_bindir}/rct
 
 # Include consumer debug CLI tool

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -331,12 +331,12 @@ NOT_COLLECTED = "non-collected-package"
 
 class TestGetServerVersions(fixture.SubManFixture):
 
-    @patch('subscription_manager.utils.Versions', spec=Versions)
     @patch('subscription_manager.utils.ClassicCheck')
-    def test_get_server_versions_classic(self, mock_classic, mock_versions):
-        self._inject_mock_invalid_consumer()
-        instance = mock_classic.return_value
+    @patch.object(certlib.ConsumerIdentity, 'existsAndValid')
+    def test_get_server_versions_classic(self, mci_exists_and_valid, MockClassicCheck):
+        instance = MockClassicCheck.return_value
         instance.is_registered_with_classic.return_value = True
+        mci_exists_and_valid.return_value = False
 
         sv = get_server_versions(None)
         self.assertEquals(sv['server-type'], "RHN Classic")
@@ -516,6 +516,13 @@ class TestGetVersion(fixture.SubManFixture):
         versions.get_release.return_value = ""
         result = get_version(versions, "foobar")
         self.assertEquals("1.0", result)
+class TestClientVersion(unittest.TestCase):
+    def test_get_client_versions(self):
+        client_versions = get_client_versions()
+        self.assertTrue('python-rhsm' in client_versions)
+        self.assertTrue('subscription-manager' in client_versions)
+        self.assertTrue(isinstance(client_versions['python-rhsm'], str))
+        self.assertTrue(isinstance(client_versions['subscription-manager'], str))
 
 
 class TestFriendlyJoin(fixture.SubManFixture):


### PR DESCRIPTION
Instead of asking the rpm db for the versions
of "subsciption-manager" and "python-rhsm", we
generate a versions.py at build time with that
info.

"make set-versions" is the make target that
does it. It will use VERSION from the env
(the spec file passes this in), or if
not specified, it will build one based
on 'git describe'.

This removes code that was on average spending
about .5s every time we started up (including
cli). This reduces it to basically nothing.

This requires latest python-rhsm (>= 1.8.14-1)