### PR TITLE
1248729: All subs filter dialog was not focused.

### DIFF
--- a/src/subscription_manager/gui/data/ui/filters.ui
+++ b/src/subscription_manager/gui/data/ui/filters.ui
@@ -5,7 +5,7 @@
   <object class="GtkWindow" id="filter_product_window">
     <property name="title" translatable="yes">Filter Options</property>
     <property name="icon-name">subscription-manager</property>
-    <property name="type_hint">menu</property>
+    <property name="type_hint">dialog</property>
     <signal handler="on_filter_product_window_delete_event" name="delete_event"/>
     <child>
       <object class="GtkAlignment" id="alignment1">


### PR DESCRIPTION
The window type hint for the filter dialog was previously
'menu', which causes the window to appear undecorated
and unfocussed. This changes it to 'dialog' to correct
that.