### PR TITLE
subscription-manager typo/grammar/outdated documentation fixes

### DIFF
--- a/bin/subscription-manager-gui
+++ b/bin/subscription-manager-gui
@@ -163,7 +163,7 @@ if __name__ == '__main__':
     parser = OptionParser(usage=USAGE,
                           formatter=WrappedIndentedHelpFormatter())
     parser.add_option("--register", action='store_true',
-                      help=_("launches the registration dialog on startup"))
+                      help=_("launches the registration dialog on start-up"))
     options, args = parser.parse_args(args=sys.argv)
 
     log = logging.getLogger("rhsm-app.subscription-manager-gui")

--- a/docs/plugins/plugins.md
+++ b/docs/plugins/plugins.md
@@ -1,15 +1,15 @@
-# Subscription Manager Plugins
+# Subscription Manager Plug-ins
 
 ## Introduction
-Subscription manager provides a simple plugin framework that allows
-third-parties to modify its behavior.  The plugins are Python modules that
+Subscription manager provides a simple plug-in framework that allows
+third-parties to modify its behavior.  The plug-ins are Python modules that
 are loaded when subscription manager starts.
 
-Plugins exist as a place to put functionality that is either uncommon or
+Plug-ins exist as a place to put functionality that is either uncommon or
 not appropriate for inclusion in subscription manager's core.
 
-## Your First Plugin
-The example below shows a very basic plugin:
+## Your First Plug-in
+The example below shows a very basic plug-in:
 
     #! /usr/bin/python
 
@@ -21,19 +21,19 @@ The example below shows a very basic plugin:
         def post_register_consumer_hook(self, conduit):
             conduit.log.error("Hello world")
 
-This plugin will log the phrase "Hello world" whenever subscription manager
+This plug-in will log the phrase "Hello world" whenever subscription manager
 is used to register the system.
 
 ## API Dependencies
-Note the `requires_api_version` attribute in the example plugin.  This
-attribute is required by subscription manager.  If your plugin does not have
-it, subscription manager will refuse to load your plugin and print a message
+Note the `requires_api_version` attribute in the example plug-in.  This
+attribute is required by subscription manager.  If your plug-in does not have
+it, subscription manager will refuse to load your plug-in and print a message
 to the log file.
- 
-For a plugin to be loaded, the major version required by the plugin must match
-the major version in subscription manager's API version. Additionally, the 
-minor version in subscription manager's API version must be greater than or 
-equal the minor version required by the plugin.  If your plugin can't be loaded
+
+For a plug-in to be loaded, the major version required by the plug-in must match
+the major version in subscription manager's API version. Additionally, the
+minor version in subscription manager's API version must be greater than or
+equal the minor version required by the plug-in.  If your plug-in can't be loaded
 because of an incompatibility with the API version, a message will be written
 to the log.
 
@@ -44,12 +44,12 @@ number to zero.  If a change is made that doesn't break backwards compatibility,
 then the minor number will be incremented.
 
 ## Slots and Hooks
-Plugins integrate with subscription manager by registering a "hook" function
+Plug-ins integrate with subscription manager by registering a "hook" function
 that corresponds to a given "slot".  A slot is just a point in subscription
 manager's execution.  When subscription manager reaches that point, it
 executes all of the hook functions associate with that slot.
 
-Registering your hook functions is easy.  The plugin class is inspected for
+Registering your hook functions is easy.  The plug-in class is inspected for
 functions names of the form *slotname*\_hook.  If a function matching a valid
 slot is found, it is automatically registered.
 
@@ -71,19 +71,19 @@ The following slots exist:
 
 ## Conduits
 All hooks are passed a single argument: a conduit.  A conduit provides methods
-and attributes that can be used by the plugin.
+and attributes that can be used by the plug-in.
 
-The conduit varies depending on the plugin slot.  Consult the source to
+The conduit varies depending on the plug-in slot.  Consult the source to
 determine which conduit is available for a given slot.  All conduits are
 subclassed from the `BaseConduit` class and have, at a minimum, handles
-to the subscription manager log and to the plugin configuration.
+to the subscription manager log and to the plug-in configuration.
 
 
-## How a plugin is invoked
-Before plugin slots are reached, subscription-manager instantiates
-a `plugins.PluginManager` object. It will search plugin configuration
-and find and load enabled plugin modules and classes. It also maps
-plugin  hooks to PluginManager slots.
+## How a plug-in is invoked
+Before plug-in slots are reached, subscription-manager instantiates
+a `plugins.PluginManager` object. It will search plug-in configuration
+and find and load enabled plug-in modules and classes. It also maps
+plug-in  hooks to PluginManager slots.
 
 In subscription-manager code, a "slot" is invoked by calling
 
@@ -91,30 +91,30 @@ In subscription-manager code, a "slot" is invoked by calling
                         plugin\_arg,
                         other\_plugin\_arg)
 
-PluginManager() looks up the slot name, and finds all the plugin
+PluginManager() looks up the slot name, and finds all the plug-in
 hooks mapped to it. It also finds the corresponding Conduit()
 class.
 
-run() then iterates over the set of plugin hook methods. For
+run() then iterates over the set of plug-in hook methods. For
 each method, it creates a new Conduit() class, passing it's constructor
 any of the method args passed to run(). Note the args to run() are
-passed to the Conduit.\_\_init\_\_, not to the plugin method hook directly.
+passed to the Conduit.\_\_init\_\_, not to the plug-in method hook directly.
 
-The new Conduit() is passed to the plugin's hook method. Nothing
+The new Conduit() is passed to the plug-in's hook method. Nothing
 is returned from pluginManager.run(). Objects passed to
-PluginManager.run() are passed by reference, so a plugin can
-modify them. If you need to return data from a plugin, the
-plugin Conduit() needs to know to add it to the conduit object
-passed to the plugin method. Only the Conduit() is passed to
-the plugin method, so anything that needs to be passed needs
+PluginManager.run() are passed by reference, so a plug-in can
+modify them. If you need to return data from a plug-in, the
+plug-in Conduit() needs to know to add it to the conduit object
+passed to the plug-in method. Only the Conduit() is passed to
+the plug-in method, so anything that needs to be passed needs
 to be added to the Conduit object.
 
-## Plugin Configuration
-Every plugin has its own configuration file located in 
+## Plug-in Configuration
+Every plug-in has its own configuration file located in
 `/etc/rhsm/pluginconf.d`.  These configuration files follow the standard INI
 file conventions used by subscription manager's own configuration file.  The
-configuration file for a plugin should follow the convention 
-`module_name`.`class_name`.conf.  For example, if our Hello World plugin
+configuration file for a plug-in should follow the convention
+`module_name`.`class_name`.conf.  For example, if our Hello World plug-in
 seen above were in a file named `hello.py`, the configuration file should be
 named `hello.HelloWorldPlugin.conf`.
 
@@ -131,13 +131,13 @@ Items can be read from the configuration via methods available on the conduit.
 If the option is missing from the configuration file, then the default value
 passed in to the method will be returned.
 
-Every plugin should have at least the following in its configuration file.
+Every plug-in should have at least the following in its configuration file.
 
     [main]
     enabled = 1
 
-The plugin framework looks for the `enabled` option in the `main` section when
-determining whether or not to load a plugin.
+The plug-in framework looks for the `enabled` option in the `main` section when
+determining whether or not to load a plug-in.
 
 ## Examples
 The best way to learn more about plugins is by looking at some examples.

--- a/docs/subscription-manager.xml
+++ b/docs/subscription-manager.xml
@@ -129,7 +129,7 @@
 	</para>
 
 			<para>
-				The basis of software management is a <emphasis>subscription</emphasis>. A subscription contains both the <emphasis>products</emphasis> that are available, the support levels, and the <emphasis>quantities</emphasis>, or number of servers, that the product can be installed on. A subscription is roughly analogous to a user license, in that it grants all of the rights to that product to that system. Unlike a user license, a subscription does not grant the right to <emphasis>use</emphasis> the software; with the subscription model, a subscription grants the ability to download the packages and receive updates. 
+				The basis of software management is a <emphasis>subscription</emphasis>. A subscription contains both the <emphasis>products</emphasis> that are available, the support levels, and the <emphasis>quantities</emphasis>, or number of servers, that the product can be installed on. A subscription is roughly analogous to a user license, in that it grants all of the rights to that product to that system. Unlike a user license, a subscription does not grant the right to <emphasis>use</emphasis> the software; with the subscription model, a subscription grants the ability to download the packages and receive updates.
 			</para>
 			<para>
 				Subscriptions are managed though a subscription management service such as the Customer Portal Subscription Management (hosted) or an on-premise service like Subscription Asset Manager. A second service delivers the actual software bits, in tandem with the subscriptions managed for a system.
@@ -138,7 +138,7 @@
 				The subscription management service maintains a list of every subscription or set of subscriptions for an organization. The list of subscriptions is a <emphasis>pool</emphasis>, identified by a unique ID (called a <emphasis>pool ID</emphasis>). A system is <emphasis>registered</emphasis>, or added, to the subscription management service to allow it to manage the subscriptions for that system. Like the subscription, the system is also added to the subscription management service inventory and is assigned a unique ID within the service. The subscriptions and system entries, together, comprise the <emphasis>inventory</emphasis>.
 			</para>
 			<para>
-				A system allocates, or <emphasis>attaches</emphasis>, one of the quantities of a product in a subscription to itself. 
+				A system allocates, or <emphasis>attaches</emphasis>, one of the quantities of a product in a subscription to itself.
 			</para>
 			<para>
 				The repository where the product software is located is organized according to the <emphasis>product</emphasis>. Each product group within
@@ -283,7 +283,7 @@
 		<primary>subscriptions</primary>
 		<secondary>registering</secondary>
 	</indexterm>
-		
+
 
 		<sect2 id="registering-ui">
 			<title>Registering Systems with Customer Portal Subscription Management</title>
@@ -308,7 +308,7 @@
 			</listitem>
 				<listitem>
 					<para>
-						Click the <guibutton>Register</guibutton> button in the <guilabel>My Installed Products</guilabel> tab. 
+						Click the <guibutton>Register</guibutton> button in the <guilabel>My Installed Products</guilabel> tab.
 					</para>
 				</listitem>
 				<listitem>
@@ -335,7 +335,7 @@
 				<para>
 					For example:
 				</para>
-				
+
 				<!--
 				code is 14 chars too long
 				adding break
@@ -372,7 +372,7 @@
 
 		<sect2 id="activating-sam"><title>Registering to Subscription Asset Manager with an Activation Key</title>
 			<para>
-				An on-premise Subscription Asset Manager can pre-configure subscriptions to use for a system, and that pre-configured set of subscriptions is identified by an activation key. That key can then be used to attach those subscriptions on a local system.
+				An on-premise Subscription Asset Manager can preconfigure subscriptions to use for a system, and that preconfigured set of subscriptions is identified by an activation key. That key can then be used to attach those subscriptions on a local system.
 			</para>
 			<para>
 				Activation keys for &SAM; are configured before the system is ever created or added to the inventory, and the activation keys are passed <emphasis>as part of</emphasis> registering the system.
@@ -380,7 +380,7 @@
 			<orderedlist>
 				<listitem>
 					<para>
