### PR TITLE
884288: Make register widgets handle resizing.

### DIFF
--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.ui
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.ui
@@ -43,16 +43,66 @@
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
-                  <object class="GtkButtonBox" id="navigation_button_box">
+                  <object class="GtkBox" id="box1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="valign">start</property>
-                    <property name="layout_style">end</property>
+                    <property name="margin_left">8</property>
+                    <property name="margin_right">8</property>
+                    <property name="margin_top">8</property>
+                    <property name="margin_bottom">8</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkButton" id="cancel_button">
-                        <property name="label" translatable="yes">Cancel</property>
+                      <object class="GtkBox" id="register_box">
                         <property name="visible">True</property>
-                        <property name="yalign">0.43999999761581421</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <object class="GtkButtonBox" id="navigation_button_box">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="valign">start</property>
+                            <property name="margin_top">4</property>
+                            <property name="margin_bottom">4</property>
+                            <child>
+                              <object class="GtkButton" id="cancel_button">
+                                <property name="label" translatable="yes">Cancel</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="yalign">0.43999999761581421</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="proceed_button">
+                                <property name="label" translatable="yes">Register</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="yalign">0.56999999284744263</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="pack_type">end</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">True</property>
@@ -60,37 +110,10 @@
                         <property name="position">0</property>
                       </packing>
                     </child>
-                    <child>
-                      <object class="GtkButton" id="proceed_button">
-                        <property name="label" translatable="yes">Register</property>
-                        <property name="visible">True</property>
-                        <property name="yalign">0.56999999284744263</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
+                    <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="pack_type">end</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox" id="register_box">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <placeholder/>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
                     <property name="position">1</property>
                   </packing>
                 </child>

--- a/src/subscription_manager/gui/data/ui/activation_key.ui
+++ b/src/subscription_manager/gui/data/ui/activation_key.ui
@@ -5,14 +5,22 @@
   <object class="GtkBox" id="container">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
+    <property name="valign">start</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkLabel" id="label1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_bottom">8</property>
+        <property name="halign">start</property>
+        <property name="margin_bottom">4</property>
+        <property name="xpad">2</property>
         <property name="label" translatable="yes">&lt;b&gt;Please enter the following for this system:&lt;/b&gt;</property>
         <property name="use_markup">True</property>
+        <property name="wrap">True</property>
+        <property name="wrap_mode">word-char</property>
+        <property name="ellipsize">end</property>
+        <property name="max_width_chars">48</property>
+        <property name="lines">3</property>
         <property name="xalign">0</property>
         <property name="yalign">0.10000000149011612</property>
       </object>
@@ -26,14 +34,19 @@
       <object class="GtkGrid" id="grid1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="valign">start</property>
+        <property name="margin_left">8</property>
+        <property name="margin_right">4</property>
+        <property name="margin_bottom">4</property>
         <property name="row_spacing">4</property>
         <child>
           <object class="GtkLabel" id="label2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="valign">center</property>
             <property name="label" translatable="yes">Organization:</property>
-            <property name="ellipsize">end</property>
-            <property name="xalign">0</property>
+            <property name="wrap">True</property>
+            <property name="xalign">1</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -44,8 +57,9 @@
           <object class="GtkLabel" id="label3">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="valign">center</property>
             <property name="label" translatable="yes">Activation Key:</property>
-            <property name="xalign">0</property>
+            <property name="xalign">1</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -56,8 +70,10 @@
           <object class="GtkLabel" id="label4">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="valign">center</property>
             <property name="label" translatable="yes">System Name:</property>
             <property name="xalign">0</property>
+            <property name="yalign">1</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -69,9 +85,10 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="tooltip_text" translatable="yes">This must be the organization key, not the name.</property>
-            <property name="margin_left">8</property>
+            <property name="margin_left">4</property>
             <property name="hexpand">True</property>
             <property name="invisible_char">●</property>
+            <property name="width_chars">24</property>
             <child internal-child="accessible">
               <object class="AtkObject" id="organization_entry-atkobject">
                 <property name="AtkObject::accessible-name" translatable="yes">organization_entry</property>
@@ -88,9 +105,10 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="tooltip_text" translatable="yes">Multiple Activation Keys can be entered by separating them with a comma or a space.</property>
-            <property name="margin_left">8</property>
+            <property name="margin_left">4</property>
             <property name="hexpand">True</property>
             <property name="invisible_char">●</property>
+            <property name="width_chars">24</property>
             <child internal-child="accessible">
               <object class="AtkObject" id="activation_key_entry-atkobject">
                 <property name="AtkObject::accessible-name" translatable="yes">activation_key_entry</property>
@@ -106,9 +124,10 @@
           <object class="GtkEntry" id="consumer_entry">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="margin_left">8</property>
+            <property name="margin_left">4</property>
             <property name="hexpand">True</property>
             <property name="invisible_char">●</property>
+            <property name="width_chars">24</property>
             <child internal-child="accessible">
               <object class="AtkObject" id="consumer_entry-atkobject">
                 <property name="AtkObject::accessible-name" translatable="yes">consumer_entry</property>
@@ -122,7 +141,7 @@
         </child>
       </object>
       <packing>
-        <property name="expand">False</property>
+        <property name="expand">True</property>
         <property name="fill">True</property>
         <property name="position">1</property>
       </packing>

--- a/src/subscription_manager/gui/data/ui/allsubs.ui
+++ b/src/subscription_manager/gui/data/ui/allsubs.ui
@@ -2,13 +2,27 @@
 <!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
+  <object class="GtkAdjustment" id="subs_vpane_hadj">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="subs_vpane_vadj">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
+    <property name="halign">start</property>
+    <property name="valign">start</property>
     <property name="icon_name">subscription-manager</property>
     <child>
       <object class="GtkBox" id="content">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">start</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">4</property>
@@ -16,12 +30,16 @@
           <object class="GtkBox" id="vbox3">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="valign">start</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkBox" id="hbox3">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">start</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label1">
@@ -116,10 +134,14 @@
               <object class="GtkBox" id="hbox2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="valign">start</property>
                 <child>
                   <object class="GtkLabel" id="edit_quantity_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="valign">start</property>
                     <property name="label" translatable="yes">* Click to Adjust Quantity</property>
                     <property name="use_markup">True</property>
                     <property name="xalign">0.99000000953674316</property>
@@ -151,15 +173,18 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="orientation">vertical</property>
-            <property name="position">2</property>
             <property name="position_set">True</property>
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow">
-                <property name="height_request">125</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="valign">start</property>
                 <property name="border_width">1</property>
-                <property name="shadow_type">etched-in</property>
+                <property name="hadjustment">subs_vpane_hadj</property>
+                <property name="vadjustment">subs_vpane_vadj</property>
+                <property name="shadow_type">etched-out</property>
+                <property name="min_content_width">240</property>
+                <property name="min_content_height">120</property>
               </object>
               <packing>
                 <property name="resize">True</property>
@@ -170,7 +195,7 @@
               <object class="GtkBox" id="details_box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
+                <property name="valign">end</property>
                 <child>
                   <placeholder/>
                 </child>
@@ -191,10 +216,13 @@
           <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="valign">start</property>
             <child>
               <object class="GtkButtonBox" id="subscribe_button_box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="valign">start</property>
                 <property name="layout_style">end</property>
                 <child>
                   <object class="GtkButton" id="subscribe_button">

--- a/src/subscription_manager/gui/data/ui/choose_server.ui
+++ b/src/subscription_manager/gui/data/ui/choose_server.ui
@@ -2,74 +2,41 @@
 <!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
-  <object class="GtkBox" id="container">
+  <object class="GtkGrid" id="container">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="valign">start</property>
+    <property name="margin_left">4</property>
+    <property name="margin_right">4</property>
+    <property name="margin_top">5</property>
+    <property name="margin_bottom">4</property>
     <property name="orientation">vertical</property>
+    <property name="row_spacing">8</property>
     <child>
