### PR TITLE
1199597: Fix UnicodeError from repolib's report

### DIFF
--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -1,4 +1,5 @@
 #
+# -*- coding: utf-8 -*-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # Authors: Jeff Ortel <jortel@redhat.com>
@@ -415,10 +416,13 @@ class RepoActionReport(ActionReport):
         return '\n'.join(r)
 
     def repo_format(self, repo):
-        return "[id:%s %s]" % (repo.id, repo['name'])
+        msg = "[id:%s %s]" % (repo.id,
+                               repo['name'])
+        return msg.encode('utf8')
 
     def section_format(self, section):
-        return "[%s]" % section
+        msg = "[%s]" % section
+        return msg.encode('utf8')
 
     def format_repos(self, repos):
         return self.format_repos_info(repos, self.repo_format)
@@ -427,13 +431,13 @@ class RepoActionReport(ActionReport):
         return self.format_repos_info(sections, self.section_format)
 
     def __str__(self):
-        s = ['Repo updates\n']
+        s = [_('Repo updates') + '\n']
         s.append(_('Total repo updates: %d') % self.updates())
         s.append(_('Updated'))
         s.append(self.format_repos(self.repo_updates))
         s.append(_('Added (new)'))
         s.append(self.format_repos(self.repo_added))
-        s.append(_('Deleted'))
+        s.append(_('Deletedfd'))
         # deleted are former repo sections, but they are the same type
         s.append(self.format_sections(self.repo_deleted))
         return '\n'.join(s)
