### PR TITLE
1159163: Fix prod id del because of --disablerepo

### DIFF
--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -744,7 +744,7 @@ class ProductManager:
 
         active = set([])
 
-        # If a package is in a enabled and 'protected' repo, and
+        # If a package is in a enabled and 'protected' repo
 
         # This searches all the package sacks in this yum instances
         # package sack, aka all the enabled repos

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -678,14 +678,19 @@ class RepoFile(ConfigParser):
         # Simulate manage repos turned off if no yum.repos.d directory exists.
         # This indicates yum is not installed so clearly no need for us to
         # manage repos.
-        if not os.path.exists(self.repos_dir):
+        if not self.path_exists(self.repos_dir):
             log.warn("%s does not exist, turning manage_repos off." %
                     self.repos_dir)
             self.manage_repos = 0
         self.create()
 
+    # Easier than trying to mock/patch os.path.exists
+    def path_exists(self, path):
+        "wrapper around os.path.exists"
+        return os.path.exists(path)
+
     def exists(self):
-        return os.path.exists(self.path)
+        return self.path_exists(self.path)
 
     def read(self):
         ConfigParser.read(self, self.path)
@@ -744,7 +749,7 @@ class RepoFile(ConfigParser):
             return Repo(section, self.items(section))
 
     def create(self):
-        if os.path.exists(self.path) or not self.manage_repos:
+        if self.path_exists(self.path) or not self.manage_repos:
             return
         f = open(self.path, 'w')
         s = []

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -118,6 +118,11 @@ class SubManFixture(unittest.TestCase):
         self.mock_calc = NonCallableMock()
         self.mock_calc.calculate.return_value = None
 
+        # Avoid trying to read real /etc/yum.repos.d/redhat.repo
+        self.mock_repofile_path_exists_patcher = patch('subscription_manager.repolib.RepoFile.path_exists')
+        mock_repofile_path_exists = self.mock_repofile_path_exists_patcher.start()
+        mock_repofile_path_exists.return_value = True
+
         inj.provide(inj.IDENTITY, id_mock)
         inj.provide(inj.PRODUCT_DATE_RANGE_CALCULATOR, self.mock_calc)
 
@@ -171,6 +176,7 @@ class SubManFixture(unittest.TestCase):
 
     def tearDown(self):
         self.dbus_patcher.stop()
+        self.mock_repofile_path_exists_patcher.stop()
         self.is_valid_server_patcher.stop()
 
         for f in self.files_to_cleanup:


### PR DESCRIPTION
If yum was invoked with --disablerepo=example-repo, and
example-repo is the only repo associated with a product id,
we would delete the product id.

The fix adds code to attempt to determine what yum repos
have been disabled temporarily. Temporarily in this case
meaning not via redhat.repo, but via the yum --disablerepo
command line option, or potentially via another yum plugin.

We load and parse redhat.repo ourself, and track repos that
are enabled there, and compare to the runtime list of enabled
repos yum computes (after it's cli options and config plugins
are applied). If anything is missing, we consider it temporarily
disabled.

When we check product certs looking for certs that may need to
be deleted, if that product is mapped to one of the temporarily
disabled repos, it is not considered for deletion now.

In addition, productid.ProductManager() was incorrectly checking
the version of 'yum'. Versions newer than 3.2.28 are required
since earlier versions don't track the repoid a package was
installed from. Yum version 3.4.x was not evaluating as greater
than 3.2.x, so product cert deletion wasn't attempted. This means
RHEL 7.x wasn't checking for product certs to remove, and was hiding
1159163. Now 7.x will attempt to check for product certs to delete
as well, and do it correctly. The RHEL 6.x case is fixed as well.