### PR TITLE
1207958: Fix traceback when contract # is None

### DIFF
--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -294,10 +294,14 @@ def restart_virt_who():
 
 
 def friendly_join(items):
-    if (not items or len(items) == 0):
+    if items is None:
         return ""
 
-    items = list(items)
+    items = [str(x) for x in items if x is not None]
+
+    if not items:
+        return ""
+
     if len(items) == 1:
         return items[0]
 
@@ -308,6 +312,7 @@ def friendly_join(items):
     if len(items) > 2:
         first_string = first_string + ','
 
+    # FIXME: This is wrong in most non english locales.
     return first_string + " %s " % _("and") + last
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -527,6 +527,18 @@ class TestFriendlyJoin(fixture.SubManFixture):
         self.assertEquals("Three, Two, and One", friendly_join(set(["One", "Two", "Three"])))
         self.assertEquals("", friendly_join([]))
         self.assertEquals("", friendly_join(None))
+        self.assertEquals("", friendly_join(set()))
+        self.assertEquals("One", friendly_join([None, "One"]))
+        self.assertEquals("One", friendly_join(["One", None]))
+        self.assertEquals("", friendly_join([None, None, None]))
+
+        # We allow any iterable, so test a set created from a list with dupes
+        words = set(["Two", "One", "Two", "Two"])
+        res = friendly_join(words)
+        self.assertTrue(res in ["One and Two", "Two and One"])
+
+        self.assertEquals("1, 2, 3, 4, 5, 6, and fish",
+                          friendly_join([1, 2, u"3", 4, "5", 6, "fish"]))
 
 
 class TestTrueValue(fixture.SubManFixture):


### PR DESCRIPTION
installedtab uses friendly_join to format the list
of contract numbers that apply to a product. If the order
info attached to an entitlement cert has no contract
number set, friendly_join would throw a TypeError.
So ignore None in the list of items now.