### PR TITLE
Don't try to set file attrs on symlinks in spec

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -259,7 +259,8 @@ rm -rf %{buildroot}
 # executables
 %attr(755,root,root) %{_sbindir}/subscription-manager
 
-%attr(755,root,root) %{_bindir}/subscription-manager
+# symlink to console-helper
+%{_bindir}/subscription-manager
 %attr(755,root,root) %{_bindir}/rhsmcertd
 
 %attr(755,root,root) %{_libexecdir}/rhsmcertd-worker
@@ -373,7 +374,8 @@ rm -rf %{buildroot}
 %files -n subscription-manager-gui -f subscription-manager.lang
 %defattr(-,root,root,-)
 %attr(755,root,root) %{_sbindir}/subscription-manager-gui
-%attr(755,root,root) %{_bindir}/subscription-manager-gui
+# symlink to console-helper
+%{_bindir}/subscription-manager-gui
 %{_bindir}/rhsm-icon
 %dir %{_datadir}/rhsm/subscription_manager/gui
 %dir %{_datadir}/rhsm/subscription_manager/gui/data


### PR DESCRIPTION
/usr/bin/subscription-manager and
/usr/bin/subscription-manager-gui are both symlinks
to console helper.

Spec file was attempting to set %attr on the links,
which has no effect, so rpmbuild was warning about it
with a message like:

warning: Explicit %attr() mode not applicaple to symlink:
/BUILDROOT/subscription-manager-1.1-1.x86_64/usr/bin/subscription-manager

This removes the %attr to stop the warning.