### PR TITLE
Fix nose failures caused by nose loading gtk2/gtk3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,8 @@
 [nosetests]
 with-xvfb=True
 with-id=True
-
+# exclude tests with names that match regex .*ga_impls.*
+# Even though there are no tests with that name, but nose tries
+# to load modules that would have that name, and seems to ignore 'ignore-files'
+# Workaround for nose/ga/pygobject issues introduced with pygobject3-3.14
+exclude=.*ga_impls.*

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -828,7 +828,7 @@ class TestReposCommand(TestCliCommand):
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
         self.cc.cp.setContentOverrides.assert_called_once_with('fake_id',
                 match_dict_list)
-        repolib_instance.update.assert_called()
+        self.assertTrue(repolib_instance.update.called)
 
     @mock.patch("subscription_manager.managercli.RepoActionInvoker")
     def test_set_repo_status_with_wildcards(self, mock_repolib):
@@ -845,7 +845,7 @@ class TestReposCommand(TestCliCommand):
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
         self.cc.cp.setContentOverrides.assert_called_once_with('fake_id',
                 match_dict_list)
-        repolib_instance.update.assert_called()
+        self.assertTrue(repolib_instance.update.called)
 
     @mock.patch("subscription_manager.managercli.RepoActionInvoker")
     def test_set_repo_status_disable_all_enable_some(self, mock_repolib):
@@ -866,7 +866,7 @@ class TestReposCommand(TestCliCommand):
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
         self.cc.cp.setContentOverrides.assert_called_once_with('fake_id',
                 match_dict_list)
-        repolib_instance.update.assert_called()
+        self.assertTrue(repolib_instance.update.called)
 
     @mock.patch("subscription_manager.managercli.RepoActionInvoker")
     def test_set_repo_status_enable_all_disable_some(self, mock_repolib):
@@ -887,7 +887,7 @@ class TestReposCommand(TestCliCommand):
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
         self.cc.cp.setContentOverrides.assert_called_once_with('fake_id',
                 match_dict_list)
-        repolib_instance.update.assert_called()
+        self.assertTrue(repolib_instance.update.called)
 
     @mock.patch("subscription_manager.managercli.RepoActionInvoker")
     def test_set_repo_status_enable_all_disable_all(self, mock_repolib):
@@ -907,7 +907,7 @@ class TestReposCommand(TestCliCommand):
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
         self.cc.cp.setContentOverrides.assert_called_once_with('fake_id',
                 match_dict_list)
-        repolib_instance.update.assert_called()
+        self.assertTrue(repolib_instance.update.called)
 
     @mock.patch("subscription_manager.managercli.RepoFile")
     def test_set_repo_status_when_disconnected(self, mock_repofile):


### PR DESCRIPTION
Despite src/subscription_manager/__init__.py having a
'__test__ = None' attribute, nose still attempts to load
all modules in src/subscription_manager/ga_impls/, which
fails. pygobject3-3.14 introduced some gobject/gi module
loading changes that raise exceptions if code attempts
to import 'gobject', if 'gi.repository' has been used.

Since nose tries to load both, and newer pygobject3 changes the
failure mode for that case, all the 'ga' using tests fail.

The 'excludes=.*ga_impls.*' added here is documented as "Don’t run tests that match
regular expression". We don't actually have any tests named that way,
but nose ends up loading module paths that could include that, and
this stops that.

--ignore-files or the '__test__ = None' seem like they should work
for this case, but seem to have no effect.