### PR TITLE
1268095: Replace SLA radio buttons w/ combobox

### DIFF
--- a/src/subscription_manager/gui/data/ui/selectsla.ui
+++ b/src/subscription_manager/gui/data/ui/selectsla.ui
@@ -1,22 +1,22 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.3 -->
 <interface>
-  <object class="GtkTextBuffer" id="textbuffer1">
-    <property name="text">Your installed products could be covered using one of multiple service levels.</property>
-  </object>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkBox" id="container">
-    <property name="orientation">vertical</property>
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="spacing">7</property>
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkLabel" id="label3">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="xalign">0</property>
+        <property name="halign">start</property>
         <property name="label" translatable="yes">&lt;b&gt;Select Service Level&lt;/b&gt;</property>
         <property name="use_markup">True</property>
+        <property name="wrap">True</property>
+        <property name="ellipsize">end</property>
+        <property name="max_width_chars">64</property>
+        <property name="xalign">0</property>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -26,25 +26,32 @@
     </child>
     <child>
       <object class="GtkBox" id="vbox2">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">12</property>
+        <property name="hexpand">False</property>
+        <property name="vexpand">False</property>
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkTextView" id="detection_label">
+          <object class="GtkLabel" id="label1">
             <property name="visible">True</property>
-            <property name="sensitive">False</property>
             <property name="can_focus">False</property>
-            <property name="editable">False</property>
-            <property name="wrap_mode">word</property>
-            <property name="left_margin">10</property>
-            <property name="right_margin">10</property>
-            <property name="cursor_visible">False</property>
-            <property name="accepts_tab">False</property>
-            <property name="buffer">textbuffer1</property>
+            <property name="margin_left">8</property>
+            <property name="margin_right">8</property>
+            <property name="margin_top">4</property>
+            <property name="margin_bottom">4</property>
+            <property name="label" translatable="yes">Your installed products could be covered using one of multiple service levels.</property>
+            <property name="wrap">True</property>
+            <property name="ellipsize">end</property>
+            <property name="max_width_chars">64</property>
+            <property name="lines">4</property>
+            <property name="xalign">0</property>
+            <property name="yalign">0</property>
+            <attributes>
+              <attribute name="background" value="#ffffffffffff"/>
+            </attributes>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
@@ -53,28 +60,16 @@
           <object class="GtkLabel" id="detected_products_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="xalign">0</property>
-            <property name="yalign">0</property>
+            <property name="halign">start</property>
+            <property name="valign">start</property>
             <property name="xpad">10</property>
             <property name="label" translatable="yes">&lt;b&gt;Installed products:&lt;/b&gt;</property>
             <property name="use_markup">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="product_list_label">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="wrap">True</property>
+            <property name="ellipsize">middle</property>
+            <property name="max_width_chars">64</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
-            <property name="xpad">25</property>
-            <property name="label" translatable="yes">prod 1, prod2, prod 3, prod 4, prod 5, prod 6, prod 7, prod 8</property>
-            <property name="use_markup">True</property>
-            <property name="wrap">True</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -83,14 +78,18 @@
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="subscribe_all_as_label">
+          <object class="GtkLabel" id="product_list_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="margin_top">4</property>
+            <property name="margin_bottom">4</property>
+            <property name="xpad">25</property>
+            <property name="label" translatable="yes">Awesome OS 14, Awesome OS 14 Super Edition, Awesome Middle Ware For Awesome App Platform Awesome Developer Editition</property>
+            <property name="use_markup">True</property>
+            <property name="wrap">True</property>
+            <property name="max_width_chars">64</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
-            <property name="xpad">10</property>
-            <property name="label" translatable="yes">&lt;b&gt;Select a common service level for this system's subscriptions:&lt;/b&gt;</property>
-            <property name="use_markup">True</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -98,66 +97,51 @@
             <property name="position">3</property>
           </packing>
         </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkGrid" id="grid2">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <child>
-          <object class="GtkScrolledWindow" id="scrolledwindow1">
+          <object class="GtkComboBox" id="sla_combobox">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="hscrollbar_policy">automatic</property>
-            <property name="vscrollbar_policy">automatic</property>
-            <child>
-              <object class="GtkViewport" id="viewport1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="resize_mode">queue</property>
-                <property name="shadow_type">none</property>
-                <child>
-                  <object class="GtkBox" id="sla_radio_container">
-                    <property name="orientation">vertical</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">4</property>
-                    <child>
-                      <object class="GtkLabel" id="label1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
-                        <property name="label" translatable="yes">label</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
-                        <property name="label" translatable="yes">label</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
+            <property name="can_focus">False</property>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="subscribe_all_as_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="valign">start</property>
+            <property name="xpad">10</property>
+            <property name="label" translatable="yes">&lt;b&gt;Select a common service level for this system's subscriptions:&lt;/b&gt;</property>
+            <property name="use_markup">True</property>
+            <property name="wrap">True</property>
+            <property name="max_width_chars">32</property>
+            <property name="xalign">0</property>
+            <property name="yalign">0</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
           </packing>
         </child>
       </object>
       <packing>
