### PR TITLE
1207306: Revert DBus compliance status code.

### DIFF
--- a/bin/subscription-manager
+++ b/bin/subscription-manager
@@ -55,9 +55,6 @@ try:
     from subscription_manager import logutil
     logutil.init_logger()
 
-    from dbus.mainloop.glib import DBusGMainLoop
-    DBusGMainLoop(set_as_default=True)
-
     from subscription_manager.injectioninit import init_dep_injection
     init_dep_injection()
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -28,7 +28,6 @@ import re
 import socket
 import sys
 from time import localtime, strftime, strptime
-import gobject
 
 from M2Crypto import X509
 
@@ -498,13 +497,6 @@ class CliCommand(AbstractCLICommand):
         except X509.X509Error, e:
             log.error(e)
             print _('System certificates corrupted. Please reregister.')
-        finally:
-            # clear the loop
-            mainloop = gobject.MainLoop()
-            mainctx = mainloop.get_context()
-            while (mainctx.pending()):
-                mainctx.iteration()
-            mainloop.quit()
 
 
 class UserPassCommand(CliCommand):

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -27,7 +27,6 @@ from rhsm.config import initConfig
 from rhsm.certificate import Key, CertificateException, create_from_pem
 
 import subscription_manager.cache as cache
-import subscription_manager.cert_sorter as cert_sorter
 from subscription_manager.cert_sorter import StackingGroupSorter, ComplianceManager
 from subscription_manager import identity
 from subscription_manager.facts import Facts
@@ -881,46 +880,3 @@ def allows_multi_entitlement(pool):
             utils.is_true_value(attribute['value']):
             return True
     return False
-
-
-def refresh_compliance_status(default_dbus_properties):
-    sorter = require(CERT_SORTER)
-    installed_products = require(PROD_DIR)
-    status = sorter.get_compliance_status()
-    dbus_properties = {}
-    dbus_properties.update(default_dbus_properties)
-
-    dbus_properties["Status"] = _("System is not registered.")
-    if not status:
-        return dbus_properties
-
-    dbus_properties["Status"] = status['status']
-
-    entitlements = {}
-
-    compliant_products = status.get('compliantProducts') or []
-    for prod in compliant_products:
-        if prod:
-            state = sorter.get_status(prod)
-            installed_product = installed_products.find_by_product(prod).products[0]
-        if installed_product and state:
-            entitlements[prod] = (installed_product.name, state, _("Subscribed"))
-
-    reasons = status.get('reasons') or []
-    for reason in reasons:
-        attrs = reason.get('attributes') or {}
-        product_id = attrs.get('product_id')
-        label = product_id or 'Unknown label'
-        name = attrs.get('name') or 'Unknown name'
-        message = reason.get('message') or 'Unknown message'
-        state = cert_sorter.UNKNOWN
-
-        if product_id:
-            state = sorter.get_status(label)
-
-        entitlements[label] = (name, state, message)
-
-    if entitlements:
-        dbus_properties["Entitlements"] = entitlements
-
-    return dbus_properties


### PR DESCRIPTION
Problematic in 7.1 and appearing again in 6.7, given the implementation is not
getting used yet and the feature needs a re-think, pulling this out for 6.7 as
well.

Revert "884285: Needs to maintain loop for dbus calls"

This reverts commit d38e4e58c709a45021307ffa60ae5926c09182b7.

Conflicts:
	src/subscription_manager/logutil.py

Revert "1159266: rhsm-icon -i fails with "TypeError: 'NoneType' object has no attribute '__getitem__'""

This reverts commit e3b6516ed3a7e1e382a38746bb2f7e1dc190679d.

Conflicts:
	src/daemons/rhsm_d.py

Revert "Send list of compliance reasons on dbus"

This reverts commit cedc122d3178f4853fc2135fc19457c8bf6fa475.

Remove some dbus testing no longer used.