### PR TITLE
1191237: Fix proxy "test connection" in firstboot.

### DIFF
--- a/src/subscription_manager/gui/firstboot/rhsm_login.py
+++ b/src/subscription_manager/gui/firstboot/rhsm_login.py
@@ -8,6 +8,8 @@ _ = lambda x: gettext.ldgettext("rhsm", x)
 
 import gtk
 
+gtk.gdk.threads_init()
+
 import rhsm
 
 sys.path.append("/usr/share/rhsm")


### PR DESCRIPTION
In the firstboot path, there was no gtk threads_init()
called. It's normally called via subscription-manager-gui,
but not by firstboot.