### PR TITLE
1136163: Ignore pythonpath to avoid selinux AVCs

### DIFF
--- a/src/daemons/rhsmcertd-worker.py
+++ b/src/daemons/rhsmcertd-worker.py
@@ -1,4 +1,6 @@
-#!/usr/bin/python
+#!/usr/bin/python -Es
+# ^ is to prevent selinux denials trying to load modules from unintended
+#   paths. See https://bugzilla.redhat.com/show_bug.cgi?id=1136163
 #
 # Copyright (c) 2012 Red Hat, Inc.
 #


### PR DESCRIPTION
For rhsmcertd-worker.py in particular, since it runs
as a child of rhsmcertd, which has very restrictive
selinux policy by default.

Because of either PYTHONPATH env var or system/site/user
changes to the pythonpath, rhsmcertd-worker.py could
end up attempting to find and open modules in path
that the selinux policy prevents it from accessing.

If the path ended up including '.', it would attempt
to read from cwd and cause denials.

So specify the '-E' and '-s' args to /usr/bin/python
-E     : ignore PYTHON* environment variables (such as PYTHONPATH)
-s     : don't add user site directory to sys.path; also
         PYTHONNOUSERSITE