### PR TITLE
1262075,1267179: Fix back/cancel nav

### DIFF
--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
@@ -80,7 +80,7 @@ class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
         self.register_box = self.builder.get_object("register_box")
         self.button_box = self.builder.get_object('navigation_button_box')
         self.proceed_button = self.builder.get_object('proceed_button')
-        self.cancel_button = self.builder.get_object('cancel_button')
+        self.back_button = self.builder.get_object('cancel_button')
 
         self.register_box.pack_start(self.register_widget.register_widget,
                                      True, True, 0)
@@ -88,7 +88,7 @@ class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
         # Hook up the nav buttons in the gui
         # TODO: add a 'start over'?
         self.proceed_button.connect('clicked', self._on_register_button_clicked)
-        self.cancel_button.connect('clicked', self._on_cancel_button_clicked)
+        self.back_button.connect('clicked', self._on_back_button_clicked)
 
         # initial-setup will likely
         self.register_widget.connect('finished', self._on_finished)
@@ -204,15 +204,16 @@ class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
 
         pass
 
-    def _on_cancel_button_clicked(self, button):
-        """Handler for self.cancel_buttons 'clicked' signal.
+    def _on_back_button_clicked(self, button):
+        """Handler for self.back_buttons 'clicked' signal.
 
         Clear out any user set values and return to the start screen."""
 
+        self.register_widget.emit('back')
         # TODO: clear out settings and restart?
         # TODO: attempt to undo the REST api calls we've made?
-        self.register_widget.set_initial_screen()
-        self.register_widget.clear_screens()
+        #self.register_widget.set_initial_screen()
+        #self.register_widget.clear_screens()
 
     def _on_register_button_clicked(self, button):
         """Handler for self.proceed_buttons 'clicked' signal.
@@ -283,6 +284,7 @@ class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
     def _on_register_screen_ready_change(self, obj, value):
         ready = self.register_widget.current_screen.get_property('ready')
         self.proceed_button.set_sensitive(ready)
+        self.back_button.set_sensitive(ready)
 
     def _on_register_status_change(self, obj, value):
         """Handler for registergui.RegisterInfo's 'register-status' property notifications."""

--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.ui
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.ui
@@ -69,11 +69,11 @@
                             <property name="margin_bottom">4</property>
                             <child>
                               <object class="GtkButton" id="cancel_button">
-                                <property name="label" translatable="yes">Cancel</property>
+                                <property name="label">gtk-go-back</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
-                                <property name="yalign">0.43999999761581421</property>
+                                <property name="use_stock">True</property>
                               </object>
                               <packing>
                                 <property name="expand">True</property>

--- a/src/subscription_manager/gui/data/glade/register_dialog.glade
+++ b/src/subscription_manager/gui/data/glade/register_dialog.glade
@@ -19,16 +19,16 @@
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="cancel_button">
-                <property name="label">gtk-cancel</property>
+              <object class="GtkButton" id="back_button">
+                <property name="label">gtk-go-back</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_stock">True</property>
                 <property name="image_position">right</property>
                 <child internal-child="accessible">
-                  <object class="AtkObject" id="cancel_button-atkobject">
-                    <property name="AtkObject::accessible-name" translatable="yes">cancel_button</property>
+                  <object class="AtkObject" id="back_button-atkobject">
+                    <property name="AtkObject::accessible-name" translatable="yes">back_button</property>
                   </object>
                 </child>
               </object>
@@ -74,7 +74,7 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="0">cancel_button</action-widget>
+      <action-widget response="0">back_button</action-widget>
       <action-widget response="0">register_button</action-widget>
     </action-widgets>
   </object>

--- a/src/subscription_manager/gui/data/ui/register_dialog.ui
+++ b/src/subscription_manager/gui/data/ui/register_dialog.ui
@@ -32,15 +32,15 @@
             <property name="margin_bottom">4</property>
             <property name="hexpand">True</property>
             <child>
-              <object class="GtkButton" id="cancel_button">
-                <property name="label">gtk-cancel</property>
+              <object class="GtkButton" id="back_button">
+                <property name="label">gtk-go-back</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_stock">True</property>
                 <child internal-child="accessible">
-                  <object class="AtkObject" id="cancel_button-atkobject">
-                    <property name="AtkObject::accessible-name">cancel_button</property>
+                  <object class="AtkObject" id="back_button-atkobject">
+                    <property name="AtkObject::accessible-name">back_button</property>
                   </object>
                 </child>
               </object>

--- a/test/test_registrationgui.py
+++ b/test/test_registrationgui.py
@@ -33,6 +33,7 @@ class RegisterWidgetTests(SubManFixture):
 
         self.rs._screens[CHOOSE_SERVER_PAGE] = Mock()
         self.rs._screens[CHOOSE_SERVER_PAGE].index = 0
+        self.rs._screens[CHOOSE_SERVER_PAGE].screens_index = 0
         self.rs._screens[CHOOSE_SERVER_PAGE].button_label = "Dummy"
         self.rs._screens[CHOOSE_SERVER_PAGE].apply.return_value = \
                 CREDENTIALS_PAGE


### PR DESCRIPTION
Replace 'cancel' with stock 'back' button.

register_dialog.ui was using the stock 'cancel', but
rhsm_gui.ui was not. But change both to stock 'back'

Add a RegisterWidget.applied_screen_history that
tracks screens shown to the user, so that back
and error handling can do the right thing. This
uses UniqueList to keep only the last time a
screen was visited.

Make back button blocked/insens when in async
screen pre(). This avoid changing screens while
waiting for a thread to finish. It also blocks
the buttons until the screens are ready().

'back' now attempts to go back to the last gui
screen that was shown to the user.