-      <object class="GtkBox" id="choose_server_vbox">
+      <object class="GtkBox" id="hbox2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="valign">start</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">16</property>
+        <property name="hexpand">True</property>
+        <property name="resize_mode">immediate</property>
         <child>
-          <object class="GtkBox" id="hbox2">
+          <object class="GtkLabel" id="choose_server_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="valign">start</property>
-            <child>
-              <object class="GtkLabel" id="choose_server_label">
-                <property name="width_request">520</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="xpad">12</property>
-                <property name="label" translatable="yes">The subscription management service you register with will provide your system with updates and allow additional management.</property>
-                <property name="use_markup">True</property>
-                <property name="wrap">True</property>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="choose_server_label-atkobject">
-                    <property name="AtkObject::accessible-name" translatable="yes">choose_server_label</property>
-                  </object>
-                </child>
+            <property name="valign">center</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="label" translatable="yes">The subscription management service you register with will provide your system with updates and allow additional management.</property>
+            <property name="wrap">True</property>
+            <property name="selectable">True</property>
+            <property name="ellipsize">end</property>
+            <property name="max_width_chars">64</property>
+            <property name="lines">3</property>
+            <property name="xalign">0</property>
+            <child internal-child="accessible">
+              <object class="AtkObject" id="choose_server_label-atkobject">
+                <property name="AtkObject::accessible-name" translatable="yes">choose_server_label</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEventBox" id="eventbox1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Registering with Customer Portal, Subscription Asset Manager, Satellite or Candlepin servers can be used to provide your system with updates and allow management through the selected server's interface.</property>
-                <property name="visible_window">False</property>
-                <child>
-                  <object class="GtkAlignment" id="alignment2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="right_padding">16</property>
-                    <child>
-                      <object class="GtkImage" id="image2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Registering with Customer Portal, Subscription Asset Manager, Satellite or Candlepin servers can be used to provide your system with updates and allow management through the selected server's interface.</property>
-                        <property name="xalign">1</property>
-                        <property name="stock">gtk-info</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
           <packing>
@@ -79,148 +46,151 @@
           </packing>
         </child>
         <child>
-          <object class="GtkTable" id="table1">
+          <object class="GtkEventBox" id="eventbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="valign">start</property>
-            <property name="n_rows">2</property>
-            <property name="n_columns">3</property>
+            <property name="tooltip_text" translatable="yes">Registering with Customer Portal, Subscription Asset Manager, Satellite or Candlepin servers can be used to provide your system with updates and allow management through the selected server's interface.</property>
+            <property name="halign">start</property>
+            <property name="valign">center</property>
+            <property name="vexpand">True</property>
+            <property name="resize_mode">immediate</property>
+            <property name="visible_window">False</property>
             <child>
-              <placeholder/>
-            </child>
-            <child>
-              <object class="GtkLabel" id="server_label">
+              <object class="GtkImage" id="image2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Registering with Customer Portal, Subscription Asset Manager, Satellite or Candlepin servers can be used to provide your system with updates and allow management through the selected server's interface.</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
                 <property name="xalign">0</property>
-                <property name="xpad">12</property>
-                <property name="label" translatable="yes">I will register with:</property>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="server_label-atkobject">
-                    <property name="AtkObject::accessible-name" translatable="yes">server_label</property>
-                  </object>
-                </child>
+                <property name="yalign">0</property>
+                <property name="stock">gtk-info</property>
               </object>
-              <packing>
-                <property name="x_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="server_entry">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tooltip_text" translatable="yes">hostname[:port][/prefix]</property>
-                <property name="invisible_char">●</property>
-                <property name="width_chars">30</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_activatable">False</property>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="server_entry-atkobject">
-                    <property name="AtkObject::accessible-name" translatable="yes">server_entry</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="default_button">
-                <property name="label" translatable="yes">Default</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Reset to register with Customer Portal.</property>
-                <signal name="clicked" handler="on_default_button_clicked" swapped="no"/>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="default_button-atkobject">
-                    <property name="AtkObject::accessible-name" translatable="yes">default_button</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="right_attach">3</property>
-                <property name="x_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEventBox" id="eventbox2">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Activation Keys are alphanumeric strings that are preconfigured by your system administrators to automatically register your system and attach all necessary subscriptions.</property>
-
-                <property name="visible_window">False</property>
-                <child>
-                  <placeholder/>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="right_attach">3</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="x_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="hbox3">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="valign">start</property>
-                <property name="spacing">5</property>
-                <child>
-                  <object class="GtkCheckButton" id="activation_key_checkbox">
-                    <property name="label" translatable="yes">I will use an Activation Key</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="xalign">0</property>
-                    <property name="draw_indicator">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkAlignment" id="alignment3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="valign">start</property>
-                    <property name="xalign">0</property>
-                    <property name="left_padding">5</property>
-                    <child>
-                      <object class="GtkImage" id="image3">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Activation Keys are alphanumeric strings that are preconfigured by your system administrators to automatically register your system and attach all necessary subscriptions.</property>
-                        <property name="xalign">1</property>
-                        <property name="stock">gtk-info</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-              </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkGrid" id="choose_server_grid">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="valign">start</property>
+        <property name="hexpand">True</property>
+        <child>
+          <object class="GtkLabel" id="server_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="margin_right">4</property>
+            <property name="label" translatable="yes">I will register with:</property>
+            <property name="xalign">0</property>
+            <child internal-child="accessible">
+              <object class="AtkObject" id="server_label-atkobject">
+                <property name="AtkObject::accessible-name" translatable="yes">server_label</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="server_entry">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="tooltip_text" translatable="yes">hostname[:port][/prefix]</property>
+            <property name="valign">center</property>
+            <property name="hexpand">True</property>
+            <property name="invisible_char">●</property>
+            <property name="width_chars">36</property>
+            <property name="primary_icon_activatable">False</property>
+            <property name="secondary_icon_activatable">False</property>
+            <child internal-child="accessible">
+              <object class="AtkObject" id="server_entry-atkobject">
+                <property name="AtkObject::accessible-name" translatable="yes">server_entry</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="default_button">
+            <property name="label" translatable="yes">Default</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Reset to register with Customer Portal.</property>
+            <property name="valign">center</property>
+            <property name="margin_left">4</property>
+            <property name="xalign">0.46000000834465027</property>
+            <signal name="clicked" handler="on_default_button_clicked" swapped="no"/>
+            <child internal-child="accessible">
+              <object class="AtkObject" id="default_button-atkobject">
+                <property name="AtkObject::accessible-name" translatable="yes">default_button</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="hbox3">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="valign">start</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkCheckButton" id="activation_key_checkbox">
+                <property name="label" translatable="yes">I will use an Activation Key</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkImage" id="image3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Activation Keys are alphanumeric strings that are preconfigured by your system administrators to automatically register your system and attach all necessary subscriptions.</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="stock">gtk-info</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">1</property>
           </packing>
         </child>
         <child>
@@ -228,67 +198,74 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="valign">start</property>
+            <property name="margin_top">4</property>
+            <property name="margin_bottom">4</property>
             <property name="label_xalign">0</property>
             <child>
-              <object class="GtkAlignment" id="alignment1">
+              <object class="GtkBox" id="hbox1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="halign">start</property>
                 <property name="valign">start</property>
-                <property name="top_padding">12</property>
-                <property name="bottom_padding">12</property>
-                <property name="left_padding">12</property>
+                <property name="margin_left">8</property>
+                <property name="margin_right">8</property>
+                <property name="margin_top">8</property>
+                <property name="margin_bottom">8</property>
                 <child>
-                  <object class="GtkBox" id="hbox1">
+                  <object class="GtkImage" id="image1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="stock">gtk-dialog-warning</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="proxy_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
                     <property name="valign">start</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkImage" id="image1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="stock">gtk-dialog-warning</property>