-			Install the configuration RPM to point Subscription Manager to the subscription application. 
+			Install the configuration RPM to point Subscription Manager to the subscription application.
 					For example:
 				</para>
 				<!--
@@ -417,7 +417,7 @@
 				</listitem>
 			</orderedlist>
 			<para>
-				After the registration completes, all of the pre-configured subscriptions are attached to the system.
+				After the registration completes, all of the preconfigured subscriptions are attached to the system.
 			</para>
 		</sect2>
 
@@ -505,7 +505,7 @@
 					</listitem>
 					<listitem>
 						<para>
-							Select the desired subscription. 
+							Select the desired subscription.
 						</para>
 					</listitem>
 					<listitem>
@@ -544,7 +544,7 @@
 					</listitem>
 					<listitem>
 						<para>
-							Select the subscription to remove. 
+							Select the subscription to remove.
 						</para>
 
 					</listitem>
@@ -558,7 +558,7 @@
 				</orderedlist>
 
 		</sect2>
-		
+
 
 			<sect2 id="ADDING-SUB">
 				<title>Manually Importing a New Subscription</title>
@@ -624,7 +624,7 @@
 				</listitem>
 					<listitem>
 						<para>
-							Launch the Subscription Manager GUI. 
+							Launch the Subscription Manager GUI.
 						</para>
 					</listitem>
 					<listitem>
@@ -671,7 +671,7 @@
 					</listitem>
 					<listitem>
 						<para>
-							In the dialog window, enter the email address to send the notification to when the redemption is complete. Because the redemption process can take several minutes to contact the vendor and receive information about the pre-configured subscriptions, the notification message is sent through email rather than through the Subscription Manager dialog window.
+							In the dialog window, enter the email address to send the notification to when the redemption is complete. Because the redemption process can take several minutes to contact the vendor and receive information about the preconfigured subscriptions, the notification message is sent through email rather than through the Subscription Manager dialog window.
 						</para>
 					</listitem>
 					<listitem>
@@ -727,7 +727,7 @@
 				The filters dynamically search for available subscriptions.
 			</para>
 						<para>
-							By default, the displayed subscriptions are filtered so that they are compatible with the system's recognized hardware, operating 
+							By default, the displayed subscriptions are filtered so that they are compatible with the system's recognized hardware, operating
 							system version, and installed products. These filters can be changed to filter by other criteria:
 						</para>
 						<itemizedlist>
@@ -766,8 +766,8 @@
 			</formalpara>
 		</sect1>
 
-		
-		
+
+
 
 	<sect1 id="sla-preferences"><title>Setting Service Level Preferences</title>
 	<indexterm>
@@ -792,7 +792,7 @@
 				The service information for each subscription is part of the subscription details. Two attributes are displayed, per subscription: its support level and its support type. The <emphasis>level</emphasis> defines how quickly support is guaranteed to respond to a case. The <emphasis>type</emphasis> defines the methods of communication; for production level support, this is always web and phone.
 			</para>
 			<para>
-				An account can have multiple levels of support available, even for the same product. 
+				An account can have multiple levels of support available, even for the same product.
 					A system can be set up to select subscriptions based on a preferred service level. This is used as a component in autoattaching subscriptions to the system.
 				</para>
 		<para>
@@ -816,7 +816,7 @@
 			</listitem>
 		</orderedlist>
 	</sect1>
-		
+
 
 	<sect1 id="ystream-preferences"><title>Setting Release Version Preferences</title>
 	<indexterm>
@@ -832,23 +832,23 @@
 		<secondary>static release version</secondary>
 	</indexterm>
 	<para>
-		Many IT environments have to be certified to meet a certain level of security or other 
-		criteria. In that case, major upgrades must be carefully planned and controlled &mdash; 
-		so administrators can't simply run <command>yum update</command> and move from version to 
+		Many IT environments have to be certified to meet a certain level of security or other
+		criteria. In that case, major upgrades must be carefully planned and controlled &mdash;
+		so administrators can't simply run <command>yum update</command> and move from version to
 		version.
 	</para>
 	<para>
 		The preferences dialog can set a preferred minor, or <emphasis>y-stream</emphasis>, release
-		number for the system to stick to. This limits the system to content repositories associated 
-		with that operating system version instead of moving to the newest or latest version repositories. 
-		For example, if the preferred operating system version is 6.3, then 6.3 content repositories are 
-		preferred for all installed and subscribed products for the system, even if other repositories 
+		number for the system to stick to. This limits the system to content repositories associated
+		with that operating system version instead of moving to the newest or latest version repositories.
+		For example, if the preferred operating system version is 6.3, then 6.3 content repositories are
+		preferred for all installed and subscribed products for the system, even if other repositories
 		are available.
 	</para>
 		<para>
 			To assign a preferred operating system version:
 		</para>
-		
+
 		<orderedlist>
 			<listitem>
 				<para>
@@ -883,8 +883,8 @@
 		<secondary>notifications</secondary>
 	</indexterm>
 		<para>
-			The Red Hat Subscription Manager provides a series of log and UI messages that indicate any changes to the valid certificates of any installed products for a system. In the Subscription Manager GUI, 
-			the status of the system subscriptions is color-coded, where <emphasis>green</emphasis> means all subscriptions are attached for all installed products, <emphasis>yellow</emphasis> 
+			The Red Hat Subscription Manager provides a series of log and UI messages that indicate any changes to the valid certificates of any installed products for a system. In the Subscription Manager GUI,
+			the status of the system subscriptions is color-coded, where <emphasis>green</emphasis> means all subscriptions are attached for all installed products, <emphasis>yellow</emphasis>
 			means that some products may not have all of the required subscriptions attached but updates are still in effect, and <emphasis>red</emphasis> means that updates are disabled.
 		</para>
 		<figure id="fig.status">
@@ -906,7 +906,7 @@
 		<para>
 			As any installed product nears the expiration date of the subscription, the Subscription Manager daemon will issue a warning. A similar message is given when the system has products without a valid certificate, meaning either there is not subscription attached that covers that product or the product is installed past the expiration of the subscription. Clicking the <guilabel>Manage My Subscriptions...</guilabel> button in the subscription notification window opens the Red Hat Subscription Manager GUI to view and update subscriptions.
 		</para>
-		
+
 		<figure id="fig.ents-nag-warning">
 			<title>Subscription Warning Message</title>
 			<mediaobject>

--- a/example-plugins/all_slots.py
+++ b/example-plugins/all_slots.py
@@ -20,7 +20,7 @@ requires_api_version = "1.0"
 
 
 class AllSlotsPlugin(SubManPlugin):
-    """Plugin with hooks for all slots."""
+    """Plug-in with hooks for all slots."""
     name = "all_slots"
     all_slots = True
 

--- a/example-plugins/facts.py
+++ b/example-plugins/facts.py
@@ -21,7 +21,7 @@ import json
 
 
 class FactsPlugin(SubManPlugin):
-    """Plugin for adding additional facts to subscription-manager facts"""
+    """Plug-in for adding additional facts to subscription-manager facts"""
     name = "facts"
 
     def post_facts_collection_hook(self, conduit):

--- a/example-plugins/product_install.py
+++ b/example-plugins/product_install.py
@@ -18,7 +18,7 @@ requires_api_version = "1.0"
 
 
 class ProductInstallPlugin(SubManPlugin):
-    """Plugin triggered when product id certs are installed"""
+    """Plug-in triggered when product id certs are installed"""
     name = "product_install"
 
     def post_product_id_install_hook(self, conduit):

--- a/example-plugins/subscribe.py
+++ b/example-plugins/subscribe.py
@@ -18,7 +18,7 @@ requires_api_version = "1.0"
 
 
 class SubscribePlugin(SubManPlugin):
-    """Plugin triggered when a consumer subscribes to an entitlement"""
+    """Plug-in triggered when a consumer subscribes to an entitlement"""
     name = "subscribe"
 
     def pre_subscribe_hook(self, conduit):

--- a/man/rct.8
+++ b/man/rct.8
@@ -1,4 +1,4 @@
-.TH rct 8
+.TH RCT 8 - - "RHSM Certificate Tool"
 .SH NAME
 rct \- Displays information (headers) about or size and statistics of a entitlement, product, or identity certificate used by Red Hat Subscription Manager.
 
@@ -208,7 +208,7 @@ Product:
 .RE
 
 .PP
-The most information is contained in the entitlement certficate. Along with the \fBCertificate\fP and \fBSubject\fP, it also has a \fBProduct\fP section that defines the product group that is covered by the subscription.
+The most information is contained in the entitlement certificate. Along with the \fBCertificate\fP and \fBSubject\fP, it also has a \fBProduct\fP section that defines the product group that is covered by the subscription.
 .PP
 Then, it contains an \fBOrder\fP section that details everything related to the purchase of the subscription (such as the contract number, service level, total quantity, quantities assigned to the system, and other details on the subscription).
 .PP

--- a/man/rhsm-debug.8
+++ b/man/rhsm-debug.8
@@ -1,4 +1,4 @@
-.TH rhsm-debug 8
+.TH RHSM-DEBUG 8 - - "RHSM Debug Tool"
 .SH NAME
 rhsm-debug \- Compiles information about system's entitlements, products, and identity used by Red Hat Subscription Manager.
 
@@ -53,7 +53,7 @@ The directory to place the resulting debug data. The default is /tmp.
 
 .TP
 .B --no-archive
-Generates an uncompressed directory intead of a gzipped file.
+Generates an uncompressed directory instead of a gzipped file.
 
 .TP
 .B --sos

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -7,7 +7,7 @@
 .\"    Source: rhsm.conf
 .\"  Language: English
 .\"
-.TH "RHSM\&.CONF" "5" "11/07/2014" "rhsm\&.conf" "\ \&"
+.TH "RHSM\&.CONF" "5" - "rhsm\&.conf" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -28,7 +28,7 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-rhsm.conf \- Configuration file for the subscription\-mananager tooling
+rhsm.conf \- Configuration file for the subscription\-manager tooling
 .SH "DESCRIPTION"
 .sp
 The rhsm\&.conf file is the configuration file for various subscription manager tooling\&. This includes \fBsubscription\-manager\fR, \fBsubscription\-manager\-gui\fR, \fBrhsmcertd\fR, and \fBvirt\-who\fR\&.
@@ -95,7 +95,7 @@ This setting is the prefix for all content which is managed by the subscription 
 .PP
 ca_cert_dir
 .RS 4
-The location for the certificates which are used to communicate with the server and to pulldown content\&.
+The location for the certificates which are used to communicate with the server and to pull down content\&.
 .RE
 .PP
 repo_ca_cert