-        <property name="expand">True</property>
+        <property name="expand">False</property>
         <property name="fill">True</property>
-        <property name="position">1</property>
+        <property name="position">2</property>
       </packing>
     </child>
   </object>

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -1105,7 +1105,7 @@ class SelectSLAScreen(Screen):
     """
     screen_enum = SELECT_SLA_PAGE
     widget_names = Screen.widget_names + ['product_list_label',
-                                          'sla_radio_container',
+                                          'sla_combobox',
                                           'owner_treeview']
     gui_file = "selectsla"
 
@@ -1115,53 +1115,41 @@ class SelectSLAScreen(Screen):
         self.pre_message = _("Finding suitable service levels")
         self.button_label = _("Next")
 
+        self.list_store = ga_Gtk.ListStore(str, ga_GObject.TYPE_PYOBJECT)
+        self.sla_combobox.set_model(self.list_store)
+
+        self.sla_combobox.connect('changed', self._on_sla_combobox_changed)
+
+        renderer_text = ga_Gtk.CellRendererText()
+        self.sla_combobox.pack_start(renderer_text, True)
+        self.sla_combobox.add_attribute(renderer_text, 'text', 0)
+
+    def _on_sla_combobox_changed(self, combobox):
+        tree_iter = combobox.get_active_iter()
+        if tree_iter is not None:
+            model = combobox.get_model()
+            sla, sla_data_map = model[tree_iter][:2]
+            self.info.set_property('dry-run-result',
+                                   sla_data_map[sla])
+
     def set_model(self, unentitled_prod_certs, sla_data_map):
         self.product_list_label.set_text(
                 self._format_prods(unentitled_prod_certs))
-        group = None
 
-        # The sla the user or kickstart requested
-        preferred_sla = self.info.get_property('preferred_sla')
-
-        # reverse iterate the list as that will most likely put 'None' last.
-        # then pack_start so we don't end up with radio buttons at the bottom
-        # of the screen.
-        chose_default = False
+        self.list_store.clear()
         for sla in reversed(sla_data_map.keys()):
-            radio = ga_Gtk.RadioButton(group=group, label=sla)
-            radio.connect("toggled",
-                          self._radio_clicked,
-                          (sla, sla_data_map))
-            # Use the user preferred sla as the default
-            # May need to handle preferred_sla not being in the suggested slas
-            if preferred_sla and preferred_sla == sla:
-                radio.set_active(True)
-                chose_default = True
+            self.list_store.append([sla, sla_data_map])
 
-            self.sla_radio_container.pack_start(radio, expand=False,
-                                                fill=False, padding=0)
-            radio.show()
-            group = radio
-
-        if not chose_default:
-            # set the initial radio button as default selection.
-            group.set_active(True)
+        self.sla_combobox.set_model(self.list_store)
+        self.sla_combobox.set_active(0)
 
     def apply(self):
         self.emit('move-to-screen', CONFIRM_SUBS_PAGE)
         return True
 
     def clear(self):
-        child_widgets = self.sla_radio_container.get_children()
-        for child in child_widgets:
-            self.sla_radio_container.remove(child)
-
-    def _radio_clicked(self, button, data):
-        sla, sla_data_map = data
-
-        if button.get_active():
-            self.info.set_property('dry-run-result',
-                                   sla_data_map[sla])
+        self.list_store.clear()
+        self.sla_combobox.set_model(self.list_store)
 
     def _format_prods(self, prod_certs):
         prod_str = ""


### PR DESCRIPTION
The box of Gtk.RadioButton widgets on SelectSLAScreen
causes an assortment of odd behavior.

Most notably, it sometimes obscures some of the available
options by having them in offscreen areas of a scrollwindow.
With default themes, it is not very obvious there is an option
to scroll and see other radio buttons.

The scrolled window was originally added to handle cases where
there is a large number of options, and a Gtk.Box of radio buttons
would cause all sorts of layout issues. Especially when the
register widgets window is a small fixed size (RHEL6 firstboot
for example).

To alleviate some of those issues, replace the box of radio
buttons with a Gtk.ComboBox.