### PR TITLE
Move module imports to top of modules (pep8 E402)

### DIFF
--- a/src/rct/printing.py
+++ b/src/rct/printing.py
@@ -14,13 +14,14 @@
 #
 
 import gettext
-_ = gettext.gettext
+import signal
 
 from rhsm.certificate2 import EntitlementCertificate, ProductCertificate, IdentityCertificate
 
 # BZ 973938 python doesn't correctly handle SIGPIPE
-import signal
 signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+_ = gettext.gettext
 
 
 # TODO: to be extra paranoid, we could ask to print

--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -14,20 +14,19 @@
 
 from copy import copy
 from datetime import datetime
+import gettext
 import logging
 
 from rhsm.certificate import GMT
 from rhsm.connection import RestlibException
 import subscription_manager.injection as inj
-
-log = logging.getLogger('rhsm-app.' + __name__)
-
 from subscription_manager.isodate import parse_date
 from subscription_manager.reasons import Reasons
 from subscription_manager import file_monitor
 
-import gettext
 _ = gettext.gettext
+
+log = logging.getLogger('rhsm-app.' + __name__)
 
 FUTURE_SUBSCRIBED = "future_subscribed"
 SUBSCRIBED = "subscribed"

--- a/src/subscription_manager/cli.py
+++ b/src/subscription_manager/cli.py
@@ -18,10 +18,9 @@ import os
 import sys
 
 from subscription_manager.printing_utils import columnize, _echo
+from subscription_manager.i18n_optparse import OptionParser, WrappedIndentedHelpFormatter
 
 _ = gettext.gettext
-
-from subscription_manager.i18n_optparse import OptionParser, WrappedIndentedHelpFormatter
 
 
 class InvalidCLIOptionError(Exception):

--- a/src/subscription_manager/dmiinfo.py
+++ b/src/subscription_manager/dmiinfo.py
@@ -13,14 +13,14 @@
 #
 
 import gettext
-import os
 import logging
+import os
+
+import dmidecode
 
 _ = gettext.gettext
 
 log = logging.getLogger('rhsm-app.' + __name__)
-
-import dmidecode
 
 
 class DmiFirmwareInfoProvider(object):

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -18,11 +18,12 @@ import inspect
 from socket import error as socket_error
 from M2Crypto.SSL import SSLError
 import gettext
-_ = gettext.gettext
 
 from rhsm import connection, utils
 
 from subscription_manager.entcertlib import Disconnected
+
+_ = gettext.gettext
 
 SOCKET_MESSAGE = _('Network error, unable to connect to server. Please see /var/log/rhsm/rhsm.log for more information.')
 NETWORK_MESSAGE = _('Network error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information.')

--- a/src/subscription_manager/gui/importsub.py
+++ b/src/subscription_manager/gui/importsub.py
@@ -19,14 +19,14 @@ import os
 
 import gtk
 
-_ = gettext.gettext
-
 from subscription_manager import rhelentbranding
 from subscription_manager.gui import messageWindow
 from subscription_manager.gui.utils import show_error_window
 from subscription_manager.managerlib import ImportFileExtractor
 
 log = logging.getLogger('rhsm-app.' + __name__)
+
+_ = gettext.gettext
 
 
 class ImportSubDialog(object):

--- a/src/subscription_manager/gui/utils.py
+++ b/src/subscription_manager/gui/utils.py
@@ -17,17 +17,14 @@ import datetime
 import gettext
 import logging
 import re
+import threading
 
 import gobject
 import gtk
 import gtk.glade
-import threading
+
 from subscription_manager.exceptions import ExceptionMapper
-
-_ = lambda x: gettext.ldgettext("rhsm", x)
-
 import rhsm.connection as connection
-
 from subscription_manager.gui import messageWindow
 
 log = logging.getLogger('rhsm-app.' + __name__)
@@ -41,6 +38,8 @@ EVEN_ROW_COLOR = '#eeeeee'
 
 # set if we are in firstboot, to disable linkify, see bz#814378
 FIRSTBOOT = False
+
+_ = lambda x: gettext.ldgettext("rhsm", x)
 
 
 def running_as_firstboot():

--- a/src/subscription_manager/injection.py
+++ b/src/subscription_manager/injection.py
@@ -12,6 +12,7 @@
 # in this software or its documentation.
 #
 
+import types
 
 # Supported Features:
 IDENTITY = "IDENTITY"
@@ -31,8 +32,6 @@ FACTS = "FACTS"
 PROFILE_MANAGER = "PROFILE_MANAGER"
 INSTALLED_PRODUCTS_MANAGER = "INSTALLED_PRODUCTS_MANAGER"
 RELEASE_STATUS_CACHE = "RELEASE_STATUS_CACHE"
-
-import types
 
 
 class FeatureBroker:

--- a/src/subscription_manager/plugin/ostree/config.py
+++ b/src/subscription_manager/plugin/ostree/config.py
@@ -17,6 +17,9 @@ import logging
 import os
 import re
 
+from rhsm import config
+from subscription_manager import utils
+
 # iniparse.utils isn't in old versions
 # but it's always there if ostree is
 iniparse_tidy = None
