### PR TITLE
Define global_ld_flags when not already defined.

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -9,6 +9,7 @@
 
 
 %global _hardened_build 1
+%{!?__global_ldflags: %global __global_ldflags -Wl,-z,relro -Wl,-z,now}
 
 # A couple files are for RHEL 5 only:
 %if 0%{?rhel} == 5


### PR DESCRIPTION
Note that this patch *does not* harden the build for RHEL 6.  RHEL 6 does not provide any PIE/PIC RPM macros and setting everything by hand would require a lot of GCC magic that I don't know (e.g. use `-fpie` unless you're on S390X, in which case use `-fPIE`).

Instead, this patch simply gets the builds running on RHEL 6 again.