### PR TITLE
'make jenkins' now hits 'build' to compile C code.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ CFLAGS ?= -g -Wall
 %.pyc: %.py
 	python -c "import py_compile; py_compile.compile('$<')"
 
-build:	set-versions rhsmcertd rhsm-icon
+build: set-versions rhsmcertd rhsm-icon
 
 # we never "remake" this makefile, so add a target so
 # we stop searching for implicit rules on how to remake it
@@ -563,7 +563,7 @@ install-pip-requirements:
 	@pip install -r test-requirements.txt
 
 .PHONY: jenkins
-jenkins: set-versions install-pip-requirements stylish stylish-harder coverage-jenkins
+jenkins: install-pip-requirements build stylish stylish-harder coverage-jenkins
 
 
 

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -182,7 +182,7 @@ subscriptions
 %setup -q
 
 %build
-make -f Makefile CFLAGS="%{optflags}"
+make -f Makefile VERSION=%{version}-%{release} CFLAGS="%{optflags}"
 
 %install
 rm -rf %{buildroot}


### PR DESCRIPTION
'jenkins' build target would run stylish and unittests, but
it was not compiling the C utils. So 'jenkins' target now
includes 'build' target and 'set-versions' is moved there.

Since 'build' (the default target) now creates the version
files, update spec file to set VERSION there as well.