### PR TITLE
1285004: Adds check for access to the required manager capability

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1637,6 +1637,11 @@ class RemoveCommand(CliCommand):
                     bad = True
             if bad:
                 system_exit(os.EX_USAGE)
+        elif self.options.pool_ids:
+            if not self.cp.has_capability("remove_by_pool_id"):
+                print _("Error: The registered entitlement server does not support remove --pool."
+                        "\nInstead, use the remove --serial option.")
+                system_exit(os.EX_UNAVAILABLE)
         elif not self.options.all and not self.options.pool_ids:
             print _("Error: This command requires that you specify one of --serial, --pool or --all.")
             system_exit(os.EX_USAGE)
@@ -1652,7 +1657,8 @@ class RemoveCommand(CliCommand):
                 if re.code == 410:
                     print re.msg
                     system_exit(os.EX_SOFTWARE)
-                failure.append(re.msg)
+                failure.append(id_)
+                log.error(re)
         return (success, failure)
 
     def _print_unbind_ids_result(self, success, failure, id_name):

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -386,6 +386,10 @@ class StubUEP(object):
         self.called_unbind_pool_id = []
         self.username = username
         self.password = password
+        self._capabilities = []
+
+    def has_capability(self, capability):
+        return capability in self._capabilities
 
     def supports_resource(self, resource):
         return False

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1148,6 +1148,18 @@ class TestRemoveCommand(TestCliProxyCommand):
         except SystemExit, e:
             self.assertEquals(e.code, 2)
 
+    def test_validate_access_to_remove_by_pool(self):
+        self.cc.main(["--pool", "a2ee88488bbd32ed8edfa2"])
+        self.cc.cp._capabilities = ["remove_by_pool_id"]
+        self.cc._validate_options()
+
+    def test_validate_no_access_to_remove_by_pool(self):
+        self.cc.main(["--pool", "a2ee88488bbd32ed8edfa2"])
+        try:
+            self.cc._validate_options()
+        except SystemExit, e:
+            self.assertEquals(e.code, 69)
+
 
 class TestUnSubscribeCommand(TestRemoveCommand):
     command_class = managercli.UnSubscribeCommand


### PR DESCRIPTION
Logs Restlib exceptions returned instead of adding them to the output.
Also checks for 'remove_by_pool_id' capability during validation if the --pool option is specified.