### PR TITLE
1149095: Fix error when yum updates subman modules

### DIFF
--- a/src/plugins/product-id.py
+++ b/src/plugins/product-id.py
@@ -24,6 +24,7 @@ sys.path.append('/usr/share/rhsm')
 from subscription_manager import logutil
 from subscription_manager.productid import ProductManager
 from subscription_manager.utils import chroot
+from subscription_manager.injectioninit import init_dep_injection
 
 requires_api_version = '2.6'
 plugin_type = (TYPE_CORE,)
@@ -39,7 +40,6 @@ def posttrans_hook(conduit):
         conduit.registerPackageName("subscription-manager")
 
     try:
-        from subscription_manager.injectioninit import init_dep_injection
         init_dep_injection()
     except ImportError, e:
         conduit.error(3, str(e))

--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -25,6 +25,8 @@ from subscription_manager import injection as inj
 from subscription_manager.repolib import RepoActionInvoker
 from subscription_manager.hwprobe import ClassicCheck
 from subscription_manager.utils import chroot
+from subscription_manager.injectioninit import init_dep_injection
+from subscription_manager import logutil
 from rhsm import connection
 from rhsm import config
 
@@ -125,10 +127,8 @@ def postconfig_hook(conduit):
     # register rpm name for yum history recording"
     # yum on 5.7 doesn't have this method, so check for it
 
-    from subscription_manager import logutil
     logutil.init_logger_for_yum()
 
-    from subscription_manager.injectioninit import init_dep_injection
     init_dep_injection()
 
     # If a tool (it's, e.g., Mock) manages a chroot via 'yum --installroot',


### PR DESCRIPTION
If product-id yum plugin was installed and enabled, and
a yum transaction updates subscription-manager code, we
could end up with the old version of 'injection', and the
new version of 'injectioninit'.

The injectioninit import was not at module scope, and would
not load the module until the plugin hook is called. But
the other subman modules in productids module scope would
cause 'injection' to be imported.

So yum starts up, loads our 'product-id' yum plugin module,
which loads 'injection' module into the process. Then we
update subscription-manager, replacing all of our modules
include 'injection' and 'injectioninit'. After the rpm
transaction runs, then we run the 'posttrans_hook' product
id plugin, which would then load 'injectioninit' from the
filesystem and get the new injectioninit.

If the new injection init references names that are in
the new 'injection' module, but not in the old one that
is already loaded into the yum process, we would get:

AttributeError: 'module' object has no attribute 'PROFILE_MANAGER"

Anything in the new injectioninit that needed the new injection
could fail.

If the subscription-manager yum plugin is enabled, it would
import 'injectioninit' in the 'postconfig_hook' step, before
the yum transaction changes anything installed. In that
scenario, the post transaction 'product-id' plugin would
get the old already loaded 'injectioninit' module, that matches
the old already loaded 'injection' module and avoid the
problem.