### PR TITLE
1246429: Stop spinbutton from blocking quantity

### DIFF
--- a/src/subscription_manager/gui/widgets.py
+++ b/src/subscription_manager/gui/widgets.py
@@ -875,7 +875,11 @@ class QuantitySelectionColumn(ga_Gtk.TreeViewColumn):
                                                       self.quantity_renderer,
                                                       text=self.quantity_store_idx)
         self.set_cell_data_func(self.quantity_renderer, self._update_cell_based_on_data)
+        self.set_sizing(1)
         self.set_expand(True)
+        self.set_min_width(1)
+        self.set_max_width(10)
+
 
     def _setup_editor(self, cellrenderer, editable, path):
         # Only allow numeric characters.

--- a/src/subscription_manager/gui/widgets.py
+++ b/src/subscription_manager/gui/widgets.py
@@ -875,6 +875,7 @@ class QuantitySelectionColumn(ga_Gtk.TreeViewColumn):
                                                       self.quantity_renderer,
                                                       text=self.quantity_store_idx)
         self.set_cell_data_func(self.quantity_renderer, self._update_cell_based_on_data)
+        self.set_expand(True)
 
     def _setup_editor(self, cellrenderer, editable, path):
         # Only allow numeric characters.


### PR DESCRIPTION
The quantity column in the contract selection dialog
uses a spin button cell renderer to adjust quantity.
Gtk3 versions expand horizontal instead of vertical,
causing the column contents to be hidden by the
spin button.

Set the column to allow the widget to expand so the
spinbutton doesn't hide it.