### PR TITLE
1257460: Set text domain on Gtk.Builder widgets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,12 +487,19 @@ coverage-jenkins:
 #
 # gettext, po files, etc
 #
-
 po/POTFILES.in:
 	# generate the POTFILES.in file expected by intltool. it wants one
 	# file per line, but we're lazy.
 	find $(SRC_DIR)/ $(RCT_SRC_DIR) $(RD_SRC_DIR) $(DAEMONS_SRC_DIR) $(YUM_PLUGINS_SRC_DIR) -name "*.py" > po/POTFILES.in
-	find $(SRC_DIR)/gui/data/ -name "*.glade" >> po/POTFILES.in
+	find $(SRC_DIR)/gui/data/glade/ -name "*.glade" >> po/POTFILES.in
+	# intltool-update doesn't recognize .ui as glade files, so
+	# build a dir of .glade symlinks to the .ui files and add to POTFILES.in
+	mkdir -p po/tmp_ui_links
+	for ui_file in ./$(SRC_DIR)/gui/data/ui/*.ui ; do \
+		ui_base=$$(basename "$$ui_file") ; \
+		ln -f -s "../../$$ui_file" "po/tmp_ui_links/$$ui_base.glade" ; \
+	done ;
+	find po/tmp_ui_links/ -name "*.glade"  >> po/POTFILES.in
 	find $(BIN_DIR) -name "*-to-rhsm" >> po/POTFILES.in
 	find $(BIN_DIR) -name "subscription-manager*" >> po/POTFILES.in
 	find $(BIN_DIR) -name "rct" >> po/POTFILES.in

--- a/src/subscription_manager/gui/widgets.py
+++ b/src/subscription_manager/gui/widgets.py
@@ -96,7 +96,7 @@ class BuilderFileBasedWidget(FileBasedGui):
         builder_based_widget = cls()
         builder_based_widget.gui_file = builder_file
 
-        #print "ga", ga.GTK_BUILDER_FILES_DIR
+        builder_based_widget.builder.set_translation_domain('rhsm')
         builder_based_widget.gui_file_suffix = ga_gtk_compat.GTK_BUILDER_FILES_SUFFIX
         builder_based_widget.file_dir = ga_gtk_compat.GTK_BUILDER_FILES_DIR
 


### PR DESCRIPTION
Makefile 'make gettext' target also now created a dir
of symlinks to the data/ui/*.ui files with the link names
ending with .glade so that intltool recognizes them as
glade files and extracts strings from them.