### PR TITLE
Alikins/spec file shuffle

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -209,7 +209,9 @@ desktop-file-validate \
 
 desktop-file-validate \
         %{buildroot}/usr/share/applications/subscription-manager-gui.desktop
+
 %find_lang rhsm
+%find_lang %{name} --with-gnome
 
 # fix timestamps on our byte compiled files so them match across arches
 find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
@@ -249,6 +251,8 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %clean
 rm -rf %{buildroot}
 
+# base/cli tools use the gettext domain 'rhsm', while the
+# gnome-help tools use domain 'subscription-manager'
 %files -f rhsm.lang
 %defattr(-,root,root,-)
 
@@ -366,7 +370,7 @@ rm -rf %{buildroot}
 %doc LICENSE
 
 
-%files -n subscription-manager-gui
+%files -n subscription-manager-gui -f subscription-manager.lang
 %defattr(-,root,root,-)
 %attr(755,root,root) %{_sbindir}/subscription-manager-gui
 %attr(755,root,root) %{_bindir}/subscription-manager-gui
@@ -399,12 +403,6 @@ rm -rf %{buildroot}
 %doc
 %{_mandir}/man8/subscription-manager-gui.8*
 %{_mandir}/man8/rhsm-icon.8*
-%{_datadir}/omf/subscription-manager
-%attr(644,root,root) %{_datadir}/omf/subscription-manager/*.omf
-%{_datadir}/gnome/help/subscription-manager
-%{_datadir}/gnome/help/subscription-manager/C
-%attr(644,root,root) %{_datadir}/gnome/help/subscription-manager/C/*.xml
-%attr(755,root,root) %{_datadir}/gnome/help/subscription-manager/C/figures/*.png
 %doc LICENSE
 
 %files -n subscription-manager-firstboot

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -5,6 +5,7 @@
 %global has_ostree %use_systemd
 %global use_old_firstboot (0%{?rhel} && 0%{?rhel} <= 6)
 %global rhsm_plugins_dir  /usr/share/rhsm-plugins
+%global use_gtk3 0
 
 
 %global _hardened_build 1
@@ -38,13 +39,18 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 Requires:  python-ethtool
 Requires:  python-iniparse
-Requires:  pygobject2
 Requires:  virt-what
 Requires:  python-rhsm >= 1.15.0
 Requires:  dbus-python
 Requires:  yum >= 3.2.19-15
 Requires:  usermode
 Requires:  python-dateutil
+%if %use_gtk3
+Requires: gobject-introspection
+Requires: pygobject3-base
+%else
+Requires:  pygobject2
+%endif
 
 # There's no dmi to read on these arches, so don't pull in this dep.
 %ifnarch ppc ppc64 s390 s390x
@@ -65,11 +71,15 @@ BuildRequires: python-devel
 BuildRequires: gettext
 BuildRequires: intltool
 BuildRequires: libnotify-devel
-BuildRequires: gtk2-devel
 BuildRequires: desktop-file-utils
 BuildRequires: redhat-lsb
 BuildRequires: scrollkeeper
 BuildRequires: GConf2-devel
+%if %use_gtk3
+BuildRequires: gtk3-devel
+%else
+BuildRequires: gtk2-devel
+%endif
 %if %use_systemd
 # We need the systemd RPM macros
 BuildRequires: systemd
@@ -125,7 +135,14 @@ from the server. Populates /etc/docker/certs.d appropriately.
 Summary: A GUI interface to manage Red Hat product subscriptions
 Group: System Environment/Base
 Requires: %{name} = %{version}-%{release}
+
+# We need pygtk3 and gtk2 until rhsm-icon is ported to gtk3
+%if %use_gtk3
+Requires: pygobject3
+Requires: gtk3
+%else
 Requires: pygtk2 pygtk2-libglade
+%endif
 Requires: usermode-gtk
 Requires: dbus-x11
 Requires: gnome-icon-theme
@@ -158,9 +175,8 @@ Requires: rhn-setup-gnome
 # Fedora can figure this out automatically, but RHEL cannot:
 Requires: librsvg2
 
-
 %description -n subscription-manager-firstboot
-This package contains the firstboot screens for subscription manager.
+This package contains the firstboot screens for subscription-manager.
 
 %package -n subscription-manager-migration
 Summary: Migration scripts for moving to certificate based subscriptions
@@ -236,23 +252,62 @@ rm -rf %{buildroot}
 %files -f rhsm.lang
 %defattr(-,root,root,-)
 
-%attr(755,root,root) %dir %{_var}/log/rhsm
-%attr(755,root,root) %dir %{_var}/spool/rhsm/debug
+# executables
+%attr(755,root,root) %{_sbindir}/subscription-manager
+
+%attr(755,root,root) %{_bindir}/subscription-manager
+%attr(755,root,root) %{_bindir}/rhsmcertd
+
+%attr(755,root,root) %{_libexecdir}/rhsmcertd-worker
+%attr(755,root,root) %{_libexecdir}/rhsmd
+
+# init scripts and systemd services
+%if %use_systemd
+    %attr(644,root,root) %{_unitdir}/rhsmcertd.service
+    %attr(644,root,root) %{_tmpfilesdir}/%{name}.conf
+%else
+    %attr(755,root,root) %{_initrddir}/rhsmcertd
+%endif
+
+# our config dirs and files
 %attr(755,root,root) %dir %{_sysconfdir}/rhsm
+%attr(644,root,root) %config(noreplace) %{_sysconfdir}/rhsm/rhsm.conf
+%config(noreplace) %attr(644,root,root) %{_sysconfdir}/rhsm/logging.conf
+
 %attr(755,root,root) %dir %{_sysconfdir}/rhsm/facts
+
 %attr(755,root,root) %dir %{_sysconfdir}/pki/consumer
 %attr(755,root,root) %dir %{_sysconfdir}/pki/entitlement
 
-%attr(644,root,root) %config(noreplace) %{_sysconfdir}/rhsm/rhsm.conf
 %config(noreplace) %{_sysconfdir}/dbus-1/system.d/com.redhat.SubscriptionManager.conf
 
-#remove the repo file when we are deleted
+# PAM config
+%{_sysconfdir}/pam.d/subscription-manager
+%{_sysconfdir}/security/console.apps/subscription-manager
+
+# remove the repo file when we are deleted
 %ghost %{_sysconfdir}/yum.repos.d/redhat.repo
 
-%config(noreplace) %attr(644,root,root) %{_sysconfdir}/rhsm/logging.conf
+# yum plugin config
 %config(noreplace) %attr(644,root,root) %{_sysconfdir}/yum/pluginconf.d/subscription-manager.conf
 %config(noreplace) %attr(644,root,root) %{_sysconfdir}/yum/pluginconf.d/product-id.conf
+
+# misc system config
 %config(noreplace) %attr(644,root,root) %{_sysconfdir}/logrotate.d/subscription-manager
+%attr(700,root,root) %{_sysconfdir}/cron.daily/rhsmd
+%{_datadir}/dbus-1/system-services/com.redhat.SubscriptionManager.service
+
+
+# /var
+%attr(755,root,root) %dir %{_var}/log/rhsm
+%attr(755,root,root) %dir %{_var}/spool/rhsm/debug
+%attr(755,root,root) %dir %{_var}/run/rhsm
+%attr(755,root,root) %dir %{_var}/lib/rhsm
+%attr(755,root,root) %dir %{_var}/lib/rhsm/facts
+%attr(755,root,root) %dir %{_var}/lib/rhsm/packages
+%attr(755,root,root) %dir %{_var}/lib/rhsm/cache
+
+# bash completion scripts
 %{_sysconfdir}/bash_completion.d/subscription-manager
 %{_sysconfdir}/bash_completion.d/rct
 %{_sysconfdir}/bash_completion.d/rhsm-debug
@@ -260,79 +315,24 @@ rm -rf %{buildroot}
 %{_sysconfdir}/bash_completion.d/rhsm-icon
 %{_sysconfdir}/bash_completion.d/rhsmcertd
 
-%attr(700,root,root) %{_sysconfdir}/cron.daily/rhsmd
-%{_datadir}/dbus-1/system-services/com.redhat.SubscriptionManager.service
 
+# code
+# python package dirs
 %dir %{_datadir}/rhsm
 %dir %{_datadir}/rhsm/subscription_manager
 %dir %{_datadir}/rhsm/subscription_manager/branding
 %dir %{_datadir}/rhsm/subscription_manager/model
 %dir %{_datadir}/rhsm/subscription_manager/plugin
 
+# code, python modules and packages
 %{_datadir}/rhsm/subscription_manager/*.py*
 %{_datadir}/rhsm/subscription_manager/branding/*.py*
 %{_datadir}/rhsm/subscription_manager/model/*.py*
-%{_datadir}/rhsm/subscription_manager/async.py*
-%{_datadir}/rhsm/subscription_manager/base_action_client.py*
-%{_datadir}/rhsm/subscription_manager/base_plugin.py*
-%{_datadir}/rhsm/subscription_manager/branding
-%{_datadir}/rhsm/subscription_manager/cache.py*
-%{_datadir}/rhsm/subscription_manager/certdirectory.py*
-%{_datadir}/rhsm/subscription_manager/certlib.py*
-%{_datadir}/rhsm/subscription_manager/content_action_client.py*
-%{_datadir}/rhsm/subscription_manager/action_client.py*
-%{_datadir}/rhsm/subscription_manager/cert_sorter.py*
-%{_datadir}/rhsm/subscription_manager/cli.py*
-%{_datadir}/rhsm/subscription_manager/dbus_interface.py*
-
-%{_datadir}/rhsm/subscription_manager/dmiinfo.py*
-%{_datadir}/rhsm/subscription_manager/entcertlib.py*
-%{_datadir}/rhsm/subscription_manager/entbranding.py*
-%{_datadir}/rhsm/subscription_manager/cp_provider.py*
-%{_datadir}/rhsm/subscription_manager/factlib.py*
-%{_datadir}/rhsm/subscription_manager/facts.py*
-%{_datadir}/rhsm/subscription_manager/healinglib.py*
-%{_datadir}/rhsm/subscription_manager/hwprobe.py*
-%{_datadir}/rhsm/subscription_manager/isodate.py*
-%{_datadir}/rhsm/subscription_manager/i18n_optparse.py*
-%{_datadir}/rhsm/subscription_manager/i18n.py*
-%{_datadir}/rhsm/subscription_manager/identity.py*
-%{_datadir}/rhsm/subscription_manager/identitycertlib.py*
-%{_datadir}/rhsm/subscription_manager/injection.py*
-%{_datadir}/rhsm/subscription_manager/injectioninit.py*
-%{_datadir}/rhsm/subscription_manager/__init__.py*
-%{_datadir}/rhsm/subscription_manager/installedproductslib.py*
-%{_datadir}/rhsm/subscription_manager/jsonwrapper.py*
-%{_datadir}/rhsm/subscription_manager/listing.py*
-%{_datadir}/rhsm/subscription_manager/lock.py*
-%{_datadir}/rhsm/subscription_manager/logutil.py*
-%{_datadir}/rhsm/subscription_manager/managercli.py*
-%{_datadir}/rhsm/subscription_manager/managerlib.py*
-%{_datadir}/rhsm/subscription_manager/model
-%{_datadir}/rhsm/subscription_manager/model/*.py
-%{_datadir}/rhsm/subscription_manager/packageprofilelib.py*
-%{_datadir}/rhsm/subscription_manager/plugins.py*
-%{_datadir}/rhsm/subscription_manager/productid.py*
-%{_datadir}/rhsm/subscription_manager/reasons.py*
-%{_datadir}/rhsm/subscription_manager/release.py*
-%{_datadir}/rhsm/subscription_manager/repolib.py*
-%{_datadir}/rhsm/subscription_manager/rhelentbranding.py*
-%{_datadir}/rhsm/subscription_manager/rhelproduct.py*
-%{_datadir}/rhsm/subscription_manager/utils.py*
-%{_datadir}/rhsm/subscription_manager/printing_utils.py*
-%{_datadir}/rhsm/subscription_manager/validity.py*
-%{_datadir}/rhsm/subscription_manager/reasons.py*
-%{_datadir}/rhsm/subscription_manager/cp_provider.py*
-%{_datadir}/rhsm/subscription_manager/file_monitor.py*
-%{_datadir}/rhsm/subscription_manager/overrides.py*
-%{_datadir}/rhsm/subscription_manager/exceptions.py*
 %{_datadir}/rhsm/subscription_manager/plugin/*.py*
 
-%{_datadir}/rhsm/subscription_manager/version.py*
 # subscription-manager plugins
 %dir %{rhsm_plugins_dir}
 %dir %{_sysconfdir}/rhsm/pluginconf.d
-# add default plugins here when we have some
 
 # yum plugins
 # Using _prefix + lib here instead of libdir as that evaluates to /usr/lib64 on x86_64,
@@ -340,25 +340,6 @@ rm -rf %{buildroot}
 %{_prefix}/lib/yum-plugins/subscription-manager.py*
 %{_prefix}/lib/yum-plugins/product-id.py*
 
-%attr(755,root,root) %{_sbindir}/subscription-manager
-%attr(755,root,root) %{_bindir}/subscription-manager
-%attr(755,root,root) %{_bindir}/rhsmcertd
-%attr(755,root,root) %{_libexecdir}/rhsmcertd-worker
-%attr(755,root,root) %{_libexecdir}/rhsmd
-%attr(755,root,root) %dir %{_var}/run/rhsm
-%attr(755,root,root) %dir %{_var}/lib/rhsm
-%attr(755,root,root) %dir %{_var}/lib/rhsm/facts
-%attr(755,root,root) %dir %{_var}/lib/rhsm/packages
-%attr(755,root,root) %dir %{_var}/lib/rhsm/cache
-%{_sysconfdir}/pam.d/subscription-manager
-%{_sysconfdir}/security/console.apps/subscription-manager
-
-%if %use_systemd
-    %attr(644,root,root) %{_unitdir}/rhsmcertd.service
-    %attr(644,root,root) %{_tmpfilesdir}/%{name}.conf
-%else
-    %attr(755,root,root) %{_initrddir}/rhsmcertd
-%endif
 
 # Incude rt CLI tool
 %dir %{_datadir}/rhsm/rct
@@ -387,10 +368,13 @@ rm -rf %{buildroot}
 
 %files -n subscription-manager-gui
 %defattr(-,root,root,-)
+%attr(755,root,root) %{_sbindir}/subscription-manager-gui
+%attr(755,root,root) %{_bindir}/subscription-manager-gui
+%{_bindir}/rhsm-icon
 %dir %{_datadir}/rhsm/subscription_manager/gui
 %dir %{_datadir}/rhsm/subscription_manager/gui/data
 %dir %{_datadir}/rhsm/subscription_manager/gui/data/icons
-%{_datadir}/rhsm/subscription_manager/gui/*
+%{_datadir}/rhsm/subscription_manager/gui/data/*.glade
 %{_datadir}/rhsm/subscription_manager/gui/data/icons/*.svg
 %{_datadir}/applications/subscription-manager-gui.desktop
 %{_datadir}/icons/hicolor/16x16/apps/*.png
@@ -401,13 +385,13 @@ rm -rf %{buildroot}
 %{_datadir}/icons/hicolor/96x96/apps/*.png
 %{_datadir}/icons/hicolor/256x256/apps/*.png
 %{_datadir}/icons/hicolor/scalable/apps/*.svg
-%attr(755,root,root) %{_sbindir}/subscription-manager-gui
-%attr(755,root,root) %{_bindir}/subscription-manager-gui
 %{_datadir}/appdata/subscription-manager-gui.appdata.xml
 
-%{_bindir}/rhsm-icon
-%{_sysconfdir}/xdg/autostart/rhsm-icon.desktop
+# code and modules
+%{_datadir}/rhsm/subscription_manager/gui/*.py*
 
+# gui system config files
+%{_sysconfdir}/xdg/autostart/rhsm-icon.desktop
 %{_sysconfdir}/pam.d/subscription-manager-gui
 %{_sysconfdir}/security/console.apps/subscription-manager-gui
 %{_sysconfdir}/bash_completion.d/subscription-manager-gui
@@ -418,8 +402,9 @@ rm -rf %{buildroot}
 %{_datadir}/omf/subscription-manager
 %attr(644,root,root) %{_datadir}/omf/subscription-manager/*.omf
 %{_datadir}/gnome/help/subscription-manager
-%attr(644,root,root) %{_datadir}/gnome/help/subscription-manager/C/*
-%attr(755,root,root) %{_datadir}/gnome/help/subscription-manager/C/figures
+%{_datadir}/gnome/help/subscription-manager/C
+%attr(644,root,root) %{_datadir}/gnome/help/subscription-manager/C/*.xml
+%attr(755,root,root) %{_datadir}/gnome/help/subscription-manager/C/figures/*.png
 %doc LICENSE
 
 %files -n subscription-manager-firstboot
@@ -430,7 +415,6 @@ rm -rf %{buildroot}
 %else
 %{_datadir}/firstboot/modules/rhsm_login.py*
 %endif
-
 
 %files -n subscription-manager-migration
 %defattr(-,root,root,-)


### PR DESCRIPTION
This is preparation for the spec file for the initial_setup/gtk3 branch that got out of hand.

Some re organizing of the spec file, the file listings in particular. 

Removed a couple of dirs and globs that had multiple matches and caused duplicate file warnings.

Removed the enumerated list of particular .py files and replaced with some globs.

Added the use_gtk3 variable for forthcoming gtk3 port.

Tried to group the included files in roughly the order they would be listed in an rpm -qa.

Use %find_lang to fix the warnings about gnome-help related docs being duplicates.

This combined with https://github.com/candlepin/subscription-manager/pull/1202 
https://github.com/candlepin/subscription-manager/pull/1201 and https://github.com/candlepin/subscription-manager/pull/1200 make for much less noisey rpm build output.