@@ -145,12 +145,12 @@ should report the system\(cqs current package profile to the subscription servic
 .PP
 pluginDir
 .RS 4
-The directory to search for subscription manager plugins
+The directory to search for subscription manager plug-ins
 .RE
 .PP
 pluginConfDir
 .RS 4
-The directory to search for plugin configuration files
+The directory to search for plug-in configuration files
 .RE
 .SH "[RHSMCERTD] OPTIONS"
 .PP
@@ -176,4 +176,4 @@ Bryan Kearney <bkearney@redhat\&.com>
 Main web site: http://www\&.candlepinproject\&.org/
 .SH "COPYING"
 .sp
-Copyright (c) 2010\-2012 Red Hat, Inc\&. This is licensed under the GNU General Public License, version 2 (GPLv2)\&. A copy of this license is available at http://www\&.gnu\&.org/licenses/old\- licenses/gpl\-2\&.0\&.txt\&.
+Copyright (c) 2010\-2012 Red Hat, Inc\&. This is licensed under the GNU General Public License, version 2 (GPLv2)\&. A copy of this license is available at http://www\&.gnu\&.org/licenses/old\-licenses/gpl\-2\&.0\&.txt\&.

--- a/man/rhsmcertd.8
+++ b/man/rhsmcertd.8
@@ -1,4 +1,4 @@
-.TH rhsmcertd 8
+.TH rhsmcertd 8 - - "Subscription Management"
 .SH NAME
 rhsmcertd \- Periodically scans and updates the entitlement certificates on a registered system.
 
@@ -26,7 +26,7 @@ At a defined interval, the process checks with the subscription management servi
 .PP
 This \fBrhsmcertd\fP process invokes the
 .B
-certmgr.py
+rhsmcertd-worker.py
 script to perform the certificate add and update operations.
 
 .PP
@@ -82,7 +82,7 @@ rhsmcertd -n
 .SS DEPRECATED USAGE
 \fBrhsmcertd\fP used to allow the certificate and auto-attach intervals to be reset simply by passing two integers as arguments.
 .PP
-\fBrhsmcertd\fP \fIcertInterval autoattachInterval\fP
+\fBrhsmcertd\fP \fIcertInterval autoAttachInterval\fP
 .PP
 For example:
 .nf

--- a/man/sat5to6.8
+++ b/man/sat5to6.8
@@ -137,7 +137,7 @@ This typically accomplished by installing the \fBkatello-ca-consumer-latest.noar
 
 .nf
 [root@system ~]# yum install http://satellite-6-fqdn/pub/katello-ca-consumer-latest.noarch.rpm
-Loaded plugins: product-id, rhnplugin, security, subscription-manager
+Loaded plug-ins: product-id, rhnplugin, security, subscription-manager
 This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
 This system is receiving updates from RHN Classic or RHN Satellite.
 Setting up Install Process

--- a/man/subscription-manager-gui.8
+++ b/man/subscription-manager-gui.8
@@ -1,4 +1,4 @@
-.TH subscription-manager-gui 8
+.TH subscription-manager-gui 8 - - "Subscription Management"
 .SH NAME
 subscription-manager-gui \- Launches the UI client of the Subscription Manager.
 
@@ -16,7 +16,7 @@ The Subscription Manager UI can also be opened by selecting the
 .B Red Hat Subscription Manager
 item from the
 .B Applications >  System Tools
-menu in RHEL 5.x or the
+menu in RHEL 5.x and RHEL 7.x, or the
 .B System > Administration
 menu in RHEL 6.x.
 
@@ -28,7 +28,7 @@ If a system has not yet been registered, then the GUI registration page can be o
 
 
 .SH REFERENCES
-For procedures and tasks that can be performed in the Subscription Manager UI, check the Gnome help files (by pressing <F1>) or refer to the RHEL Subscription Management Guide at <https://access.redhat.com/knowledge/docs/en-US/Red_Hat_Subscription_Management/1.0/html/Subscription_Management_Guide/index.html>.
+For procedures and tasks that can be performed in the Subscription Manager UI, check the Gnome help files (by pressing <F1>) or refer to the RHEL Subscription Management Guide at <https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html/RHSM/index.html>.
 
 
 .SH ASSOCIATED FILES

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -1,4 +1,4 @@
-.TH subscription-manager 8
+.TH subscription-manager 8 - - "Subscription Management"
 .SH NAME
 subscription-manager \- Registers systems to a subscription management service and then attaches and manages subscriptions for software products.
 
@@ -228,7 +228,7 @@ the existing system entry is unregistered first, all of its subscriptions are re
 .B --org=ORG
 Assigns the system to an organization. Infrastructures which are managed on-site may be
 .I multi-tenant,
-meaning that there are multiple organizations within one customer unit. A system may be assigned manually to one of these suborganizations. When a system is registered with the Customer Portal, this is not required. When a system is registered with an on-premise application such as Subscription Asset Manager, this argument \fIis\fP required, even if there is only a single organization configured.
+meaning that there are multiple organizations within one customer unit. A system may be assigned manually to one of these organizations. When a system is registered with the Customer Portal, this is not required. When a system is registered with an on-premise application such as Subscription Asset Manager, this argument \fIis\fP required, unless there is only a single organization configured.
 
 .TP
 .B --environment=ENV
@@ -238,9 +238,9 @@ Registers the system to an environment within an organization.
 .B --type=CONSUMERTYPE
 Sets the type of unit to register. Most units in the inventory will use the default value of
 .B system.
-For development or test systems, this can be
+For development or test units, this can be
 .B person
-, which indicates a personal (rather than organizational) subscription. Other systems can be
+, which indicates a personal (rather than organizational) unit. Another type of unit can be
 .B candlepin
 for a local content service or
 .B domain
@@ -302,7 +302,7 @@ Enables the auto-attach option for the system. If there is any change in the sub
 
 .TP
 .B --disable
-Disables the auto-attach option for the system. If auto-attach is disabled, then any changes in installed products or subscriptions for the system (including expirations) must be addressed manually by the administrator.
+Disables the auto-attach option for the system. If auto-attach is disabled, then any changes in installed products or subscriptions for the system (including expired subscriptions) must be addressed manually by the administrator.
 
 .TP
 .B --show
@@ -658,7 +658,7 @@ command removes all of the subscription and identity data from the local system
 .I without affecting the system information in the subscription management service.
 This means that any of the subscriptions applied to the system are not available for other systems to use. The
 .B clean
-command is useful in cases where the local subscription information is corrupted or lost somehow, and the system will be reregistered using the
+command is useful in cases where the local subscription information is corrupted or lost somehow, and the system will be re-registered using the
 .B register --consumerid=EXISTING_ID
 command.
 
@@ -988,7 +988,7 @@ option.
 
 .RS
 .nf
-subscription-manager list --instaled --matches="*Server*"
+subscription-manager list --installed --matches="*Server*"
 
 +-------------------------------------------+
     Installed Product Status
@@ -1019,7 +1019,7 @@ subscription-manager attach
 .pp
 As with the
 .B register
-command, the system can be auto-attached to the best-fitting subscriptions. This is the default action and is equilivent to  using the
+command, the system can be auto-attached to the best-fitting subscriptions. This is the default action and is equivalent to  using the
 .B --auto
 option:
 

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -77,7 +77,7 @@ has specific options available for each command, depending on what operation is 
 6. release
 
 .IP
-7. servicelevel
+7. service-level
 
 .IP
 8. import
@@ -346,16 +346,16 @@ Sets the minor (Y-stream) release version to use, such as 6.3.
 Removes any previously set release version preference.
 
 
-.SS servicelevel OPTIONS
+.SS service-level OPTIONS
 The
-.B servicelevel
+.B service-level
 command displays the current configured service level
 .I preference
 for products installed on the system. For example, if the service-level preference is standard, then a subscription with a standard service level is selected when auto-attaching subscriptions to the system.
 
 .IP
 The
-.B servicelevel
+.B service-level
 command does not set the service level for the system; it only shows its current setting or available settings. The service-level preference must be set in the Subscription Manager GUI.
 
 .TP

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -62,7 +62,7 @@ has specific options available for each command, depending on what operation is 
 1. register
 
 .IP
-2. unregister
+2. deregister
 
 .IP
 3. attach
@@ -247,9 +247,9 @@ for a local content service or
 for an IP domain.
 
 
-.SS UNREGISTER OPTIONS
+.SS DEREGISTER OPTIONS
 The
-.B unregister
+.B deregister
 command removes a system's subscriptions and removes it from the subscription management service.
 
 .PP
@@ -790,7 +790,7 @@ has two major tasks:
 makes it easier for network administrators to maintain parity between software subscriptions and updates and their installed products by tracking and managing what subscriptions are attached to a system and when those subscriptions expire or are exceeded.
 
 
-.SS REGISTERING AND UNREGISTERING MACHINES
+.SS REGISTERING AND DEREGISTERING MACHINES
 A system is either
 .I registered
 to a subscription management service -- which makes all of the subscriptions available to the system -- or it is not registered. Unregistered systems necessarily lack valid software subscriptions because there is no way to record that the subscriptions have been used nor any way to renew them.
@@ -888,12 +888,12 @@ eff9a4c9-3579-49e5-a52f-83f2db29ab52 server.example.com
 
 .PP
 A system is unregistered and removed from the subscription management service simply by running the
-.B unregister
-command. Unregistering a system and removing its attached subscriptions can free up subscriptions when a system is taken offline or moved to a different department.
+.B deregister
+command. Deregistering a system and removing its attached subscriptions can free up subscriptions when a system is taken offline or moved to a different department.
 
 .RS
 .nf
-subscription-manager unregister
+subscription-manager deregister
 .fi
 .RE
 

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -443,7 +443,7 @@ option.
 .B --matches=SEARCH
 Limits the output of --installed, --available and --consumed to only subscriptions or products which contain SEARCH in the subscription or product information, varying with the list requested and the server version.
 .br
-SEARCH may contain the wildcards ? or * to match a single character or zero or more characters, respectively. The wildcard characters may be escaped with a backslash to represent a literal
+SEARCH may contain the wild-cards ? or * to match a single character or zero or more characters, respectively. The wild-card characters may be escaped with a backslash to represent a literal
 question mark or asterisk. Likewise, to represent a backslash, it must be escaped with another backslash.
 
 .TP

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -530,23 +530,23 @@ parameter is for the on-premise Subscription Asset Manager server.
 .SS PLUGIN OPTIONS
 The
 .B plugins
-command lists the available subscription-manager plugins.
+command lists the available subscription-manager plug-ins.
 
 .TP
 .B --list
-List the available subscription-manager plugins.
+List the available subscription-manager plug-ins.
 
 .TP
 .B --listslots
-List the available plugin slots
+List the available plug-in slots
 
 .TP
 .B --listhooks
-List the available plugin slots and the hooks that handle them.
+List the available plug-in slots and the hooks that handle them.
 
 .TP
 .B --verbose
-Show additional info about the plugins, such as the plugin configuration values.
+Show additional info about the plug-ins, such as the plug-in configuration values.
 
 .SS REPO-OVERRIDE OPTIONS
 The

--- a/pylintrc
+++ b/pylintrc
@@ -19,7 +19,7 @@ ignore=.#
 # Pickle collected data for later comparisons.
 persistent=yes
 
-# List of plugins (as comma separated values of python modules names) to load,
+# List of plug-ins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 load-plugins=
 

--- a/rpmlint.config
+++ b/rpmlint.config
@@ -1,6 +1,6 @@
 # this seems ok to me
 addFilter('invalid-url')
-# all yum plugins seem to hardcode paths
+# all yum plug-ins seem to hardcode paths
 addFilter("hardcoded-library-path .*lib/yum-plugins/.*")
 #sytemd tmpfiles are in /usr/lib
 addFilter("hardcoded-library-path .*lib/tmpfiles.d/.*")

--- a/src/content_plugins/container_content.py
+++ b/src/content_plugins/container_content.py
@@ -14,7 +14,7 @@
 #
 
 """
-A subscription-manager plugin to watch for docker content in
+A subscription-manager plug-in to watch for docker content in
 entitlement certificates, and correctly configure to use them.
 """
 
@@ -30,7 +30,7 @@ HOSTNAME_CERT_DIR = "/etc/docker/certs.d/"
 
 
 class ContainerContentPlugin(base_plugin.SubManPlugin):
-    """Plugin for adding docker content action to subscription-manager"""
+    """Plug-in for adding docker content action to subscription-manager"""
     name = "container_content"
 
     def update_content_hook(self, conduit):

--- a/src/content_plugins/ostree_content.py
+++ b/src/content_plugins/ostree_content.py
@@ -21,7 +21,7 @@ from subscription_manager.plugin.ostree import action_invoker
 
 
 class OstreeContentPlugin(base_plugin.SubManPlugin):
-    """Plugin for adding ostree content action to subscription-manager"""
+    """Plug-in for adding ostree content action to subscription-manager"""
     name = "ostree_content"
 
     def update_content_hook(self, conduit):
@@ -31,7 +31,7 @@ class OstreeContentPlugin(base_plugin.SubManPlugin):
         Args:
             conduit: A UpdateContentConduit
         """
-        conduit.log.info("ostree update_content_hook plugin.")
+        conduit.log.info("ostree update_content_hook plug-in.")
 
         report = action_invoker.OstreeContentUpdateActionCommand(ent_source=conduit.ent_source).perform()
         conduit.reports.add(report)

--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -208,7 +208,7 @@ cert_check (gboolean heal)
 		warn ("(%s) Update failed (%d), retry will occur on next run.",
 		      action, status);
 	}
-	//returning FALSE will unregister the timer, always return TRUE
+	//returning FALSE will deregister the timer, always return TRUE
 	return TRUE;
 }
 

--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -440,7 +440,7 @@ main (int argc, char *argv[])
 
 	// note that we call the function directly first, before assigning a timer
 	// to it. Otherwise, it would only get executed when the timer went off, and
-	// not at startup.
+	// not at start-up.
 	//
 	// NOTE: We put the initial checks on a timer so that in the case of systemd,
 	// we can ensure that the network interfaces are all up before the initial

--- a/src/subscription_manager/action_client.py
+++ b/src/subscription_manager/action_client.py
@@ -72,11 +72,11 @@ class HealingActionClient(base_action_client.BaseActionClient):
 # *Lib things are weird, since some are idempotent, but
 # some arent. entcertlib/repolib .update can both install
 # certs, and/or delete all of them.
-class UnregisterActionClient(base_action_client.BaseActionClient):
-    """CertManager for cleaning up on unregister.
+class DeregisterActionClient(base_action_client.BaseActionClient):
+    """CertManager for cleaning up on deregister.
 
     This class should not need a consumer id, or a uep connection, since it
-    is running post unregister.
+    is running post deregister.
     """
     def _get_libset(self):
 

--- a/src/subscription_manager/base_plugin.py
+++ b/src/subscription_manager/base_plugin.py
@@ -17,12 +17,12 @@
 class SubManPlugin(object):
     """Base class for all subscription-manager "rhsm-plugins"
 
-    Plugins need to subclass SubManPlugin() to be found
+    Plug-ins need to subclass SubManPlugin() to be found
     """
     name = None
     conf = None
     # if all_slots is set, the plugin will get registered to all slots
-    # it is up to the plugin to handle providing callables
+    # it is up to the plug-in to handle providing callables
     all_slots = None
 
     # did we have hooks that match provided slots? aka

--- a/src/subscription_manager/branding/__init__.py
+++ b/src/subscription_manager/branding/__init__.py
@@ -79,7 +79,7 @@ class DefaultBranding(object):
 
     def __init__(self):
         self.CLI_REGISTER = _("Register the system to the server")
-        self.CLI_UNREGISTER = _("Unregister the system from the server")
+        self.CLI_DEREGISTER = _("Deregister the system from the server")
         self.RHSMD_REGISTERED_TO_OTHER = \
                 _("This system is registered to spacewalk")
         self.REGISTERED_TO_OTHER_WARNING = _("WARNING") + \

--- a/src/subscription_manager/branding/redhat_branding.py
+++ b/src/subscription_manager/branding/redhat_branding.py
@@ -5,7 +5,7 @@ _ = gettext.gettext
 class Branding(object):
     def __init__(self):
         self.CLI_REGISTER = _("Register this system to the Customer Portal or another subscription management service")
-        self.CLI_UNREGISTER = _("Unregister this system from the Customer Portal or another subscription management service")
+        self.CLI_DEREGISTER = _("Deregister this system from the Customer Portal or another subscription management service")
         self.RHSMD_REGISTERED_TO_OTHER = \
                 _("This system is registered to RHN Classic.")
         self.REGISTERED_TO_OTHER_WARNING = _("WARNING") + \
@@ -14,7 +14,7 @@ class Branding(object):
             "\n\n" + \
             _("Your system is being registered again using Red Hat Subscription Management. Red Hat recommends that customers only register once.") + \
             "\n\n" + \
-            _("To learn how to unregister from either service please consult this Knowledge Base Article: https://access.redhat.com/kb/docs/DOC-45563")
+            _("To learn how to deregister from either service please consult this Knowledge Base Article: https://access.redhat.com/kb/docs/DOC-45563")
         self.REGISTERED_TO_OTHER_SUMMARY = _("RHN Classic")
         self.REGISTERED_TO_SUBSCRIPTION_MANAGEMENT_SUMMARY = _("Red Hat Subscription Management")
         self.GUI_REGISTRATION_HEADER = \

--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -306,7 +306,7 @@ class CertSorter(ComplianceManager):
     Originally this class actually sorted certificates and calculated status,
     but this is handled by the server today.
 
-    If unregistered we report status as unknown.
+    If unregistered, we report status as unknown.
 
     On every successful server fetch (for *right now*), we cache the results.
     In the event we are unable to reach the server periodically, we will

--- a/src/subscription_manager/content_action_client.py
+++ b/src/subscription_manager/content_action_client.py
@@ -26,31 +26,31 @@ log = logging.getLogger('rhsm-app.' + __name__)
 
 
 class ContentPluginActionReport(certlib.ActionReport):
-    """Aggragate the info reported by each content plugin.
+    """Aggragate the info reported by each content plug-in.
 
     Just a set of reports that include info about the content
-    plugin that created it.
+    plug-in that created it.
     """
-    name = "Content Plugin Reports"
+    name = "Content Plug-in Reports"
 
     def __init__(self):
         super(ContentPluginActionReport, self).__init__()
         self.reports = set()
 
     def add(self, report):
-        # report should include info about what plugin generated it
+        # report should include info about what plug-in generated it
         self.reports.add(report)
 
 
 class ContentPluginActionCommand(object):
-    """An ActionCommand used to wrap 'content_update' plugin invocations.
+    """An ActionCommand used to wrap 'content_update' plug-in invocations.
 
     args:
         content_plugin_runner: a PluginHookRunner created with
               PluginManager.runiter('content_update').runiter()
 
     perform() runs the PluginHookRunner and returns the ContentActionReport
-      that PluginHookRunner.run() adds to the content plugin conduit.
+      that PluginHookRunner.run() adds to the content plug-in conduit.
     """
     def __init__(self, content_plugin_runner):
         self.runner = content_plugin_runner
@@ -64,7 +64,7 @@ class ContentPluginActionCommand(object):
 class ContentPluginActionInvoker(certlib.BaseActionInvoker):
     """ActionInvoker for ContentPluginActionCommands."""
     def __init__(self, content_plugin_runner):
-        """Create a ContentPluginActionInvoker to wrap content plugin PluginHookRunner.
+        """Create a ContentPluginActionInvoker to wrap content plug-in PluginHookRunner.
 
         Pass a PluginHookRunner to ContentPluginActionCommand. Do the
         normal ActionInvoker tasks and collect ActionReports.
@@ -84,10 +84,10 @@ class ContentPluginActionInvoker(certlib.BaseActionInvoker):
 class ContentActionClient(base_action_client.BaseActionClient):
 
     def _get_libset(self):
-        """Return a generator that creates a ContentPluginAction* for each update_content plugin.
+        """Return a generator that creates a ContentPluginAction* for each update_content plug-in.
 
         The iterable return includes the yum repo action invoker, and a ContentPluginActionInvoker
-        for each plugin hook mapped to the 'update_content_hook' slot.
+        for each plug-in hook mapped to the 'update_content_hook' slot.
         """
 
         yield repolib.RepoActionInvoker()

--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -226,7 +226,7 @@ class EntCertUpdateAction(object):
 
         identity = inj.require(inj.IDENTITY)
         if not identity.is_valid():
-            # We can get here on unregister, with no id or ent certs or repos,
+            # We can get here on deregister, with no id or ent certs or repos,
             # but don't want to raise an exception that would be logged. So
             # empty result set is returned.
             return results

--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -294,7 +294,7 @@ class EntitlementCertBundlesInstaller(object):
         self.exceptions = bundle_installer.exceptions
         self.post_install()
 
-    # TODO: add subman plugin slot,conduit,hooks
+    # TODO: add subman plug-in slot,conduit,hooks
     def pre_install(self):
         """Hook called before any ent cert bundles are installed."""
         log.debug("cert bundles pre_install")
@@ -345,7 +345,7 @@ class EntitlementCertBundleInstaller(object):
 
         self.post_install(bundle)
 
-    # TODO: add subman plugin, slot, and conduit
+    # TODO: add subman plug-in, slot, and conduit
     def pre_install(self, bundle):
         """Hook called before an ent cert bundle is installed."""
         log.debug("Ent cert bundle pre_install")

--- a/src/subscription_manager/facts.py
+++ b/src/subscription_manager/facts.py
@@ -55,7 +55,7 @@ class Facts(CacheManager):
         # that we need to update
         self.graylist = ['cpu.cpu_mhz', 'lscpu.cpu_mhz']
 
-        # plugin manager so we can add custom facst via plugin
+        # plug-in manager so we can add custom facst via plug-in
         self.plugin_manager = require(PLUGIN_MANAGER)
 
     def get_last_update(self):

--- a/src/subscription_manager/gui/data/choose_server.glade
+++ b/src/subscription_manager/gui/data/choose_server.glade
@@ -138,7 +138,7 @@
               <widget class="GtkEventBox" id="eventbox2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="tooltip" translatable="yes">Activation Keys are alphanumeric strings that are pre-configured by your system administrators to automatically register your system and attach all necessary subscriptions.</property>
+                <property name="tooltip" translatable="yes">Activation Keys are alphanumeric strings that are preconfigured by your system administrators to automatically register your system and attach all necessary subscriptions.</property>
                 <property name="visible_window">False</property>
                 <child>
                   <placeholder/>
@@ -182,7 +182,7 @@
                       <widget class="GtkImage" id="image3">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="tooltip" translatable="yes">Activation Keys are alphanumeric strings that are pre-configured by your system administrators to automatically register your system and attach all necessary subscriptions.</property>
+                        <property name="tooltip" translatable="yes">Activation Keys are alphanumeric strings that are preconfigured by your system administrators to automatically register your system and attach all necessary subscriptions.</property>
                         <property name="xalign">1</property>
                         <property name="stock">gtk-info</property>
                       </widget>

--- a/src/subscription_manager/gui/data/mainwindow.glade
+++ b/src/subscription_manager/gui/data/mainwindow.glade
@@ -45,16 +45,16 @@
                       </widget>
                     </child>
                     <child>
-                      <widget class="GtkImageMenuItem" id="unregister_menu_item">
-                        <property name="label" translatable="yes">_Unregister</property>
+                      <widget class="GtkImageMenuItem" id="deregister_menu_item">
+                        <property name="label" translatable="yes">_Deregister</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">False</property>
-                        <signal name="activate" handler="on_unregister_menu_item_activate" />
+                        <signal name="activate" handler="on_deregister_menu_item_activate" />
                         <accelerator key="u" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <child internal-child="image">
-                          <widget class="GtkImage" id="unregister_image">
+                          <widget class="GtkImage" id="deregister_image">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="stock">gtk-disconnect</property>

--- a/src/subscription_manager/gui/firstboot/rhsm_login.py
+++ b/src/subscription_manager/gui/firstboot/rhsm_login.py
@@ -158,7 +158,7 @@ class PerformRegisterScreen(registergui.PerformRegisterScreen):
         identity = require(IDENTITY)
         if identity.is_valid():
             try:
-                managerlib.unregister(self._parent.backend.cp_provider.get_consumer_auth_cp(),
+                managerlib.deregister(self._parent.backend.cp_provider.get_consumer_auth_cp(),
                         self._parent.identity.uuid)
             except socket.error, e:
                 handle_gui_exception(e, e, self._parent.window)
@@ -306,7 +306,7 @@ class moduleClass(RhsmFirstbootModule, registergui.RegisterScreen):
         if self._skip_apply_for_page_jump:
             self._skip_apply_for_page_jump = False
             # Reset back to first screen in our module in case the user hits back.
-            # The firstboot register screen subclass will handle unregistering
+            # The firstboot register screen subclass will handle deregistering
             # if necessary when it runs again.
             self.show()
             return self._RESULT_SUCCESS

--- a/src/subscription_manager/healinglib.py
+++ b/src/subscription_manager/healinglib.py
@@ -58,7 +58,7 @@ class HealingUpdateAction(object):
     Returns an EntCertUpdateReport with information about any ent
     certs that were changed.
 
-    Plugin hooks:
+    Plug-in hooks:
         pre_auto_attach
         post_auto_attach
     """

--- a/src/subscription_manager/injectioninit.py
+++ b/src/subscription_manager/injectioninit.py
@@ -63,7 +63,7 @@ def init_dep_injection():
 
     inj.provide(inj.CERT_SORTER, CertSorter, singleton=True)
 
-    # Set up plugin manager as a singleton.
+    # Set up PluginManager as a singleton.
     # FIXME: should we aggressively catch exceptions here? If we can't
     # create a PluginManager we should probably raise an exception all the way up
     inj.provide(inj.PLUGIN_MANAGER, PluginManager, singleton=True)

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -39,7 +39,7 @@ from rhsm.certificate import GMT
 
 from subscription_manager.branding import get_branding
 from subscription_manager.entcertlib import EntCertActionInvoker
-from subscription_manager.action_client import ActionClient, UnregisterActionClient
+from subscription_manager.action_client import ActionClient, DeregisterActionClient
 from subscription_manager.cert_sorter import ComplianceManager, FUTURE_SUBSCRIBED, \
         SUBSCRIBED, NOT_SUBSCRIBED, EXPIRED, PARTIALLY_SUBSCRIBED, UNKNOWN
 from subscription_manager.cli import AbstractCLICommand, CLI, system_exit
@@ -1033,13 +1033,13 @@ class RegisterCommand(UserPassCommand):
             # errors are encountered.
             old_uuid = self.identity.uuid
             try:
-                managerlib.unregister(self.cp, old_uuid)
+                managerlib.deregister(self.cp, old_uuid)
                 self.entitlement_dir.__init__()
                 self.product_dir.__init__()
-                log.info("--force specified, unregistered old consumer: %s" % old_uuid)
-                print(_("The system with UUID %s has been unregistered") % old_uuid)
+                log.info("--force specified, deregistered old consumer: %s" % old_uuid)
+                print(_("The system with UUID %s has been deregistered") % old_uuid)
             except Exception, e:
-                log.error("Unable to unregister consumer: %s" % old_uuid)
+                log.error("Unable to deregister consumer: %s" % old_uuid)
                 log.exception(e)
 
         facts = inj.require(inj.FACTS)
@@ -1220,13 +1220,23 @@ class RegisterCommand(UserPassCommand):
         return owner_key
 
 
-class UnRegisterCommand(CliCommand):
+class DeregisterCommand(CliCommand):
 
     def __init__(self):
-        shortdesc = get_branding().CLI_UNREGISTER
+        super(DeregisterCommand, self).__init__(
+            self._command_name(),
+            self._short_description(),
+            self._primary()
+        )
 
-        super(UnRegisterCommand, self).__init__("unregister", shortdesc,
-                                                True)
+    def _short_description(self):
+        return get_branding().CLI_DEREGISTER
+
+    def _command_name(self):
+        return "deregister"
+
+    def _primary(self):
+        return True
 
     def _validate_options(self):
         pass
@@ -1237,11 +1247,11 @@ class UnRegisterCommand(CliCommand):
             system_exit(ERR_NOT_REGISTERED_CODE, _("This system is currently not registered."))
 
         try:
-            managerlib.unregister(self.cp, self.identity.uuid)
+            managerlib.deregister(self.cp, self.identity.uuid)
         except Exception, e:
-            handle_exception("Unregister failed", e)
+            handle_exception("Deregister failed", e)
 
-        # managerlib.unregister reloads the now None provided identity
+        # managerlib.deregister reloads the now None provided identity
         # so cp_provider provided auth_cp's should fail, like the below
 
         #this block is simply to ensure that the yum repos got updated. If it fails,
@@ -1250,7 +1260,7 @@ class UnRegisterCommand(CliCommand):
         try:
             # there is no consumer cert at this point, a uep object
             # is not useful
-            cleanup_certmgr = UnregisterActionClient()
+            cleanup_certmgr = DeregisterActionClient()
             cleanup_certmgr.update()
         except Exception, e:
             pass
@@ -1260,7 +1270,21 @@ class UnRegisterCommand(CliCommand):
         # We have new credentials, restart virt-who
         restart_virt_who()
 
-        print(_("System has been unregistered."))
+        print(_("System has been deregistered."))
+
+
+class UnregisterCommand(DeregisterCommand):
+    def __init__(self):
+        super(UnregisterCommand, self).__init__()
+
+    def _short_description(self):
+        return _("Deprecated, see deregister")
+
+    def _command_name(self):
+        return "unregister"
+
+    def _primary(self):
+        return False
 
 
 class RedeemCommand(CliCommand):
@@ -2609,8 +2633,8 @@ class StatusCommand(CliCommand):
 class ManagerCLI(CLI):
 
     def __init__(self):
-        commands = [RegisterCommand, UnRegisterCommand, ConfigCommand, ListCommand,
-                    SubscribeCommand, UnSubscribeCommand, FactsCommand,
+        commands = [RegisterCommand, DeregisterCommand, UnregisterCommand, ConfigCommand,
+                    ListCommand, SubscribeCommand, UnSubscribeCommand, FactsCommand,
                     IdentityCommand, OwnersCommand, RefreshCommand, CleanCommand,
                     RedeemCommand, ReposCommand, ReleaseCommand, StatusCommand,
                     EnvironmentsCommand, ImportCertCommand, ServiceLevelCommand,

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1833,19 +1833,19 @@ class ImportCertCommand(CliCommand):
 
 class PluginsCommand(CliCommand):
     def __init__(self):
-        shortdesc = _("View and configure subscription-manager plugins")
+        shortdesc = _("View and configure subscription-manager plug-ins")
         super(PluginsCommand, self).__init__("plugins", shortdesc, False)
 
         SM = "subscription-manager"
         self.parser.add_option("--list", action="store_true",
-                                help=_("list %s plugins") % SM)
+                                help=_("list %s plug-ins") % SM)
         self.parser.add_option("--listslots", action="store_true",
-                                help=_("list %s plugin slots") % SM)
+                                help=_("list %s plug-in slots") % SM)
         self.parser.add_option("--listhooks", action="store_true",
-                                help=_("list %s plugin hooks") % SM)
+                                help=_("list %s plug-in hooks") % SM)
         self.parser.add_option("--verbose", action="store_true",
                                default=False,
-                               help=_("show verbose plugin info"))
+                               help=_("show verbose plug-in info"))
 
     def _validate_options(self):
         # default to list

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1930,10 +1930,10 @@ class ReposCommand(CliCommand):
                                help=_("list known, disabled repositories for this system"))
         self.parser.add_option("--enable", dest="enable", type="str",
                                action='callback', callback=repo_callback, metavar="REPOID",
-                               help=_("repository to enable (can be specified more than once). Wildcards (* and ?) are supported."))
+                               help=_("repository to enable (can be specified more than once). Wild-cards (* and ?) are supported."))
         self.parser.add_option("--disable", dest="disable", type="str",
                                action='callback', callback=repo_callback, metavar="REPOID",
-                               help=_("repository to disable (can be specified more than once). Wildcards (* and ?) are supported."))
+                               help=_("repository to disable (can be specified more than once). Wild-cards (* and ?) are supported."))
 
     def _validate_options(self):
         if not (self.options.list or hasattr(self.options, 'repo_actions')):

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -781,13 +781,13 @@ def format_date(dt):
         return ""
 
 
