### PR TITLE
1268088 trim spoke status

### DIFF
--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
@@ -73,6 +73,8 @@ class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
 
         backend = managergui.Backend()
         self.info = registergui.RegisterInfo()
+        # BZ 1267322 Set the registration status message
+        self._status_message = self.info.get_registration_status()
         self.register_widget = registergui.RegisterWidget(backend, facts,
                                                           reg_info=self.info,
                                                           parent_window=self.main_window)

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -190,6 +190,12 @@ class RegisterInfo(ga_GObject.GObject):
         self.set_property('port', CFG.get('server', 'port'))
         self.set_property('prefix', CFG.get('server', 'prefix'))
 
+    def get_registration_status(self):
+        msg = _("This system is currently not registered.")
+        if self.identity and self.identity.is_valid():
+            msg = _("System Already Registered")
+        return msg
+
 
 class RegisterWidget(widgets.SubmanBaseWidget):
     gui_file = "registration"
@@ -358,7 +364,7 @@ class RegisterWidget(widgets.SubmanBaseWidget):
         self.info.set_property('register-status', msg)
 
     def do_register_finished(self):
-        msg = _("The system has been registered with ID: %s ") % self.info.identity.uuid
+        msg = _("System '%s' successfully registered.\n") % self.info.identity.name
         self.info.set_property('register-status', msg)
 
     def do_finished(self):
@@ -402,6 +408,8 @@ class RegisterWidget(widgets.SubmanBaseWidget):
 
         if self.info.identity.is_valid():
             self.emit('register-finished')
+            msg = _("System '%s' successfully registered.\n") % self.info.identity.name
+            self.info.set_property('register-status', msg.rstrip())
             # We are done if auto bind is being skipped ("Manually attach
             # to subscriptions" is clicked in the gui)
             if self.info.get_property('skip-auto-bind'):
@@ -409,7 +417,8 @@ class RegisterWidget(widgets.SubmanBaseWidget):
             self.current_screen.emit('move-to-screen', SELECT_SLA_PAGE)
             self.register_widget.show_all()
             return False
-
+        msg = _("This system is currently not registered.")
+        self.info.set_property('register-status', msg)
         self.current_screen.stay()
         self.register_widget.show_all()
         return False


### PR DESCRIPTION
Implemented suggestions 2 (with barnaby's addendum) and 3 as quoted from jsefler below
>Here are my suggestions...
>
>1. Move "The system has been registered with ID: %s " from beneath the spoke icon to the final >panel of the subscription-manager-initial-setup-addon workflow where you are currently displaying >"Registration with Red Hat Subscription Management is Done!"  I think this is more informative and >avoids seeing the word "Done" on the final screen in two places.
>
>2. Display a short message "This system is registered." beneath the spoke icon after registration is >done.  (Note: this string does not exist among the translated 1.15.X strings)
>
>3. Display a short message "This system is currently not registered." or "System is not registered." >beneath the spoke icon before registration happens.  (Note: both of these two strings have already >been translated.)  In version subscription-manager-initial-setup-addon-1.15.9-13.el7 the is no >message being displayed and it looks a little finny when the other spokes are displaying a message.


barnaby's addendum:
>Addendum for suggestion 2
>
>I would suggest using the existing string "System '%s' successfully registered.\n" for the immediate >release, this will at least ensure that 'registered' is the last word which will be displayed in the text >block.