### PR TITLE
1211557: Fix crash when rsyslog not running.

### DIFF
--- a/etc-conf/logging.conf
+++ b/etc-conf/logging.conf
@@ -2,10 +2,10 @@
 keys=root,rhsm-app,rhsm,subscription_manager,py.warnings
 
 [handlers]
-keys=syslog,rhsm_log,subman_debug
+keys=rhsm_log,subman_debug
 
 [formatters]
-keys=syslog,rhsm_log,subman_debug
+keys=rhsm_log,subman_debug
 
 
 


### PR DESCRIPTION
Recent logging changes included a config for a presently unused syslog handler.
This however causes a full crash in yum plugin and subscription-manager when
trying to configure logging if rsyslog isn't running.

As this is meant to be an optional logging handler, remove it from the
configured handler and formatter keys.