-def unregister(uep, consumer_uuid):
+def deregister(uep, consumer_uuid):
     """
-    Shared logic for un-registration.
+    Shared logic for deregistration.
     """
     uep.unregisterConsumer(consumer_uuid)
-    log.info("Successfully un-registered.")
-    system_log("Unregistered machine with identity: %s" % consumer_uuid)
+    log.info("Successfully deregistered.")
+    system_log("Deregistered machine with identity: %s" % consumer_uuid)
     clean_all_data(backup=False)
 
 

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -609,10 +609,10 @@ class MigrationEngine(object):
                 self.disable_yum_rhn_plugin()
             except Exception:
                 pass
-            print _("System successfully unregistered from legacy server.")
+            print _("System successfully deregistered from legacy server.")
         else:
             # If the legacy server reports that deletion just failed, then quit.
-            system_exit(1, _("Unable to unregister system from legacy server.  ") + SEE_LOG_FILE)
+            system_exit(1, _("Unable to deregister system from legacy server.  ") + SEE_LOG_FILE)
 
     def load_transition_data(self, rpc_session):
         # We need to send up the entire contents of the systemid file which is referred to in
@@ -786,7 +786,7 @@ class MigrationEngine(object):
 
         if self.options.registration_state == "purge":
             print
-            print _("Preparing to unregister system from legacy server...")
+            print _("Preparing to deregister system from legacy server...")
             self.legacy_purge(rpc_session, session_key)
         elif self.options.registration_state == "unentitle":
             self.legacy_unentitle(rpc_session)

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -578,8 +578,8 @@ class MigrationEngine(object):
         try:
             rpc_session.system.unentitle(system_id)
         except Exception, e:
