### PR TITLE
Updated initial-setup-addon package requirement to initial-setup-gui

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -197,7 +197,7 @@ This package contains the firstboot screens for subscription-manager.
 Summary: initial-setup screens for subscription-manager
 Group: System Environment/Base
 Requires: %{name}-gui = %{version}-%{release}
-Requires: initial-setup
+Requires: initial-setup-gui
 Obsoletes: subscription-manager-firstboot < 1.15.3-1
 
 %description -n subscription-manager-initial-setup-addon


### PR DESCRIPTION
- Changed one of the required packages for
  subscription-manager-initial-setup-addon from initial-setup to
  initial-setup-gui