### PR TITLE
Make rhsm-debug test cases clean up better.

### DIFF
--- a/src/rhsm_debug/debug_commands.py
+++ b/src/rhsm_debug/debug_commands.py
@@ -73,6 +73,9 @@ class SystemCommand(CliCommand):
                                help=_("include subscription data"))
         self.assemble_path = ASSEMBLE_DIR
 
+        # so we can track the path of the archive for tests.
+        self.final_destination_path = None
+
     def _get_usage(self):
         return _("%%prog %s [OPTIONS] ") % self.name
 
@@ -177,6 +180,9 @@ class SystemCommand(CliCommand):
                     tf.close()
 
                 final_path = os.path.join(self.options.destination, "rhsm-debug-system-%s.tar.gz" % code)
+
+                self.final_destination_path = final_path
+
                 sfm = SaferFileMove()
                 sfm.move(tar_file_path, final_path)
                 print _("Wrote: %s") % final_path


### PR DESCRIPTION
We were creating temp test dirs but never
deleting them. So do that in the tearDown().

Use a tempdir via tempfile.mkdtemp for test temp
directory instead of os.getcwd()/testing-dir. tempdir
tmp directory is also likely on tmpfs, so a little
faster.

Add a final_destination_path attribute to rhsm-debugs
SystemCommand that tracks the name of the archive
that was written, so tests can clean up.

Add some test helper methods to remove some
duplication.