### PR TITLE
1221273: Auto-attach failure should not short-circuit other parts of …

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1118,8 +1118,11 @@ class RegisterCommand(UserPassCommand):
             if 'serviceLevel' not in consumer and self.options.service_level:
                 system_exit(os.EX_UNAVAILABLE, _("Error: The --servicelevel option is not supported "
                                  "by the server. Did not complete your request."))
-            autosubscribe(self.cp, consumer['uuid'],
-                    service_level=self.options.service_level)
+            try:
+                autosubscribe(self.cp, consumer['uuid'],
+                        service_level=self.options.service_level)
+            except connection.RestlibException, re:
+                print(re.msg)
 
         if (self.options.consumerid or self.options.activation_keys or self.autoattach):
             log.info("System registered, updating entitlements if needed")


### PR DESCRIPTION
…registration

The registration occurs and is successful regardless of auto-bind. If the serverurl is
set as per the bug, then the received identity cert is from a system that is no longer
reflected in the system configuration.