### PR TITLE
Use idle_add from ga_Object for 6.x

### DIFF
--- a/src/daemons/rhsm_d.py
+++ b/src/daemons/rhsm_d.py
@@ -66,7 +66,6 @@ def excepthook_logging(exc_type, exc_value, exc_traceback):
 sys.excepthook = excepthook_logging
 
 from subscription_manager.ga import GObject as ga_GObject
-from subscription_manager.ga import GLib as ga_GLib
 from subscription_manager.injectioninit import init_dep_injection
 init_dep_injection()
 
@@ -157,7 +156,7 @@ class StatusChecker(dbus.service.Object):
     #certain parts of that are async
     def watchdog(self):
         if not self.keep_alive:
-            ga_GLib.idle_add(check_if_ran_once, self, self.loop)
+            ga_GObject.idle_add(check_if_ran_once, self, self.loop)
 
     @dbus.service.method(
         dbus_interface="com.redhat.SubscriptionManager.EntitlementStatus",


### PR DESCRIPTION
ga_GLib.idle_add only exists on RHEL7 where
ga.GLib -> gi.repository.GLib.

On RHEL6, ga_GLib doesn't have idle_add, but
ga_Gobject does. So update to use that. RHEL 7
also has ga_Gobject.idle_add, so this works for
both.