### PR TITLE
Set register-status in RegisterInfo init.

### DIFF
--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
@@ -60,7 +60,6 @@ class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
     def __init__(self, data, storage, payload, instclass):
         NormalSpoke.__init__(self, data, storage, payload, instclass)
         self._done = False
-        self._status_message = ""
         self._addon_data = self.data.addons.com_redhat_subscription_manager
 
     def initialize(self):
@@ -73,8 +72,7 @@ class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
 
         backend = managergui.Backend()
         self.info = registergui.RegisterInfo()
-        # BZ 1267322 Set the registration status message
-        self._status_message = self.info.get_registration_status()
+
         self.register_widget = registergui.RegisterWidget(backend, facts,
                                                           reg_info=self.info,
                                                           parent_window=self.main_window)
@@ -105,8 +103,6 @@ class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
         self.register_widget.connect('notify::screen-ready',
                                      self._on_register_screen_ready_change)
 
-        self.info.connect('notify::register-status', self._on_register_status_change)
-
         self.register_box.show_all()
         self.register_widget.initialize()
 
@@ -136,7 +132,8 @@ class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
         """A string property indicating a user facing summary of the spokes status.
         This is displayed under the spokes name on it's hub."""
 
-        return self._status_message
+        # The status property is only used read/only, so no setter required.
+        return self.info.get_property('register-status')
 
     def refresh(self):
         """Update gui widgets to reflect state of self.data.
@@ -287,11 +284,6 @@ class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
         ready = self.register_widget.current_screen.get_property('ready')
         self.proceed_button.set_sensitive(ready)
         self.back_button.set_sensitive(ready)
-
-    def _on_register_status_change(self, obj, value):
-        """Handler for registergui.RegisterInfo's 'register-status' property notifications."""
-
-        self._status_message = obj.get_property('register-status')
 
     def _on_register_button_label_change(self, obj, value):
         """Handler for registergui.RegisterWidgets's 'register-button-label' property notifications.

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -183,6 +183,7 @@ class RegisterInfo(ga_GObject.GObject):
     def __init__(self):
         ga_GObject.GObject.__init__(self)
         self._defaults_from_config()
+        self._initial_registration_status()
 
     def _defaults_from_config(self):
         """Load the current server values from configuration (rhsm.conf)."""
@@ -190,11 +191,11 @@ class RegisterInfo(ga_GObject.GObject):
         self.set_property('port', CFG.get('server', 'port'))
         self.set_property('prefix', CFG.get('server', 'prefix'))
 
-    def get_registration_status(self):
+    def _initial_registration_status(self):
         msg = _("This system is currently not registered.")
         if self.identity and self.identity.is_valid():
             msg = _("System Already Registered")
-        return msg
+        self.set_property('register-status', msg)
 
 
 class RegisterWidget(widgets.SubmanBaseWidget):


### PR DESCRIPTION
And reference it via RHSMSpoke's 'status' python property
that queries RegisterInfo's 'register-status' gobject property.

This makes RegisterInfo's 'register-status' the only source of
that string.

Remove RHSMSpokes 'notify::register-status' handler since
RHSMSpoke.status is only read when initial-setup needs to
(ie, when revisiting the hub)