+                    <property name="label" translatable="yes">If required, please configure your proxy before moving forward. </property>
+                    <property name="wrap">True</property>
+                    <property name="wrap_mode">word-char</property>
+                    <property name="ellipsize">end</property>
+                    <property name="max_width_chars">60</property>
+                    <property name="lines">8</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="proxy_button">
+                    <property name="label" translatable="yes">Configure Proxy</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                    <property name="margin_left">4</property>
+                    <property name="margin_right">4</property>
+                    <signal name="clicked" handler="on_proxy_button_clicked" swapped="no"/>
+                    <child internal-child="accessible">
+                      <object class="AtkObject" id="proxy_button-atkobject">
+                        <property name="AtkObject::accessible-name" translatable="yes">proxy_button</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="proxy_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">If required, please configure your proxy before moving forward.</property>
-                        <property name="wrap">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="proxy_button">
-                        <property name="label" translatable="yes">Configure Proxy</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <signal name="clicked" handler="on_proxy_button_clicked" swapped="no"/>
-                        <child internal-child="accessible">
-                          <object class="AtkObject" id="proxy_button-atkobject">
-                            <property name="AtkObject::accessible-name" translatable="yes">proxy_button</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="padding">6</property>
-                        <property name="position">2</property>
-                      </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
                 </child>
               </object>
             </child>
@@ -297,18 +274,21 @@
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="padding">1</property>
-            <property name="position">2</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">2</property>
+            <property name="width">3</property>
           </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
         </child>
       </object>
       <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="padding">12</property>
-        <property name="position">0</property>
+        <property name="left_attach">0</property>
+        <property name="top_attach">1</property>
       </packing>
     </child>
   </object>

--- a/src/subscription_manager/gui/data/ui/confirmsubs.ui
+++ b/src/subscription_manager/gui/data/ui/confirmsubs.ui
@@ -2,17 +2,30 @@
 <!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment2">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkBox" id="container">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
+    <property name="valign">start</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkLabel" id="label4">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="xalign">0</property>
+        <property name="halign">start</property>
+        <property name="valign">start</property>
         <property name="label" translatable="yes">&lt;b&gt;Confirm Subscriptions&lt;/b&gt;</property>
         <property name="use_markup">True</property>
+        <property name="xalign">0</property>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -24,23 +37,31 @@
       <object class="GtkBox" id="vbox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="halign">start</property>
         <property name="valign">start</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">12</property>
+        <property name="spacing">4</property>
         <child>
           <object class="GtkBox" id="vbox2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="valign">start</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkBox" id="hbox2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">start</property>
+                <property name="resize_mode">immediate</property>
                 <child>
                   <object class="GtkLabel" id="label3">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xpad">10</property>
+                    <property name="halign">start</property>
+                    <property name="valign">start</property>
+                    <property name="xpad">8</property>
                     <property name="label" translatable="yes">Using service level:</property>
                   </object>
                   <packing>
@@ -53,6 +74,8 @@
                   <object class="GtkLabel" id="sla_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">start</property>
                     <property name="label" translatable="yes">SLA</property>
                   </object>
                   <packing>
@@ -72,10 +95,12 @@
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="xpad">10</property>
+                <property name="halign">start</property>
+                <property name="valign">start</property>
+                <property name="xpad">8</property>
                 <property name="label" translatable="yes">The following subscriptions will be attached:</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -90,80 +115,72 @@
             <property name="position">0</property>
           </packing>
         </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkScrolledWindow" id="scrolledwindow1">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="margin_left">8</property>
+        <property name="margin_right">4</property>
+        <property name="margin_top">4</property>
+        <property name="margin_bottom">4</property>
+        <property name="hexpand">True</property>
+        <property name="vexpand">True</property>
+        <property name="resize_mode">queue</property>
+        <property name="hadjustment">adjustment1</property>
+        <property name="vadjustment">adjustment2</property>
+        <property name="shadow_type">in</property>
+        <property name="min_content_width">400</property>
+        <property name="min_content_height">80</property>
         <child>
-          <placeholder/>
-        </child>
-        <child>
-          <object class="GtkScrolledWindow" id="scrolledwindow1">
+          <object class="GtkTreeView" id="subs_treeview">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <child>
-              <object class="GtkViewport" id="viewport1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="valign">start</property>
-                <property name="resize_mode">queue</property>
-                <child>
-                  <object class="GtkBox" id="hbox1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="valign">start</property>
-                    <property name="orientation">vertical</property>
-                    <child>
-                      <object class="GtkTreeView" id="subs_treeview">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="valign">start</property>
-                        <child internal-child="selection">
-                          <object class="GtkTreeSelection" id="treeview-selection1"/>
-                        </child>
-                        <child internal-child="accessible">
-                          <object class="AtkObject" id="subs_treeview-atkobject">
-                            <property name="AtkObject::accessible-name" translatable="yes">Selected Subscriptions Table</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                  </object>
-                </child>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <child internal-child="selection">
+              <object class="GtkTreeSelection" id="treeview-selection"/>
+            </child>
+            <child internal-child="accessible">
+              <object class="AtkObject" id="subs_treeview-atkobject">
+                <property name="AtkObject::accessible-name" translatable="yes">Selected Subscriptions Table</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="label2">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="xalign">0</property>
-            <property name="xpad">10</property>
-            <property name="label" translatable="yes">Core repositories will be enabled for each product.</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="padding">5</property>
-            <property name="position">3</property>
-          </packing>
         </child>
       </object>
       <packing>
         <property name="expand">True</property>
         <property name="fill">True</property>
-        <property name="padding">7</property>
-        <property name="position">1</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label2">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">start</property>
+        <property name="xpad">8</property>
+        <property name="label" translatable="yes">Core repositories will be enabled for each product.</property>
+        <property name="wrap">True</property>
+        <property name="wrap_mode">word-char</property>
+        <property name="ellipsize">end</property>
+        <property name="max_width_chars">64</property>
+        <property name="lines">4</property>
+        <property name="xalign">0</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="padding">5</property>
+        <property name="position">3</property>
       </packing>
     </child>
   </object>

--- a/src/subscription_manager/gui/data/ui/contract_selection.ui
+++ b/src/subscription_manager/gui/data/ui/contract_selection.ui
@@ -2,6 +2,16 @@
 <!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment2">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkWindow" id="contract_selection_window">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Contract Selection</property>
@@ -15,7 +25,6 @@
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="vexpand">True</property>
         <property name="border_width">4</property>
         <property name="orientation">vertical</property>
         <property name="spacing">3</property>
@@ -40,160 +49,6 @@
                 <property name="position">0</property>
               </packing>
             </child>
-            <child>
-              <object class="GtkSeparator" id="hseparator1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="vbox3">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">16</property>
-                <property name="vexpand">True</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">3</property>
-                <child>
-                  <object class="GtkGrid" id="grid1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="row_spacing">4</property>
-                    <child>
-                      <object class="GtkLabel" id="label2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">&lt;b&gt;Subscription:&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
-                        <property name="xalign">1</property>
-                        <property name="yalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label3">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">&lt;b&gt;Total Contracts:&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
-                        <property name="wrap">True</property>
-                        <property name="wrap_mode">word-char</property>
-                        <property name="xalign">1</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="subscription_name_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">16</property>
-                        <property name="hexpand">True</property>
-                        <property name="wrap">True</property>
-                        <property name="wrap_mode">word-char</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="total_contracts_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">16</property>
-                        <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox" id="hbox1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkLabel" id="edit_quantity_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">* Click to Change Quantity</property>
-                        <property name="use_markup">True</property>
-                        <property name="xalign">1</property>
-                        <property name="yalign">1</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="pack_type">end</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkScrolledWindow" id="scrolledwindow1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hexpand">True</property>
-                    <property name="vexpand">True</property>
-                    <property name="shadow_type">etched-in</property>
-                    <child>
-                      <object class="GtkTreeView" id="contract_selection_treeview">
-                        <property name="width_request">450</property>
-                        <property name="height_request">200</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="vexpand">True</property>
-                        <property name="rules_hint">True</property>
-                        <child internal-child="selection">
-                          <object class="GtkTreeSelection" id="treeview-selection"/>
-                        </child>
-                        <child internal-child="accessible">
-                          <object class="AtkObject" id="contract_selection_treeview-atkobject">
-                            <property name="AtkObject::accessible-name" translatable="yes">SLA Selection Table</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -202,9 +57,184 @@
           </packing>
         </child>
         <child>
