### PR TITLE
BZ: 1145077, disabled column wrapping during redirects

### DIFF
--- a/src/subscription_manager/printing_utils.py
+++ b/src/subscription_manager/printing_utils.py
@@ -39,8 +39,10 @@ def columnize(caption_list, callback, *args, **kwargs):
     """
     indent = kwargs.get('indent', 0)
     caption_list = [" " * indent + caption for caption in caption_list]
-    padding = min(sorted(map(utf8_width, caption_list))[-1] + 1,
-            int(get_terminal_width() / 2))
+    columns = get_terminal_width()
+    padding = sorted(map(utf8_width, caption_list))[-1] + 1
+    if columns:
+        padding = min(padding, int(columns / 2))
     padded_list = []
     for caption in caption_list:
         lines = format_name(caption, indent, padding - 1).split('\n')
@@ -49,7 +51,6 @@ def columnize(caption_list, callback, *args, **kwargs):
         padded_list.append(fixed_caption)
 
     lines = zip(padded_list, args)
-    columns = get_terminal_width()
     output = []
     for (caption, value) in lines:
         if isinstance(value, list):

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -19,6 +19,7 @@ import logging
 import os
 import pprint
 import re
+import sys
 
 import signal
 import socket
@@ -170,6 +171,8 @@ def get_terminal_width():
     """
     Attempt to determine the current terminal size.
     """
+    if not sys.stdout.isatty():
+        return None
     dim = None
     try:
         def ioctl_gwinsz(fd):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1145077 

get_terminal_width() in utils.py now accounts for redirects

wrapped:
```
[root@jmolet-vm0 ~]# subscription-manager list --available 
+-------------------------------------------+
    Available Subscriptions
+-------------------------------------------+
Subscription Name:   Red Hat Enterprise Linux Server, Premium (8
                     sockets) (Up to 4 guests)
Provides:            Red Hat Beta
                     Oracle Java (for RHEL Server)
                     Red Hat Enterprise Linux Server
                     Red Hat Software Collections Beta (for RHEL
                     Server)
SKU:                 RH0103708
Contract:            10697277
```

redirected:
```
[root@jmolet-vm0 ~]# subscription-manager list --available > blah && cat blah
+-------------------------------------------+
    Available Subscriptions
+-------------------------------------------+
Subscription Name:   Red Hat Enterprise Linux Server, Premium (8 sockets) (Up to 4 guests)
Provides:            Red Hat Beta
                     Oracle Java (for RHEL Server)
                     Red Hat Enterprise Linux Server
                     Red Hat Software Collections Beta (for RHEL Server)
SKU:                 RH0103708
Contract:            10697277
```