### PR TITLE
1248833: Ensure the displayMessage is displayed regardless of success…

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1301,7 +1301,10 @@ class RedeemCommand(CliCommand):
             profile_mgr = inj.require(inj.PROFILE_MANAGER)
             profile_mgr.update_check(self.cp, self.identity.uuid)
 
-            self.cp.activateMachine(self.identity.uuid, self.options.email, self.options.locale)
+            # BZ 1248833 Ensure we print out the display message if we get any back
+            response = self.cp.activateMachine(self.identity.uuid, self.options.email, self.options.locale)
+            if response and response.get('displayMessage'):
+                system_exit(0, response.get('displayMessage'))
 
         except connection.RestlibException, e:
             #candlepin throws an exception during activateMachine, even for


### PR DESCRIPTION
… or failure


Previously python-rhsm raised RestlibExceptions for response from candlepin with the response code 202, or 204. Python-rhsm was changed recently to no longer consider those exceptions. The subscription manager redeem command was expecting a RestlibException to be raised in the case of any 2XX response code. Now Subscription manager redeem will print the 'displayMessage' field from the response if one is provided.