### PR TITLE
Ignore pep8 error W503

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,11 @@
 # E402 module level import not at top of file
 # E731 do not assign a lambda expression, use a def
 [pep8]
-ignore=E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E265,E402,E501,E713,E714,E731
+ignore=E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E265,E402,E501,W503,E713,E714,E731
 max-line-length=300
 
 [flake8]
-ignore=E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E265,E402,E501,E713,E714,E731
+ignore=E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E265,E402,E501,W503,E713,E714,E731
 exclude=*certdata*,*manifestdata*
 jobs=auto
 max-line-length=300


### PR DESCRIPTION
W503 "line break before binary operator"
and was added to pep8 in version 1.6.2.