### PR TITLE
1268094: Avoid traceback on unreg with >1 sub

### DIFF
--- a/src/subscription_manager/gui/mysubstab.py
+++ b/src/subscription_manager/gui/mysubstab.py
@@ -265,7 +265,13 @@ class MySubscriptionsTab(widgets.SubscriptionManagerTab):
         self.unsubscribe_button.set_property('sensitive', True)
         # Load the entitlement certificate for the selected row:
         serial = selection['serial']
+        if not serial:
+            return
+
         cert = self.entitlement_dir.find(long(serial))
+        if not cert:
+            return
+
         order = cert.order
         products = [(product.name, product.id)
                         for product in cert.products]


### PR DESCRIPTION
When unregistering with the gui, if there are more
than one subscriptions attached, there is a traceback
on the console.

The on_selection callback is getting called with a
selection that points to a serial/cert that isn't
valid by the time the callback runs. So the the
cert lookup returns None, and the rest of the code
didn't expect that. So just check for that and return.