### PR TITLE
1161157,1155954: Improve performance of Repository Dialog

### DIFF
--- a/src/subscription_manager/ga_impls/ga_gtk2/__init__.py
+++ b/src/subscription_manager/ga_impls/ga_gtk2/__init__.py
@@ -9,6 +9,8 @@ GTK_BUILDER_FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__),
                                                       "../../gui/data/glade/"))
 GTK_BUILDER_FILES_SUFFIX = "glade"
 
+GTK_COMPAT_VERSION = "2"
+
 __all__ = [GTK_BUILDER_FILES_DIR,
            GTK_BUILDER_FILES_SUFFIX,
            tree_row_reference]

--- a/src/subscription_manager/ga_impls/ga_gtk3.py
+++ b/src/subscription_manager/ga_impls/ga_gtk3.py
@@ -8,6 +8,8 @@ GTK_BUILDER_FILES_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__),
                                                       "../gui/data/ui/"))
 GTK_BUILDER_FILES_SUFFIX = "ui"
 
+GTK_COMPAT_VERSION = "3"
+
 
 # gtk3 requires constructing with .new(), where
 # gtk2 does not have a .new()

--- a/src/subscription_manager/gui/data/glade/repositories.glade
+++ b/src/subscription_manager/gui/data/glade/repositories.glade
@@ -1,104 +1,54 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <object class="GtkTextBuffer" id="textbuffer1">
-    <property name="text">Manage the repositories your subscriptions grant you access to by enabling, disabling and overriding certain fields.</property>
-  </object>
   <!-- interface-requires gtk+ 2.10 -->
-  <!--
- interface-naming-policy project-wide -->
+  <!-- interface-naming-policy toplevel-contextual -->
   <object class="GtkDialog" id="main_window">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Manage Repositories</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
-    <property name="default_width">600</property>
-    <property name="default_height">400</property>
+    <property name="default_width">800</property>
+    <property name="default_height">600</property>
     <property name="destroy_with_parent">True</property>
     <property name="icon_name">subscription-manager</property>
     <property name="type_hint">dialog</property>
     <property name="deletable">False</property>
-    <accessibility/>
-    <signal handler="on_dialog_delete_event" name="delete_event"/>
+    <child internal-child="accessible">
+      <object class="AtkObject" id="main_window-atkobject">
+        <property name="AtkObject::accessible-name" translatable="yes">manage_repositories_dialog</property>
+      </object>
+    </child>
+    <signal name="delete-event" handler="on_dialog_delete_event" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkVBox" id="main_container">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area1">
+        <child>
+          <object class="GtkLabel" id="description_text">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="layout_style">edge</property>
-            <child>
-              <object class="GtkButton" id="reset_button">
-                <property name="label" translatable="yes">Remove All Overrides</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="xalign">0.45</property>
-                <accessibility/>
-                <signal handler="on_reset_button_clicked" name="clicked"/>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="a11y-reset_button1">
-                    <property name="AtkObject::accessible-name" translatable="yes">remove_all_overrides_button</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="close_button">
-                <property name="label" translatable="yes">Close</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <accessibility/>
-                <signal handler="on_close_button_clicked" name="clicked"/>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="a11y-close_button1">
-                    <property name="AtkObject::accessible-name" translatable="yes">close_button</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
+            <property name="xalign">0</property>
+            <property name="yalign">0</property>
+            <property name="ypad">10</property>
+            <property name="label" translatable="yes">Manage the repositories your subscriptions grant you access to by enabling, disabling and overriding certain fields.</property>
+            <property name="wrap">True</property>
+            <property name="wrap_mode">word-char</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox1">
+          <object class="GtkVBox" id="main_content_container">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <child>
-              <object class="GtkTextView" id="description_text">
-                <property name="visible">True</property>
-                <property name="sensitive">False</property>
-                <property name="can_focus">True</property>
-                <property name="editable">False</property>
-                <property name="wrap_mode">word</property>
-                <property name="buffer">textbuffer1</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="padding">6</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow">
                 <property name="visible">True</property>
@@ -109,7 +59,7 @@
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
@@ -117,184 +67,144 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkLabel" id="label2">
+                  <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
-                    <property name="ypad">3</property>
+                    <property name="yalign">0</property>
+                    <property name="ypad">6</property>
                     <property name="label" translatable="yes">&lt;b&gt;Repository Details&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkFrame" id="frame1">
-                    <property name="height_request">96</property>
+                  <object class="GtkTable" id="table1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="n_rows">3</property>
+                    <property name="n_columns">2</property>
                     <child>