+          <object class="GtkBox" id="vbox3">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">3</property>
+            <child>
+              <object class="GtkGrid" id="grid1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="row_spacing">4</property>
+                <child>
+                  <object class="GtkLabel" id="label2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">&lt;b&gt;Subscription:&lt;/b&gt;</property>
+                    <property name="use_markup">True</property>
+                    <property name="xalign">1</property>
+                    <property name="yalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">&lt;b&gt;Total Contracts:&lt;/b&gt;</property>
+                    <property name="use_markup">True</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap_mode">word-char</property>
+                    <property name="xalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="subscription_name_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap_mode">word-char</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="total_contracts_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator" id="separator1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkBox" id="hbox1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <child>
+                  <object class="GtkLabel" id="edit_quantity_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="valign">start</property>
+                    <property name="label" translatable="yes">* Click to Change Quantity</property>
+                    <property name="use_markup">True</property>
+                    <property name="xalign">1</property>
+                    <property name="yalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="pack_type">end</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow" id="scrolledwindow1">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="hadjustment">adjustment1</property>
+                <property name="vadjustment">adjustment2</property>
+                <property name="shadow_type">etched-out</property>
+                <property name="min_content_width">300</property>
+                <property name="min_content_height">60</property>
+                <child>
+                  <object class="GtkTreeView" id="contract_selection_treeview">
+                    <property name="width_request">450</property>
+                    <property name="height_request">100</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="rules_hint">True</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection" id="treeview-selection"/>
+                    </child>
+                    <child internal-child="accessible">
+                      <object class="AtkObject" id="contract_selection_treeview-atkobject">
+                        <property name="AtkObject::accessible-name" translatable="yes">SLA Selection Table</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkButtonBox" id="hbuttonbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="valign">start</property>
             <property name="border_width">6</property>
             <property name="spacing">5</property>
             <property name="layout_style">end</property>
@@ -214,6 +244,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="receives_default">False</property>
+                <property name="valign">start</property>
                 <property name="use_stock">True</property>
                 <signal name="clicked" handler="on_cancel_button_clicked" swapped="no"/>
               </object>
@@ -229,6 +260,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
+                <property name="valign">start</property>
                 <signal name="clicked" handler="on_subscribe_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -242,7 +274,7 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="pack_type">end</property>
-            <property name="position">1</property>
+            <property name="position">5</property>
           </packing>
         </child>
       </object>

--- a/src/subscription_manager/gui/data/ui/credentials.ui
+++ b/src/subscription_manager/gui/data/ui/credentials.ui
@@ -6,18 +6,23 @@
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="valign">start</property>
-    <property name="border_width">25</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">5</property>
     <child>
       <object class="GtkLabel" id="registration_header_label">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="valign">center</property>
+        <property name="halign">start</property>
+        <property name="valign">start</property>
+        <property name="margin_top">4</property>
+        <property name="margin_bottom">4</property>
+        <property name="label" translatable="yes">&lt;b&gt;Please enter your Red Hat account information:&lt;/b&gt;</property>
+        <property name="use_markup">True</property>
+        <property name="wrap">True</property>
+        <property name="wrap_mode">word-char</property>
+        <property name="ellipsize">end</property>
+        <property name="max_width_chars">64</property>
         <property name="xalign">0</property>
         <property name="yalign">0</property>
-        <property name="use_markup">True</property>
-        <property name="single_line_mode">True</property>
         <child internal-child="accessible">
           <object class="AtkObject" id="registration_header_label-atkobject">
             <property name="AtkObject::accessible-name">registration_header_label</property>
@@ -25,165 +30,169 @@
         </child>
       </object>
       <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="padding">8</property>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
         <property name="position">0</property>
       </packing>
     </child>
     <child>
-      <object class="GtkAlignment" id="initial_login_window_alignment">
+      <object class="GtkGrid" id="credentials_grid">
+        <property name="name">CredentialsGrid</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="valign">start</property>
-        <property name="left_padding">12</property>
+        <property name="margin_left">8</property>
         <child>
-          <object class="GtkTable" id="initial_login_window_table">
+          <object class="GtkLabel" id="login_user_entry_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Login:</property>
+            <property name="use_markup">True</property>
+            <property name="wrap">True</property>
+            <property name="xalign">1</property>
+            <child internal-child="accessible">
+              <object class="AtkObject" id="login_user_entry_label-atkobject">
+                <property name="AtkObject::accessible-name">login_user_entry_label</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="account_login">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
             <property name="valign">start</property>
-            <property name="n_rows">3</property>
-            <property name="n_columns">2</property>
-            <property name="column_spacing">14</property>
-            <property name="row_spacing">13</property>
+            <property name="margin_left">4</property>
+            <property name="margin_right">4</property>
+            <property name="margin_bottom">4</property>
+            <property name="hexpand">True</property>
+            <property name="invisible_char">●</property>
+            <property name="width_chars">36</property>
+            <child internal-child="accessible">
+              <object class="AtkObject" id="account_login-atkobject">
+                <property name="AtkObject::accessible-name">account_login</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="login_password_entry_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Password:</property>
+            <property name="use_markup">True</property>
+            <property name="wrap">True</property>
+            <property name="xalign">0</property>
+            <child internal-child="accessible">
+              <object class="AtkObject" id="login_password_entry_label-atkobject">
+                <property name="AtkObject::accessible-name">login_password_entry_label</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="account_password">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="valign">start</property>
+            <property name="margin_left">4</property>
+            <property name="margin_right">4</property>
+            <property name="margin_bottom">4</property>
+            <property name="hexpand">True</property>
+            <property name="visibility">False</property>
+            <property name="invisible_char">●</property>
+            <property name="activates_default">True</property>
+            <property name="width_chars">38</property>
+            <child internal-child="accessible">
+              <object class="AtkObject" id="account_password-atkobject">
+                <property name="AtkObject::accessible-name">account_password</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="forgot_info_hbox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="valign">start</property>
+            <property name="hexpand">True</property>
             <child>
-              <placeholder/>
+              <object class="GtkImage" id="tip_icon_hosted">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">center</property>
+                <property name="yalign">0</property>
+                <property name="stock">gtk-info</property>
+                <child internal-child="accessible">
+                  <object class="AtkObject" id="tip_icon_hosted-atkobject">
+                    <property name="AtkObject::accessible-name">tip_icon_hosted</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
             </child>
             <child>
-              <object class="GtkBox" id="forgot_info_hbox">
+              <object class="GtkLabel" id="registration_tip_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">start</property>
-                <child>
-                  <object class="GtkImage" id="tip_icon_hosted">
-                    <property name="visible">True</property>
-                    <property name="valign">center</property>
-                    <property name="can_focus">False</property>
-                    <property name="yalign">0</property>
-                    <property name="stock">gtk-info</property>
-                    <child internal-child="accessible">
-                      <object class="AtkObject" id="tip_icon_hosted-atkobject">
-                        <property name="AtkObject::accessible-name">tip_icon_hosted</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="registration_tip_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="valign">start</property>
-                    <property name="selectable">True</property>
-                    <property name="ellipsize">middle</property>
-                    <property name="xpad">1</property>
-                    <property name="ypad">2</property>
-                    <property name="use_markup">True</property>
-                    <property name="lines">1</property>
-                    <property name="wrap">True</property>
-                    <child internal-child="accessible">
-                      <object class="AtkObject" id="registration_tip_label-atkobject">
-                        <property name="AtkObject::accessible-name">registration_tip_label</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="account_login">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="invisible_char">●</property>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="account_login-atkobject">
-                    <property name="AtkObject::accessible-name">account_login</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="account_password">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="visibility">False</property>
-                <property name="invisible_char">●</property>
-                <property name="activates_default">True</property>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="account_password-atkobject">
-                    <property name="AtkObject::accessible-name">account_password</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="login_password_entry_label">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">1</property>
-                <property name="label" translatable="yes">Password:</property>
+                <property name="hexpand">True</property>
+                <property name="xpad">1</property>
+                <property name="ypad">2</property>
+                <property name="label" translatable="yes">&lt;small&gt;Tip: Forgot your login or password? Look it up at http://redhat.com/forgot_password&lt;/small&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="wrap">True</property>
+                <property name="selectable">True</property>
+                <property name="ellipsize">start</property>
+                <property name="max_width_chars">96</property>
+                <property name="lines">2</property>
                 <child internal-child="accessible">
