### PR TITLE
1248664: Fix GtkAdjustment related warnings

### DIFF
--- a/src/subscription_manager/gui/data/ui/installed.ui
+++ b/src/subscription_manager/gui/data/ui/installed.ui
@@ -2,6 +2,23 @@
 <interface>
   <!-- interface-requires gtk+ 2.10 -->
   <!-- interface-naming-policy project-wide -->
+
+  <object class="GtkAdjustment" id="scrolled_window_3_h_adjustment">
+    <property name="upper">0</property>
+    <property name="lower">0</property>
+    <property name="value">0</property>
+    <property name="step_increment">0</property>
+    <property name="page_increment">0</property>
+    <property name="page_size">0</property>
+  </object>
+  <object class="GtkAdjustment" id="scrolled_window_3_v_adjustment">
+    <property name="upper">0</property>
+    <property name="lower">0</property>
+    <property name="value">0</property>
+    <property name="step_increment">0</property>
+    <property name="page_increment">0</property>
+    <property name="page_size">0</property>
+  </object>
   <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
     <property name="icon_name">subscription-manager</property>
@@ -191,8 +208,8 @@
                               <object class="GtkScrolledWindow" id="scrolledwindow3">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="hadjustment">0 0 396 39.600000000000001 356.40000000000003 396</property>
-                                <property name="vadjustment">37 0 116 7.9000000000000004 71.100000000000009 79</property>
+                                <property name="hadjustment">scrolled_window_3_h_adjustment</property>
+                                <property name="vadjustment">scrolled_window_3_v_adjustment</property>
                                 <property name="hscrollbar_policy">automatic</property>
                                 <property name="vscrollbar_policy">automatic</property>
                                 <property name="shadow_type">in</property>

--- a/src/subscription_manager/gui/data/ui/subdetails.ui
+++ b/src/subscription_manager/gui/data/ui/subdetails.ui
@@ -2,6 +2,14 @@
 <interface>
   <!-- interface-requires gtk+ 2.10 -->
   <!-- interface-naming-policy project-wide -->
+  <object class="GtkAdjustment" id="viewport_2_v_adjustment">
+    <property name="upper">0</property>
+    <property name="lower">0</property>
+    <property name="value">0</property>
+    <property name="step_increment">0</property>
+    <property name="page_increment">0</property>
+    <property name="page_size">0</property>
+  </object>
   <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
     <property name="icon_name">subscription-manager</property>
@@ -47,7 +55,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="resize_mode">queue</property>
-                        <property name="vadjustment">0 0 206 20.600000000000001 185.40000000000001 206</property>
+                        <property name="vadjustment">viewport_2_v_adjustment</property>
                         <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkTable" id="table2">


### PR DESCRIPTION
Old gtk/glade used a string value for hadjustment/vadjustment attributes
for widgets, but newer versions want a GtkAdjustment object name
instead, so update these ui definations to do that.

This eliminates warnings like:
(subscription-manager-gui:28289): Gtk-WARNING **: No object called: 0 0
396 39.600000000000001 356.40000000000003 396