-            log.exception("Could not unentitle system on Satellite 5.", e)
-            system_exit(1, _("Could not unentitle system on legacy server.  ") + SEE_LOG_FILE)
+            log.exception("Could not remove system entitlement on Satellite 5.", e)
+            system_exit(1, _("Could not remove system entitlement on legacy server.  ") + SEE_LOG_FILE)
         try:
             self.disable_yum_rhn_plugin()
         except Exception:

--- a/src/subscription_manager/plugin/container.py
+++ b/src/subscription_manager/plugin/container.py
@@ -13,7 +13,7 @@
 # in this software or its documentation.
 #
 
-""" Core code for the container content plugin. """
+""" Core code for the container content plug-in. """
 
 import gettext
 import logging
@@ -138,7 +138,7 @@ class ContainerCertDir(object):
         log.debug("Syncing container certificates to %s" % self.path)
         if not os.path.exists(self.host_cert_dir):
             log.warn("Container cert directory does not exist: %s" % self.host_cert_dir)
-            log.warn("Exiting plugin")
+            log.warn("Exiting plug-in")
             return
         if not os.path.exists(self.path):
             log.info("Container cert directory does not exist, creating it.")

--- a/src/subscription_manager/plugin/ostree/action_invoker.py
+++ b/src/subscription_manager/plugin/ostree/action_invoker.py
@@ -23,7 +23,7 @@ from subscription_manager.model import find_content
 
 from subscription_manager.plugin.ostree import model
 
