### PR TITLE
1263037: Change RHSM Icon reporting of unregistered system

### DIFF
--- a/src/daemons/rhsm_d.py
+++ b/src/daemons/rhsm_d.py
@@ -109,8 +109,9 @@ def pre_check_status(force_signal):
         return RHN_CLASSIC
 
     identity = require(IDENTITY)
+    sorter = require(CERT_SORTER)
 
-    if not identity.is_valid():
+    if not identity.is_valid() and not sorter.has_entitlements():
         debug("The system is not currently registered.")
         return RHSM_REGISTRATION_REQUIRED
     return None

--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -389,6 +389,11 @@ class CertSorter(ComplianceManager):
         self.identity.reload()
         self.cp_provider.clean()
 
+    # check to see if there are certs in the directory
+    def has_entitlements(self):
+        return len(self.entitlement_dir.list()) > 0
+
+
 
 class StackingGroupSorter(object):
     def __init__(self, entitlements):


### PR DESCRIPTION
Stop "Register System For Support and Updates" message
when system has imported entitlements. This is the indicator of
an intentional offline system.