### PR TITLE
1285004: Subs can be removed by pool id using existing api methods

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1655,15 +1655,10 @@ class RemoveCommand(CliCommand):
                 failure.append(re.msg)
         return (success, failure)
 
-    def _print_unbind_ids_result(self, success, failure, id_name):
-        if success:
-            print _("%s successfully removed at the server:" % id_name)
-            for id_ in success:
-                print "   %s" % id_
-        if failure:
-            print _("%s unsuccessfully removed at the server:" % id_name)
-            for id_ in failure:
-                print "   %s" % id_
+    def _print_ids(self, display_message, ids):
+        print display_message
+        for id_ in ids:
+            print "   %s" % id_
 
     def _do_command(self):
         """
@@ -1689,20 +1684,29 @@ class RemoveCommand(CliCommand):
                     removed_serials = []
                     if self.options.pool_ids:
                         pool_id_to_serials = self.entitlement_dir.list_serials_for_pool_ids(self.options.pool_ids)
-                        success, failure = self._unbind_ids(self.cp.unbindByPoolId, identity.uuid, self.options.pool_ids)
-                        if not success:
-                            return_code = 1
-                        else:
-                            self._print_unbind_ids_result(success, failure, "Pools")
-                            for pool_id in success:
-                                removed_serials.extend(pool_id_to_serials[pool_id])
+                        for pool_id, serials in pool_id_to_serials.iteritems():
+                            success, failure = self._unbind_ids(self.cp.unbindBySerial, identity.uuid, serials)
+                            if success:
+                                self._print_ids(_("Serial numbers successfully"
+                                                  " removed at the server for pool '%s':" % pool_id),
+                                                success)
+                                removed_serials.extend(success)
+                            else:
+                                return_code = 1
+                            if failure:
+                                self._print_ids(_("Serial numbers unsuccessfully"
+                                                  " removed at the server for pool '%s':" % pool_id),
+                                                failure)
                     if self.options.serials:
                         serials_to_remove = [serial for serial in self.options.serials if serial not in removed_serials]  # Don't remove serials already removed by a pool
                         success, failure = self._unbind_ids(self.cp.unbindBySerial, identity.uuid, serials_to_remove)
                         removed_serials.extend(success)
                         if not success:
                             return_code = 1
-                    self._print_unbind_ids_result(removed_serials, failure, "Serial numbers")
+                        else:
+                            self._print_ids(_("Serial numbers successfully removed at the server:"), success)
+                        if failure:
+                            self._print_ids(_("Serial numbers unsuccessfully removed at the server:"), failure)
                 self.entcertlib.update()
             except connection.RestlibException, re:
                 log.error(re)

--- a/test/test_remove.py
+++ b/test/test_remove.py
@@ -28,6 +28,12 @@ class CliRemoveTests(fixture.SubManFixture):
         super(CliRemoveTests, self).setUp()
 
     def test_unsubscribe_registered(self):
+        pool_id1 = '39993922b'
+        prod = StubProduct('stub_product')
+        pool = StubPool(pool_id1)
+        ent = StubEntitlementCertificate(prod, pool=pool)
+        inj.provide(inj.ENT_DIR, StubEntitlementDirectory([ent]))
+
         cmd = managercli.RemoveCommand()
 
         mock_identity = self._inject_mock_valid_consumer()
@@ -45,10 +51,8 @@ class CliRemoveTests(fixture.SubManFixture):
         cmd.main(['remove', '--serial=%s' % serial1, '--serial=%s' % serial2])
         self.assertEquals(cmd.cp.called_unbind_serial, [serial1, serial2])
 
-        pool_id1 = '39993922b'
         cmd.main(['remove', '--serial=%s' % serial1, '--serial=%s' % serial2, '--pool=%s' % pool_id1])
-        self.assertEquals(cmd.cp.called_unbind_serial, [serial1, serial2])
-        self.assertEquals(cmd.cp.called_unbind_pool_id, [pool_id1])
+        self.assertEquals(set(cmd.cp.called_unbind_serial), set([serial1, serial2, str(ent.serial)]))
 
     def test_unsubscribe_unregistered(self):
         prod = StubProduct('stub_product')


### PR DESCRIPTION
This PR updates the remove --pool logic to use the existing api method unbindBySerial (DELETE /{consumer_uuid}/certificates/{serial})  for each cert that has the given pool id.

The pro to this implementation is that as there is no requirement for a new version of candlepin people can make use of this new subman feature immediately.
The main con is, in my opinion, that candlepin has no knowledge of what was actually done (the fact that the consumer intended to unbind/remove all entitlements that can from a particular pool). I'm not entirely sure how useful it would be for candlepin to have that knowledge but it is something worth considering.

Tests are updated as well as the core logic. As there is no present need for the new candlepin API method, it might be worth removing.