-                  <object class="AtkObject" id="login_password_entry_label-atkobject">
-                    <property name="AtkObject::accessible-name">login_password_entry_label</property>
+                  <object class="AtkObject" id="registration_tip_label-atkobject">
+                    <property name="AtkObject::accessible-name">registration_tip_label</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options">GTK_FILL</property>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="login_user_entry_label">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">Login:</property>
-                <property name="use_markup">True</property>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="login_user_entry_label-atkobject">
-                    <property name="AtkObject::accessible-name">login_user_entry_label</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options">GTK_FILL</property>
-              </packing>
+              <placeholder/>
             </child>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child internal-child="accessible">
+          <object class="AtkObject" id="credentials_grid-atkobject">
+            <property name="AtkObject::accessible-name" translatable="yes">credentials_grid</property>
           </object>
         </child>
       </object>
@@ -195,13 +204,11 @@
     </child>
     <child>
       <object class="GtkSeparator" id="hseparator1">
-        <property name="visible">True</property>
         <property name="can_focus">False</property>
       </object>
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
-        <property name="padding">10</property>
         <property name="position">2</property>
       </packing>
     </child>
@@ -209,10 +216,14 @@
       <object class="GtkLabel" id="system_instructions_label">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="xalign">0</property>
-        <property name="yalign">0</property>
+        <property name="halign">start</property>
+        <property name="margin_left">4</property>
+        <property name="margin_top">4</property>
+        <property name="margin_bottom">4</property>
         <property name="label" translatable="yes">&lt;b&gt;Please enter the following for this system:&lt;/b&gt;</property>
         <property name="use_markup">True</property>
+        <property name="xalign">0</property>
+        <property name="yalign">0</property>
         <child internal-child="accessible">
           <object class="AtkObject" id="system_instructions_label-atkobject">
             <property name="AtkObject::accessible-name" translatable="yes">system_instructions_label</property>
@@ -222,88 +233,94 @@
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
-        <property name="position">3</property>
+        <property name="position">4</property>
       </packing>
     </child>
     <child>
-      <object class="GtkAlignment" id="system_name_alignment">
+      <object class="GtkGrid" id="system_name_grid">
+        <property name="name">SystemNameGrid</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="left_padding">12</property>
+        <property name="margin_left">8</property>
         <child>
-          <object class="GtkTable" id="system_name_table">
+          <object class="GtkLabel" id="system_name_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="n_rows">2</property>
-            <property name="n_columns">2</property>
-            <property name="column_spacing">15</property>
-            <property name="row_spacing">10</property>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <object class="GtkLabel" id="system_name_label">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">1</property>
-                <property name="label" translatable="yes">System Name:</property>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="system_name_label-atkobject">
-                    <property name="AtkObject::accessible-name" translatable="yes">system_name_label</property>
-                  </object>
-                </child>
+            <property name="label" translatable="yes">System Name:</property>
+            <property name="xalign">1</property>
+            <child internal-child="accessible">
+              <object class="AtkObject" id="system_name_label-atkobject">
+                <property name="AtkObject::accessible-name" translatable="yes">system_name_label</property>
               </object>
-              <packing>
-                <property name="x_options">GTK_FILL</property>
-              </packing>
             </child>
-            <child>
-              <object class="GtkEntry" id="consumer_name">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tooltip_text" translatable="yes">A unique label for this system</property>
-                <property name="invisible_char">●</property>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="consumer_name-atkobject">
-                    <property name="AtkObject::accessible-name">consumer_name</property>
-                  </object>
-                </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="consumer_name">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="tooltip_text" translatable="yes">A unique label for this system</property>
+            <property name="margin_left">4</property>
+            <property name="margin_right">4</property>
+            <property name="hexpand">True</property>
+            <property name="invisible_char">●</property>
+            <child internal-child="accessible">
+              <object class="AtkObject" id="consumer_name-atkobject">
+                <property name="AtkObject::accessible-name">consumer_name</property>
               </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-              </packing>
             </child>
-            <child>
-              <object class="GtkCheckButton" id="skip_auto_bind">
-                <property name="label" translatable="yes">Manually attach subscriptions after registration</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="relief">none</property>
-                <property name="xalign">0.5</property>
-                <property name="draw_indicator">True</property>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="skip_auto_bind-atkobject">
-                    <property name="AtkObject::accessible-name">auto_bind</property>
-                  </object>
-                </child>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="skip_auto_bind">
+            <property name="label" translatable="yes">Manually attach subscriptions after registration</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="halign">start</property>
+            <property name="relief">none</property>
+            <property name="xalign">0</property>
+            <property name="draw_indicator">True</property>
+            <child internal-child="accessible">
+              <object class="AtkObject" id="skip_auto_bind-atkobject">
+                <property name="AtkObject::accessible-name">auto_bind</property>
               </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-              </packing>
             </child>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child internal-child="accessible">
+          <object class="AtkObject" id="system_name_grid-atkobject">
+            <property name="AtkObject::accessible-name" translatable="yes">system_name_grid</property>
           </object>
         </child>
       </object>
       <packing>
         <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="position">4</property>
+        <property name="fill">True</property>
+        <property name="position">5</property>
       </packing>
     </child>
   </object>
+  <object class="GtkSizeGroup" id="sizegroup1">
+    <property name="mode">both</property>
+  </object>
+  <object class="GtkSizeGroup" id="sizegroup2">
+    <property name="mode">both</property>
+  </object>
+  <object class="GtkSizeGroup" id="sizegroup3"/>
 </interface>

--- a/src/subscription_manager/gui/data/ui/environment.ui
+++ b/src/subscription_manager/gui/data/ui/environment.ui
@@ -1,22 +1,24 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.3 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkBox" id="container">
-    <property name="orientation">vertical</property>
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="border_width">25</property>
+    <property name="orientation">vertical</property>
     <property name="spacing">7</property>
     <child>
       <object class="GtkLabel" id="env_select_vbox_label">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="xalign">0</property>
+        <property name="halign">start</property>
+        <property name="valign">start</property>
+        <property name="margin_left">8</property>
         <property name="label" translatable="yes">&lt;b&gt;Environment Selection&lt;/b&gt;</property>
         <property name="use_markup">True</property>
+        <property name="xalign">0</property>
         <child internal-child="accessible">
-          <object class="AtkObject" id="a11y-env_select_vbox_label1">
+          <object class="AtkObject" id="env_select_vbox_label-atkobject">
             <property name="AtkObject::accessible-name" translatable="yes">env_select_vbox_label</property>
           </object>
         </child>
@@ -31,16 +33,21 @@
       <object class="GtkScrolledWindow" id="env_select_vbox_scrolledwindow">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
-        <property name="border_width">8</property>
-        <property name="hscrollbar_policy">automatic</property>
-        <property name="vscrollbar_policy">automatic</property>
+        <property name="margin_left">8</property>
+        <property name="margin_right">8</property>
+        <property name="margin_bottom">8</property>
         <property name="shadow_type">etched-in</property>
+        <property name="min_content_width">400</property>
+        <property name="min_content_height">80</property>
         <child>
           <object class="GtkTreeView" id="environment_treeview">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
