### PR TITLE
1262989: Changed the error code returned when the consumer has been deleted on the server

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -500,11 +500,11 @@ class CliCommand(AbstractCLICommand):
                 return return_code
         except X509.X509Error, e:
             log.error(e)
-            print _('System certificates corrupted. Please reregister.')
+            system_exit(os.EX_SOFTWARE, _('System certificates corrupted. Please reregister.'))
         except connection.GoneException, ge:
             if ge.deleted_id == self.identity.uuid:
                 log.critical(_("This consumer's profile has been deleted from the server. "))
-                print (_("This consumer's profile has been deleted from the server. You can use command clean or unregister to remove local profile."))
+                system_exit(os.EX_UNAVAILABLE, _("This consumer's profile has been deleted from the server. You can use command clean or unregister to remove local profile."))
             else:
                 raise ge
 


### PR DESCRIPTION
- When a x509 error occurs during a CLI command, or the active consumer was deleted
  on the server, subman now returns a non-zero error code and prints the message to
  stderr rather than stdout