### PR TITLE
After unregister, call cp_provider.clean()

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1046,6 +1046,8 @@ class RegisterCommand(UserPassCommand):
                 log.error("Unable to unregister consumer: %s" % old_uuid)
                 log.exception(e)
 
+        self.cp_provider.clean()
+
         facts = inj.require(inj.FACTS)
 
         # Proceed with new registration:


### PR DESCRIPTION
Reset cp_provider so we get new requests.Sessions
(both basic auth and client auth).

Before we would create a client cert uep at start up
of register --force, then unregister, then create a new
basic auth to register with, but cp.provider.get_consumer_auth_cp
would return the origin uep connection with the now invalid
consumer cert.

cp_provider.clean() unsets any state on cp_provider.