### PR TITLE
1268102: Stop main window from opening duplicate dialogs.

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -359,18 +359,19 @@ class MainWindow(widgets.SubmanBaseWidget):
 
     def _register_item_clicked(self, widget):
         registration_dialog = registergui.RegisterDialog(self.backend, self.facts)
-        if widget:
-            def disable(x):
-                widget.set_sensitive(False)
+        registration_dialog.register_dialog.connect('destroy',
+                                                    self._on_dialog_destroy,
+                                                    widget)
 
-            def enable(x):
-                widget.set_sensitive(True)
-
-            registration_dialog.register_dialog.connect('show', disable)
-            registration_dialog.register_dialog.connect('destroy', enable)
+        if registration_dialog and widget:
+            widget.set_sensitive(False)
 
         registration_dialog.initialize()
         registration_dialog.show()
+
+    def _on_dialog_destroy(self, obj, widget):
+        widget.set_sensitive(True)
+        return False
 
     def _preferences_item_clicked(self, widget):
         try:
@@ -435,18 +436,13 @@ class MainWindow(widgets.SubmanBaseWidget):
         self.import_sub_dialog.show()
 
     def _update_certificates_button_clicked(self, widget):
-        autobind_wizard = registergui.AutobindWizardDialog(self.backend,
-                                                           self.facts)
-        if widget:
-            def disable(x):
-                widget.set_sensitive(False)
+        autobind_wizard = registergui.AutobindWizardDialog(self.backend, self.facts)
+        autobind_wizard.register_dialog.connect('destroy',
+                                                self._on_dialog_destroy,
+                                                widget)
 
-            def enable(x):
-                widget.set_sensitive(True)
-
-            autobind_wizard.register_dialog.connect('show', disable)
-            autobind_wizard.register_dialog.connect('destroy', enable)
-            autobind_wizard.register_dialog.connect('hide', enable)
+        if autobind_wizard and widget:
+            widget.set_sensitive(False)
 
         autobind_wizard.initialize()
         autobind_wizard.show()

--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -359,6 +359,16 @@ class MainWindow(widgets.SubmanBaseWidget):
 
     def _register_item_clicked(self, widget):
         registration_dialog = registergui.RegisterDialog(self.backend, self.facts)
+        if widget:
+            def disable(x):
+                widget.set_sensitive(False)
+
+            def enable(x):
+                widget.set_sensitive(True)
+
+            registration_dialog.register_dialog.connect('show', disable)
+            registration_dialog.register_dialog.connect('destroy', enable)
+
         registration_dialog.initialize()
         registration_dialog.show()
 
@@ -427,6 +437,17 @@ class MainWindow(widgets.SubmanBaseWidget):
     def _update_certificates_button_clicked(self, widget):
         autobind_wizard = registergui.AutobindWizardDialog(self.backend,
                                                            self.facts)
+        if widget:
+            def disable(x):
+                widget.set_sensitive(False)
+
+            def enable(x):
+                widget.set_sensitive(True)
+
+            autobind_wizard.register_dialog.connect('show', disable)
+            autobind_wizard.register_dialog.connect('destroy', enable)
+            autobind_wizard.register_dialog.connect('hide', enable)
+
         autobind_wizard.initialize()
         autobind_wizard.show()
 

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -718,8 +718,8 @@ class RegisterDialog(widgets.SubmanBaseWidget):
         self.register_dialog.show()
 
     def cancel(self, button):
-        self.register_dialog.hide()
-        return True
+        self.register_dialog.destroy()
+        return False
 
     def on_register_message(self, obj, msg, msg_type=None):
         # NOTE: We ignore the message type here, but initial-setup wont.


### PR DESCRIPTION
I am a little uncertain about the `destroy` versus `hide` signal.  The Autobind dialog seems to `hide` itself upon successful completion although it seems to me like it should `destroy` itself.  Regardless, it can still be `destroy`ed if you right-click then close it while it's running.