### PR TITLE
1266480: Refresh TreeView selection after subscriptions are removed.

### DIFF
--- a/src/subscription_manager/gui/mysubstab.py
+++ b/src/subscription_manager/gui/mysubstab.py
@@ -153,7 +153,7 @@ class MySubscriptionsTab(widgets.SubscriptionManagerTab):
             # unregistered, just delete the certs directly
             action = EntCertDeleteAction(self.entitlement_dir)
             action.perform([serial])
-            self.update_subscriptions()
+        self.update_subscriptions()
 
     def unsubscribe_button_clicked(self, widget):
         selection = widgets.SelectionWrapper(self.top_view.get_selection(), self.store)


### PR DESCRIPTION
I'm a little *meh* about this fix, but given time constraints, I think it will have to suffice.  I don't like that when you unsubscribe an item say 4 rows down in the TreeView that the selection jumps back up to row 0 after the unsubscribe is finished.

I tried

```python
selection.store.remove(selection.tree_iter)
```

which moves the selection up one row, but something else is running shortly thereafter that moves the selection back to 0.