### PR TITLE
1240553: Fix detection of cert dir changes

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -268,6 +268,7 @@ class MainWindow(widgets.SubmanBaseWidget):
 
     def _on_cert_check_timer(self):
         self.backend.on_cert_check_timer()
+        return True
 
     def _on_sla_back_button_press(self):
         self._perform_unregister()


### PR DESCRIPTION
The timeout that called the file monitor objects was
not returning True, so it would run once, and then be
removed from the event loop sources. Now it returns
True forever.

This fixes issues where changes to certificate directories
(/etc/pki/entitlement/ for ex) were not being noticed by the
gui. This included changes by running the cli command at the
same time, or using the "Import cert" dialog to import an
entitlement certificate.