### PR TITLE
1264964: Ignore uuid=None on package sync

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -135,6 +135,22 @@ class CacheManager(object):
         """
         Check if data has changed, and push an update if so.
         """
+
+        # The package_upload.py yum plugin from katello-agent will
+        # end up calling this with consumer_uuid=None if the system
+        # is unregistered.
+        if not consumer_uuid:
+            msg = _("consumer_uuid=%s is not a valid consumer_uuid. "
+                    "Not attempting to sync %s cache with server.") % \
+                (consumer_uuid, self.__class__.__name__)
+            log.debug(msg)
+
+            # Raising an exception here would be better, but that is just
+            # going to cause the package_upload plugin to spam yum
+            # output for unregistered systems, and can only be resolved by
+            # registering to rhsm.
+            return 0
+
         log.debug("Checking current system info against cache: %s" % self.CACHE_FILE)
         if self.has_changed() or force:
             log.debug("System data has changed, updating server.")

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -152,6 +152,16 @@ class TestProfileManager(unittest.TestCase):
         self.assertTrue(self.profile_mgr.has_changed())
         self.profile_mgr._read_cache.assert_called_with()
 
+    def test_update_check_consumer_uuid_none(self):
+        uuid = None
+        uep = Mock()
+
+        self.profile_mgr.has_changed = Mock(return_value=True)
+        self.profile_mgr.write_cache = Mock()
+
+        res = self.profile_mgr.update_check(uep, uuid)
+        self.assertEquals(0, res)
+
     @staticmethod
     def _mock_pkg_profile(packages):
         """


### PR DESCRIPTION
The 'package_upload' yum plugin from katello-agent
will call packageprofilelib._do_update with
consumer_uuid=None, resulting in an invalid request
to the rhsm REST API, if the consumer system is
not registered to rhsm.

So if we get as far as CacheManagers update_check with
consumer_uuid=None, just log it and return. We can't
raise an exception in that case without causing yum
to show the exception message on stderr for what is
a valid configuration.

For 'package_upload', it doesn't check if the consumer
if registered and calls into ActionClient.profilelib._do_update,
which is past any checks for registration. This change
just prevents it from making a request to the rhsm REST
API like 'PUT /consumers/None/packages'.

Rhsm registered systems with a valid consumer_uuid will
continue to make the package profile upload request.