+            <child internal-child="selection">
+              <object class="GtkTreeSelection" id="treeview-selection1"/>
+            </child>
             <child internal-child="accessible">
-              <object class="AtkObject" id="a11y-environment_treeview1">
+              <object class="AtkObject" id="environment_treeview-atkobject">
                 <property name="AtkObject::accessible-name" translatable="yes">environment_treeview</property>
               </object>
             </child>
@@ -54,7 +61,7 @@
       </packing>
     </child>
     <child internal-child="accessible">
-      <object class="AtkObject" id="a11y-container1">
+      <object class="AtkObject" id="container-atkobject">
         <property name="AtkObject::accessible-name">env_select_vbox</property>
       </object>
     </child>

--- a/src/subscription_manager/gui/data/ui/mainwindow.ui
+++ b/src/subscription_manager/gui/data/ui/mainwindow.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.3 -->
 <interface>
-  <requires lib="gtk+" version="2.24"/>
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkAccelGroup" id="accelgroup1"/>
   <object class="GtkImage" id="facts_image">
     <property name="visible">True</property>
@@ -24,9 +24,40 @@
     <property name="can_focus">False</property>
     <property name="stock">gtk-add</property>
   </object>
+  <object class="GtkImage" id="proxy_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-network</property>
+  </object>
+  <object class="GtkImage" id="redeem_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-goto-first</property>
+  </object>
+  <object class="GtkImage" id="register_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-connect</property>
+  </object>
+  <object class="GtkImage" id="settings_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-preferences</property>
+  </object>
+  <object class="GtkImage" id="settings_image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-preferences</property>
+  </object>
+  <object class="GtkImage" id="unregister_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-disconnect</property>
+  </object>
   <object class="GtkWindow" id="main_window">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Subscription Manager</property>
+    <property name="window_position">center</property>
     <property name="default_width">800</property>
     <property name="default_height">600</property>
     <property name="icon_name">subscription-manager</property>
@@ -35,9 +66,9 @@
     </accel-groups>
     <child>
       <object class="GtkBox" id="vbox1">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <child>
           <object class="GtkMenuBar" id="menubar1">
             <property name="visible">True</property>
@@ -60,8 +91,8 @@
                         <property name="use_underline">True</property>
                         <property name="image">register_image</property>
                         <property name="use_stock">False</property>
-                        <accelerator key="r" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_register_menu_item_activate" swapped="no"/>
+                        <accelerator key="r" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -72,8 +103,8 @@
                         <property name="use_underline">True</property>
                         <property name="image">unregister_image</property>
                         <property name="use_stock">False</property>
-                        <accelerator key="u" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_unregister_menu_item_activate" swapped="no"/>
+                        <accelerator key="u" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -90,8 +121,8 @@
                         <property name="use_underline">True</property>
                         <property name="image">import_cert_img</property>
                         <property name="use_stock">False</property>
-                        <accelerator key="i" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_import_cert_menu_item_activate" swapped="no"/>
+                        <accelerator key="i" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -102,8 +133,8 @@
                         <property name="use_underline">True</property>
                         <property name="image">redeem_image</property>
                         <property name="use_stock">False</property>
-                        <accelerator key="e" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_redeem_menu_item_activate" swapped="no"/>
+                        <accelerator key="e" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -114,8 +145,8 @@
                         <property name="use_underline">True</property>
                         <property name="image">facts_image</property>
                         <property name="use_stock">False</property>
-                        <accelerator key="f" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_view_facts_menu_item_activate" swapped="no"/>
+                        <accelerator key="f" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -126,8 +157,8 @@
                         <property name="use_underline">True</property>
                         <property name="image">proxy_image</property>
                         <property name="use_stock">False</property>
-                        <accelerator key="x" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_proxy_config_menu_item_activate" swapped="no"/>
+                        <accelerator key="x" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -138,8 +169,8 @@
                         <property name="use_underline">True</property>
                         <property name="image">settings_image1</property>
                         <property name="use_stock">False</property>
-                        <accelerator key="s" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_repos_menu_item_activate" swapped="no"/>
+                        <accelerator key="s" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -150,8 +181,8 @@
                         <property name="use_underline">True</property>
                         <property name="image">settings_image</property>
                         <property name="use_stock">False</property>
-                        <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_preferences_menu_item_activate" swapped="no"/>
+                        <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -193,8 +224,8 @@
                         <property name="use_underline">True</property>
                         <property name="image">getting_started_image</property>
                         <property name="use_stock">False</property>
-                        <accelerator key="h" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_getting_started_menu_item_activate" swapped="no"/>
+                        <accelerator key="h" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -205,8 +236,8 @@
                         <property name="use_underline">True</property>
                         <property name="image">image1</property>
                         <property name="use_stock">False</property>
-                        <accelerator key="o" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_online_docs_menu_item_activate" swapped="no"/>
+                        <accelerator key="o" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -223,8 +254,8 @@
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <property name="accel_group">accelgroup1</property>
-                        <accelerator key="a" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_about_menu_item_activate" swapped="no"/>
+                        <accelerator key="a" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                   </object>
@@ -279,35 +310,5 @@
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkImage" id="proxy_image">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-network</property>
-  </object>
-  <object class="GtkImage" id="redeem_image">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-goto-first</property>
-  </object>
-  <object class="GtkImage" id="register_image">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-connect</property>
-  </object>
-  <object class="GtkImage" id="settings_image">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-preferences</property>
-  </object>
-  <object class="GtkImage" id="settings_image1">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-preferences</property>
-  </object>
-  <object class="GtkImage" id="unregister_image">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-disconnect</property>
   </object>
 </interface>

--- a/src/subscription_manager/gui/data/ui/register_dialog.ui
+++ b/src/subscription_manager/gui/data/ui/register_dialog.ui
@@ -3,28 +3,34 @@
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkDialog" id="register_dialog">
+    <property name="width_request">500</property>
+    <property name="height_request">300</property>
     <property name="can_focus">False</property>
-    <property name="halign">center</property>
-    <property name="valign">end</property>
     <property name="title" translatable="yes">System Registration</property>
-    <property name="resizable">False</property>
     <property name="window_position">center-on-parent</property>
     <property name="destroy_with_parent">True</property>
     <property name="icon_name">subscription-manager</property>
     <property name="type_hint">dialog</property>
-    <property name="deletable">False</property>
+    <property name="has_resize_grip">True</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="register_dialog_main_vbox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="valign">end</property>
+        <property name="margin_left">4</property>
+        <property name="margin_right">4</property>
+        <property name="margin_top">4</property>
+        <property name="margin_bottom">4</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area3">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="margin_left">4</property>
+            <property name="margin_right">5</property>
+            <property name="margin_top">4</property>
+            <property name="margin_bottom">4</property>
+            <property name="hexpand">True</property>
             <child>
               <object class="GtkButton" id="cancel_button">
                 <property name="label">gtk-cancel</property>
@@ -32,7 +38,6 @@
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_stock">True</property>
-                <property name="image_position">right</property>
                 <child internal-child="accessible">
                   <object class="AtkObject" id="cancel_button-atkobject">
                     <property name="AtkObject::accessible-name">cancel_button</property>
@@ -41,7 +46,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
@@ -63,7 +68,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -75,8 +80,7 @@
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="pack_type">end</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -84,7 +88,7 @@
           <placeholder/>
         </child>
         <child internal-child="accessible">
-          <object class="AtkObject" id="register_dialog_main_vbox_atkobject">
+          <object class="AtkObject" id="register_dialog_main_vbox-atkobject">
             <property name="AtkObject::accessible-name" translatable="yes">register_dialog_main_vbox</property>
           </object>
         </child>