-                      <object class="GtkAlignment" id="alignment1">
+                      <object class="GtkLabel" id="name_label1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Name:&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="x_options">GTK_FILL</property>
+                        <property name="y_options">GTK_FILL</property>
+                        <property name="x_padding">4</property>
+                        <property name="y_padding">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="base_url_label1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Base URL:&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="top_attach">1</property>
+                        <property name="bottom_attach">2</property>
+                        <property name="x_options">GTK_FILL</property>
+                        <property name="y_options">GTK_FILL</property>
+                        <property name="x_padding">4</property>
+                        <property name="y_padding">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="other_overrides_label1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Other Overrides:&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="top_attach">2</property>
+                        <property name="bottom_attach">3</property>
+                        <property name="x_options">GTK_FILL</property>
+                        <property name="y_options">GTK_FILL</property>
+                        <property name="x_padding">4</property>
+                        <property name="y_padding">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="name_text">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap_mode">word-char</property>
+                        <property name="selectable">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="right_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="baseurl_text">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap_mode">word-char</property>
+                        <property name="selectable">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="right_attach">2</property>
+                        <property name="top_attach">1</property>
+                        <property name="bottom_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow1">
+                        <property name="height_request">120</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hscrollbar_policy">automatic</property>
+                        <property name="vscrollbar_policy">automatic</property>
                         <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow2">
+                          <object class="GtkTreeView" id="other_overrides_view">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="hscrollbar_policy">automatic</property>
-                            <property name="vscrollbar_policy">automatic</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkViewport" id="viewport2">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="resize_mode">queue</property>
-                                <property name="vadjustment">0 0 1 0.10000000000000001 0.90000000000000002 1</property>
-                                <property name="shadow_type">none</property>
-                                <child>
-                                  <object class="GtkTable" id="repo_data_table">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="n_rows">2</property>
-                                    <property name="n_columns">3</property>
-                                    <property name="column_spacing">3</property>
-                                    <child>
-                                      <object class="GtkLabel" id="name_label">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
-                                        <property name="label" translatable="yes">&lt;b&gt;Name:&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                        <property name="x_padding">4</property>
-                                        <property name="y_padding">4</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkTextView" id="name_text">
-                                        <property name="visible">True</property>
-                                        <property name="sensitive">False</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="pixels_above_lines">5</property>
-                                        <property name="editable">False</property>
-                                        <property name="left_margin">10</property>
-                                        <property name="cursor_visible">False</property>
-                                        <accessibility/>
-                                        <child internal-child="accessible">
-                                          <object class="AtkObject" id="a11y-name_text1">
-                                            <property name="AtkObject::accessible-name" translatable="yes">Subscription Text</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="base_url_label">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
-                                        <property name="label" translatable="yes">&lt;b&gt;Base URL:&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                        <property name="x_padding">4</property>
-                                        <property name="y_padding">4</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkTextView" id="baseurl_text">
-                                        <property name="visible">True</property>
-                                        <property name="sensitive">False</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="pixels_above_lines">5</property>
-                                        <property name="editable">False</property>
-                                        <property name="wrap_mode">none</property>
-                                        <property name="left_margin">10</property>
-                                        <property name="cursor_visible">False</property>
-                                        <accessibility/>
-                                        <child internal-child="accessible">
-                                          <object class="AtkObject" id="a11y-baseurl_text1">
-                                            <property name="AtkObject::accessible-name" translatable="yes">SKU Text</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="other_overrides_label">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
-                                        <property name="yalign">0</property>
-                                        <property name="label" translatable="yes">&lt;b&gt;Other Overrides:&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                        <property name="x_padding">4</property>
-                                        <property name="y_padding">4</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkTreeView" id="other_overrides_view">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="rules_hint">True</property>
-                                        <property name="enable_search">False</property>
-                                        <property name="search_column">0</property>
-                                        <property name="show_expanders">False</property>
-                                        <accessibility/>
-                                        <child internal-child="accessible">
-                                          <object class="AtkObject" id="a11y-other_overrides_view1">
-                                            <property name="AtkObject::accessible-name" translatable="yes">Other Overrides Table</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                </child>
+                            <property name="rules_hint">True</property>
+                            <property name="enable_search">False</property>
+                            <property name="search_column">0</property>
+                            <property name="show_expanders">False</property>
+                            <child internal-child="accessible">
+                              <object class="AtkObject" id="other_overrides_view-atkobject">
+                                <property name="AtkObject::accessible-name" translatable="yes">Other Overrides Table</property>
                               </object>
                             </child>
                           </object>
                         </child>
                       </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="right_attach">2</property>
+                        <property name="top_attach">2</property>
+                        <property name="bottom_attach">3</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
+                    <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
@@ -302,8 +212,8 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
@@ -313,12 +223,81 @@
             <property name="position">1</property>
           </packing>
         </child>
+        <child internal-child="action_area">
+          <object class="GtkHButtonBox" id="dialog-action_area1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="reset_button">
+                <property name="label" translatable="yes">Remove All Overrides</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="xalign">0.44999998807907104</property>
+                <child internal-child="accessible">
+                  <object class="AtkObject" id="reset_button-atkobject">
+                    <property name="AtkObject::accessible-name" translatable="yes">remove_all_overrides_button</property>
+                  </object>
+                </child>
+                <signal name="clicked" handler="on_reset_button_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack_type">end</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="apply_button">
+                <property name="label" translatable="yes">Apply</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <signal name="clicked" handler="on_apply_button_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="close_button">
+                <property name="label" translatable="yes">Close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <child internal-child="accessible">
+                  <object class="AtkObject" id="close_button-atkobject">
+                    <property name="AtkObject::accessible-name" translatable="yes">close_button</property>
+                  </object>
+                </child>
+                <signal name="clicked" handler="on_close_button_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack_type">end</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
       </object>
     </child>
