### PR TITLE
1223860: Revert to default value on remove command

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2104,7 +2104,7 @@ class ConfigCommand(CliCommand):
                         cfg.set(section, name, '')
                         print _("You have removed the value for section %s and name %s.") % (section, name)
                     else:
-                        cfg.remove_option(section, name)
+                        cfg.set(section, name, cfg.get_default(section, name))
                         print _("You have removed the value for section %s and name %s.") % (section, name)
                         print _("The default value for %s will now be used.") % (name)
                 except Exception:


### PR DESCRIPTION
Removal of entry completely means that default is the only value that will
 be used going forward. By inserting the default insead, the behavoir is
 correct, but future changes are not limited.