### PR TITLE
Make code pass pep8 W503 warning

### DIFF
--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -208,9 +208,9 @@ class ComplianceManager(object):
         """
         # Subtract out the valid and partially valid items from the
         # list of installed products
-        unknown_products = dict((k, v) for (k, v) in self.installed_products.items()
-                                if k not in self.valid_products.keys()
-                                and k not in self.partially_valid_products.keys())
+        unknown_products = dict((k, v) for (k, v) in self.installed_products.items() if
+                                k not in self.valid_products.keys() and
+                                k not in self.partially_valid_products.keys())
         ent_certs = self.entitlement_dir.list()
 
         on_date = datetime.now(GMT())

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2446,12 +2446,12 @@ class OverrideCommand(CliCommand):
                 system_exit(os.EX_USAGE, _("Error: You may not use --add or --remove with --remove-all and --list"))
         if self.options.list and self.options.remove_all:
             system_exit(os.EX_USAGE, _("Error: You may not use --list with --remove-all"))
-        if self.options.repos and not (self.options.list or self.options.additions
-                or self.options.removals or self.options.remove_all):
+        if self.options.repos and not (self.options.list or self.options.additions or
+                                       self.options.removals or self.options.remove_all):
             system_exit(os.EX_USAGE, _("Error: The --repo option must be used with --list or --add or --remove."))
         # If no relevant options were given, just show a list
-        if not (self.options.repos or self.options.additions
-                or self.options.removals or self.options.remove_all or self.options.list):
+        if not (self.options.repos or self.options.additions or
+                self.options.removals or self.options.remove_all or self.options.list):
             self.options.list = True
 
     def _do_command(self):

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -469,11 +469,11 @@ class EntitlementCertificateFilter(ProductCertificateFilter):
 
         # Check filter string (contains-text)
         fs_check = self._fs_regex is None or (
-            super(EntitlementCertificateFilter, self).match(cert)
-            or (cert.order.name and self._fs_regex.match(cert.order.name) is not None)
-            or (cert.order.sku and self._fs_regex.match(cert.order.sku) is not None)
-            or (cert.order.service_level and self._fs_regex.match(cert.order.service_level) is not None)
-            or (cert.order.contract and self._fs_regex.match(cert.order.contract) is not None)
+            super(EntitlementCertificateFilter, self).match(cert) or
+            (cert.order.name and self._fs_regex.match(cert.order.name) is not None) or
+            (cert.order.sku and self._fs_regex.match(cert.order.sku) is not None) or
+            (cert.order.service_level and self._fs_regex.match(cert.order.service_level) is not None) or
+            (cert.order.contract and self._fs_regex.match(cert.order.contract) is not None)
         )
 
         return sl_check and fs_check and (self._sl_filter is not None or self._fs_regex is not None)

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,11 @@
 # E402 module level import not at top of file
 # E731 do not assign a lambda expression, use a def
 [pep8]
-ignore=E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E265,E402,E501,W503,E713,E714,E731
+ignore=E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E265,E402,E501,E713,E714,E731
 max-line-length=300
 
 [flake8]
-ignore=E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E265,E402,E501,W503,E713,E714,E731
+ignore=E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E265,E402,E501,E713,E714,E731
 exclude=*certdata*,*manifestdata*
 jobs=auto
 max-line-length=300


### PR DESCRIPTION
"The preferred place to break around a binary operator is after the
operator, not before it."

Versions of pep8 >= 1.6.2 check that, so this makes the code
confirm.