### PR TITLE
Cast return daemon() to void to quiet warnings.

### DIFF
--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -426,7 +426,9 @@ main (int argc, char *argv[])
 	int heal_interval_seconds = config->heal_interval_seconds;
 	free (config);
 
-	daemon (0, 0);
+	if (daemon (0, 0) == -1)
+        return EXIT_FAILURE;
+
 	if (get_lock () != 0) {
 		error ("unable to get lock, exiting");
 		return EXIT_FAILURE;


### PR DESCRIPTION
We don't need to check the return value of
daemon, but do it anyway to quiet compiler warnings.