### PR TITLE
1251853: Manage repos config entry needs to allow blank value

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1923,7 +1923,7 @@ class ReposCommand(CliCommand):
     def _do_command(self):
         self._validate_options()
         rc = 0
-        if cfg.has_option('rhsm', 'manage_repos') and not int(cfg.get('rhsm', 'manage_repos')):
+        if cfg.has_option('rhsm', 'manage_repos') and not cfg.get_int('rhsm', 'manage_repos'):
             print _("Repositories disabled by configuration.")
             return rc
 

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -191,7 +191,7 @@ class RepoUpdateActionCommand(object):
         self.manage_repos = 1
         self.apply_overrides = apply_overrides
         if CFG.has_option('rhsm', 'manage_repos'):
-            self.manage_repos = int(CFG.get('rhsm', 'manage_repos'))
+            self.manage_repos = CFG.get_int('rhsm', 'manage_repos')
 
         self.release = None
         self.overrides = {}
@@ -684,7 +684,7 @@ class RepoFile(ConfigParser):
         self.repos_dir = Path.abs(self.PATH)
         self.manage_repos = 1
         if CFG.has_option('rhsm', 'manage_repos'):
-            self.manage_repos = int(CFG.get('rhsm', 'manage_repos'))
+            self.manage_repos = CFG.get_int('rhsm', 'manage_repos')
         # Simulate manage repos turned off if no yum.repos.d directory exists.
         # This indicates yum is not installed so clearly no need for us to
         # manage repos.


### PR DESCRIPTION
The configuration.get_int handles blanks where int() does not.