### PR TITLE
1218377: Added missing option to the migration manual page

### DIFF
--- a/man/rhn-migrate-classic-to-rhsm.8
+++ b/man/rhn-migrate-classic-to-rhsm.8
@@ -21,7 +21,7 @@
 rhn-migrate-classic-to-rhsm \- Migrates a system profile from Red Hat Network Classic Hosted to Customer Portal Subscription Management (hosted) or Subscription Asset Manager (on-premise).
 
 .SH SYNOPSIS
-rhn-migrate-classic-to-rhsm [--force] | [--no-auto] | [--servicelevel=SERVICE_LEVEL] | [--destination-url=URL] | [--legacy-user=LEGACY_USER] | [--legacy-password=LEGACY_PASSWORD] | [-destination-user=DESTINATION_USER] | [--destination-password=DESTINATION_PASSWORD] | [--org=ORG] | [--environment=ENVIRONMENT] | [--no-proxy] [--activation-key=ACTIVATION_KEY] | [--help]
+rhn-migrate-classic-to-rhsm [--force] | [--no-auto] [--keep] | [--servicelevel=SERVICE_LEVEL] | [--destination-url=URL] | [--legacy-user=LEGACY_USER] | [--legacy-password=LEGACY_PASSWORD] | [--destination-user=DESTINATION_USER] | [--destination-password=DESTINATION_PASSWORD] | [--org=ORG] | [--environment=ENVIRONMENT] | [--no-proxy] [--activation-key=ACTIVATION_KEY] | [--help]
 
 .SH DESCRIPTION
 \fBrhn-migrate-classic-to-rhsm\fP migrates a system profile which is registered with Red Hat Network Classic to Customer Portal Subscription Management. This is intended for migrating from the host service, not for migrating from a Satellite system.


### PR DESCRIPTION
- The --keep option has been added to the synopsis line in the man
  page for rhn-migrate-classic-to-rhsm.
- Added a missing hyphen for the destination-user option in the
  synopsis