-# plugins get
+# plug-ins get
 log = logging.getLogger('rhsm-app.' + __name__)
 
 _ = gettext.gettext

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -53,7 +53,7 @@ _ = gettext.gettext
 
 
 class PluginException(Exception):
-    """Base exception for rhsm plugins."""
+    """Base exception for rhsm plug-ins."""
     def _add_message(self, repr_msg):
         if hasattr(self, "msg") and self.msg:
             repr_msg = "\n".join([repr_msg, "Message: %s" % self.msg])
@@ -68,26 +68,26 @@ class PluginImportException(PluginException):
         self.msg = msg
 
     def __str__(self):
-        repr_msg = "Plugin \"%s\" can't be imported from file %s" % \
+        repr_msg = "Plug-in \"%s\" can't be imported from file %s" % \
                     (self.module_name, self.module_file)
         return self._add_message(repr_msg)
 
 
 class PluginModuleImportException(PluginImportException):
-    """Raise when a plugin module can not be imported."""
+    """Raise when a plug-in module can not be imported."""
 
 
 class PluginModuleImportApiVersionMissingException(PluginImportException):
-    """Raised when a plugin module does not include a 'requires_api_version'."""
+    """Raised when a plug-in module does not include a 'requires_api_version'."""
     def __str__(self):
-        repr_msg = """Plugin module "%s" in %s has no API version.
+        repr_msg = """Plug-in module "%s" in %s has no API version.
                    'requires_api_version' should be set.""" % \
                     (self.module_name, self.module_file)
         return self._add_message(repr_msg)
 
 
 class PluginModuleImportApiVersionException(PluginImportException):
-    """Raised when a plugin module's 'requires_api_version' can not be met."""
+    """Raised when a plug-in module's 'requires_api_version' can not be met."""
     def __init__(self, module_file, module_name, module_ver, api_ver, msg=None):
         self.module_file = module_file
         self.module_name = module_name
@@ -96,7 +96,7 @@ class PluginModuleImportApiVersionException(PluginImportException):
         self.msg = msg
 
     def __str__(self):
-        repr_msg = "Plugin \"%s\" requires API version %s. Supported API is %s" % \
+        repr_msg = "Plug-in \"%s\" requires API version %s. Supported API is %s" % \
             (self.module_name, self.module_ver, self.api_ver)
         return self._add_message(repr_msg)
 
@@ -108,7 +108,7 @@ class PluginConfigException(PluginException):
         self.msg = msg
 
     def __str__(self):
-        repr_msg = "Cannot load configuration for plugin \"%s\"" % (self.plugin_name)
+        repr_msg = "Cannot load configuration for plug-in \"%s\"" % (self.plugin_name)
         return self._add_message(repr_msg)
 
 
@@ -123,7 +123,7 @@ class SlotNameException(Exception):
 
 
 class BaseConduit(object):
-    """An API entry point for rhsm plugins.
+    """An API entry point for rhsm plug-ins.
 
     Conduit()'s are used to provide access to the data a SubManPlugin may need.
     Each 'slot_name' has a BaseConduit() subclass associated with it by PluginManager().
@@ -157,11 +157,11 @@ class BaseConduit(object):
         else:
             self._conf = clazz.conf
 
-        # maybe useful to have a per conduit/per plugin logger space
+        # maybe useful to have a per conduit/per plug-in logger space
         self.log = logging.getLogger("rhsm-app." + clazz.__name__)
 
     def conf_string(self, section, option, default=None):
-        """get string from plugin config
+        """get string from plug-in config
 
         Args:
             section: config section name
@@ -182,7 +182,7 @@ class BaseConduit(object):
             return str(default)
 
     def conf_bool(self, section, option, default=None):
-        """get boolean value from plugin config
+        """get boolean value from plug-in config
 
         Args:
             section: config section name
@@ -207,7 +207,7 @@ class BaseConduit(object):
                 raise ValueError("Boolean value expected")
 
     def conf_int(self, section, option, default=None):
-        """get integer value from plugin config
+        """get integer value from plug-in config
 
         Args:
             section: config section name
@@ -231,7 +231,7 @@ class BaseConduit(object):
             return val
 
     def conf_float(self, section, option, default=None):
-        """get float value from plugin config
+        """get float value from plug-in config
 
         Args:
             section: config section name
@@ -290,7 +290,7 @@ class PostRegistrationConduit(BaseConduit):
 
 
 class ProductConduit(BaseConduit):
-    """Conduit for use with plugins that handle product id functions."""
+    """Conduit for use with plug-ins that handle product id functions."""
     slots = ['pre_product_id_install', 'post_product_id_install']
 
     def __init__(self, clazz, product_list):
@@ -304,7 +304,7 @@ class ProductConduit(BaseConduit):
 
 
 class ProductUpdateConduit(BaseConduit):
-    """Conduit for use with plugins that handle product id update functions."""
+    """Conduit for use with plug-ins that handle product id update functions."""
     slots = ['pre_product_id_update', 'post_product_id_update']
 
     def __init__(self, clazz, product_list):
@@ -409,11 +409,11 @@ class PostAutoAttachConduit(PostSubscriptionConduit):
 
 
 class PluginConfig(object):
-    """Represents configuation for each rhsm plugin.
+    """Represents configuation for each rhsm plug-in.
 
     Attributes:
-        plugin_conf_path: where plugin config files are found
-        plugin_key: a string identifier for plugins, For ex, 'facts.FactsPlugin'
+        plugin_conf_path: where plug-in config files are found
+        plugin_key: a string identifier for plug-ins, For ex, 'facts.FactsPlugin'
                     Used to find the configuration file.
     """
     plugin_key = None
@@ -424,9 +424,9 @@ class PluginConfig(object):
 
         Args:
             plugin_key: string id for class
-            plugin_conf_path: string file path to where plugin config files are found
+            plugin_conf_path: string file path to where plug-in config files are found
         Raises:
-            PluginConfigException: error when finding or loading plugin config
+            PluginConfigException: error when finding or loading plug-in config
         """
         self.plugin_conf_path = plugin_conf_path
         self.plugin_key = plugin_key
@@ -452,14 +452,14 @@ class PluginConfig(object):
         self.conf_files.append(conf_file)
 
     def is_plugin_enabled(self):
-        """returns True if the plugin is enabled in it's config."""
+        """returns True if the plug-in is enabled in it's config."""
         try:
             enabled = self.parser.getboolean('main', 'enabled')
         except Exception, e:
             raise PluginConfigException(self.plugin_key, e)
 
         if not enabled:
-            log.debug("Not loading \"%s\" plugin as it is disabled" % self.plugin_key)
+            log.debug("Not loading \"%s\" plug-in as it is disabled" % self.plugin_key)
             return False
         return True
 
@@ -473,10 +473,10 @@ class PluginConfig(object):
 
 
 class PluginHookRunner(object):
-    """Encapsulates a Conduit() instance and a bound plugin method.
+    """Encapsulates a Conduit() instance and a bound plug-in method.
 
     PluginManager.runiter() returns an iterable that will yield
-    a PluginHookRunner for each plugin hook to be triggered.
+    a PluginHookRunner for each plug-in hook to be triggered.
     """
     def __init__(self, conduit, func):
         self.conduit = conduit
@@ -493,17 +493,17 @@ class PluginHookRunner(object):
 #NOTE: need to be super paranoid here about existing of cfg variables
 # BasePluginManager with our default config info
 class BasePluginManager(object):
-    """Finds, load, and provides acccess to subscription-manager plugins."""
+    """Finds, load, and provides acccess to subscription-manager plug-ins."""
     def __init__(self, search_path=None, plugin_conf_path=None):
         """init for BasePluginManager().
 
         attributes:
             conduits: BaseConduit subclasses that can register slots
-            search_path: where to find plugin modules
-            plugin_conf_path: where to find plugin config files
+            search_path: where to find plug-in modules
+            plugin_conf_path: where to find plug-in config files
             _plugins: map of a plugin_key to a SubManPlugin instance
-            _plugin_classes: list of plugin classes found
-            _slot_to_funcs: map of a slotname to a list of plugin methods that handle it
+            _plugin_classes: list of plug-in classes found
+            _slot_to_funcs: map of a slotname to a list of plug-in methods that handle it
             _slot_to_conduit: map of a slotname to a Conduit() that is passed to the slot
                               associated
         """
@@ -553,21 +553,21 @@ class BasePluginManager(object):
         """Needs to be implemented in subclass.
 
         Returns:
-            A list of modules to load plugins classes from
+            A list of modules to load plug-ins classes from
         """
         return []
 
     def _import_plugins(self):
         """Needs to be implemented in subclass.
 
-        This loads plugin modules, checks them, and loads plugins
+        This loads plug-in modules, checks them, and loads plug-ins
         from them with self.add_plugins_from_module
         """
         # by default, we create PluginConfig's as needed, so no need for
         # plugin_to_config_map to be passed in
         self.add_plugins_from_modules(self.modules)
-        log.debug("loaded plugin modules: %s" % self.modules)
-        log.debug("loaded plugins: %s" % self._plugins)
+        log.debug("loaded plug-in modules: %s" % self.modules)
+        log.debug("loaded plug-ins: %s" % self._plugins)
 
     def _populate_slots(self):
         for conduit_class in self.conduits:
@@ -577,12 +577,12 @@ class BasePluginManager(object):
                 self._slot_to_funcs[slot] = []
 
     def add_plugins_from_modules(self, modules, plugin_to_config_map=None):
-        """Add SubMan plugins from a list of modules
+        """Add SubMan plug-ins from a list of modules
 
         Args:
             modules: a list of python module objects
             plugin_to_config_map: a dict mapping a plugin_key to a PluginConfig
-                                  object. If a plugin finds it's config in here,
+                                  object. If a plug-in finds it's config in here,
                                   that is used instead of creating a new PluginConfig()
                                   (which needs an actual file in plugin_conf_dir)
         Side effects:
@@ -597,7 +597,7 @@ class BasePluginManager(object):
                 log.error(e)
 
     def add_plugins_from_module(self, module, plugin_to_config_map=None):
-        """add SubManPlugin based plugins from a module.
+        """add SubManPlugin based plug-ins from a module.
 
         Will also look for a PluginConfig() associated with the
         SubManPlugin classes. Config files should be in self.plugin_conf_path
@@ -607,16 +607,16 @@ class BasePluginManager(object):
             module: an import python module object, that contains
                     SubManPlugin subclasses.
             plugin_to_config_map: a dict mapping a plugin_key to a PluginConfig
-                                  object.If a plugin finds it's config in here,
+                                  object.If a plug-in finds it's config in here,
                                   that is used instead of creating a new PluginConfig()
         Side Effects:
             self._modules is populated
             whatever add_plugin_class does
         Raises:
-            PluginException: multiple plugins with the same name
+            PluginException: multiple plug-ins with the same name
         """
