### PR TITLE
Allow 'back' to go back multiple times.

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -380,12 +380,6 @@ class RegisterWidget(widgets.SubmanBaseWidget):
         except IndexError:
             pass
 
-    def _last_screen(self):
-        try:
-            self._set_screen(self.applied_screen_history.last())
-        except IndexError:
-            pass
-
     # methods for moving around between screens and tracking the state
 
     # On showing the widget, it could start at initial_screen, but with something
@@ -500,7 +494,7 @@ class RegisterWidget(widgets.SubmanBaseWidget):
         self.apply_current_screen()
 
     def _on_back(self, obj):
-        self._last_screen()
+        self._pop_last_screen()
 
     # switch-page should be after the current screen is reset
     def _on_switch_page(self, notebook, page, page_num):


### PR DESCRIPTION
Replace 'back' usage of _last_screen() with
_pop_last_screen() that keeps better track of the
stack of visited screens.

_last_screen() only understands the last uniq screen
visited, so would prevent 'back' from allowing
user to go back more than one screen.