--- a/src/subscription_manager/gui/data/ui/registration.ui
+++ b/src/subscription_manager/gui/data/ui/registration.ui
@@ -7,26 +7,35 @@
     <property name="can_focus">False</property>
     <property name="valign">start</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">2</property>
     <child>
       <object class="GtkNotebook" id="register_notebook">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="valign">start</property>
         <property name="show_tabs">False</property>
         <property name="show_border">False</property>
         <child>
           <object class="GtkBox" id="progressVbox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="border_width">25</property>
+            <property name="valign">start</property>
+            <property name="margin_left">8</property>
+            <property name="margin_right">8</property>
+            <property name="margin_top">4</property>
+            <property name="margin_bottom">4</property>
+            <property name="resize_mode">queue</property>
             <property name="orientation">vertical</property>
-            <property name="spacing">7</property>
             <child>
               <object class="GtkLabel" id="progress_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="valign">start</property>
                 <property name="label" translatable="yes">&lt;b&gt;Registering&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="wrap">True</property>
+                <property name="wrap_mode">word-char</property>
+                <property name="ellipsize">middle</property>
+                <property name="max_width_chars">64</property>
                 <property name="xalign">0</property>
                 <child internal-child="accessible">
                   <object class="AtkObject" id="progress_label-atkobject">
@@ -45,7 +54,6 @@
               <object class="GtkProgressBar" id="register_progressbar">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="pulse_step">0.1</property>
                 <child internal-child="accessible">
                   <object class="AtkObject" id="register_progressbar-atkobject">
                     <property name="AtkObject::accessible-name" translatable="yes">register_progressbar</property>
@@ -53,7 +61,7 @@
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
+                <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
@@ -62,7 +70,13 @@
               <object class="GtkLabel" id="register_details_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">start</property>
                 <property name="use_markup">True</property>
+                <property name="wrap">True</property>
+                <property name="wrap_mode">word-char</property>
+                <property name="ellipsize">end</property>
+                <property name="max_width_chars">64</property>
                 <property name="xalign">0</property>
                 <child internal-child="accessible">
                   <object class="AtkObject" id="register_details_label-atkobject">

--- a/src/subscription_manager/gui/data/ui/registration_info.ui
+++ b/src/subscription_manager/gui/data/ui/registration_info.ui
@@ -1,35 +1,42 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.3 -->
 <interface>
-  <!-- interface-requires gtk+ 2.16 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkBox" id="container">
-    <property name="orientation">vertical</property>
     <property name="visible">True</property>
     <property name="can_focus">False</property>
+    <property name="valign">start</property>
+    <property name="vexpand">True</property>
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox" id="main_vbox">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="border_width">15</property>
-        <property name="spacing">15</property>
+        <property name="valign">start</property>
+        <property name="orientation">vertical</property>
         <child>
           <object class="GtkLabel" id="label98">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="vexpand">True</property>
+            <property name="xpad">4</property>
+            <property name="ypad">4</property>
+            <property name="label" translatable="yes">This assistant will guide you through the process of registering your system with Red Hat to receive software updates and other benefits. </property>
+            <property name="wrap">True</property>
+            <property name="width_chars">48</property>
+            <property name="max_width_chars">64</property>
+            <property name="lines">5</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
-            <property name="label" translatable="yes">This assistant will guide you through the process of registering your system with Red Hat to receive software updates and other benefits. You will need the following to register:</property>
-            <property name="wrap">True</property>
             <child internal-child="accessible">
-              <object class="AtkObject" id="a11y-label981">
+              <object class="AtkObject" id="label98-atkobject">
                 <property name="AtkObject::accessible-name" translatable="yes">This assistant will guide you through the process of registering your system with Red Hat to receive software updates and other benefits. You will need the following to register:</property>
               </object>
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -37,21 +44,35 @@
           <object class="GtkAlignment" id="alignment4">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="valign">start</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
-            <property name="left_padding">9</property>
+            <property name="left_padding">4</property>
             <child>
               <object class="GtkBox" id="vbox15">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="spacing">5</property>
+                <property name="valign">start</property>
+                <property name="margin_top">4</property>
+                <property name="margin_bottom">4</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkLabel" id="label35">
+                  <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="label" translatable="yes"> You will need the following to register:</property>
+                    <property name="wrap">True</property>
+                    <property name="width_chars">48</property>
+                    <property name="max_width_chars">64</property>
+                    <property name="lines">5</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">&#x2022; A network connection</property>
+                    <property name="yalign">0</property>
+                    <child internal-child="accessible">
+                      <object class="AtkObject" id="label1-atkobject">
+                        <property name="AtkObject::accessible-name" translatable="yes">This assistant will guide you through the process of registering your system with Red Hat to receive software updates and other benefits. You will need the following to register:</property>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -60,16 +81,17 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="label36">
+                  <object class="GtkLabel" id="label35">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">start</property>
+                    <property name="label" translatable="yes">• A network connection</property>
+                    <property name="wrap">True</property>
+                    <property name="ellipsize">end</property>
+                    <property name="max_width_chars">64</property>
+                    <property name="lines">2</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">&#x2022; Your account login</property>
-                    <child internal-child="accessible">
-                      <object class="AtkObject" id="a11y-label361">
-                        <property name="AtkObject::accessible-name" translatable="yes">Your account login</property>
-                      </object>
-                    </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -78,11 +100,22 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="label152">
+                  <object class="GtkLabel" id="label36">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">start</property>
+                    <property name="label" translatable="yes">• Your account login</property>
+                    <property name="wrap">True</property>
+                    <property name="ellipsize">end</property>
+                    <property name="max_width_chars">64</property>
+                    <property name="lines">2</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">&#x2022; The address of a subscription management service (optional)</property>
+                    <child internal-child="accessible">
+                      <object class="AtkObject" id="label36-atkobject">
+                        <property name="AtkObject::accessible-name" translatable="yes">Your account login</property>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -90,42 +123,64 @@
                     <property name="position">2</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkLabel" id="label152">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">start</property>
+                    <property name="label" translatable="yes">• The address of a subscription management service (optional)</property>
+                    <property name="wrap">True</property>
+                    <property name="ellipsize">end</property>
+                    <property name="max_width_chars">64</property>
+                    <property name="lines">2</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
               </object>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="hbox9">
-            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="valign">start</property>
+            <property name="margin_top">4</property>
+            <property name="margin_bottom">4</property>
+            <property name="orientation">vertical</property>
             <child>
               <object class="GtkButton" id="why_register_button">
                 <property name="label" translatable="yes">_Why Should I Register?</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="valign">start</property>
+                <property name="margin_left">16</property>
+                <property name="margin_right">16</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_why_register_button_clicked" name="clicked"/>
+                <signal name="clicked" handler="on_why_register_button_clicked" swapped="no"/>
                 <child internal-child="accessible">
-                  <object class="AtkObject" id="a11y-why_register_button1">
+                  <object class="AtkObject" id="why_register_button-atkobject">
                     <property name="AtkObject::accessible-name" translatable="yes">Why Should I Register?</property>
                   </object>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
-            </child>
-            <child>
-              <placeholder/>
             </child>
           </object>
           <packing>
@@ -136,19 +191,24 @@
         </child>
         <child>
           <object class="GtkBox" id="skip_vbox">
-            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="border_width">5</property>
-            <property name="spacing">5</property>
+            <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="label57">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
+                <property name="margin_left">4</property>
+                <property name="margin_top">4</property>
                 <property name="label" translatable="yes">Would you like to register your system at this time? &lt;b&gt;(Strongly recommended.)&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
                 <property name="wrap">True</property>
+                <property name="ellipsize">end</property>
+                <property name="width_chars">48</property>
+                <property name="max_width_chars">64</property>
+                <property name="lines">4</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -157,35 +217,57 @@
               </packing>
             </child>
             <child>