-    <child internal-child="accessible">
-      <object class="AtkObject" id="a11y-main_window1">
-        <property name="AtkObject::accessible-name" translatable="yes">manage_repositories_dialog</property>
-      </object>
-    </child>
+    <action-widgets>
+      <action-widget response="0">close_button</action-widget>
+      <action-widget response="0">apply_button</action-widget>
+      <action-widget response="0">reset_button</action-widget>
+    </action-widgets>
   </object>
 </interface>

--- a/src/subscription_manager/gui/data/ui/repositories.ui
+++ b/src/subscription_manager/gui/data/ui/repositories.ui
@@ -1,45 +1,44 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.3 -->
 <interface>
-  <object class="GtkTextBuffer" id="textbuffer1">
-    <property name="text">Manage the repositories your subscriptions grant you access to by enabling, disabling and overriding certain fields.</property>
-  </object>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="main_window">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Manage Repositories</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
-    <property name="default_width">600</property>
-    <property name="default_height">400</property>
+    <property name="default_width">800</property>
+    <property name="default_height">600</property>
     <property name="destroy_with_parent">True</property>
     <property name="icon_name">subscription-manager</property>
     <property name="type_hint">dialog</property>
     <property name="deletable">False</property>
-    <signal handler="on_dialog_delete_event" name="delete_event"/>
+    <signal name="delete-event" handler="on_dialog_delete_event" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="main_container">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area1">
-            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="layout_style">edge</property>
+            <property name="valign">end</property>
+            <property name="margin_top">12</property>
+            <property name="hexpand">True</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="reset_button">
                 <property name="label" translatable="yes">Remove All Overrides</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="xalign">0.45</property>
-                <signal handler="on_reset_button_clicked" name="clicked"/>
+                <property name="xalign">0.44999998807907104</property>
+                <signal name="clicked" handler="on_reset_button_clicked" swapped="no"/>
                 <child internal-child="accessible">
-                  <object class="AtkObject" id="a11y-reset_button1">
+                  <object class="AtkObject" id="reset_button-atkobject">
                     <property name="AtkObject::accessible-name" translatable="yes">remove_all_overrides_button</property>
                   </object>
                 </child>
@@ -51,14 +50,35 @@
               </packing>
             </child>
             <child>
+              <object class="GtkButton" id="apply_button">
+                <property name="label" translatable="yes">Apply</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <signal name="clicked" handler="on_apply_button_clicked" swapped="no"/>
+                <child internal-child="accessible">
+                  <object class="AtkObject" id="apply_button-atkobject">
+                    <property name="AtkObject::accessible-name" translatable="yes">apply_button</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="padding">8</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="close_button">
                 <property name="label" translatable="yes">Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <signal handler="on_close_button_clicked" name="clicked"/>
+                <signal name="clicked" handler="on_close_button_clicked" swapped="no"/>
                 <child internal-child="accessible">
-                  <object class="AtkObject" id="a11y-close_button1">
+                  <object class="AtkObject" id="close_button-atkobject">
                     <property name="AtkObject::accessible-name" translatable="yes">close_button</property>
                   </object>
                 </child>
@@ -66,44 +86,50 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">1</property>
+                <property name="pack_type">end</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="fill">True</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="vbox1">
-            <property name="orientation">vertical</property>
+          <object class="GtkBox" id="main_content_container">
+            <property name="name">main_content_container</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="vexpand">True</property>
+            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkTextView" id="description_text">
+              <object class="GtkLabel" id="description_text">
                 <property name="visible">True</property>
-                <property name="sensitive">False</property>
-                <property name="can_focus">True</property>
-                <property name="editable">False</property>
-                <property name="wrap_mode">word</property>
-                <property name="buffer">textbuffer1</property>
+                <property name="can_focus">False</property>
+                <property name="margin_bottom">12</property>
+                <property name="label" translatable="yes">Manage the repositories your subscriptions grant you access to by enabling, disabling and overriding certain fields.</property>
+                <property name="wrap">True</property>
+                <property name="xalign">0</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="padding">6</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow">
+                <property name="height_request">-1</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -113,185 +139,153 @@
             </child>
             <child>
               <object class="GtkBox" id="details_vbox">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkLabel" id="label2">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="margin_top">6</property>
                     <property name="ypad">3</property>
                     <property name="label" translatable="yes">&lt;b&gt;Repository Details&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="ellipsize">start</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkFrame" id="frame1">
-                    <property name="height_request">96</property>
+                  <object class="GtkGrid" id="grid1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="valign">end</property>
+                    <property name="vexpand">False</property>
                     <child>
-                      <object class="GtkAlignment" id="alignment1">
+                      <object class="GtkLabel" id="name_label">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Name:&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="base_url_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Base URL:&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="other_overrides_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Other Overrides:&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow1">
+                        <property name="height_request">116</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="margin_left">6</property>
+                        <property name="margin_top">3</property>
+                        <property name="margin_bottom">3</property>
+                        <property name="shadow_type">in</property>
                         <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow2">
