### PR TITLE
Revert "Remove logrotating in favor of logrotate daemon"

### DIFF
--- a/src/subscription_manager/logutil.py
+++ b/src/subscription_manager/logutil.py
@@ -53,7 +53,7 @@ class SubmanDebugLoggingFilter(object):
 # NOTE: python 2.6 and earlier versions of the logging module
 #       defined the log handlers as old style classes. In order
 #       to use super(), we also inherit from 'object'
-class RHSMLogHandler(logging.handlers.FileHandler, object):
+class RHSMLogHandler(logging.handlers.RotatingFileHandler, object):
     """Logging Handler for /var/log/rhsm/rhsm.log"""
     def __init__(self, *args, **kwargs):
         try:


### PR DESCRIPTION
This reverts commit 17163bb84ec26f2bafbac1bbb9207a478567d001.

FileHandler breaks nosetests. Revert for the time being.