### PR TITLE
1246680: Hide rhsm-debug --subscriptions options

### DIFF
--- a/src/rhsm_debug/debug_commands.py
+++ b/src/rhsm_debug/debug_commands.py
@@ -15,6 +15,7 @@
 
 import errno
 import gettext
+import optparse
 import os
 import sys
 import shutil
@@ -61,6 +62,18 @@ class SystemCommand(CliCommand):
         self.parser.add_option("--sos", action='store_true',
                                default=False, dest="sos",
                                help=_("only data not already included in sos report will be collected"))
+        # These options don't do anything anymore, since current versions of
+        # RHSM api doesn't support it, and previously they failed silently.
+        # So now they are hidden, and they are not hooked up to anything. This
+        # avoids breaking existing scripts, since it also didn't do anything
+        # before. See rhbz #1246680
+        self.parser.add_option("--no-subscriptions", action='store_true',
+                               dest="placeholder_for_subscriptions_option",
+                               default=False, help=optparse.SUPPRESS_HELP)
+        self.parser.add_option("--subscriptions", action='store_true',
+                               dest="placeholder_for_subscriptions_option",
+                               default=False, help=optparse.SUPPRESS_HELP)
+
         self.assemble_path = ASSEMBLE_DIR
 
         # so we can track the path of the archive for tests.
@@ -80,6 +93,9 @@ class SystemCommand(CliCommand):
                         "must exist on the same file system as the "
                         "data assembly directory '%s'." % (self.options.destination, self.assemble_path))
                 raise InvalidCLIOptionError(msg)
+        # In case folks are using this in a script
+        if self.options.placeholder_for_subscriptions_option:
+            log.info("The rhsm-debug options '--subscriptions' and '--no-subscriptions' have no effect now.")
 
     def _dirs_on_same_device(self, dir1, dir2):
         return os.stat(dir1).st_dev == os.stat(dir2).st_dev


### PR DESCRIPTION
And disconnect them from anything aside from a log
message that they no longer do anything. This avoids
breaking any scripts that specify --subscriptions, and
doesn't change any behaviour against most server versions.