### PR TITLE
1254349: move Resgistering to message

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -534,8 +534,6 @@ class UserPassCommand(CliCommand):
     @property
     def username(self):
         if not self._username:
-            print _("Registering to: %s:%s%s") % \
-                (cfg.get("server", "hostname"), cfg.get("server", "port"), cfg.get("server", "prefix"))
             (self._username, self._password) = self._get_username_and_password(
                     self.options.username, self.options.password)
         return self._username
@@ -1043,6 +1041,8 @@ class RegisterCommand(UserPassCommand):
         # Proceed with new registration:
         try:
             if not self.options.activation_keys:
+                print _("Registering to: %s:%s%s") % \
+                    (cfg.get("server", "hostname"), cfg.get("server", "port"), cfg.get("server", "prefix"))
                 self.cp_provider.set_user_pass(self.username, self.password)
                 admin_cp = self.cp_provider.get_basic_auth_cp()
             else:


### PR DESCRIPTION
def username(self) is called in more places than we need the "Registering to" message, so moved the message so that its displayed only when a user is registering.

fixes [1254353 , 1254349 , 1254578, 1256960](https://bugzilla.redhat.com/buglist.cgi?quicksearch=1256960%2C%201254578%2C%201254353%2C1254349%20&list_id=3760820)