### PR TITLE
1232232: Add supported API to enable content repositories.

### DIFF
--- a/src/subscription_manager/api/__init__.py
+++ b/src/subscription_manager/api/__init__.py
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+"""
+Class and methods made available in __all__ are provided for use by
+external applications.
+
+All reasonable efforts will be made to maintain compatibility.
+"""
+
+from .repos import disable_yum_repositories, enable_yum_repositories
+
+from subscription_manager.version import rpm_version as version
+
+from functools import wraps
+
+__all__ = [
+    'disable_yum_repositories',
+    'enable_yum_repositories',
+    'version',
+]

--- a/src/subscription_manager/api/__init__.py
+++ b/src/subscription_manager/api/__init__.py
@@ -22,6 +22,9 @@ injected = False
 
 
 def request_injection(func):
+    """This idempotent decorator can be applied to initialize the dependency
+    injection used by subscription manager.  Users of the API methods will not
+    normally need to use this decorator as it will already have been called."""
     @wraps(func)
     def func_wrapper(*args, **kwargs):
         global injected

--- a/src/subscription_manager/api/__init__.py
+++ b/src/subscription_manager/api/__init__.py
@@ -16,14 +16,32 @@ external applications.
 
 All reasonable efforts will be made to maintain compatibility.
 """
+from functools import wraps
+
+injected = False
+
+
+def request_injection(func):
+    @wraps(func)
+    def func_wrapper(*args, **kwargs):
+        global injected
+        if not injected:
+            from subscription_manager import logutil
+            logutil.init_logger()
+
+            from subscription_manager.injectioninit import init_dep_injection
+            init_dep_injection()
+            injected = True
+        return func(*args, **kwargs)
+    return func_wrapper
+
 
 from .repos import disable_yum_repositories, enable_yum_repositories
 
 from subscription_manager.version import rpm_version as version
 
-from functools import wraps
-
 __all__ = [
+    'request_injection',
     'disable_yum_repositories',
     'enable_yum_repositories',
     'version',

--- a/src/subscription_manager/api/repos.py
+++ b/src/subscription_manager/api/repos.py
@@ -12,16 +12,13 @@
 #
 import fnmatch
 
-from subscription_manager import logutil
-logutil.init_logger()
-
-from subscription_manager.injectioninit import init_dep_injection
-init_dep_injection()
-
 import subscription_manager.injection as inj
+
+from subscription_manager.api import request_injection
 from subscription_manager.repolib import RepoActionInvoker, RepoFile
 
 
+@request_injection
 def _set_enable_for_yum_repositories(setting, *repo_ids):
     invoker = RepoActionInvoker()
     repos = invoker.get_repos()

--- a/src/subscription_manager/api/repos.py
+++ b/src/subscription_manager/api/repos.py
@@ -1,0 +1,76 @@
+#
+# Copyright (c) 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+import fnmatch
+
+from subscription_manager import logutil
+logutil.init_logger()
+
+from subscription_manager.injectioninit import init_dep_injection
+init_dep_injection()
+
+import subscription_manager.injection as inj
+from subscription_manager.repolib import RepoActionInvoker, RepoFile
+
+
+def _set_enable_for_yum_repositories(setting, *repo_ids):
+    invoker = RepoActionInvoker()
+    repos = invoker.get_repos()
+    repos_to_change = []
+
+    for r in repo_ids:
+        matches = set([repo for repo in repos if fnmatch.fnmatch(repo.id, r)])
+        repos_to_change.extend(matches)
+
+    if len(repos_to_change) == 0:
+        return 0
+
+    # The cache should be primed at this point by the invoker.get_repos()
+    cache = inj.require(inj.OVERRIDE_STATUS_CACHE)
+    identity = inj.require(inj.IDENTITY)
+    cp_provider = inj.require(inj.CP_PROVIDER)
+
+    if identity.is_valid() and cp_provider.get_consumer_auth_cp().supports_resource('content_overrides'):
+        overrides = [{'contentLabel': repo.id, 'name': 'enabled', 'value': setting} for repo in repos_to_change]
+        cp = cp_provider.get_consumer_auth_cp()
+        results = cp.setContentOverrides(identity.uuid, overrides)
+
+        cache = inj.require(inj.OVERRIDE_STATUS_CACHE)
+
+        # Update the cache with the returned JSON
+        cache.server_status = results
+        cache.write_cache()
+
+        invoker.update()
+    else:
+        for repo in repos_to_change:
+            repo['enabled'] = setting
+
+        repo_file = RepoFile()
+        repo_file.read()
+        for repo in repos_to_change:
+            repo_file.update(repo)
+        repo_file.write()
+
+    return len(repos_to_change)
+
+
+def enable_yum_repositories(*repo_ids):
+    """Enable a Yum repo by repoid.  Wildcards are honored.  Any matching repos are
+    enabled *even if they are already enabled*."""
+    return _set_enable_for_yum_repositories('1', *repo_ids)
+
+
+def disable_yum_repositories(*repo_ids):
+    """Disable a Yum repo by repoid.  Wildcards are honored.  Any matching repos are
+    disabled *even if they are already enabled*."""
+    return _set_enable_for_yum_repositories('0', *repo_ids)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,0 +1,120 @@
+#
+# Copyright (c) 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+from mock import patch, call
+
+from subscription_manager import api
+from subscription_manager.repolib import Repo
+
+from test.fixture import SubManFixture
+from test.stubs import StubUEP
+
+
+class ApiVersionTest(SubManFixture):
+    def test_version_is_available(self):
+        from subscription_manager import version
+        self.assertEquals(version.rpm_version, api.version)
+
+
+class RepoApiTest(SubManFixture):
+    def setUp(self):
+        super(RepoApiTest, self).setUp()
+        self.invoker_patcher = patch("subscription_manager.api.repos.RepoActionInvoker", autospec=True)
+        self.invoker = self.invoker_patcher.start().return_value
+
+        self.repo_file_patcher = patch("subscription_manager.api.repos.RepoFile", autospec=True)
+        self.repo_file = self.repo_file_patcher.start().return_value
+
+    def tearDown(self):
+        super(RepoApiTest, self).tearDown()
+        self.invoker_patcher.stop()
+        self.repo_file_patcher.stop()
+
+    def test_disable_repo(self):
+        repo_settings = {
+            'enabled': '1',
+        }
+        self.invoker.get_repos.return_value = [
+            Repo('hello', repo_settings.items()),
+        ]
+        self.repo_file.items.return_value = repo_settings.items()
+        result = api.disable_yum_repositories('hello')
+
+        self.assertIn(call.write(), self.repo_file.mock_calls)
+        self.assertEquals(1, result)
+
+    def test_enable_repo(self):
+        repo_settings = {
+            'enabled': '0',
+        }
+        self.invoker.get_repos.return_value = [
+            Repo('hello', repo_settings.items()),
+        ]
+        self.repo_file.items.return_value = repo_settings.items()
+        result = api.enable_yum_repositories('hello')
+
+        self.assertIn(call.write(), self.repo_file.mock_calls)
+        self.assertEquals(1, result)
+
+    def test_enable_repo_wildcard(self):
+        repo_settings = {
+            'enabled': '0',
+        }
+
+        self.invoker.get_repos.return_value = [
+            Repo('hello', repo_settings.copy().items()),
+            Repo('helium', repo_settings.copy().items()),
+        ]
+        self.repo_file.items.return_value = repo_settings.copy().items()
+
+        result = api.enable_yum_repositories('he*')
+
+        self.assertIn(call.write(), self.repo_file.mock_calls)
+        self.assertEquals(2, result)
+
+    def test_does_not_enable_nonmatching_repos(self):
+        repo_settings = {
+            'enabled': '0',
+        }
+        self.invoker.get_repos.return_value = [
+            Repo('x', repo_settings.items()),
+        ]
+        self.repo_file.items.return_value = repo_settings.items()
+        result = api.enable_yum_repositories('hello')
+
+        self.assertNotIn(call.write(), self.repo_file.mock_calls)
+        self.assertEquals(0, result)
+
+    @patch.object(StubUEP, 'supports_resource')
+    @patch.object(StubUEP, 'setContentOverrides', create=True)
+    def test_update_overrides_cache(self, mock_set, mock_supports):
+        mock_supports.return_value = True
+
+        self._inject_mock_valid_consumer("123")
+
+        repo_settings = {
+            'enabled': '0',
+        }
+        self.invoker.get_repos.return_value = [
+            Repo('hello', repo_settings.items()),
+        ]
+        self.repo_file.items.return_value = repo_settings.items()
+        result = api.enable_yum_repositories('hello')
+
+        expected_overrides = [{
+            'contentLabel': 'hello',
+            'name': 'enabled',
+            'value': '1',
+        }]
+        self.assertIn(call("123", expected_overrides), mock_set.mock_calls)
+        self.assertIn(call.update(), self.invoker.mock_calls)
+        self.assertEquals(1, result)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -99,8 +99,6 @@ class RepoApiTest(SubManFixture):
     def test_update_overrides_cache(self, mock_set, mock_supports):
         mock_supports.return_value = True
 
-        self._inject_mock_valid_consumer("123")
-
         repo_settings = {
             'enabled': '0',
         }
@@ -108,7 +106,13 @@ class RepoApiTest(SubManFixture):
             Repo('hello', repo_settings.items()),
         ]
         self.repo_file.items.return_value = repo_settings.items()
-        result = api.enable_yum_repositories('hello')
+
+        @api.request_injection
+        def munge_injection():
+            self._inject_mock_valid_consumer("123")
+            return api.enable_yum_repositories('hello')
+
+        result = munge_injection()
 
         expected_overrides = [{
             'contentLabel': 'hello',

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -49,7 +49,7 @@ class RepoApiTest(SubManFixture):
         self.repo_file.items.return_value = repo_settings.items()
         result = api.disable_yum_repositories('hello')
 
-        self.assertIn(call.write(), self.repo_file.mock_calls)
+        self.assertTrue(call.write() in self.repo_file.mock_calls)
         self.assertEquals(1, result)
 
     def test_enable_repo(self):
@@ -62,7 +62,7 @@ class RepoApiTest(SubManFixture):
         self.repo_file.items.return_value = repo_settings.items()
         result = api.enable_yum_repositories('hello')
 
-        self.assertIn(call.write(), self.repo_file.mock_calls)
+        self.assertTrue(call.write() in self.repo_file.mock_calls)
         self.assertEquals(1, result)
 
     def test_enable_repo_wildcard(self):
@@ -78,7 +78,7 @@ class RepoApiTest(SubManFixture):
 
         result = api.enable_yum_repositories('he*')
 
-        self.assertIn(call.write(), self.repo_file.mock_calls)
+        self.assertTrue(call.write() in self.repo_file.mock_calls)
         self.assertEquals(2, result)
 
     def test_does_not_enable_nonmatching_repos(self):
@@ -91,7 +91,7 @@ class RepoApiTest(SubManFixture):
         self.repo_file.items.return_value = repo_settings.items()
         result = api.enable_yum_repositories('hello')
 
-        self.assertNotIn(call.write(), self.repo_file.mock_calls)
+        self.assertFalse(call.write() in self.repo_file.mock_calls)
         self.assertEquals(0, result)
 
     @patch.object(StubUEP, 'supports_resource')
@@ -119,6 +119,6 @@ class RepoApiTest(SubManFixture):
             'name': 'enabled',
             'value': '1',
         }]
-        self.assertIn(call("123", expected_overrides), mock_set.mock_calls)
-        self.assertIn(call.update(), self.invoker.mock_calls)
+        self.assertTrue(call("123", expected_overrides) in mock_set.mock_calls)
+        self.assertTrue(call.update() in self.invoker.mock_calls)
         self.assertEquals(1, result)


### PR DESCRIPTION
How to test:

1. Attach to some valid subscriptions so that you have something present in `redhat.repo`
1. `cp /etc/yum.repos.d/redhat.repo /tmp/redhat.bak`
1. Take a look at `redhat.repo` and find some disabled repos
1. Run `PYTHONPATH=src/ python`
1. In the REPL, do the following.  (The argument passed to `enable_repositories` should be the ID for one of the repos you picked in step 3)

    ```
    >>> from subscription_manager import api
    >>> api.enable_repositories('rhs-big-data*')
    ```
1. The result should be non-zero
1. Quit the REPL with Ctrl-D
1. `diff -u /tmp/redhat.bak /etc/yum.repos.d/redhat.repo`
1. The only differences should be the newly enabled repositories. Additionally, `/var/log/rhsm/rhsm.log` should have messages generated when a repositories is enabled.