@@ -24,10 +27,6 @@ try:
     from iniparse.utils import tidy as iniparse_tidy
 except ImportError:
     pass
-
-
-from rhsm import config
-from subscription_manager import utils
 
 log = logging.getLogger("rhsm-app." + __name__)
 

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -14,22 +14,16 @@
 # in this software or its documentation.
 #
 import gettext
-_ = gettext.gettext
-
 import glob
 import imp
 import inspect
+import logging
 import os
 
 from iniparse import SafeConfigParser
 from iniparse.compat import NoSectionError, NoOptionError
 
-import logging
-log = logging.getLogger('rhsm-app.' + __name__)
-
 from rhsm.config import initConfig
-cfg = initConfig()
-
 from subscription_manager.base_plugin import SubManPlugin
 
 # The API_VERSION constant defines the current plugin API version. It is used
@@ -50,6 +44,12 @@ API_VERSION = "1.1"
 
 DEFAULT_SEARCH_PATH = "/usr/share/rhsm-plugins/"
 DEFAULT_CONF_PATH = "/etc/rhsm/pluginconf.d/"
+
+cfg = initConfig()
+
+log = logging.getLogger('rhsm-app.' + __name__)
+
+_ = gettext.gettext
 
 
 class PluginException(Exception):

--- a/test/modelhelpers.py
+++ b/test/modelhelpers.py
@@ -17,6 +17,9 @@
 Helper methods for mocking up JSON model objects, certificates, etc.
 """
 
+from datetime import timedelta, datetime
+
+from rhsm.certificate import GMT
 
 hashlib = None
 md5 = None
@@ -24,10 +27,6 @@ try:
     import hashlib
 except ImportError:
     import md5
-
-from datetime import timedelta, datetime
-
-from rhsm.certificate import GMT
 
 
 #grumble, no hashblib on 2.4 and

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -14,11 +14,12 @@
 #
 
 import StringIO
-from rhsm import config
-import random
+from datetime import datetime, timedelta
 import mock
+import random
 import tempfile
 
+from rhsm import config
 from subscription_manager.cert_sorter import CertSorter
 from subscription_manager.cache import EntitlementStatusCache, ProductStatusCache, \
         OverrideStatusCache, ProfileManager, InstalledProductsManager, ReleaseStatusCache
@@ -27,6 +28,13 @@ from subscription_manager.lock import ActionLock
 from rhsm.certificate import GMT
 from subscription_manager.gui.utils import AsyncWidgetUpdater, handle_gui_exception
 from rhsm.certificate2 import Version
+from subscription_manager.certdirectory import EntitlementDirectory, ProductDirectory
+
+from rhsm.certificate import parse_tags
+from rhsm.certificate2 import EntitlementCertificate, ProductCertificate, \
+        Product, Content, Order
+from rhsm import profile
+
 
 from rhsm import ourjson as json
 
@@ -94,15 +102,6 @@ config.CFG = StubConfig()
 
 # we are not actually reading test/rhsm.conf, it's just a placeholder
 config.CFG.read("test/rhsm.conf")
-
-from datetime import datetime, timedelta
-
-from subscription_manager.certdirectory import EntitlementDirectory, ProductDirectory
-
-from rhsm.certificate import parse_tags
-from rhsm.certificate2 import EntitlementCertificate, ProductCertificate, \
-        Product, Content, Order
-from rhsm import profile
 
 
 class MockActionLock(ActionLock):

--- a/test/test_gui_utils.py
+++ b/test/test_gui_utils.py
@@ -2,14 +2,13 @@ import unittest
 
 import gtk
 
+from subscription_manager.gui import utils
+from subscription_manager.gui import storage
+
 # we need gtk 2.18+ to do the right markup in likify
 MIN_GTK_MAJOR = 2
 MIN_GTK_MINOR = 18
 MIN_GTK_MICRO = 0
-
-
-from subscription_manager.gui import utils
-from subscription_manager.gui import storage
 
 
 class TestLinkify(unittest.TestCase):

--- a/test/test_po_files.py
+++ b/test/test_po_files.py
@@ -1,13 +1,9 @@
 import os
+import gettext
 import glob
+import locale
 import unittest
 import sys
-
-import locale
-import gettext
-_ = gettext.gettext
-
-#locale.setlocale(locale.LC_ALL, '')
 
 from stubs import MockStderr
 from subscription_manager import managercli
@@ -19,6 +15,7 @@ APP = "rhsm"
 DIR = '/usr/share/locale/'
 gettext.bindtextdomain(APP, DIR)
 gettext.textdomain(APP)
+_ = gettext.gettext
 
 po_files = glob.glob("po/*.po")
 langs = []


### PR DESCRIPTION
"Imports are always put at the top of the file, just after any module
comments and docstrings, and before module globals and constants."

pep8 checker versions since 1.6.2 check for this, so clean up
the places it finds. There are still modules that will fail, since
they alter sys.path and then do imports. Pep8 checker fails these
cases though pep 8 itself is vague about that case.