### PR TITLE
1265904: requires auto help message

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1410,7 +1410,7 @@ class AttachCommand(CliCommand):
         self.parser.add_option("--auto", action='store_true',
             help=_("Automatically attach compatible subscriptions to this system. This is the default action."))
         self.parser.add_option("--servicelevel", dest="service_level",
-                               help=_("service level to apply to this system"))
+                               help=_("Automatically attach only subscriptions matching the specified service level; only used with --auto"))
         self.parser.add_option("--file", dest="file",
                                 help=_("A file from which to read pool IDs. If a hyphen is provided, pool IDs will be read from stdin."))
 
@@ -1436,7 +1436,7 @@ class AttachCommand(CliCommand):
         return True
 
     def _validate_options(self):
-        if self.options.pool:
+        if self.options.pool or self.options.file:
             if self.options.auto:
                 system_exit(os.EX_USAGE, _("Error: --auto may not be used when specifying pools."))
             if self.options.service_level:

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1055,7 +1055,7 @@ class TestAttachCommand(TestCliProxyCommand):
     def test_servicelevel_option_but_no_auto_option(self):
         with self.mock_stdin(open(self.tempfiles[1][1])):
             self.cc.main(["--servicelevel", "Super", "--file", "-"])
-            self.cc._validate_options()
+            self.assertRaises(SystemExit, self.cc._validate_options)
 
     def test_servicelevel_option_with_pool_option(self):
         self.cc.main(["--servicelevel", "Super", "--pool", "1232342342313"])


### PR DESCRIPTION
* adds the help message as suggested in the BZ:
```
$subscription-manager attach --help
Usage: subscription-manager attach [OPTIONS]

Attach a specified subscription to the registered system

Options:
  -h, --help            show this help message and exit
  --proxy=PROXY_URL     proxy URL in the form of proxy_hostname:proxy_port
  --proxyuser=PROXY_USER
                        user for HTTP proxy with basic authentication
  --proxypassword=PROXY_PASSWORD
                        password for HTTP proxy with basic authentication
  --pool=POOL           the ID of the pool to attach (can be specified more
                        than once)
  --quantity=QUANTITY   number of subscriptions to attach
  --auto                Automatically attach compatible subscriptions to this
                        system. This is the default action.
  --servicelevel=SERVICE_LEVEL
                        Automatically attach only subscriptions matching the
                        specified service level; only used with --auto
  --file=FILE           A file from which to read pool IDs. If a hyphen is
                        provided, pool IDs will be read from stdin.
```
* in addition, added a validation which does not let users use service-level with file:
```
subscription-manager attach --file=pools.txt --service-level=premium
```