### PR TITLE
1251853: Fix errors if "manage_repos = " in cfg

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -49,7 +49,7 @@ from subscription_manager.jsonwrapper import PoolWrapper
 from subscription_manager import managerlib
 from subscription_manager.managerlib import valid_quantity, format_date
 from subscription_manager.release import ReleaseBackend
-from subscription_manager.repolib import RepoActionInvoker, RepoFile
+from subscription_manager.repolib import RepoActionInvoker, RepoFile, manage_repos_enabled
 from subscription_manager.utils import parse_server_info, \
         parse_baseurl_info, format_baseurl, is_valid_server_info, \
         MissingCaCertException, get_client_versions, get_server_versions, \
@@ -260,10 +260,6 @@ def get_installed_product_status(product_directory, entitlement_directory, uep, 
                 ))
 
     return product_status
-
-
-def managed_repos_disabled():
-    return cfg.has_option('rhsm', 'manage_repos') and not int(cfg.get('rhsm', 'manage_repos'))
 
 
 class CliCommand(AbstractCLICommand):
@@ -1939,7 +1935,7 @@ class ReposCommand(CliCommand):
     def _do_command(self):
         self._validate_options()
         rc = 0
-        if managed_repos_disabled():
+        if not manage_repos_enabled():
             print _("Repositories disabled by configuration.")
             return rc
 
@@ -2499,7 +2495,7 @@ class OverrideCommand(CliCommand):
 
         overrides = Overrides()
 
-        if managed_repos_disabled():
+        if not manage_repos_enabled():
             print _("Repositories disabled by configuration.")
 
         if self.options.list:

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 import contextlib
 
+
 # for monkey patching config
 import stubs
 


### PR DESCRIPTION
Move managercli.managed_repos_disabled to repolib.manage_repos_enabled()

Make the function handle potential ConfigParser errors, and make
it return a bool.

Update managercli and repolib to use it.

Add test cases to test_repolib.py