### PR TITLE
Make desktop-file-validate warnings.

### DIFF
--- a/etc-conf/rhsm-icon.desktop.in
+++ b/etc-conf/rhsm-icon.desktop.in
@@ -1,9 +1,6 @@
 
 [Desktop Entry]
-Encoding=UTF-8
 _Name=Red Hat Subscription Validity Applet
-_GenericName=Subscription Validity Applet
-_Comment=Subscription Validity Applet
 Icon=subscription-manager
 Exec=rhsm-icon
 Terminal=false

--- a/etc-conf/subscription-manager-gui.desktop.in
+++ b/etc-conf/subscription-manager-gui.desktop.in
@@ -1,10 +1,7 @@
 [Desktop Entry]
-Encoding=UTF-8
 _Name=Red Hat Subscription Manager
-_GenericName=Subscription Manager
-_Comment=Subscription Manager
 Icon=subscription-manager
 Exec=subscription-manager-gui
 Terminal=false
 Type=Application
-Categories=System;Settings;X-Red-Hat-Base;
+Categories=System;X-Red-Hat-Base;


### PR DESCRIPTION
It was complaining about GenericName and Comment being
redundant, and indeed, they were. So they have been
removed.

'Encoding' type is also now deprecated and UTF-8 is
the default, so remove it as well.

The Catagories 'System' and 'Settings' are both
'Main' categories. And validate wants only one
main category. 'Settings' seems unused by anything
now, so we removed it.