### PR TITLE
1262989: Updated error message to include consumer UUID

### DIFF
--- a/src/daemons/rhsmcertd-worker.py
+++ b/src/daemons/rhsmcertd-worker.py
@@ -88,9 +88,9 @@ def main(options, log):
         # cert, but making a request for a different consumer uuid, so unlikely. Could register
         # with --consumerid get there?
         if ge.deleted_id == uuid:
-            log.critical(_("This consumer's profile has been deleted from the server. Its local certificates will now be archived"))
+            log.critical("Consumer profile \"%s\" has been deleted from the server. Its local certificates will now be archived", uuid)
             managerlib.clean_all_data()
-            log.critical(_("Certificates archived to '/etc/pki/consumer.old'. Contact your system administrator if you need more information."))
+            log.critical("Certificates archived to '/etc/pki/consumer.old'. Contact your system administrator if you need more information.")
 
         raise ge
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -503,8 +503,8 @@ class CliCommand(AbstractCLICommand):
             system_exit(os.EX_SOFTWARE, _('System certificates corrupted. Please reregister.'))
         except connection.GoneException, ge:
             if ge.deleted_id == self.identity.uuid:
-                log.critical(_("This consumer's profile has been deleted from the server. "))
-                system_exit(os.EX_UNAVAILABLE, _("This consumer's profile has been deleted from the server. You can use command clean or unregister to remove local profile."))
+                log.critical("Consumer profile \"%s\" has been deleted from the server.", self.identity.uuid)
+                system_exit(os.EX_UNAVAILABLE, _("Consumer profile \"%s\" has been deleted from the server. You can use command clean or unregister to remove local profile.") % self.identity.uuid)
             else:
                 raise ge
 


### PR DESCRIPTION
- The error messages that can occur in subman when a consumer is
  deleted from the server before unregistering now include the
  consumer's UUID in the error messages.
- Log messages related to this issue are no longer translated