### PR TITLE
Use Notebook 'page' prop notify signal for tests

### DIFF
--- a/test/stubs.py
+++ b/test/stubs.py
@@ -442,7 +442,7 @@ class StubUEP(object):
     def getCertificateSerials(self, consumer):
         return []
 
-    def getCompliance(self, uuid):
+    def getCompliance(self, uuid, on_data=None):
         return {}
 
     def getEntitlementList(self, uuid):


### PR DESCRIPTION
Instead of expecting the state of the notebook widget
to be updated by the time the 'register-error' handler
fires, instead wait for a notify signal from the notebooks
'page' property to indicate we successfully changes pages
(or that we didn't change pages in this case for
test_registergui.py)