### PR TITLE
1168268: Add rhsm.conf proxy info to ostree repo

### DIFF
--- a/src/subscription_manager/plugin/ostree/model.py
+++ b/src/subscription_manager/plugin/ostree/model.py
@@ -114,6 +114,14 @@ class OstreeRemote(object):
     def tls_ca_path(self, value):
         self.data['tls_ca_path'] = value
 
+    @property
+    def proxy(self):
+        return self.data.get('proxy')
+
+    @proxy.setter
+    def proxy(self, value):
+        self.data['proxy'] = value
+
     @classmethod
     def from_config_section(cls, section, items):
         """Create a OstreeRemote object from a repo config section name and map of items.
@@ -211,9 +219,9 @@ class OstreeRemote(object):
 
     def __repr__(self):
         r = super(OstreeRemote, self).__repr__()
-        template = "%s\n (name=%s\n url=%s\n gpg_verify=%s\n tls_client_cert_path=%s\n tls_client_key_path=%s)"
+        template = "%s\n (name=%s\n url=%s\n gpg_verify=%s\n tls_client_cert_path=%s\n tls_client_key_path=%s\n proxy=%s)"
         return template % (r, self.name, self.url, self.gpg_verify,
-               self.tls_client_cert_path, self.tls_client_key_path)
+               self.tls_client_cert_path, self.tls_client_key_path, self.proxy)
 
     def report(self):
         return self.report_template.format(self=self)

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -49,10 +49,10 @@ port = 8443
 insecure = 1
 ssl_verify_depth = 3
 ca_cert_dir = /etc/rhsm/ca/
-proxy_hostname =
-proxy_port =
-proxy_user =
-proxy_password =
+proxy_hostname = notaproxy.grimlock.usersys.redhat.com
+proxy_port = 3128
+proxy_user = proxy_user
+proxy_password = proxy_password
 
 [rhsm]
 baseurl= https://content.example.com

--- a/test/test_ostree_content_plugin.py
+++ b/test/test_ostree_content_plugin.py
@@ -820,6 +820,24 @@ tls-client-key-path = /etc/pki/entitlement/12345-key.pem
 
         rf.set_remote(remote)
 
+        expected_proxy = "http://proxy_user:proxy_password@notaproxy.grimlock.usersys.redhat.com:3128"
+        repo_proxy_uri = rf.config_parser.get('remote "awesomeos-remote"', 'proxy')
+        self.assertEquals(expected_proxy, repo_proxy_uri)
+
+    @mock.patch('subscription_manager.plugin.ostree.config.RepoFile._get_config_parser')
+    def section_set_remote(self, mock_get_config_parser):
+        mock_get_config_parser.return_value = self._rf_cfg()
+        rf = config.RepoFile('')
+
+        remote = model.OstreeRemote()
+        remote.url = "/some/path"
+        remote.name = "awesomeos-remote"
+        remote.gpg_verify = 'true'
+        remote.tls_client_cert_path = "/etc/pki/entitlement/54321.pem"
+        remote.tls_client_key_path = "/etc/pki/entitlement/54321-key.pem"
+
+        rf.set_remote(remote)
+
 
 class TestOstreeRepoFileNoRemote(BaseOstreeRepoFileTest):
     repo_cfg = """


### PR DESCRIPTION
This extract the proxy port, hostname, username, password
from rhsm.conf to the ostree repo's 'proxy' setting.