### PR TITLE
1253275: Fix initial-setup ks mode

### DIFF
--- a/src/initial-setup/com_redhat_subscription_manager/ks/rhsm_ks.py
+++ b/src/initial-setup/com_redhat_subscription_manager/ks/rhsm_ks.py
@@ -34,9 +34,11 @@ __all__ = ["RHSMAddonData"]
 class RHSMAddonData(AddonData):
     log = logging.getLogger(__name__)
 
-    def setup(self, storage, ksdata, instclass):
-        super(RHSMAddonData, self).__init__(storage, ksdata, instclass)
+    def setup(self, storage, ksdata, instClass):
+        super(RHSMAddonData, self).setup(storage, ksdata, instClass)
 
         self.log.debug("storage %s", storage)
         self.log.debug("ksdata %s", ksdata)
-        self.log.debug("instclass %s", instclass)
+        self.log.debug("instClass %s", instClass)
+
+    # NOTE: no execute() or handle_line() yet


### PR DESCRIPTION
This module doesn't really do anything yet, but at least now
it does nothing correctly. Previous the setup() method
of RHSMAddonData was calling super().__init__ mistakenly,
but also the method signature changed when initial-setup was
rebased.