### PR TITLE
1133647: Fix messageWindow deprecation warning.

### DIFF
--- a/src/subscription_manager/gui/messageWindow.py
+++ b/src/subscription_manager/gui/messageWindow.py
@@ -66,12 +66,6 @@ class MessageWindow(gobject.GObject):
         # escape product strings see rh bz#633438
         self.dialog.set_markup(text)
 
-        # If translations contain bad markup (perhaps from bad text encoding)
-        # that doesn't render, just show the message including the markup.
-        # See rhbz #865702
-        if self.dialog.label.get_text() == '':
-            self.dialog.label.set_use_markup(False)
-
         self.dialog.set_default_response(0)
 
         self.dialog.set_position(gtk.WIN_POS_CENTER_ON_PARENT)


### PR DESCRIPTION
As part of a workaround for #865702, we were
accessing a gtk.MessageDialogs private label so we
could detect if it failed to parse the markup in
error messages from the server, which at the time
was the clonepin proxy. Access the private label
causes a DeprecationWarning.

Those messages have since been updated, and clonepin
decommissioned, so the workaround is no longer
needed.