+                          <object class="GtkTreeView" id="other_overrides_view">
+                            <property name="height_request">80</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="hscrollbar_policy">automatic</property>
-                            <property name="vscrollbar_policy">automatic</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkViewport" id="viewport2">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="resize_mode">queue</property>
-                                <property name="vadjustment">0 0 1 0.10000000000000001 0.90000000000000002 1</property>
-                                <property name="shadow_type">none</property>
-                                <child>
-                                  <object class="GtkTable" id="repo_data_table">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="n_rows">2</property>
-                                    <property name="n_columns">3</property>
-                                    <property name="column_spacing">3</property>
-                                    <child>
-                                      <object class="GtkLabel" id="name_label">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
-                                        <property name="label" translatable="yes">&lt;b&gt;Name:&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                        <property name="x_padding">4</property>
-                                        <property name="y_padding">4</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkTextView" id="name_text">
-                                        <property name="visible">True</property>
-                                        <property name="sensitive">False</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="pixels_above_lines">5</property>
-                                        <property name="editable">False</property>
-                                        <property name="left_margin">10</property>
-                                        <property name="cursor_visible">False</property>
-                                        <child internal-child="accessible">
-                                          <object class="AtkObject" id="a11y-name_text1">
-                                            <property name="AtkObject::accessible-name" translatable="yes">Subscription Text</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="base_url_label">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
-                                        <property name="label" translatable="yes">&lt;b&gt;Base URL:&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                        <property name="x_padding">4</property>
-                                        <property name="y_padding">4</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkTextView" id="baseurl_text">
-                                        <property name="visible">True</property>
-                                        <property name="sensitive">False</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="pixels_above_lines">5</property>
-                                        <property name="editable">False</property>
-                                        <property name="wrap_mode">none</property>
-                                        <property name="left_margin">10</property>
-                                        <property name="cursor_visible">False</property>
-                                        <child internal-child="accessible">
-                                          <object class="AtkObject" id="a11y-baseurl_text1">
-                                            <property name="AtkObject::accessible-name" translatable="yes">SKU Text</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="other_overrides_label">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
-                                        <property name="yalign">0</property>
-                                        <property name="label" translatable="yes">&lt;b&gt;Other Overrides:&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                        <property name="x_padding">4</property>
-                                        <property name="y_padding">4</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkTreeView" id="other_overrides_view">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="rules_hint">True</property>
-                                        <property name="enable_search">False</property>
-                                        <property name="search_column">0</property>
-                                        <property name="show_expanders">False</property>
-                                        <child internal-child="accessible">
-                                          <object class="AtkObject" id="a11y-other_overrides_view1">
-                                            <property name="AtkObject::accessible-name" translatable="yes">Other Overrides Table</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                </child>
+                            <property name="margin_top">3</property>
+                            <property name="margin_bottom">3</property>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">False</property>
+                            <property name="rules_hint">True</property>
+                            <property name="enable_search">False</property>
+                            <property name="search_column">0</property>
+                            <property name="show_expanders">False</property>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection" id="treeview-selection"/>
+                            </child>
+                            <child internal-child="accessible">
+                              <object class="AtkObject" id="other_overrides_view-atkobject">
+                                <property name="AtkObject::accessible-name" translatable="yes">Other Overrides Table</property>
                               </object>
                             </child>
                           </object>
                         </child>
                       </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="name_text">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">6</property>
+                        <property name="margin_top">3</property>
+                        <property name="margin_bottom">3</property>
+                        <property name="hexpand">True</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap_mode">word-char</property>
+                        <property name="selectable">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="baseurl_text">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">6</property>
+                        <property name="margin_top">3</property>
+                        <property name="margin_bottom">3</property>
+                        <property name="hexpand">True</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap_mode">word-char</property>
+                        <property name="selectable">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
+                    <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
@@ -299,8 +293,8 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>
@@ -313,9 +307,12 @@
       </object>
     </child>
     <child internal-child="accessible">
-      <object class="AtkObject" id="a11y-main_window1">
+      <object class="AtkObject" id="main_window-atkobject">
         <property name="AtkObject::accessible-name" translatable="yes">manage_repositories_dialog</property>
       </object>
     </child>
+  </object>
+  <object class="GtkTextBuffer" id="textbuffer1">
+    <property name="text">Manage the repositories your subscriptions grant you access to by enabling, disabling and overriding certain fields.</property>
   </object>
 </interface>

--- a/src/subscription_manager/gui/progress.py
+++ b/src/subscription_manager/gui/progress.py
@@ -24,7 +24,7 @@ class Progress(widgets.SubmanBaseWidget):
     widget_names = ['progressWindow', 'progressLabel', 'progressBar', 'statusLabel']
     gui_file = "progress"
 
-    def __init__(self, title, label):
+    def __init__(self, title, label, support_markup=False):
         super(Progress, self).__init__()
 
         self.progressWindow.connect("delete-event", self._on_delete_event)
@@ -34,7 +34,7 @@ class Progress(widgets.SubmanBaseWidget):
         self.lastProgress = 0.0
 
         self.set_title(title)
-        self.set_label(label)
+        self.set_label(label, support_markup)
 
     def hide(self):
         self.progressWindow.hide()
@@ -43,8 +43,11 @@ class Progress(widgets.SubmanBaseWidget):
     def set_title(self, text):
         self.progressWindow.set_title(text)
 
