### PR TITLE
1248821: All subs date picker was failing.

### DIFF
--- a/src/subscription_manager/ga_impls/ga_gtk2/Gtk.py
+++ b/src/subscription_manager/ga_impls/ga_gtk2/Gtk.py
@@ -11,6 +11,7 @@ from gtk import FileChooserDialog, FileFilter, Frame, HBox, HButtonBox, Image
 from gtk import Label, ListStore, MessageDialog, RadioButton, SpinButton
 from gtk import TextBuffer
 from gtk import TreeStore, TreeView, TreeViewColumn, VBox, Viewport
+from gtk import Window
 
 # enums
 from gtk import BUTTONBOX_END
@@ -126,7 +127,7 @@ widgets = [AboutDialog, Adjustment, Builder, Button, Calendar, CellRendererPixbu
            Entry, FileChooserDialog, FileFilter, Frame, HBox,
            HButtonBox, Image, Label, ListStore, MessageDialog,
            RadioButton, SpinButton, TextBuffer, TreeStore, TreeView, TreeViewColumn,
-           VBox, Viewport]
+           VBox, Viewport, Window]
 
 methods = [check_version, main, main_quit]
 

--- a/src/subscription_manager/gui/widgets.py
+++ b/src/subscription_manager/gui/widgets.py
@@ -727,8 +727,6 @@ class DatePicker(ga_Gtk.HBox):
         self._calendar_window.set_type_hint(ga_Gdk.WindowTypeHint.DIALOG)
         self._calendar_window.set_modal(True)
         self._calendar_window.set_title(_("Date Selection"))
-        self._calendar_window.set_transient_for(
-                self.get_parent())
 
         self._calendar.select_month(self._date.month - 1, self._date.year)
         self._calendar.select_day(self._date.day)


### PR DESCRIPTION
DatePicker is a subclass of HBox, so self.get_parent()
doesn't make sense, so clicking on the date picker would
throw an error:

TypeError: argument parent: Expected Gtk.Window, but got
gi.overrides.Gtk.Box