-        # track the modules we try to load plugins from
-        # we'll add plugin classes if we find them
+        # track the modules we try to load plug-ins from
+        # we'll add plug-in classes if we find them
         self._modules[module] = []
 
         # verify we are a class, and in particular, a subclass
@@ -624,11 +624,11 @@ class BasePluginManager(object):
         def is_plugin(c):
             return inspect.isclass(c) and c.__module__ == module.__name__ and issubclass(c, SubManPlugin)
 
-        # note we sort the list of plugin classes, since that potentially
+        # note we sort the list of plug-in classes, since that potentially
         # alters order hooks are mapped to slots
         plugin_classes = sorted(inspect.getmembers(module, is_plugin))
 
-        # find all the plugin classes with valid configs first
+        # find all the plug-in classes with valid configs first
         # then add them, so we skip the module if a class has a bad config
         found_plugin_classes = []
         for name, clazz in sorted(plugin_classes):
@@ -640,7 +640,7 @@ class BasePluginManager(object):
             found_plugin_classes.append(clazz)
 
         for plugin_class in found_plugin_classes:
-            # NOTE: we currently do not catch plugin init exceptions
+            # NOTE: we currently do not catch plug-in init exceptions
             # here, and let them bubble. But we could...? that would
             # let some classes from a module fail
             self.add_plugin_class(plugin_class,
@@ -653,14 +653,14 @@ class BasePluginManager(object):
             plugin_clazz: A SubManPlugin child class, with a
                           .conf PluginConfig() class
             plugin_to_config_map: a dict mapping a plugin_key to a PluginConfig
-                                  object.If a plugin finds it's config in here,
+                                  object.If a plug-in finds it's config in here,
                                   that is used instead of creating a new PluginConfig()
         Side effects:
-            self._plugin_classes is populated with all found plugin classes
-            self._modules is populated with plugin classes per plugin module
-            self._plugins is populated with valid and enabled plugin instances
+            self._plugin_classes is populated with all found plug-in classes
+            self._modules is populated with plug-in classes per plug-in module
+            self._plugins is populated with valid and enabled plug-in instances
         Raises:
-            PluginException: multiple plugins with the same name
+            PluginException: multiple plug-ins with the same name
         """
         # either look up what we were passed, or create a new PluginConfig
         # default is to create a PluginConfig
@@ -693,8 +693,8 @@ class BasePluginManager(object):
             self._plugins[plugin_key] = instance
         else:
             # This shouldn't ever happen
-            raise PluginException("Two or more plugins with the name \"%s\" exist "
-                                  "in the plugin search path" %
+            raise PluginException("Two or more plug-ins with the name \"%s\" exist "
+                                  "in the plug-in search path" %
                                   plugin_clazz.__name__)
 
         # this is a valid plugin, with config, that instantiates, and is not a  dupe
@@ -719,14 +719,14 @@ class BasePluginManager(object):
                 else:
                     # found the attribute, but it is not callable
                     # note we let AttributeErrors bubble up
-                    log.debug("%s plugin does not have a callable() method %s" % (plugin_key, func_name))
+                    log.debug("%s plug-in does not have a callable() method %s" % (plugin_key, func_name))
 
         # if we don't find any place to use this class, note that on the plugin class
         if class_is_used:
             plugin_clazz.found_slots_for_hooks = True
 
     def _track_plugin_class_to_modules(self, plugin_clazz):
-        """Keep a map of plugin classes loaded from each plugin module."""
+        """Keep a map of plug-in classes loaded from each plug-in module."""
         if plugin_clazz.__module__ not in self._modules:
             self._modules[plugin_clazz.__module__] = []
         self._modules[plugin_clazz.__module__].append(plugin_clazz)
@@ -744,7 +744,7 @@ class BasePluginManager(object):
             Nothing.
         Raises:
             SlotNameException: slot_name isn't found
-            (Anything else is plugin and conduit specific)
+            (Anything else is plug-in and conduit specific)
         """
         for runner in self.runiter(slot_name, **kwargs):
             runner.run()
@@ -753,7 +753,7 @@ class BasePluginManager(object):
         """Return an iterable of PluginHookRunner objects.
 
         The iterable will return a PluginHookRunner object
-        for each plugin hook mapped to slot_name. Multiple plugins
+        for each plug-in hook mapped to slot_name. Multiple plug-ins
         with hooks for the same slot will result in multiple
         PluginHookRunners in the iterable.
 
@@ -810,7 +810,7 @@ class BasePluginManager(object):
         return PluginConfig(plugin_clazz.get_plugin_key(), self.plugin_conf_path)
 
     def get_plugins(self):
-        """list of plugins."""
+        """list of plug-ins."""
         return self._plugin_classes
 
     def get_slots(self):
@@ -837,8 +837,8 @@ class BasePluginManager(object):
 
 
 class PluginManager(BasePluginManager):
-    """Finds, load, and provides acccess to subscription-manager plugins
-    using subscription-manager default plugin search path and plugin
+    """Finds, load, and provides acccess to subscription-manager plug-ins
+    using subscription-manager default plug-in search path and plug-in
     conf path.
     """
     default_search_path = DEFAULT_SEARCH_PATH
@@ -858,7 +858,7 @@ class PluginManager(BasePluginManager):
             cfg_search_path = cfg.get("rhsm", "pluginDir")
             cfg_conf_path = cfg.get("rhsm", "pluginConfDir")
         except NoOptionError:
-            log.warning("no config options found for plugin paths, using defaults")
+            log.warning("no config options found for plug-in paths, using defaults")
             cfg_search_path = None
             cfg_conf_path = None
 
@@ -870,7 +870,7 @@ class PluginManager(BasePluginManager):
                                         plugin_conf_path=init_plugin_conf_path)
 
     def _get_conduits(self):
-        """get subscription-manager specific plugin conduits."""
+        """get subscription-manager specific plug-in conduits."""
         # we should be able to collect this from the sub classes of BaseConduit
         return [BaseConduit, ProductConduit, ProductUpdateConduit,
                 RegistrationConduit, PostRegistrationConduit,
@@ -886,15 +886,15 @@ class PluginManager(BasePluginManager):
 
     # subman specific module/plugin loading
     def _find_plugin_module_files(self, search_path):
-        """Load all the plugins in the search path.
+        """Load all the plug-ins in the search path.
 
         Raise:
-            PluginException: plugin load fails
+            PluginException: plug-in load fails
         """
         module_files = []
         if not os.path.isdir(search_path):
-            log.error("Could not find %s for plugin import" % search_path)
-            # NOTE: if this is not found, we don't load any plugins
+            log.error("Could not find %s for plug-in import" % search_path)
+            # NOTE: if this is not found, we don't load any plug-ins
             # so self._plugins/_plugins_funcs are empty
             return []
         mask = os.path.join(search_path, "*.py")
@@ -939,9 +939,9 @@ class PluginManager(BasePluginManager):
             log.exception(e)
             raise PluginModuleImportException(module_file, module_name)
 
-        # FIXME: look up module conf, so we can enable entire plugin modules
+        # FIXME: look up module conf, so we can enable entire plug-in modules
         if not hasattr(loaded_module, "requires_api_version"):
-            raise PluginModuleImportApiVersionMissingException(module_file, module_name, "Plugin doesn't specify required API version")
+            raise PluginModuleImportApiVersionMissingException(module_file, module_name, "Plug-in doesn't specify required API version")
         if not api_version_ok(API_VERSION, loaded_module.requires_api_version):
             raise PluginModuleImportApiVersionException(module_file, module_name,
                                                         module_ver=loaded_module.requires_api_version, api_ver=API_VERSION)

--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -411,7 +411,7 @@ class ProductManager:
         products_installed = []
 
         # track updated product ids seperately in case we want
-        # to run plugins
+        # to run plug-ins
         products_to_update = []
 
         # enabled means we have a repo, it's enabled=1, it has a productid metadata
@@ -531,7 +531,7 @@ class ProductManager:
 
     def install_product_certs(self, product_certs):
         # collect info, then do the needful later, so we can hook
-        # up a plugin in between and let it munge these lists, so a plugin
+        # up a plug-in in between and let it munge these lists, so a plug-in
         # could blacklist a product cert for example.
         self.plugin_manager.run('pre_product_id_install', product_list=product_certs)
         # ProductCertDb.install()
@@ -680,12 +680,12 @@ class ProductManager:
             if delete_product_cert:
                 certs_to_delete.append((p, cert))
 
-        # TODO: plugin hook for pre_product_id_delete
+        # TODO: plug-in hook for pre_product_id_delete
         for (product, cert) in certs_to_delete:
             log.info("product cert %s for %s is being deleted" % (product.id, product.id))
             cert.delete()
             self.pdir.refresh()
-            #TODO: plugin hook for post_product_id_delete
+            #TODO: plug-in hook for post_product_id_delete
 
             # it should be safe to delete it's entry now, we either dont
             # know anything about it's repos, it doesnt have any, or none

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -350,7 +350,7 @@ class ProductCertificateFilter(CertificateFilter):
     def set_filter_string(self, filter_string):
         """
         Sets this filter's filter string to the specified string. The filter string may use ? or *
-        for wildcards, representing one or any characters, respectively.
+        for wild-cards, representing one or any characters, respectively.
 
         Returns True if the specified filter string was processed and assigned successfully; False
         otherwise.
@@ -370,7 +370,7 @@ class ProductCertificateFilter(CertificateFilter):
                 [^*?\\]*        # Character literals and other uninteresting junk (greedy)
                 (?:\\.?)*       # Anything escaped with a backslash, or just a trailing backslash
             )*)                 # Repeat the above sequence 0+ times, greedily
