### PR TITLE
1092564: Add LDFLAGS to make file so RPM can modify them.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ VERSION ?= $(shell git describe | awk ' { sub(/subscription-manager-/,"")};1' )
 
 # inherit from env if set so rpm can override
 CFLAGS ?= -g -Wall
+LDFLAGS ?=
 
 %.pyc: %.py
 	python -c "import py_compile; py_compile.compile('$<')"
@@ -72,16 +73,16 @@ STYLEFILES=$(PYFILES) $(BIN_FILES) $(TESTFILES)
 GLADEFILES=`find src/subscription_manager/gui/data -name "*.glade"`
 
 rhsmcertd: $(DAEMONS_SRC_DIR)/rhsmcertd.c bin
-	$(CC) $(CFLAGS) $(RHSMCERTD_FLAGS) $(DAEMONS_SRC_DIR)/rhsmcertd.c -o bin/rhsmcertd
+	$(CC) $(CFLAGS) $(LDFLAGS) $(RHSMCERTD_FLAGS) $(DAEMONS_SRC_DIR)/rhsmcertd.c -o bin/rhsmcertd
 
 check-syntax:
-	$(CC) $(CFLAGS) $(ICON_FLAGS) -o nul -S $(CHK_SOURCES)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(ICON_FLAGS) -o nul -S $(CHK_SOURCES)
 
 
 ICON_FLAGS = `pkg-config --cflags --libs gtk+-2.0 libnotify gconf-2.0 dbus-glib-1`
 
 rhsm-icon: $(RHSM_ICON_SRC_DIR)/rhsm_icon.c bin
-	$(CC) $(CFLAGS) $(ICON_FLAGS) -o bin/rhsm-icon $(RHSM_ICON_SRC_DIR)/rhsm_icon.c;\
+	$(CC) $(CFLAGS) $(LDFLAGS) $(ICON_FLAGS) -o bin/rhsm-icon $(RHSM_ICON_SRC_DIR)/rhsm_icon.c
 
 dbus-service-install:
 	install -d $(PREFIX)/etc/dbus-1/system.d

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -182,7 +182,7 @@ subscriptions
 %setup -q
 
 %build
-make -f Makefile VERSION=%{version}-%{release} CFLAGS="%{optflags}"
+make -f Makefile VERSION=%{version}-%{release} CFLAGS="%{optflags}" LDFLAGS="%{__global_ldflags}"
 
 %install
 rm -rf %{buildroot}


### PR DESCRIPTION
Building a PIE requires both special CFLAGS and LDFLAGS.  We were
missing the LDFLAGS so our executables weren't PIEs.

Testing that an executable is hardened can be done via the
`hardening-check` package available in Fedora.

Save the following script as `pie-check.sh`:

```bash
#! /bin/bash

p=$1

echo "Checking $p"

rpm2cpio $p | cpio -idm
echo

find . -type f -exec file {} \; | grep -o '.*:.* ELF' | while read -r f
do
    f=${f%:* ELF}

    pushd ${f%/*} >/dev/null
        readelf -W -l ${f##*/} > ~-/program_headers 2>  ~-/erroutput
        readelf -W -d ${f##*/} > ~-/dynamic_section 2>> ~-/erroutput
        readelf -W -h ${f##*/} > ~-/elf_header      2>> ~-/erroutput
    popd >/dev/null

    TYPE=$(grep -m1 -F 'Type:' elf_header | awk '{ print $2; }')

    if [[ -s erroutput ]]
    then
        printf "PROCESSING FAILED: (%04d) %s : %s\n" $cnt "$pkg" "$f"
    elif [[ $TYPE != EXEC && $TYPE != DYN ]]
    then
        printf "%4s: (%04d) %s : %s\n" $TYPE $cnt "$pkg" "$f"
        continue
    else
        printf "PROCESSED: (%04d) %s : %s\n" $cnt "$pkg" "$f"
    fi
    f=${f#.}

    RELRO=no
    PIE=no
    grep -F -m1 -q GNU_RELRO program_headers && RELRO=partial
    [[ $RELRO = partial ]] && grep -F -m1 -q BIND_NOW dynamic_section && RELRO=full
    grep -m1 -q 'Type:[[:space:]]*DYN' elf_header && PIE=dso
    [[ $PIE = dso ]] && grep -m1 -F -q '(DEBUG)' dynamic_section && PIE=yes

    printf "RELRO=%s\nPIE=%s\n\n" $RELRO $PIE 

done; unset f
```

1. `tito build --rpm`
1. `./pie-check.sh /tmp/tito/x86_64/subscription-manager-1.*.rpm`
1. See that the RPM is not hardened.
1. `rm /tmp/tito/x86_64/subscription-manager*`
1. `tito build --rpm --test`
1. `./pie-check.sh /tmp/tito/x86_64/subscription-manager-1.*.rpm`

Note that you should run `pie-check.sh` in a scratch directory in `/tmp` because it extracts the RPM and does not clean up after itself.