### PR TITLE
Fix register_dialog window type hint.

### DIFF
--- a/src/subscription_manager/gui/data/glade/register_dialog.glade
+++ b/src/subscription_manager/gui/data/glade/register_dialog.glade
@@ -7,7 +7,6 @@
     <property name="border_width">5</property>
     <property name="title" translatable="yes">System Registration</property>
     <property name="icon_name">subscription-manager</property>
-    <property name="type_hint">splashscreen</property>
     <child internal-child="vbox">
       <object class="GtkVBox" id="register_dialog_main_vbox">
         <property name="visible">True</property>


### PR DESCRIPTION
It is not a splash screen. Not even the
most boring splash screen in the world.
So remove the bogus 'splashscreen' type hint.