### PR TITLE
Remove locale based DatePicker tests.

### DIFF
--- a/test/test_widgets.py
+++ b/test/test_widgets.py
@@ -12,12 +12,7 @@
 # in this software or its documentation.
 #
 
-import os
-import locale
-import gettext
 import unittest
-
-import test_po_files
 
 import gtk
 from datetime import datetime, timedelta
@@ -27,7 +22,6 @@ from subscription_manager.gui.storage import MappedTreeStore
 from subscription_manager.gui.widgets import MachineTypeColumn, QuantitySelectionColumn, \
                                              SubDetailsWidget, ContractSubDetailsWidget, \
                                              DatePicker
-from fixture import Capture
 from dateutil.tz import tzlocal
 
 
@@ -100,44 +94,34 @@ class TestContractSubDetailsWidget(TestSubDetailsWidget):
 
 
 class TestDatePicker(unittest.TestCase):
-    def tearDown(self):
-        self._setupLang("en_US")
-
     def test_date_picker_date(self):
         d = datetime(2033, 12, 29, tzinfo=tzlocal())
-        date_picker = DatePicker(d)
-        date_picker.date
+        self._assert_is_isoformat(d)
 
-    def test_date_validate_default_date_locale(self):
-        d = datetime(2000, 1, 1, tzinfo=tzlocal())
-        date_picker = DatePicker(d)
-        date_picker.date_entry_validate()
+    def test_date_validate_2000_12_1(self):
+        d = datetime(2000, 12, 1, tzinfo=tzlocal())
+        self._assert_is_isoformat(d)
 
-    def test_date_validate_supported_locales_1_1_2000(self):
+    def test_date_validate_2000_1_22(self):
+        d = datetime(2000, 1, 12, tzinfo=tzlocal())
+        self._assert_is_isoformat(d)
+
+    def test_date_validate_1_1_2000(self):
         d = datetime(2000, 1, 1, tzinfo=tzlocal())
-        self.__date_validate_supported_locales(d)
+        self._assert_is_isoformat(d)
 
     # why? because some locales fail to parse in dates with
     # double digt months
-    def test_date_validate_supported_locales_12_29_2020(self):
-        with Capture(silent=True):
-            d = datetime(2020, 12, 29, tzinfo=tzlocal())
-            self.__date_validate_supported_locales(d)
+    def test_date_validate_12_29_2020(self):
+        #with Capture(silent=True):
+        d = datetime(2020, 12, 29, tzinfo=tzlocal())
+        self._assert_is_isoformat(d)
 
-    def __date_validate_supported_locales(self, d):
-        test_locales = test_po_files.TestLocale.test_locales
-        for test_locale in test_locales:
-            lc = "%s.UTF-8" % test_locale
-            self._setupLang(lc)
-            date_picker = DatePicker(d)
-            valid = date_picker.date_entry_validate()
-            self.assertTrue(valid)
-            self.assertEquals(date_picker._date_entry.get_text(), d.date().isoformat())
-
-    def _setupLang(self, lang):
-        os.environ['LANG'] = lang
-        locale.setlocale(locale.LC_ALL, '')
-        gettext.bindtextdomain(test_po_files.APP, test_po_files.DIR)
+    def _assert_is_isoformat(self, d):
+        date_picker = DatePicker(d)
+        valid = date_picker.date_entry_validate()
+        self.assertTrue(valid)
+        self.assertEquals(date_picker._date_entry.get_text(), d.date().isoformat())
 
 
 class BaseColumnTest(unittest.TestCase):


### PR DESCRIPTION
DatePicker always uses isoformat() for date now, so
we don't need to test it for each locale.

Also removed a Capture() from a test, I believe the
py/gtk warnings capture in fixtures does the same thing
now.

Shaves off about .5sec off a unit tests run if nothing else.