### PR TITLE
1240801: Use latest initial-setup API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,11 +247,11 @@ install-initial-setup-real:
 	install -d $(INITIAL_SETUP_INST_DIR)
 	install -d $(INITIAL_SETUP_INST_DIR)/gui
 	install -d $(INITIAL_SETUP_INST_DIR)/gui/spokes
-	install -d $(INITIAL_SETUP_INST_DIR)/gui/categories
+	install -d $(INITIAL_SETUP_INST_DIR)/categories
 	install -d $(INITIAL_SETUP_INST_DIR)/ks
 	install -m 644 -p $(ANACONDA_ADDON_MODULE_SRC_DIR)/*.py $(INITIAL_SETUP_INST_DIR)/
 	install -m 644 -p $(ANACONDA_ADDON_MODULE_SRC_DIR)/gui/*.py $(INITIAL_SETUP_INST_DIR)/gui/
-	install -m 644 -p $(ANACONDA_ADDON_MODULE_SRC_DIR)/gui/categories/*.py $(INITIAL_SETUP_INST_DIR)/gui/categories/
+	install -m 644 -p $(ANACONDA_ADDON_MODULE_SRC_DIR)/categories/*.py $(INITIAL_SETUP_INST_DIR)/categories/
 	install -m 644 -p $(ANACONDA_ADDON_MODULE_SRC_DIR)/gui/spokes/*.py $(INITIAL_SETUP_INST_DIR)/gui/spokes/
 	install -m 644 -p $(ANACONDA_ADDON_MODULE_SRC_DIR)/gui/spokes/*.ui $(INITIAL_SETUP_INST_DIR)/gui/spokes/
 	install -m 644 -p $(ANACONDA_ADDON_MODULE_SRC_DIR)/ks/*.py $(INITIAL_SETUP_INST_DIR)/ks/

--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
@@ -21,7 +21,7 @@ import sys
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.common import FirstbootOnlySpokeMixIn
-from pyanaconda.ui.gui.categories.system import SystemCategory
+from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.gui import GUIObject
 
 log = logging.getLogger(__name__)

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -459,13 +459,13 @@ rm -rf %{buildroot}
 %dir %{_datadir}/anaconda/addons/com_redhat_subscription_manager/
 %dir %{_datadir}/anaconda/addons/com_redhat_subscription_manager/gui/
 %dir %{_datadir}/anaconda/addons/com_redhat_subscription_manager/gui/spokes/
-%dir %{_datadir}/anaconda/addons/com_redhat_subscription_manager/gui/categories/
+%dir %{_datadir}/anaconda/addons/com_redhat_subscription_manager/categories/
 %dir %{_datadir}/anaconda/addons/com_redhat_subscription_manager/ks/
 %{_datadir}/anaconda/addons/com_redhat_subscription_manager/*.py*
 %{_datadir}/anaconda/addons/com_redhat_subscription_manager/gui/*.py*
 %{_datadir}/anaconda/addons/com_redhat_subscription_manager/gui/spokes/*.ui
 %{_datadir}/anaconda/addons/com_redhat_subscription_manager/gui/spokes/*.py*
-%{_datadir}/anaconda/addons/com_redhat_subscription_manager/gui/categories/*.py*
+%{_datadir}/anaconda/addons/com_redhat_subscription_manager/categories/*.py*
 %{_datadir}/anaconda/addons/com_redhat_subscription_manager/ks/*.py*
 %else
 


### PR DESCRIPTION
When initial-setup and anaconda were rebased to more
recent versions, some of the API changed. Most notably
the move of the 'ui.gui.categories' package to 'ui.categories'.
rhsm_gui.py was updated to reflect that.

The required module layout also changed in a similar manner,
so Makefile and spec file also updated to reflect that.

This should resolve errors loading our initial-setup
module.