### PR TITLE
Ignore glib warnings about class properties.

### DIFF
--- a/bin/subscription-manager-gui
+++ b/bin/subscription-manager-gui
@@ -42,11 +42,8 @@ import gettext
 _ = gettext.gettext
 
 # Capture python (and pygtk) warnings that normally print to
-# stderr and log them. This is mainly to avoid the
-# "Attempt to add property * after class was initialised" warning we
-# get with glib2-2.40
-# See https://bugzilla.gnome.org/show_bug.cgi?id=698614 for why we can
-# ignore this warning (it was reverted in glib2-2.42 and later...)
+# stderr and log them.
+# Additional warnings filters are in gui/widgets.py
 
 try:
     # python 2.7+ only

--- a/src/subscription_manager/gui/widgets.py
+++ b/src/subscription_manager/gui/widgets.py
@@ -49,6 +49,13 @@ EXPIRED_COLOR = '#FFAF99'
 warnings.filterwarnings(action="ignore",
                         category=Warning,
                         message=".*Whoever translated.*wrongly.")
+# Ignore warnings about "Attempt to add property * after class was initialised"
+# we get with glib2-2.40
+# See https://bugzilla.gnome.org/show_bug.cgi?id=698614 for why we can
+# ignore this warning (it was reverted in glib2-2.42 and later...)
+warnings.filterwarnings(action="ignore",
+                        category=Warning,
+                        message=".*ttempt to add property.*after class.*")
 
 
 class GladeWidget(object):


### PR DESCRIPTION
Warnings like "Attempt to add property * after class was initialised"
can be ignore, the code that issued that was added in
glib2-2.40 and removed in glib2-2.42. So add a warnings
filter to ignore them.

Added in widgets.py so unit tests also ignore them.