### PR TITLE
1245557: Fix release and service level preferences

### DIFF
--- a/src/subscription_manager/gui/preferences.py
+++ b/src/subscription_manager/gui/preferences.py
@@ -63,6 +63,13 @@ class PreferencesDialog(widgets.SubmanBaseWidget):
         self.release_combobox.set_model(self.release_model)
         self.sla_combobox.set_model(self.sla_model)
 
+        cell_renderer = ga_Gtk.CellRendererText()
+        self.release_combobox.pack_start(cell_renderer, True)
+        self.release_combobox.add_attribute(cell_renderer, "text", 0)
+
+        self.sla_combobox.pack_start(cell_renderer, True)
+        self.sla_combobox.add_attribute(cell_renderer, "text", 0)
+
         self.close_button.connect("clicked", self._close_button_clicked)
         self.sla_combobox.connect("changed", self._sla_changed)
         self.release_combobox.connect("changed", self._release_changed)


### PR DESCRIPTION
The combobox widgets for release version and service level
in the preferences dialog were showing up empty. They were
missing a CellRendererText() added to the entries, and were
not being rendered.