@@ -487,6 +491,7 @@ class Repo(dict):
         the release version string.
         """
 
+        log.debug("content.label %s %s", content.label, type(content.label))
         repo = cls(content.label)
 
         repo['name'] = content.name

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -1,4 +1,5 @@
 import difflib
+import locale
 import os
 import pprint
 import unittest
@@ -42,6 +43,17 @@ def temp_file(content, *args, **kwargs):
         yield fh.name
     finally:
         os.unlink(fh.name)
+
+
+@contextmanager
+def locale_context(new_locale, category=None):
+    category = category or locale.LC_ALL
+    old_locale = locale.getlocale(category)
+    locale.setlocale(category, new_locale)
+    try:
+        yield
+    finally:
+        locale.setlocale(category, old_locale)
 
 
 class FakeLogger:

--- a/test/test_entcertlib.py
+++ b/test/test_entcertlib.py
@@ -16,19 +16,17 @@
 
 from mock import Mock, patch
 from datetime import timedelta, datetime
-import locale
-import os
 
 from stubs import StubEntitlementCertificate, StubProduct, StubEntitlementDirectory
 
-from fixture import SubManFixture
+import fixture
 
 from subscription_manager.certdirectory import Writer
 from subscription_manager import entcertlib
 from subscription_manager import injection as inj
 
 
-class TestDisconnected(SubManFixture):
+class TestDisconnected(fixture.SubManFixture):
     def test_repr(self):
         # no err_msg, so empty repr
         discon = entcertlib.Disconnected()
@@ -42,7 +40,7 @@ class TestingUpdateAction(entcertlib.EntCertUpdateAction):
         entcertlib.EntCertUpdateAction.__init__(self)
 
 
-class TestEntCertUpdateReport(SubManFixture):
+class TestEntCertUpdateReport(fixture.SubManFixture):
     def test(self):
         r = entcertlib.EntCertUpdateReport()
         r.expected = u'12312'
@@ -54,13 +52,9 @@ class TestEntCertUpdateReport(SubManFixture):
         report_str = str(r)
         '%s' % report_str
 
-        self._set_locale('de_DE.utf8')
-        report_str = str(r)
-        '%s' % r
-
-    def _set_locale(self, lang):
-        os.environ['LANG'] = lang
-        locale.setlocale(locale.LC_ALL, '')
+        with fixture.locale_context('de_DE.utf8'):
+            report_str = str(r)
+            '%s' % r
 
     def _stub_cert(self):
         stub_ent_cert = StubEntitlementCertificate(StubProduct(u"ஒரு அற்புதமான இயங்கு"))
@@ -68,7 +62,7 @@ class TestEntCertUpdateReport(SubManFixture):
         return stub_ent_cert
 
 
-class UpdateActionTests(SubManFixture):
+class UpdateActionTests(fixture.SubManFixture):
 
     @patch("subscription_manager.entcertlib.EntitlementCertBundleInstaller.build_cert")
     @patch.object(Writer, "write")

--- a/test/test_entcertlib.py
+++ b/test/test_entcertlib.py
@@ -1,4 +1,5 @@
 #
+# -*- coding: utf-8 -*-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,
@@ -15,6 +16,8 @@
 
 from mock import Mock, patch
 from datetime import timedelta, datetime
+import locale
+import os
 
 from stubs import StubEntitlementCertificate, StubProduct, StubEntitlementDirectory
 
@@ -37,6 +40,32 @@ class TestingUpdateAction(entcertlib.EntCertUpdateAction):
 
     def __init__(self):
         entcertlib.EntCertUpdateAction.__init__(self)
+
+
+class TestEntCertUpdateReport(SubManFixture):
+    def test(self):
+        r = entcertlib.EntCertUpdateReport()
+        r.expected = u'12312'
+        r.valid = [u'2342∰']
+        r.added.append(self._stub_cert())
+        r.rogue.append(self._stub_cert())
+
+        # an UnicodeError will fail the tests
+        report_str = str(r)
+        '%s' % report_str
+
+        self._set_locale('de_DE.utf8')
+        report_str = str(r)
+        '%s' % r
+
+    def _set_locale(self, lang):
+        os.environ['LANG'] = lang
+        locale.setlocale(locale.LC_ALL, '')
+
+    def _stub_cert(self):
+        stub_ent_cert = StubEntitlementCertificate(StubProduct(u"ஒரு அற்புதமான இயங்கு"))
+        stub_ent_cert.order.name = u'一些秩序'
+        return stub_ent_cert
 
 
 class UpdateActionTests(SubManFixture):

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -20,7 +20,7 @@ from iniparse import RawConfigParser
 from mock import Mock, patch
 from StringIO import StringIO
 
-from fixture import SubManFixture
+import fixture
 from stubs import StubCertificateDirectory, StubProductCertificate, \
         StubProduct, StubEntitlementCertificate, StubContent, \
         StubProductDirectory, StubConsumerIdentity
@@ -74,7 +74,29 @@ class RepoTests(unittest.TestCase):
         self.assertTrue(('fake_prop', 'fake') in existing_repo.items())
 
 
-class RepoUpdateActionTests(SubManFixture):
+class RepoActionReportTests(fixture.SubManFixture):
+    def test(self):
+        report = repolib.RepoActionReport()
+        repo = self._repo(u'a-unicode-content-label', u'A unicode repo name')
+        report.repo_updates.append(repo)
+        report.repo_added.append(repo)
+        deleted_section = u'einige-repo-name'
+        deleted_section_2 = u'一些回購名稱'
+        report.repo_deleted = [deleted_section, deleted_section_2]
+
+        # okay as long as no UnicodeErrors
+        str(report)
+
+        with fixture.locale_context('de_DE.utf8'):
+            str(report)
+
+    def _repo(self, id, name):
+        repo = repolib.Repo(repo_id=id)
+        repo['name'] = name
+        return repo
+
+
+class RepoUpdateActionTests(fixture.SubManFixture):
 
     def setUp(self):
         super(RepoUpdateActionTests, self).setUp()
@@ -488,7 +510,7 @@ class TidyWriterTests(unittest.TestCase):
         self.assertEquals("test stuff\n\ntest\n", output.getvalue())
 
 
-class YumReleaseverSourceTest(SubManFixture):
+class YumReleaseverSourceTest(fixture.SubManFixture):
     def test_init(self):
         #inj.provide(inj.RELEASE_STATUS_CACHE, Mock())
         #override_cache_mock = inj.require(inj.OVERRIDE_STATUS_CACHE)
@@ -552,7 +574,7 @@ class YumReleaseverSourceTest(SubManFixture):
         self.assertEquals(release_source._expansion, YumReleaseverSource.default)
 
 
-class YumReleaseverSourceIsNotEmptyTest(SubManFixture):
+class YumReleaseverSourceIsNotEmptyTest(fixture.SubManFixture):
     def test_empty_string(self):
         self.assertFalse(YumReleaseverSource.is_not_empty(""))
 
@@ -569,7 +591,7 @@ class YumReleaseverSourceIsNotEmptyTest(SubManFixture):
         self.assertTrue(YumReleaseverSource.is_not_empty("Super"))
 
 
-class YumReleaseverSourceIsSetTest(SubManFixture):
+class YumReleaseverSourceIsSetTest(fixture.SubManFixture):
     def test_none(self):
         self.assertFalse(YumReleaseverSource.is_set(None))
 

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -1,4 +1,5 @@
 #
+# -*- coding: utf-8 -*-#
 # Copyright (c) 2010, 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,
@@ -39,6 +40,17 @@ class RepoTests(unittest.TestCase):
         repo_id = 'valid-label'
         repo = Repo(repo_id)
         self.assertEquals(repo_id, repo.id)
+
+    def test_valid_unicode_just_ascii_label_for_id(self):
+        repo_id = u'valid-label'
+        repo = Repo(repo_id)
+        self.assertEquals(repo_id, repo.id)
+
+    def test_invalid_unicode_label_for_id(self):
+        repo_id = u'valid-不明-label'
+        repo = Repo(repo_id)
+        expected = 'valid----label'
+        self.assertEquals(expected, repo.id)
 
     def test_invalid_label_with_spaces(self):
         repo_id = 'label with spaces'


### PR DESCRIPTION
The str() for repolib.RepoActionReport would fail if
it tried to join together str's that could not be
decoded into ascii, when combining the translation for
'Added (new)' and a unicode string of the content label
or a repo section id. So make sure content info is
encoded to utf8 for display.

This bug is dependent on the absence of python-simplejson
on RHEL7. The 'ourjson' module will use either the built
in python 'json' module or simplejson if it is installed.
python-simplejson is not an rpm dep however, so it is
optionaly. However, the API of python's 'json' and
'simplejson' differ slightly. The built in 'json' module
will deserialize JSON strings into unicode strings allways,
where simplejson does not.

So if python-simplejson was installed, the repolib report
does not cause the UnicodeDecodeError, since the content
labels are str's. But without it (the default), and with
a LANG that provides translations for the report fields that
can not be encoded to 'ascii', you will see an error like:

'ascii' codec can't decode byte 0xc3 in position 8: ordinal not in
range(128)

So this changes the report code to handle any of the gettext
strings or content info being str's or unicode strs.

Test cases added for repolib and entcertlib Report classes.