### PR TITLE
1225435: Use LC_ALL instead of LANG for lscpu.

### DIFF
--- a/src/subscription_manager/hwprobe.py
+++ b/src/subscription_manager/hwprobe.py
@@ -563,7 +563,9 @@ class Hardware:
 
         self.lscpuinfo = {}
         # let us specify a test dir of /sys info for testing
-        ls_cpu_path = 'LANG=en_US.UTF-8 /usr/bin/lscpu'
+        # If the user env sets LC_ALL, it overrides a LANG here, so
+        # use LC_ALL here. See rhbz#1225435
+        ls_cpu_path = 'LC_ALL=en_US.UTF-8 /usr/bin/lscpu'
         ls_cpu_cmd = ls_cpu_path
 
         if self.testing:


### PR DESCRIPTION
fact collection was using 'LANG=en_US.UTF-8 lscpu' to
get lscpu facts, including the field descriptions, that
are marked for translations.

If the user env set a locale using LC_ALL instead of LANG,
the LC_ALL value would override the LANG used for lscpu, so
specify LC_ALL=en_US.UTF-8 when running lscpu now.

Previously, this would end up with garbled fact names
(ja_JP localized UTF8 strings manipulated with .lower()/.replace)
and would cause registration failures.

Users should set locale with the LANG env variable, not
LC_ALL, but let lscpu invocation override either with it's
own LC_ALL value.