### PR TITLE
1195501: Properly refresh repo file on override deletion

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -230,7 +230,7 @@ class StatusCache(CacheManager):
         Prefer in memory cache to avoid io.  If it doesn't exist, save
         the disk cache to the in-memory cache to avoid reading again.
         """
-        if not self.server_status:
+        if self.server_status is None:
             self.server_status = super(StatusCache, self)._read_cache()
         return self.server_status
 
@@ -239,7 +239,7 @@ class StatusCache(CacheManager):
         If a cache exists in memory, we have written it to the disk
         No need for unnecessary disk io here.
         """
-        if self.server_status:
+        if not self.server_status is None:
             return True
         return super(StatusCache, self)._cache_exists()
 
@@ -257,7 +257,7 @@ class StatusCache(CacheManager):
         no default, the None likely indicates an error needs to be raised.
         """
 
-        if not self.server_status:
+        if self.server_status is None:
             self.server_status = self.load_status(uep, uuid)
         return self.server_status
 


### PR DESCRIPTION
When deleting overrides, if it was the last one, the cache would
reload from disk since 'if not self.server_status' will be True
for []. This presented a race condition for the cash write and
repo_lib update threads, which made the bug hard to reproduce on
some slower systems.

The cache should be checking server_status against None since
[] does not mean that the cache was not read.

NOTE: There are no tests as I couldn't find a way to reliably test this scenario due to stubbing. I am open to suggestions.