-    def set_label(self, text):
-        self.progressLabel.set_text(text)
+    def set_label(self, text, markup=False):
+        if markup:
+            self.progressLabel.set_markup(text)
+        else:
+            self.progressLabel.set_text(text)
 
     def pulse(self):
         """

--- a/src/subscription_manager/gui/reposgui.py
+++ b/src/subscription_manager/gui/reposgui.py
@@ -17,12 +17,16 @@ import gettext
 import logging
 
 from subscription_manager.ga import Gtk as ga_Gtk
+from subscription_manager.ga import gtk_compat
+from subscription_manager.ga import GObject as ga_GObject
 from subscription_manager.ga import GdkPixbuf as ga_GdkPixbuf
 
 import rhsm.config
 from subscription_manager.gui.utils import handle_gui_exception
 from subscription_manager.gui import widgets
+from subscription_manager.gui import progress
 
+from subscription_manager.async import AsyncRepoOverridesUpdate
 from subscription_manager.injection import IDENTITY, ENT_DIR, require
 from subscription_manager.gui.storage import MappedListStore
 from subscription_manager.gui.widgets import TextTreeViewColumn, CheckBoxColumn,\
@@ -41,9 +45,10 @@ class RepositoriesDialog(widgets.SubmanBaseWidget, HasSortableWidget):
     """
     GTK dialog for managing repositories and their overrides.
     """
-    widget_names = ['main_window', 'reset_button', 'close_button',
+    widget_names = ['main_window', 'reset_button', 'close_button', 'apply_button',
                     'name_text', 'baseurl_text', 'scrolledwindow',
-                    'other_overrides_view']
+                    'other_overrides_view', 'details_vbox', 'main_content_container',
+                    'description_text']
     gui_file = "repositories"
 
     ENTS_PROVIDE_NO_REPOS = _("Attached subscriptions do not provide any repositories.")
@@ -52,6 +57,21 @@ class RepositoriesDialog(widgets.SubmanBaseWidget, HasSortableWidget):
 
     def __init__(self, backend, parent):
         super(RepositoriesDialog, self).__init__()
+
+        # Label wrapping on resize does not work very well on GTK2+
+        # so we resize on the fly.
+        if gtk_compat.GTK_COMPAT_VERSION == "2":
+            # Set the title to wrap and connect to size-allocate to
+            # properly resize the label so that it takes up the most
+            # space it can.
+            self.description_text.set_line_wrap(True)
+            self.description_text.connect('size-allocate', lambda label, size: label.set_size_request(size.width - 1, -1))
+
+            self.name_text.set_line_wrap(True)
+            self.name_text.connect('size-allocate', lambda label, size: label.set_size_request(size.width - 1, -1))
+
+            self.baseurl_text.set_line_wrap(True)
+            self.baseurl_text.connect('size-allocate', lambda label, size: label.set_size_request(size.width - 1, -1))
 
         # Set up dynamic elements
         self.overrides_treeview = ga_Gtk.TreeView()
@@ -67,11 +87,13 @@ class RepositoriesDialog(widgets.SubmanBaseWidget, HasSortableWidget):
         # FIXME: We really shouldn't have to worry about our connection info
         #        changing out from under us.
         self.backend = backend
+        self.async_update = AsyncRepoOverridesUpdate(self.backend.overrides)
         self.identity = require(IDENTITY)
         self.ent_dir = require(ENT_DIR)
 
         self.connect_signals({"on_dialog_delete_event": self._on_close,
                               "on_close_button_clicked": self._on_close,
+                              "on_apply_button_clicked": self._on_apply_request,
                               "on_reset_button_clicked": self._on_reset_repo})
 
         self.overrides_store = MappedListStore({
@@ -127,6 +149,11 @@ class RepositoriesDialog(widgets.SubmanBaseWidget, HasSortableWidget):
         self.overrides_treeview.get_selection().connect('changed', self._on_selection)
         self.overrides_treeview.set_rules_hint(True)
 
+        # Progress bar
+        self.pb = None
+        self.timer = 0
+
+        self.parent = parent
         self.main_window.set_transient_for(parent)
 
     def hide(self):
@@ -134,16 +161,25 @@ class RepositoriesDialog(widgets.SubmanBaseWidget, HasSortableWidget):
 
     def show(self):
         self._load_data()
-        self.main_window.present()
 
     def _load_data(self):
-        # pull the latest overrides from the cache which will be the ones from the server.
-        current_overrides = self.backend.overrides.get_overrides(self.identity.uuid) or []
-        self._refresh(current_overrides)
-        # By default sort by repo_id
-        self.overrides_store.set_sort_column_id(0, ga_Gtk.SortType.ASCENDING)
+        self._show_progress_bar(_("Loading Repository Data"), _("Retrieving repository data from server."), self.parent)
+        self.async_update.load_data(self._on_async_load_data_success, self._on_async_load_data_failure)
 
-    def _refresh(self, current_overrides, repo_id_to_select=None):
+    def _on_async_load_data_success(self, current_overrides, current_repos):
+        self.overrides_store.set_sort_column_id(0, ga_Gtk.SortType.ASCENDING)
+        self._refresh(current_overrides, current_repos)
+        self._clear_progress_bar()
+        self.main_window.present()
+        # By default sort by repo_id
+
+    def _on_async_load_data_failure(self, e):
+        self._clear_progress_bar()
+        handle_gui_exception(e, _("Unable to load repository data."),
+                     self._get_dialog_widget())
+
+    def _refresh(self, current_overrides, current_repos, repo_id_to_select=None):
+        # Current overrides from server
         overrides_per_repo = {}
 
         for override in current_overrides:
@@ -151,12 +187,17 @@ class RepositoriesDialog(widgets.SubmanBaseWidget, HasSortableWidget):
             overrides_per_repo.setdefault(repo_id, {})
             overrides_per_repo[repo_id][override.name] = override.value
 
+        self.apply_button.set_sensitive(False)
+
         self.overrides_store.clear()
         self.other_overrides.clear()
+        self.main_content_container.remove(self.details_vbox)
 
-        current_repos = self.backend.overrides.repo_lib.get_repos(apply_overrides=False)
+        # Switch the dialog view depending on content availability
         if (current_repos):
             self.widget_switcher.set_active(1)
+            self.main_content_container.add(self.details_vbox)
+            #self.details_vbox.set_visible(True)
         else:
             ent_count = len(self.ent_dir.list_valid())
             no_repos_message = self.ENTS_PROVIDE_NO_REPOS
@@ -168,29 +209,16 @@ class RepositoriesDialog(widgets.SubmanBaseWidget, HasSortableWidget):
                 no_repos_message = self.REPOS_DISABLED_BY_CFG
 
             self.no_repos_label.set_markup("<b>%s</b>" % no_repos_message)
+
+#            self.details_vbox.set_visible(False)
             self.widget_switcher.set_active(0)
 
-        # Fetch the repositories from repolib without any overrides applied.
-        # We do this so that we can tell if anything has been modified by
-        # overrides.
+        self.main_content_container.show_all()
+
+        # Update the table model from our gathered override/repo data
         for repo in current_repos:
             overrides = overrides_per_repo.get(repo.id, None)
-            modified = not overrides is None
-            enabled = self._get_boolean(self._get_model_value(repo, overrides, 'enabled')[0])
-            gpgcheck, gpgcheck_modified = self._get_model_value(repo, overrides, 'gpgcheck')
-            gpgcheck = self._get_boolean(gpgcheck)
-            self.overrides_store.add_map({
-                'enabled': bool(int(enabled)),
-                'repo_id': repo.id,
-                'modified': modified,
-                'modified-icon': self._get_modified_icon(modified),
-                'name': repo['name'],
-                'baseurl': repo['baseurl'],
-                'gpgcheck': gpgcheck,
-                'gpgcheck_modified': gpgcheck_modified,
-                'repo_data': repo,
-                'override_data': overrides
-            })
+            self.overrides_store.add_map(self._build_table_row_data(repo, overrides))
 
         first_row_iter = self.overrides_store.get_iter_first()
         if not first_row_iter:
@@ -200,6 +228,37 @@ class RepositoriesDialog(widgets.SubmanBaseWidget, HasSortableWidget):
         else:
             self.overrides_treeview.get_selection().select_iter(first_row_iter)
 
+    def _build_table_row_data(self, repo_data, repo_overrides):
+        modified = not repo_overrides is None
+        enabled = self._get_boolean(self._get_model_value(repo_data, repo_overrides, 'enabled')[0])
+        gpgcheck, gpgcheck_modified = self._get_model_value(repo_data, repo_overrides, 'gpgcheck')
+        gpgcheck = self._get_boolean(gpgcheck)
+
+        return {
+            'enabled': bool(int(enabled)),
+            'repo_id': repo_data.id,
+            'modified': modified,
+            'modified-icon': self._get_modified_icon(modified),
+            'name': repo_data['name'],
+            'baseurl': repo_data['baseurl'],
+            'gpgcheck': gpgcheck,
+            'gpgcheck_modified': gpgcheck_modified,
+            'repo_data': repo_data,
+            'override_data': repo_overrides
+        }
+
+    def _show_progress_bar(self, title, label, progress_parent=None):
+        self.pb = progress.Progress(title, label, True)
+        self.timer = ga_GObject.timeout_add(100, self.pb.pulse)
+        self.pb.set_parent_window(progress_parent or self._get_dialog_widget())
+
+    def _clear_progress_bar(self):
+        if self.pb:
+            self.pb.hide()
+            ga_GObject.source_remove(self.timer)
+            self.timer = 0
+            self.pb = None
+
     def _get_modified_icon(self, modified):
         icon = None
         if modified:
@@ -208,8 +267,7 @@ class RepositoriesDialog(widgets.SubmanBaseWidget, HasSortableWidget):
 
     def _get_selected_repo_id(self):
         selected = None
-        override_selection = SelectionWrapper(self.overrides_treeview.get_selection(),
-                                              self.overrides_store)
+        override_selection = SelectionWrapper(self.overrides_treeview.get_selection(), self.overrides_store)
         if override_selection.is_valid():
             selected = override_selection['repo_id']
         return selected
@@ -269,75 +327,173 @@ class RepositoriesDialog(widgets.SubmanBaseWidget, HasSortableWidget):
 
         repo_id = selection['repo_id']
 
-        try:
-            self._delete_all_overrides(repo_id)
-        except Exception, e:
-            handle_gui_exception(e, _("Unable to reset repository overrides."),
-                                 self._get_dialog_widget())
+        self._show_progress_bar(_("Removing Repository Overrides"), _("Removing all overrides for repository <b>%s</b>") % repo_id)
+        self.async_update.remove_all_overrides([repo_id], self._on_async_delete_all_overrides_success,
+                                          self._on_async_delete_all_overrides_failure)
+
+    def _on_async_delete_all_overrides_success(self, current_overrides, current_repos):
+        selection = SelectionWrapper(self.overrides_treeview.get_selection(),
+                                     self.overrides_store)
+
+        repo_id = selection['repo_id']
+        repo_data = None
+        for repo in current_repos:
+            if repo_id == repo.id:
+                repo_data = repo
+                break
+
+        if repo_data:
+            override_data = None
+            for override in current_overrides:
+                if repo_id == override.repo_id:
+                    override_data = override
+                    break
+
+            row_data = self._build_table_row_data(repo_data, override_data)
+            self.overrides_store.update_map(selection.tree_iter, row_data)
+
+        # Update the UI based on the current selection as no selection change is
+        # triggered, but data may enable/disable different widgets based on data
+        # change.
+        self._on_selection(self.overrides_treeview.get_selection())
+
+        self._clear_progress_bar()
+
+    def _on_async_delete_all_overrides_failure(self, e):
+        self._clear_progress_bar()
+        handle_gui_exception(e, _("Unable to reset repository overrides."),
+                     self._get_dialog_widget())
 
     def _on_selection(self, tree_selection):
         selection = SelectionWrapper(tree_selection, self.overrides_store)
 
         self.other_overrides.clear()
-        self.reset_button.set_sensitive(selection.is_valid() and selection['modified'])
+        reset_enabled = False
         if selection.is_valid():
-            self.name_text.get_buffer().set_text(selection['name'])
-            self.baseurl_text.get_buffer().set_text(selection['baseurl'])
+            overrides = selection['override_data']
+            reset_enabled = overrides is not None and len(overrides) > 0
+
+            self.name_text.set_text(selection['name'])
+            self.baseurl_text.set_text(selection['baseurl'])
 
             for key, value in (selection['override_data'] or {}).items():
                 if key not in ['gpgcheck', 'enabled']:
                     self.other_overrides.add_override(key, value)
 
+        self.reset_button.set_sensitive(reset_enabled)
+
+    def _get_changed_overrides(self):
+        override_mapping = {
+            'to_add': [],
+            'to_remove': []
+        }
+
+        # Process each row in the model and build up a mapping of overrides.
+        self.overrides_store.foreach(self._get_overrides_for_row, override_mapping)
+        return override_mapping
+
+    def _on_apply_request(self, button, event=None):
+        override_mapping = self._get_changed_overrides()
+        self._apply_override_changes(override_mapping, self._on_update_success)
+
+    def _apply_override_changes(self, override_mapping, success_handler):
+        self._show_progress_bar(_("Updating Repository Overrides"), _("Applying override changes to repositories."))
+        self.async_update.update_overrides(override_mapping['to_add'], override_mapping['to_remove'],
+                                      success_handler, self._on_update_failure)
+
+    def _on_update_success(self, current_overrides, current_repos):
+        self._refresh(current_overrides, current_repos, self._get_selected_repo_id())
+        self._clear_progress_bar()
+
+    def _on_update_failure(self, e):
+        handle_gui_exception(e, _("Unable to update overrides."), self._get_dialog_widget())
+
     def _on_close(self, button, event=None):
+        override_mapping = self._get_changed_overrides()
+        if (len(override_mapping["to_add"]) == 0 and len(override_mapping["to_remove"]) == 0):
+            self.close_dialog()
+            return True
+
+        # There are changes pending, check if the user would like to save changes.
+        confirm = YesNoDialog(_("Repositories have changes. Save changes?"),
+                                 self._get_dialog_widget(), _("Save Changes"))
+        confirm.connect("response", self._on_apply_changes_on_close_response, override_mapping)
+
+    def _on_apply_changes_on_close_response(self, dialog, response, override_mapping):
+        if not response:
+            self.close_dialog()
+            return
+        self._apply_override_changes(override_mapping, self._on_async_close_request)
+
+    def _on_async_close_request(self, current_overrides, current_repos):
+        self.close_dialog()
+
+    def close_dialog(self):
+        self._clear_progress_bar()
         self.hide()
-        return True
+
+    def _get_overrides_for_row(self, model, path, iter, override_mapping):
+        self._update_override_mapping("gpgcheck", model, path, iter, override_mapping)
+        self._update_override_mapping("enabled", model, path, iter, override_mapping)
+
+    def _update_override_mapping(self, attribute, model, path, iter, override_mapping):
+        '''
+        Process a single model row and determine if an override should be added/removed.
+        '''
+        repo = model.get_value(iter, model['repo_data'])
+        remote_overrides = model.get_value(iter, model['override_data'])
+
+        repo_attribute_value = self._get_boolean(repo[attribute])
+        model_attribute_value = self._get_boolean(model.get_value(iter, model[attribute]))
+        has_remote_override = remote_overrides and attribute in remote_overrides
+
+        if not has_remote_override and model_attribute_value != repo_attribute_value:
+            override_mapping["to_add"].append(Override(repo.id, attribute, str(int(model_attribute_value))))
+        elif has_remote_override and model_attribute_value == repo_attribute_value:
+            override_mapping["to_remove"].append(Override(repo.id, attribute))
 
     def _on_toggle_changed(self, override_model_iter, enabled, key):
+        '''
+        Update the gui based on check box change.
+        '''
         repo = self.overrides_store.get_value(override_model_iter,
                                               self.overrides_store['repo_data'])
         overrides = self.overrides_store.get_value(override_model_iter,
                                               self.overrides_store['override_data'])
 
-        value = repo[key]
-        has_active_override = overrides and key in overrides
+        current_gpg_check = self._get_boolean(self.overrides_store.get_value(override_model_iter,
+                                                                             self.overrides_store['gpgcheck']))
+        repo_gpg_check = self._get_boolean(repo['gpgcheck'])
 
-        try:
-            if not has_active_override and enabled != int(value):
-                # We get True/False from the model, convert to int so that
-                # the override gets the correct value.
-                self._add_override(repo.id, key, int(enabled))
+        current_enabled = self._get_boolean(self.overrides_store.get_value(override_model_iter,
+                                                                           self.overrides_store['enabled']))
+        repo_enabled = self._get_boolean(repo['enabled'])
 
-            elif has_active_override and overrides[key] != value:
-                self._delete_override(repo.id, key)
-            else:
-                # Should only ever be one path here, else we have a UI logic error.
-                self._add_override(repo.id, key, int(enabled))
-        except Exception, e:
-            handle_gui_exception(e, _("Unable to update %s override.") % key,
-                                 self._get_dialog_widget())
+        has_extra = self._has_extra_overrides(overrides)
+
+        mark_modified = has_extra or repo_gpg_check != current_gpg_check or repo_enabled != current_enabled
+        enable_reset = overrides is not None and len(overrides) > 0
+
+        self.reset_button.set_sensitive(enable_reset)
+        self.overrides_store.set_value(override_model_iter, self.overrides_store['modified'], mark_modified)
+        self.overrides_store.set_value(override_model_iter, self.overrides_store['modified-icon'],
+                                       self._get_modified_icon(mark_modified))
+
+        changed = self._get_changed_overrides()
+        activate_apply_button = len(changed["to_add"]) != 0 or len(changed["to_remove"]) != 0
+        self.apply_button.set_sensitive(activate_apply_button)
+
+    def _has_extra_overrides(self, override_data):
+        for key, value in (override_data or {}).items():
+            if key not in ['gpgcheck', 'enabled']:
+                return True
+        return False
 
     def _on_enable_repo_toggle(self, override_model_iter, enabled):
         return self._on_toggle_changed(override_model_iter, enabled, 'enabled')
 
     def _on_gpgcheck_toggle_changed(self, override_model_iter, enabled):
         return self._on_toggle_changed(override_model_iter, enabled, 'gpgcheck')
-
-    def _add_override(self, repo, name, value):
-        to_add = Override(repo, name, value)
-        current_overrides = self.backend.overrides.add_overrides(self.identity.uuid, [to_add])
-        self.backend.overrides.update(current_overrides)
-        self._refresh(current_overrides, self._get_selected_repo_id())
-
-    def _delete_override(self, repo, name):
-        to_delete = Override(repo, name)
-        current_overrides = self.backend.overrides.remove_overrides(self.identity.uuid, [to_delete])
-        self.backend.overrides.update(current_overrides)
-        self._refresh(current_overrides, self._get_selected_repo_id())
-
-    def _delete_all_overrides(self, repo_id):
-        current_overrides = self.backend.overrides.remove_all_overrides(self.identity.uuid, [repo_id])
-        self.backend.overrides.update(current_overrides)
-        self._refresh(current_overrides, self._get_selected_repo_id())
 
     def _get_dialog_widget(self):
         return self.main_window

--- a/src/subscription_manager/gui/storage.py
+++ b/src/subscription_manager/gui/storage.py
@@ -80,6 +80,10 @@ class MappedListStore(MappedStore, ga_Gtk.ListStore):
         """
         self.append(self._create_initial_entry(item_map))
 
+    def update_map(self, iter, item_map):
+        for key, value in item_map.iteritems():
+            self.set_value(iter, self[key], value)
+
 
 class MappedTreeStore(MappedStore, ga_Gtk.TreeStore):
     def __init__(self, type_map):


### PR DESCRIPTION
Instead of immediately sending repo override changes to
the server on each checkbox click, queue them up and send
them when the 'Apply' button is clicked.

All communication with the server while saving/loading
data, is done async, and the user will be presented with
a progess window until the request completes.

Closing the dialog will detect if there were any local
changes made, and prompt the user to save changes before
closing.

The Remove All Overrides button will only be enabled if
there are currently overrides on the server for the
selected repository.

This commit also addresses varions layout/display issues
for GTK3.

**Testing Notes**
This change affects the dialog in both RHEL6 and RHEL7. When testing, please check both.