-              <object class="GtkRadioButton" id="register_radio">
-                <property name="label" translatable="yes">_Yes, I'd like to register now.</property>
+              <object class="GtkBox" id="box1">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_underline">True</property>
-                <property name="active">True</property>
-                <property name="draw_indicator">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">start</property>
+                <property name="margin_left">8</property>
+                <property name="margin_right">8</property>
+                <property name="margin_top">4</property>
+                <property name="vexpand">True</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkRadioButton" id="register_radio">
+                    <property name="label" translatable="yes">_Yes, I'd like to register now.</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">start</property>
+                    <property name="use_underline">True</property>
+                    <property name="xalign">0.5</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="skip_radio">
+                    <property name="label" translatable="yes">_No, I prefer to register at a later time.</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="use_underline">True</property>
+                    <property name="xalign">0</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">True</property>
+                <property name="fill">False</property>
                 <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkRadioButton" id="skip_radio">
-                <property name="label" translatable="yes">_No, I prefer to register at a later time.</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_underline">True</property>
-                <property name="draw_indicator">True</property>
-                <property name="group">register_radio</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
               </packing>
             </child>
           </object>
@@ -215,22 +297,22 @@
     <property name="deletable">False</property>
     <child>
       <object class="GtkBox" id="vbox21">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="border_width">20</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">10</property>
         <child>
           <object class="GtkLabel" id="label119">
             <property name="width_request">600</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="xalign">0</property>
-            <property name="yalign">0</property>
             <property name="label" translatable="yes">Registering your system with Red Hat allows you to take full advantage of the benefits of a paid subscription, including:</property>
             <property name="wrap">True</property>
+            <property name="xalign">0</property>
+            <property name="yalign">0</property>
             <child internal-child="accessible">
-              <object class="AtkObject" id="a11y-label1191">
+              <object class="AtkObject" id="label119-atkobject">
                 <property name="AtkObject::accessible-name" translatable="yes">Registering your system with Red Hat allows you to take full advantage of the benefits of a paid subscription, including:</property>
               </object>
             </child>
@@ -243,11 +325,23 @@
         </child>
         <child>
           <object class="GtkBox" id="hbox16">
-            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <placeholder/>
+              <object class="GtkAspectFrame" id="aspectframe1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
             </child>
             <child>
               <object class="GtkButton" id="back_to_reg_button">
@@ -256,9 +350,9 @@
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_back_to_reg_button_clicked" name="clicked"/>
+                <signal name="clicked" handler="on_back_to_reg_button_clicked" swapped="no"/>
                 <child internal-child="accessible">
-                  <object class="AtkObject" id="a11y-back_to_reg_button1">
+                  <object class="AtkObject" id="back_to_reg_button-atkobject">
                     <property name="AtkObject::accessible-name" translatable="yes">Close</property>
                   </object>
                 </child>
@@ -285,17 +379,17 @@
             <property name="left_padding">15</property>
             <child>
               <object class="GtkBox" id="vbox14">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">5</property>
                 <child>
                   <object class="GtkLabel" id="label61">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
                     <property name="label" translatable="yes">&lt;b&gt;Security &amp;amp; Updates:&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -310,7 +404,6 @@
                     <property name="left_padding">15</property>
                     <child>
                       <object class="GtkBox" id="hbox24">
-                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">8</property>
@@ -319,7 +412,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="icon_name">up2date</property>
-                            <property name="icon-size">5</property>
+                            <property name="icon_size">5</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -332,10 +425,10 @@
                             <property name="width_request">460</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
                             <property name="label" translatable="yes">Receive the latest software updates, including security updates, keeping this Red Hat Enterprise Linux system &lt;b&gt;updated&lt;/b&gt; and &lt;b&gt;secure&lt;/b&gt;.</property>
                             <property name="use_markup">True</property>
                             <property name="wrap">True</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
                             <property name="expand">True</property>
@@ -356,9 +449,9 @@
                   <object class="GtkLabel" id="label63">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
                     <property name="label" translatable="yes">&lt;b&gt;Downloads &amp;amp; Upgrades:&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -373,7 +466,6 @@
                     <property name="left_padding">15</property>
                     <child>
                       <object class="GtkBox" id="hbox25">
-                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">8</property>
@@ -382,7 +474,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="stock">gtk-cdrom</property>
-                            <property name="icon-size">5</property>
+                            <property name="icon_size">5</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -395,10 +487,10 @@
                             <property name="width_request">460</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
                             <property name="label" translatable="yes">Download installation images for Red Hat Enterprise Linux releases, including new releases.</property>
                             <property name="use_markup">True</property>
                             <property name="wrap">True</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
                             <property name="expand">True</property>
@@ -419,9 +511,9 @@
                   <object class="GtkLabel" id="label65">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
                     <property name="label" translatable="yes">&lt;b&gt;Support:&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -436,7 +528,6 @@
                     <property name="left_padding">15</property>
                     <child>
                       <object class="GtkBox" id="hbox26">
-                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">8</property>
@@ -445,7 +536,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="stock">gtk-help</property>
-                            <property name="icon-size">5</property>
+                            <property name="icon_size">5</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -458,10 +549,10 @@
                             <property name="width_request">460</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
                             <property name="label" translatable="yes">Access to the technical support experts at Red Hat or Red Hat's partners for help with any issues you might encounter with this system.</property>
                             <property name="use_markup">True</property>
                             <property name="wrap">True</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
                             <property name="expand">True</property>
@@ -482,11 +573,11 @@
                   <object class="GtkLabel" id="label67">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
                     <property name="label" translatable="yes">&lt;b&gt;Management:&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
                     <child internal-child="accessible">
-                      <object class="AtkObject" id="a11y-label671">
+                      <object class="AtkObject" id="label67-atkobject">
                         <property name="AtkObject::accessible-name" translatable="yes">Management</property>
                       </object>
                     </child>
@@ -504,7 +595,6 @@
                     <property name="left_padding">15</property>
                     <child>
                       <object class="GtkBox" id="hbox27">
-                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">8</property>
@@ -513,7 +603,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="stock">gtk-paste</property>
-                            <property name="icon-size">5</property>
+                            <property name="icon_size">5</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -526,12 +616,12 @@
                             <property name="width_request">460</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
                             <property name="label" translatable="yes">Manage subscriptions and systems registered to Customer Portal via access.redhat.com or through one of our other subscription management services.</property>
                             <property name="use_markup">True</property>
                             <property name="wrap">True</property>
+                            <property name="xalign">0</property>
                             <child internal-child="accessible">
-                              <object class="AtkObject" id="a11y-label681">
+                              <object class="AtkObject" id="label68-atkobject">
                                 <property name="AtkObject::accessible-name" translatable="yes">Manage subscriptions and systems registered to Customer Portal via access.redhat.com or through one of our other subscription management services.</property>
                               </object>
                             </child>
@@ -562,7 +652,6 @@
         </child>
         <child>
           <object class="GtkBox" id="hbox15">
-            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="spacing">5</property>


### PR DESCRIPTION
For wide windows or dialogs, most widgets were set to
use a align mode of 'fill'. This causes things like entry
boxes to expand to the entire width of the parent. Combined
with widget package that was causing the RegisterWidget to
expand to cover the widgets register screen, many widgets
fill the entire width of the screen.

Make Entry widgets set a min and max width, but allow them
to expand and fill up to that max width.

Tweak most of the Labels to auto wrap. Enabling end ellipsing
on most labels, but also give them plenty of room to expand with
by setting the suggest number of lines before ellipsing. Labels
also get set to expand. That combo removes the behavior of
labels that require a ton of horizontal space, forcing the
RegisterWidget to be very wide (and causing entries and the
like to fill all of that space).

Add Gtk.Adjustments for any ScrolledWindows that need it. Remove
some Gtk.ViewPorts that are not needed (those holding a TreeView
for example).

Set min size requests for the ScrollWindows, so the defualt size
allocated doesn't hide the contents.

Replace some Gtk.Box based layouts with Gtk.Grid instead. Especially
those that need Gtk.Alignment widgets for formatting.

Generally reduce some of the spacing and margins of the widgets,
especially around the edges of notebook screens. It should be up
to the parent that holds the RegisterWidget to setup borders, spacing,
and margins.

Add size groups for some of the more fussier layouts.