### PR TITLE
Removes the additional blank line before the StackingGroupSorter class.

### DIFF
--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -394,7 +394,6 @@ class CertSorter(ComplianceManager):
         return len(self.entitlement_dir.list()) > 0
 
 
-
 class StackingGroupSorter(object):
     def __init__(self, entitlements):
         self.groups = []


### PR DESCRIPTION
This fixes the flake8 error that jenkins is presently upset about.