### PR TITLE
1180273: Migrate from RHN Classic without credentials

### DIFF
--- a/etc-conf/rhn-migrate-classic-to-rhsm.completion.sh
+++ b/etc-conf/rhn-migrate-classic-to-rhsm.completion.sh
@@ -11,7 +11,7 @@ _rhn-migrate-classic-to-rhsm()
 	first="${COMP_WORDS[1]}"
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	opts="-h --help --environment -f --force -n --no-auto --no-proxy --org -s --servicelevel --legacy-user --legacy-password --destination-url --destination-user --destination-password --activation-key"
+	opts="-h --help --environment -f --force -n --no-auto --no-proxy --org -s --servicelevel --legacy-user --legacy-password --destination-url --destination-user --destination-password --activation-key --keep"
 
 	case "${cur}" in
 		-*)

--- a/man/rhn-migrate-classic-to-rhsm.8
+++ b/man/rhn-migrate-classic-to-rhsm.8
@@ -76,6 +76,10 @@ Sets which environment within the organization the system belongs to. Every acco
 Sets an activation key to use during registration to the subscription management service.  Use of an activation key requires the user to supply the \fIorganization\fP that the system will be registered to.  This option may be supplied multiple times.
 
 .TP
+.B --keep
+Leaves the system profile on the legacy system.  Normally the system profile on the legacy system is deleted.
+
+.TP
 .B --no-proxy
 Disables or ignores any previous RHN proxy settings when migrating to the new subscription management service.
 


### PR DESCRIPTION
This commit builds on a previous effort to allow users to migrate from
RHN Classic without a password.  In this commit, the option for leaving
a profile on RHN Classic (it is the deletion of a profile that requires
a password) has been switched to a flag rather than an option as it was
previously.

Additionally this commit fixes an issue where users were not being
required to provide credentials to the destination when leaving a
profile on RHN Classic.