-            ([*?]|\Z)           # Any of our wildcards (* or ?) not preceded by a backslash OR end of input
+            ([*?]|\Z)           # Any of our wild-cards (* or ?) not preceded by a backslash OR end of input
         """
 
         if filter_string is not None:

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1,6 +1,6 @@
 # Prefer systemd over sysv on Fedora 17+ and RHEL 7+
 %global use_systemd (0%{?fedora} && 0%{?fedora} >= 17) || (0%{?rhel} && 0%{?rhel} >= 7)
-# For optional building of ostree-plugin sub package. Unrelated to systemd
+# For optional building of ostree-plugin subpackage. Unrelated to systemd
 # but the same versions apply at the moment.
 %global has_ostree %use_systemd
 %global use_old_firstboot (0%{?rhel} && 0%{?rhel} <= 6)
@@ -84,11 +84,11 @@ platform.
 
 %if %has_ostree
 %package -n subscription-manager-plugin-ostree
-Summary: A plugin for handling OSTree content.
+Summary: A plug-in for handling OSTree content.
 Group: System Environment/Base
 
 Requires: pygobject3-base
-# plugin needs a slightly newer version of python-iniparse for 'tidy'
+# plug-in needs a slightly newer version of python-iniparse for 'tidy'
 Requires:  python-iniparse >= 0.4
 
 %description -n subscription-manager-plugin-ostree
@@ -104,7 +104,7 @@ the remote in the currently deployed .origin file.
 %endif
 
 %package -n subscription-manager-plugin-container
-Summary: A plugin for handling container content.
+Summary: A plug-in for handling container content.
 Group: System Environment/Base
 
 %description -n subscription-manager-plugin-container
@@ -206,7 +206,7 @@ touch %{buildroot}%{_sysconfdir}/yum.repos.d/redhat.repo
 mkdir -p %{buildroot}%{_sysconfdir}/pki/consumer
 mkdir -p %{buildroot}%{_sysconfdir}/pki/entitlement
 
-# Setup cert directories for the container plugin:
+# Setup cert directories for the container plug-in:
 mkdir -p %{buildroot}%{_sysconfdir}/docker/certs.d/
 mkdir %{buildroot}%{_sysconfdir}/docker/certs.d/cdn.redhat.com
 install -m 644 %{_builddir}/%{buildsubdir}/etc-conf/redhat-entitlement-authority.pem %{buildroot}%{_sysconfdir}/docker/certs.d/cdn.redhat.com/redhat-entitlement-authority.crt
@@ -329,14 +329,14 @@ rm -rf %{buildroot}
 %{_datadir}/rhsm/subscription_manager/plugin/*.py*
 
 %{_datadir}/rhsm/subscription_manager/version.py*
-# subscription-manager plugins
+# subscription-manager plug-ins
 %dir %{rhsm_plugins_dir}
 %dir %{_sysconfdir}/rhsm/pluginconf.d
-# add default plugins here when we have some
+# add default plug-ins here when we have some
 
-# yum plugins
+# yum plug-ins
 # Using _prefix + lib here instead of libdir as that evaluates to /usr/lib64 on x86_64,
-# but yum plugins seem to normally be sent to /usr/lib/:
+# but yum plug-ins seem to normally be sent to /usr/lib/:
 %{_prefix}/lib/yum-plugins/subscription-manager.py*
 %{_prefix}/lib/yum-plugins/product-id.py*
 

--- a/test/plugins/config_plugin.py
+++ b/test/plugins/config_plugin.py
@@ -5,18 +5,18 @@ from subscription_manager.base_plugin import SubManPlugin
 requires_api_version = "1.0"
 
 
-# This plugin should fail to load as there is no associated
+# This plug-in should fail to load as there is no associated
 # config file.
 class NoConfigPlugin(SubManPlugin):
     pass
 
 
-# This plugin should fail to load as there is a malformed
+# This plug-in should fail to load as there is a malformed
 # associated config file.
 class BadConfigPlugin(SubManPlugin):
     pass
 
 
-# This plugin should load.
+# This plug-in should load.
 class GoodConfigPlugin(SubManPlugin):
     pass

--- a/test/plugins/disabled_plugin.py
+++ b/test/plugins/disabled_plugin.py
@@ -5,7 +5,7 @@ from subscription_manager.base_plugin import SubManPlugin
 requires_api_version = "1.0"
 
 
-# This plugin should load but not be enabled.
+# This plug-in should load but not be enabled.
 class DisabledPlugin(SubManPlugin):
     def post_product_id_install_hook(self, conduit):
         conduit.log.error("Hello World")

--- a/test/plugins/dummy_plugin_2.py
+++ b/test/plugins/dummy_plugin_2.py
@@ -5,8 +5,8 @@ from subscription_manager.base_plugin import SubManPlugin
 requires_api_version = "1.0"
 
 
-# This is the same class name as the plugin in dummy_plugin.py
-# We should be able to load both plugins since they are in different
+# This is the same class name as the plug-in in dummy_plugin.py
+# We should be able to load both plug-ins since they are in different
 # modules.
 class DummyPlugin(SubManPlugin):
     def __init__(self):

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -61,7 +61,7 @@ run_sm () {
 }
 
 # basics
-run_sm unregister
+run_sm deregister
 run_sm register --username "${USERNAME}" --password "${PASSWORD}" --org "${ORG}" --force
 run_sm list --installed
 run_sm list --available
@@ -81,18 +81,18 @@ run_sm orgs --username "${USERNAME}" --password "${PASSWORD}"
 run_sm release --list
 run_sm remove --all
 run_sm plugins --list
-run_sm unregister
+run_sm deregister
 
 # activation keys
-run_sm unregister
+run_sm deregister
 run_sm register --activationkey "${ACTIVATION_KEY}" --org "${ORG}" --force
-run_sm unregister
+run_sm deregister
 run_sm register --activationkey "${ACTIVATION_KEY}" --org "${ORG}" --force --auto-attach
-run_sm unregister
+run_sm deregister
 
 # what to run after the tests, ie, restore configs, etc
 #post () {
-#    
+#
 #}
 
 #post

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -378,7 +378,7 @@ class StubUEP:
                  cert_file=None, key_file=None):
         self.registered_consumer_info = {"uuid": 'dummy-consumer-uuid'}
         self.environment_list = []
-        self.called_unregister_uuid = None
+        self.called_deregister_uuid = None
         self.called_unbind_uuid = None
         self.called_unbind_serial = []
         self.username = username
@@ -392,7 +392,7 @@ class StubUEP:
         return self.registered_consumer_info
 
     def unregisterConsumer(self, uuid):
-        self.called_unregister_uuid = uuid
+        self.called_deregister_uuid = uuid
 
     def getOwnerList(self, username):
         return [{'key': 'dummyowner'}]

--- a/test/test_branding.py
+++ b/test/test_branding.py
@@ -56,5 +56,5 @@ class BrandingTests(unittest.TestCase):
         custom_branding = TestBranding()
         branding = Branding(custom_branding)
 
-        self.assertEquals("Unregister the system from the server",
-                branding.CLI_UNREGISTER)
+        self.assertEquals("Deregister the system from the server",
+                branding.CLI_DEREGISTER)

--- a/test/test_cert_sorter.py
+++ b/test/test_cert_sorter.py
@@ -94,7 +94,7 @@ class CertSorterTests(SubManFixture):
         self.sorter.is_registered = Mock(return_value=True)
 
     @patch('subscription_manager.cache.InstalledProductsManager.update_check')
-    def test_unregistered_status(self, mock_update):
+    def test_deregistered_status(self, mock_update):
         sorter = CertSorter()
         sorter.is_registered = Mock(return_value=False)
         self.assertEquals(UNKNOWN, sorter.get_status(INST_PID_1))
@@ -120,7 +120,7 @@ class CertSorterTests(SubManFixture):
         self.assertEquals(expected, sorter.get_system_status())
 
     @patch('subscription_manager.cache.InstalledProductsManager.update_check')
-    def test_unregistered_system_status(self, mock_update):
+    def test_deregistered_system_status(self, mock_update):
         self.status_mgr.load_status = Mock(
                 return_value=None)
         sorter = CertSorter()

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -642,8 +642,8 @@ class TestListCommand(TestCliProxyCommand):
             self.assertTrue(cert.pool.id in captured.out)
 
 
-class TestUnRegisterCommand(TestCliProxyCommand):
-    command_class = managercli.UnRegisterCommand
+class TestDeregisterCommand(TestCliProxyCommand):
+    command_class = managercli.DeregisterCommand
 
 
 class TestRedeemCommand(TestCliProxyCommand):

--- a/test/test_migration.py
+++ b/test/test_migration.py
@@ -991,7 +991,7 @@ class TestMigration(SubManFixture):
             self.assertTrue(re.match(regex, channel))
 
     @patch("shutil.move", autospec=True)
-    def test_unregister_from_rhn_exception(self, mock_shutil):
+    def test_deregister_from_rhn_exception(self, mock_shutil):
         rhn_config = {"systemIdPath": "/some/path"}
         self.engine.rhncfg = rhn_config
         sc = MagicMock()
@@ -1026,7 +1026,7 @@ class TestMigration(SubManFixture):
         self.assertTrue(mo.write.call_args_list == expected)
 
     @patch("os.remove", autospec=True)
-    def test_unregister_from_rhn(self, mock_remove):
+    def test_deregister_from_rhn(self, mock_remove):
         rhn_config = {"systemIdPath": "/some/path"}
         self.engine.rhncfg = rhn_config
         sc = MagicMock()

--- a/test/test_mysubstab.py
+++ b/test/test_mysubstab.py
@@ -137,7 +137,7 @@ class MySubscriptionsTabTest(SubManFixture):
         self._assert_entry_1(column_entries[1])
         self._assert_entry_2(column_entries[2])
 
-    def test_no_subscriptions_unregister_button_is_blank(self):
+    def test_no_subscriptions_deregister_button_is_blank(self):
         cert_dir = StubCertificateDirectory([])
         my_subs_tab = MySubscriptionsTab(self.backend,
                                          None,
@@ -145,7 +145,7 @@ class MySubscriptionsTabTest(SubManFixture):
                                          StubProductDirectory([]))
         self.assertFalse(my_subs_tab.unsubscribe_button.get_property('sensitive'))
 
-    def test_unselect_unregister_button_is_blank(self):
+    def test_unselect_deregister_button_is_blank(self):
         self.my_subs_tab.on_no_selection()
         self.assertFalse(self.my_subs_tab.unsubscribe_button.get_property('sensitive'))
 

--- a/test/test_unregistration.py
+++ b/test/test_unregistration.py
@@ -24,15 +24,15 @@ from mock import patch
 class CliUnRegistrationTests(SubManFixture):
 
     @patch('subscription_manager.managerlib.clean_all_data')
-    def test_unregister_removes_consumer_cert(self, clean_data_mock):
+    def test_deregister_removes_consumer_cert(self, clean_data_mock):
         connection.UEPConnection = StubUEP
 
         mock_injected_identity = self._inject_mock_valid_consumer()
 
         # When
-        cmd = managercli.UnRegisterCommand()
+        cmd = managercli.DeregisterCommand()
 
         CacheManager.delete_cache = classmethod(lambda cls: None)
 
-        cmd.main(['unregister'])
-        self.assertEquals(mock_injected_identity.uuid, cmd.cp.called_unregister_uuid)
+        cmd.main(['deregister'])
+        self.assertEquals(mock_injected_identity.uuid, cmd.cp.called_deregister_uuid)


### PR DESCRIPTION
Several fixes to subman's output and documentation to fix grammar, typos and outdated information.

The largest commit which should probably get the most attention is the "unregister" to "deregister" change, as a new command was added ("deregister") to replace the previous "unregister" command (note: unregister still exists, just listed as deprecated), whereas most other commits are three to five line typo corrections.