### PR TITLE
Remove use of Widget.is_toplevel()

### DIFF
--- a/src/subscription_manager/gui/allsubs.py
+++ b/src/subscription_manager/gui/allsubs.py
@@ -363,9 +363,7 @@ class AllSubscriptionsTab(widgets.SubscriptionManagerTab):
                 # show pulsating progress bar while we wait for results
                 self.pb = progress.Progress(pb_title, pb_label)
                 self.timer = ga_GObject.timeout_add(100, self.pb.pulse)
-                tl = self.content.get_toplevel()
-                if tl.is_toplevel():
-                    self.pb.set_parent_window(tl)
+                self.pb.set_transient_for(self.parent_win)
 
             # fire off async refresh
             async_stash = async.AsyncPool(self.pool_stash)
@@ -410,11 +408,7 @@ class AllSubscriptionsTab(widgets.SubscriptionManagerTab):
         self.pb = progress.Progress(_("Attaching"),
                 _("Attaching subscription. Please wait."))
         self.timer = ga_GObject.timeout_add(100, self.pb.pulse)
-        content_toplevel = self.content.get_toplevel()
-        # get_toplevel() can return a GtkWindow that is within another
-        # GtkWindow. See the get_toplevel() gtk docs
-        if content_toplevel.is_toplevel():
-            self.pb.set_parent_window(content_toplevel)
+        self.pb.set_transient_for(self.parent_win)
         # Spin off a thread to handle binding the selected pool.
         # After it has completed the actual bind call, available
         # subs will be refreshed, but we won't re-run compliance
@@ -451,10 +445,7 @@ class AllSubscriptionsTab(widgets.SubscriptionManagerTab):
         self.contract_selection = ContractSelectionWindow(
                 self._contract_selected, self._contract_selection_cancelled)
 
-        content_toplevel = self.content.get_toplevel()
-        self.log.debug("content_toplevel %s", content_toplevel)
-        if content_toplevel.is_toplevel():
-            self.contract_selection.set_parent_window(content_toplevel)
+        self.contract_selection.set_parent_window(self.parent_win)
         #self.log.debug("user_data %s", pw.get_user_data())
         merged_pools.sort_virt_to_top()
 

--- a/src/subscription_manager/gui/contract_selection.py
+++ b/src/subscription_manager/gui/contract_selection.py
@@ -168,14 +168,6 @@ class ContractSelectionWindow(widgets.SubmanBaseWidget):
             'quantity_increment': quantity_increment,
             })
 
-    def toplevel(self):
-        tl = self.get_toplevel()
-        if tl.is_toplevel():
-            return tl
-        else:
-            self.log.debug("no toplevel window?")
-            return None
-
     def set_parent_window(self, window):
         self.log.debug('window %s', window)
         self.contract_selection_window.set_transient_for(window)

--- a/src/subscription_manager/gui/mysubstab.py
+++ b/src/subscription_manager/gui/mysubstab.py
@@ -146,9 +146,7 @@ class MySubscriptionsTab(widgets.SubscriptionManagerTab):
             self.pb = progress.Progress(_("Removing"),
                     _("Removing subscription. Please wait."))
             self.timer = ga_GObject.timeout_add(100, self.pb.pulse)
-            content_toplevel = self.content.get_toplevel()
-            if content_toplevel.is_toplevel():
-                self.pb.set_parent_window(content_toplevel)
+            self.pb.set_transient_for(self.parent_win)
             self.async_bind.unbind(serial, selection, self._unsubscribe_callback, self._handle_unbind_exception)
         else:
             # unregistered, just delete the certs directly

--- a/src/subscription_manager/gui/networkConfig.py
+++ b/src/subscription_manager/gui/networkConfig.py
@@ -279,7 +279,7 @@ class NetworkConfigDialog(widgets.SubmanBaseWidget):
         else:
             self.progress_bar = progress.Progress(_("Testing Connection"), _("Please wait"))
             self.timer = ga_GObject.timeout_add(100, self.progress_bar.pulse)
-            self.progress_bar.set_parent_window(self.networkConfigDialog)
+            self.progress_bar.set_transient_for(self.networkConfigDialog)
 
     def _clear_progress_bar(self):
         if not self.progress_bar:  # progress bar could be none iff self.test_connection is called directly

--- a/src/subscription_manager/gui/progress.py
+++ b/src/subscription_manager/gui/progress.py
@@ -75,7 +75,7 @@ class Progress(widgets.SubmanBaseWidget):
     def set_status_label(self, text):
         self.statusLabel.set_text(text)
 
-    def set_parent_window(self, window):
+    def set_transient_for(self, window):
         self.progressWindow.set_transient_for(window)
 
     def _on_delete_event(self, widget, event):

--- a/src/subscription_manager/gui/reposgui.py
+++ b/src/subscription_manager/gui/reposgui.py
@@ -250,7 +250,7 @@ class RepositoriesDialog(widgets.SubmanBaseWidget, HasSortableWidget):
     def _show_progress_bar(self, title, label, progress_parent=None):
         self.pb = progress.Progress(title, label, True)
         self.timer = ga_GObject.timeout_add(100, self.pb.pulse)
-        self.pb.set_parent_window(progress_parent or self._get_dialog_widget())
+        self.pb.set_transient_for(progress_parent or self._get_dialog_widget())
 
     def _clear_progress_bar(self):
         if self.pb:


### PR DESCRIPTION
Gtk.Widget.is_toplevel() is only available for
gtk 2.22 and higher, so RHEL6 versions with older
gtk would throw an attribute error on is_toplevel().

Remove use of is_toplevel(), since the places it
was used also have a reference to the parent window
so we use that instead.