### PR TITLE
Fix the logger name lock.py requests.

### DIFF
--- a/src/subscription_manager/lock.py
+++ b/src/subscription_manager/lock.py
@@ -25,7 +25,7 @@ import time
 LOCK_WAIT_DURATION = 0.5
 
 import logging
-log = logging.getLogger("rhsm-app." + __file__)
+log = logging.getLogger("rhsm-app." + __name__)
 
 
 class LockFile(object):


### PR DESCRIPTION
It was grabbing the logger based on file name instead
of module name, so it would end up with the logger
named 'rhsm-app./usr/share/rhsm/subscription_manager/lock.py'
instead of 'rhsm-app.lock'