### PR TITLE
1266929: Fix bug with exception reporting in register dialog.

### DIFF
--- a/src/subscription_manager/gui/utils.py
+++ b/src/subscription_manager/gui/utils.py
@@ -111,14 +111,14 @@ def format_mapped_message(e, msg, mapped_message, format_msg=True):
         # the message from the server as an info dialog. (not an error)
         if 200 < int(e.code) < 300:
             message = linkify(mapped_message)
+            return message
+    try:
+        if format_msg:
+            message = msg % linkify(mapped_message)
         else:
-            try:
-                if format_msg:
-                    message = msg % linkify(mapped_message)
-                else:
-                    message = linkify(mapped_message)
-            except Exception:
-                message = msg
+            message = linkify(mapped_message)
+    except Exception:
+        message = msg
     return message
 
 


### PR DESCRIPTION
@alikins This seems to work well except for the fact that the message reads

```
Unable to register the system.
Network error, unable to connect to server. Please see /var/log/rhsm/rhsm.log for more information.
Please see /var/log/rhsm/rhsm.log for more information.
```

Should we just chop the "Please see" out of the SOCKET_MESSAGE or does that message get displayed independently?

On a more general note, the error reporting code seems really complicated and looks to have some redundancies between handle_gui_exception and a lot of the other ones.  Could we unify the reporting into one method that renders the error message?

```python
INFO = "INFO"
ERROR = "ERROR"  

def handle_gui_exception(e, msg, parent, format_msg=True, log_msg=None):
    (message, level) = render_message(e, msg, format_msg, log_msg)
    if level == INFO:
        messageWindow.InfoDialog(...)
    else:
        show_error_window(msg, parent=parent)

def handle_nongui_exception(e, msg, format_msg=True, log_msg=True):
    # I assume this is mostly for showing errors in initial-setup?

def render_msg(e, msg, format_msg, log_msg)
    # most of the logic from the current handle_gui_exception here
    level = ERROR
    if 200 < int(e.code) < 300:
        level = INFO
    # ...
    return (message, level)
```