### PR TITLE
1270204: Crash report no longer sent when widget is none

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -370,7 +370,8 @@ class MainWindow(widgets.SubmanBaseWidget):
         registration_dialog.show()
 
     def _on_dialog_destroy(self, obj, widget):
-        widget.set_sensitive(True)
+        if widget:
+            widget.set_sensitive(True)
         return False
 
     def _preferences_item_clicked(self, widget):


### PR DESCRIPTION
There was a crash report being generated when the registeration dialog was completed after s-m-gui was started by clicking 'Register Now' on rhsm-icon. This was a result of the widget (that started the registeration process) being set to None. The fix is to check if the widget being handled is None.