### PR TITLE
Set help file name for the Subscription Manager spoke

### DIFF
--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
@@ -50,6 +50,8 @@ class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
     mainWidgetName = "RHSMSpokeWindow"
 
     uiFile = "rhsm_gui.ui"
+    
+    helpFile = "SubscriptionManagerSpoke.xml"
 
     category = SystemCategory
 


### PR DESCRIPTION
Set help file name for the Subscription Manager spoke so that the Anaconda build in help system can show help content for it.