### PR TITLE
1170314: Clarify that manage_repos 0 will delete redhat.repo.

### DIFF
--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -124,7 +124,7 @@ Set this to
 \fI1\fR
 if subscription manager should manage a yum repos file\&. If set, it will manage the file /etc/yum\&.repos\&.d/redhat\&.repo\&. If set to
 \fI0\fR
-then the subscription is only used for tracking purposes, not content\&.
+then the subscription is only used for tracking purposes, not content\&. The /etc/yum\&.repos\&.d/redhat\&.repo file will either be purged or deleted\&.
 .RE
 .PP
 full_refresh_on_yum


### PR DESCRIPTION
Attempt to clarify the behaviour when manage_repos is set to 0 in rhsm.conf man
page. Leaving redhat.repo around would be a very quick path to broken yum as
soon as content changed, so we cannot leave the file laying around.