### PR TITLE
1217835: Specified error codes on system_exit in rhn-migrate-classic-to-rhsm

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1202,7 +1202,7 @@ class RegisterCommand(UserPassCommand):
         owners = cp.getOwnerList(self.username)
 
         if len(owners) == 0:
-            system_exit(os.EX_SOFTWARE, _("%s cannot register with any organizations.") % self.username)
+            system_exit(1, _("%s cannot register with any organizations.") % self.username)
         if len(owners) == 1:
             return owners[0]['key']
 

--- a/test/test_migration.py
+++ b/test/test_migration.py
@@ -12,6 +12,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
+import os
 import re
 import rhsm.config
 import StringIO
@@ -374,7 +375,7 @@ class TestMigration(SubManFixture):
         try:
             self.engine.transfer_http_proxy_settings()
         except SystemExit, e:
-            self.assertEquals(e.code, 1)
+            self.assertEquals(e.code, os.EX_CONFIG)
         else:
             self.fail("No exception raised")
 
@@ -581,7 +582,7 @@ class TestMigration(SubManFixture):
         try:
             self.engine.check_ok_to_proceed()
         except SystemExit, e:
-            self.assertEquals(e.code, 1)
+            self.assertEquals(e.code, os.EX_SOFTWARE)
         else:
             self.fail("No exception raised")
 
@@ -638,7 +639,7 @@ class TestMigration(SubManFixture):
         try:
             self.engine.get_org("some_username")
         except SystemExit, e:
-            self.assertEquals(e.code, 1)
+            self.assertEquals(e.code, os.EX_DATAERR)
         else:
             self.fail("No exception raised")
 
@@ -662,7 +663,7 @@ class TestMigration(SubManFixture):
         try:
             self.engine.get_org("some_username")
         except SystemExit, e:
-            self.assertEquals(e.code, 1)
+            self.assertEquals(e.code, os.EX_DATAERR)
         else:
             self.fail("No exception raised")
 
@@ -671,7 +672,7 @@ class TestMigration(SubManFixture):
         try:
             self.engine.get_environment("some_org")
         except SystemExit, e:
-            self.assertEquals(e.code, 1)
+            self.assertEquals(e.code, os.EX_SOFTWARE)
         else:
             self.fail("No exception raised")
 
@@ -758,7 +759,7 @@ class TestMigration(SubManFixture):
         try:
             self.engine.get_environment("some_org")
         except SystemExit, e:
-            self.assertEquals(e.code, 1)
+            self.assertEquals(e.code, os.EX_DATAERR)
         else:
             self.fail("No exception raised")
 
@@ -787,7 +788,7 @@ class TestMigration(SubManFixture):
         try:
             self.engine.get_environment("some_org")
         except SystemExit, e:
-            self.assertEquals(e.code, 1)
+            self.assertEquals(e.code, os.EX_DATAERR)
         else:
             self.fail("No exception raised")
 
@@ -798,7 +799,7 @@ class TestMigration(SubManFixture):
         try:
             self.engine.get_environment("some_org")
         except SystemExit, e:
-            self.assertEquals(e.code, 1)
+            self.assertEquals(e.code, os.EX_UNAVAILABLE)
         else:
             self.fail("No exception raised")
 


### PR DESCRIPTION
- Many calls to system_exit now specify an error code on exit instead
  of using a common non-zero value
- Reverted an error code in manager_cli to be consistent with general error-code usage and the migrate script