### PR TITLE
1191237: Allow firstboot to exit on network errors

### DIFF
--- a/src/subscription_manager/gui/firstboot/rhsm_login.py
+++ b/src/subscription_manager/gui/firstboot/rhsm_login.py
@@ -242,6 +242,9 @@ class moduleClass(RhsmFirstbootModule, registergui.RegisterScreen):
 
         self._apply_result = self._RESULT_FAILURE
 
+        # FIXME: This is specific to rhel7 firstboot
+        self.exit_on_error = True
+
     def _set_initial_screen(self):
         """
         Override parent method as in some cases, we use a different
@@ -444,7 +447,10 @@ class moduleClass(RhsmFirstbootModule, registergui.RegisterScreen):
         log.info("Finishing registration, failed=%s" % failed)
         if failed:
             self._set_navigation_sensitive(True)
-            self._run_pre(registergui.CREDENTIALS_PAGE)
+            # on error, go straight to FINISH, which will shortly be
+            # back into this method with failed=False, which is a lie,
+            # but it lets us exit firstboot.
+            self._run_pre(registergui.FINISH)
         else:
             self._registration_finished = True
             self._skip_remaining_screens(self.interface)


### PR DESCRIPTION
If we want to exit out of firstboot, we have to return
success from the result of the 'Done' button, otherwise
we redisplay the screen.

We were returning familure status to the firstboot nav,
but now it just means to show our module again. And since
it is the first, last, and only firstboot module, 'Back'
or 'Next' aren't meaninful, so it was possible to get
stuck in firstboot if you weren't able to complete a
subscription. Either because of network errors (or
if we incorrectly get shown on systems with no working network)
or if there are server errors, or just no available accounts.

If we get exceptions that are normally handled by displaying
error dialogs, we go straight to the end of the finish
page instead. The initial server selections screen is a
bit of a special case, since it tries to fail softly on
network errors instead of raising exceptions. So we just
track a network_error flag on the widgets and check it
when deciding to precede or not.