### PR TITLE
1185958: Remove ostree plugins req on ostree

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -123,8 +123,6 @@ platform.
 Summary: A plugin for handling OSTree content.
 Group: System Environment/Base
 
-# ostree package also includes the gobject info for pygobject
-Requires: ostree
 Requires: pygobject3-base
 # plugin needs a slightly newer version of python-iniparse for 'tidy'
 Requires:  python-iniparse >= 0.4


### PR DESCRIPTION
ostree isn't provided in RHEL7, so the dep can't be
resolved, and it's a base dep on atomic. This allows
for testing/dev on non-atomic RHEL7.