### PR TITLE
1223860: Fix API used by openshift clients.

### DIFF
--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -286,10 +286,15 @@ class RepoUpdateActionCommand(object):
         # assumes items in content_list are hashable
         return set(content_list)
 
-    def get_all_content(self, baseurl, ca_cert):
-        matching_content = model.find_content(self.ent_source,
-                                              content_type="yum")
+    # Expose as public API for RepoActionInvoker.is_managed, since that
+    # is used by openshift tooling.
+    # See https://bugzilla.redhat.com/show_bug.cgi?id=1223038
+    def matching_content(self):
+        return model.find_content(self.ent_source,
+                                  content_type="yum")
 
+    def get_all_content(self, baseurl, ca_cert):
+        matching_content = self.matching_content()
         content_list = []
 
         # avoid checking for release/etc if there is no matching_content

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -24,12 +24,60 @@ from StringIO import StringIO
 import fixture
 from stubs import StubCertificateDirectory, StubProductCertificate, \
         StubProduct, StubEntitlementCertificate, StubContent, \
-        StubProductDirectory, StubConsumerIdentity
-from subscription_manager.repolib import Repo, RepoUpdateActionCommand, \
-        TidyWriter, RepoFile, YumReleaseverSource
+        StubProductDirectory, StubConsumerIdentity, StubEntitlementDirectory
+from subscription_manager.repolib import Repo, RepoActionInvoker, \
+        RepoUpdateActionCommand, TidyWriter, RepoFile, YumReleaseverSource
 from subscription_manager import injection as inj
 
 from subscription_manager import repolib
+
+
+class TestRepoActionInvoker(fixture.SubManFixture):
+    def _stub_content(self):
+        stub_prod = StubProduct('stub_product',
+                                provided_tags="stub-product")
+
+        stub_content = StubContent("a_test_repo",
+                                   required_tags="stub-product")
+
+        stub_ent_cert = StubEntitlementCertificate(stub_prod,
+                                                   content=[stub_content])
+        stub_prod_cert = StubProductCertificate(stub_prod)
+
+        stub_ent_dir = StubEntitlementDirectory([stub_ent_cert])
+        stub_prod_dir = StubProductDirectory([stub_prod_cert])
+
+        inj.provide(inj.ENT_DIR, stub_ent_dir)
+        inj.provide(inj.PROD_DIR, stub_prod_dir)
+
+    def test_is_managed(self):
+        self._stub_content()
+        repo_action_invoker = RepoActionInvoker()
+        repo_label = 'a_test_repo'
+
+        im_result = repo_action_invoker.is_managed(repo_label)
+
+        self.assertTrue(im_result)
+
+    def test_get_repo_file(self):
+        repo_action_invoker = RepoActionInvoker()
+
+        repo_file = repo_action_invoker.get_repo_file()
+        print repo_file
+        self.assertFalse(repo_file is None)
+
+    def test_get_repos_empty_dirs(self):
+        repo_action_invoker = RepoActionInvoker()
+        repos = repo_action_invoker.get_repos()
+        if repos:
+            self.fail("get_repos() should have returned an empty set but did not.")
+
+    def test_get_repos(self):
+        self._stub_content()
+        repo_action_invoker = RepoActionInvoker()
+        repos = repo_action_invoker.get_repos()
+        if len(repos) == 0:
+            self.fail("get_repos() should have a set of Repo's, but the set is empty.")
 
 
 class RepoTests(unittest.TestCase):


### PR DESCRIPTION
repolib.RepoActionInvoker.is_managed is used by some
openshift utilities, but it was busted when the rest of
repolib moved to using model.ent_cert.

Add a public matching_content method to the RepoActionCommand
class, so that RepoActionInvoker.is_managed works again.

Add test cases for RepoActionInvoker.is_managed, since it is
only used by external tools.