### PR TITLE
Move gtk_compat features to sub ga module.

### DIFF
--- a/bin/subscription-manager-gui
+++ b/bin/subscription-manager-gui
@@ -108,10 +108,10 @@ if _LIBPATH not in sys.path:
 from subscription_manager import ga_loader
 ga_loader.init_ga()
 
-from subscription_manager.ga import GObject as ga_GObject
 from subscription_manager.ga import Gtk as ga_Gtk
+from subscription_manager.ga import gtk_compat
 
-ga_GObject.threads_init()
+gtk_compat.threads_init()
 
 # quick check to see if you are a super-user.
 if os.getuid() != 0:

--- a/src/subscription_manager/ga_impls/ga_gtk2/GObject.py
+++ b/src/subscription_manager/ga_impls/ga_gtk2/GObject.py
@@ -1,6 +1,4 @@
 
-# To get gtk.gdk.threads_init
-import gtk
 
 # objects
 from gobject import GObject
@@ -14,11 +12,6 @@ from gobject import markup_escape_text
 from gobject import SIGNAL_RUN_LAST
 from gobject import TYPE_BOOLEAN, TYPE_PYOBJECT, PARAM_READWRITE
 
-# These are not exact replacements, but for our purposes they
-# are used in the same places in the same way. A purely GObject
-# app with no gui may want to distinquish.
-threads_init = gtk.gdk.threads_init
-
 
 class SignalFlags(object):
     RUN_LAST = SIGNAL_RUN_LAST
@@ -26,7 +19,7 @@ class SignalFlags(object):
 
 constants = [TYPE_BOOLEAN, TYPE_PYOBJECT, PARAM_READWRITE]
 methods = [add_emission_hook, idle_add, markup_escape_text,
-           source_remove, threads_init, timeout_add]
+           source_remove, timeout_add]
 enums = [SignalFlags]
 objects = [GObject, MainLoop]
 __all__ = objects + methods + constants + enums

--- a/src/subscription_manager/ga_impls/ga_gtk2/Gtk.py
+++ b/src/subscription_manager/ga_impls/ga_gtk2/Gtk.py
@@ -9,7 +9,7 @@ from gtk import CellRendererProgress, CellRendererSpin, CellRendererText
 from gtk import CellRendererToggle, Entry
 from gtk import FileChooserDialog, FileFilter, Frame, HBox, HButtonBox, Image
 from gtk import Label, ListStore, MessageDialog, RadioButton, SpinButton
-from gtk import TextBuffer, TreeRowReference
+from gtk import TextBuffer
 from gtk import TreeStore, TreeView, TreeViewColumn, VBox, Viewport
 
 # enums
@@ -111,13 +111,6 @@ class GaImage(Image):
 #       the Gtk.Image is not provided here.
 Image = GaImage
 
-
-# Gtk2's TreeRowReference is a class, while Gtk3's TreeRowReference is
-# non-callable class that has to be constructed with it's .new() method.
-# Provide a helper method that provides a compatible interface. snake_case
-# naming used to distinquish it from the "real" TreeRowReference.
-def tree_row_reference(model, path):
-    return TreeRowReference(model, path)
 
 # Attempt to keep the list of faux Gtk 3 names we are
 # providing to a min.

--- a/src/subscription_manager/ga_impls/ga_gtk2/__init__.py
+++ b/src/subscription_manager/ga_impls/ga_gtk2/__init__.py
@@ -1,7 +1,5 @@
 
 import os
-# so ga.gtk_compat.tree_row_reference finds it
-from Gtk import tree_row_reference
 
 # ../../gui/data/glade/
 ourfile = __file__
@@ -10,5 +8,4 @@ GTK_BUILDER_FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__),
 GTK_BUILDER_FILES_SUFFIX = "glade"
 
 __all__ = [GTK_BUILDER_FILES_DIR,
-           GTK_BUILDER_FILES_SUFFIX,
-           tree_row_reference]
+           GTK_BUILDER_FILES_SUFFIX]

--- a/src/subscription_manager/ga_impls/ga_gtk2/gtk_compat.py
+++ b/src/subscription_manager/ga_impls/ga_gtk2/gtk_compat.py
@@ -1,0 +1,28 @@
+
+import os
+
+from gtk import TreeRowReference
+from gtk.gdk import threads_init
+
+
+# Gtk2's TreeRowReference is a class, while Gtk3's TreeRowReference is
+# non-callable class that has to be constructed with it's .new() method.
+# Provide a helper method that provides a compatible interface. snake_case
+# naming used to distinquish it from the "real" TreeRowReference.
+def tree_row_reference(model, path):
+    return TreeRowReference(model, path)
+
+
+# These are not exact replacements, but for our purposes they
+# are used in the same places in the same way. A purely GObject
+# app with no gui may want to distinquish.
+threads_init = threads_init
+
+# ../../gui/data/glade/
+ourfile = __file__
+GTK_BUILDER_FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__),
+                                                      "../../gui/data/glade/"))
+GTK_BUILDER_FILES_SUFFIX = "glade"
+
+__all__ = [GTK_BUILDER_FILES_DIR,
+           GTK_BUILDER_FILES_SUFFIX]

--- a/src/subscription_manager/ga_impls/ga_gtk3.py
+++ b/src/subscription_manager/ga_impls/ga_gtk3.py
@@ -1,6 +1,7 @@
 
 import os
 from gi.repository import Gtk
+from gi.repository import GObject
 
 # ../../gui/data/glade/
 ourfile = __file__
@@ -13,3 +14,5 @@ GTK_BUILDER_FILES_SUFFIX = "ui"
 # gtk2 does not have a .new()
 def tree_row_reference(model, path):
     return Gtk.TreeRowReference.new(model, path)
+
+threads_init = GObject.threads_init

--- a/src/subscription_manager/ga_loader.py
+++ b/src/subscription_manager/ga_loader.py
@@ -179,8 +179,8 @@ class GaImporterGtk3(GaImporter):
 
 class GaImporterGtk2(GaImporter):
     virtual_modules = {'subscription_manager.ga': None,
-                       'subscription_manager.ga.gtk_compat': ['subscription_manager.ga_impls',
-                                                              'ga_gtk2'],
+                       'subscription_manager.ga.gtk_compat': ['subscription_manager.ga_impls.ga_gtk2',
+                                                              'gtk_compat'],
                        'subscription_manager.ga.GObject': ['subscription_manager.ga_impls.ga_gtk2',
                                                            'GObject'],
                        'subscription_manager.ga.Gdk': ['subscription_manager.ga_impls.ga_gtk2',


### PR DESCRIPTION
ga_gtk2/GObject.py was importing gtk to wrap
TreeRowReference, so code that imported just
ga.GObject were also pulling in gtk, which
fails if there is no $DISPLAY set.

Likewise, the common threads_init was moved to
gtk_compat.threads_init.

Glade file location helpers were also moved to
gtk_compat.