### PR TITLE
1246429: Stop spinbutton from blocking quantity

### DIFF
--- a/src/subscription_manager/gui/widgets.py
+++ b/src/subscription_manager/gui/widgets.py
@@ -876,6 +876,9 @@ class QuantitySelectionColumn(ga_Gtk.TreeViewColumn):
                                                       text=self.quantity_store_idx)
         self.set_cell_data_func(self.quantity_renderer, self._update_cell_based_on_data)
 
+        self.set_max_width(100)
+        self.set_min_width(100)
+
     def _setup_editor(self, cellrenderer, editable, path):
         # Only allow numeric characters.
         editable.set_property("numeric", True)


### PR DESCRIPTION
The quantity column in the contract selection dialog
uses a spin button cell renderer to adjust quantity.
Gtk3 versions expand horizontal instead of vertical,
causing the column contents to be hidden by the
spin button.

Set a max/min width on the quantity column so it
is a fixed width large enough for the spin button. The
column is not set to expand to avoid it using all
extra space if the window is widened horizontally.