### PR TITLE
Make 'service-level' man page title all caps.

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -349,7 +349,7 @@ Sets the minor (Y-stream) release version to use, such as 6.3.
 Removes any previously set release version preference.
 
 
-.SS service-level OPTIONS
+.SS SERVICE-LEVEL OPTIONS
 The
 .B service-level
 command displays the current configured service level


### PR DESCRIPTION
So it matches the rest of the sub command options
entries.