### PR TITLE
Break out of firstboot on network error. [Do not merge]

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -666,7 +666,12 @@ class OrganizationScreen(Screen):
         if error is not None:
             handle_gui_exception(error, REGISTER_ERROR,
                     self._parent.window)
-            self._parent.pre_done(CREDENTIALS_PAGE)
+            # rhbz #1191237 - On error, tell firstboot "success", so that
+            #                 we can get out of the loop. _parent._apply_result
+            #                 is in the rhsm_login.moduleClass firstboot module,
+            #                 and lets us proceed to the next firstboot screen,
+            #                 which is actually the end.
+            self._parent._apply_result = self._parent._RESULT_SUCCESS
             return
 
         owners = [(owner['key'], owner['displayName']) for owner in owners]


### PR DESCRIPTION
If we return a failure code to the firstboot screens,
we end on the same screen again, with no option to skip
or to go back to a point we could skip. In practice this
means if a user selects to register in firstboot, and then
doesn't or can't complete the process, they are stuck in
firstboot.

This forces the rhsm_login module to report success in that
case, so firstboot advances past the screen, to the end, and
exits.