### PR TITLE
Replace watchdog code with a resetable timer

### DIFF
--- a/etc-conf/com.redhat.SubscriptionManager.conf
+++ b/etc-conf/com.redhat.SubscriptionManager.conf
@@ -13,6 +13,12 @@
   <policy context="default">
     <allow send_destination="com.redhat.SubscriptionManager"/>
     <allow send_destination="com.redhat.SubscriptionManager.EntitlementStatus"/>
+
+    <!-- Basic D-Bus API stuff -->
+    <allow send_destination="org.freedesktop.NetworkManager"
+       send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="org.freedesktop.NetworkManager"
+       send_interface="org.freedesktop.DBus.Properties"/>
   </policy>
 
 </busconfig>

--- a/src/subscription_manager/ga_impls/ga_gtk2/GLib.py
+++ b/src/subscription_manager/ga_impls/ga_gtk2/GLib.py
@@ -1,6 +1,7 @@
 import gobject
 
 timeout_add = gobject.timeout_add
+timeout_add_seconds = gobject.timeout_add_seconds
 idle_add = gobject.idle_add
 
-__all__ = [timeout_add, idle_add]
+__all__ = [timeout_add, timeout_add_seconds, idle_add]

--- a/src/subscription_manager/ga_impls/ga_gtk2/GObject.py
+++ b/src/subscription_manager/ga_impls/ga_gtk2/GObject.py
@@ -6,7 +6,7 @@ from gobject import MainLoop
 
 # methods
 from gobject import add_emission_hook, idle_add, property
-from gobject import source_remove, timeout_add
+from gobject import source_remove, timeout_add, timeout_add_seconds
 from gobject import markup_escape_text
 
 # enums
@@ -20,7 +20,7 @@ class SignalFlags(object):
 
 constants = [TYPE_BOOLEAN, TYPE_PYOBJECT, PARAM_READWRITE]
 methods = [add_emission_hook, idle_add, markup_escape_text,
-           property, source_remove, timeout_add]
+           property, source_remove, timeout_add, timeout_add_seconds]
 enums = [SignalFlags]
 objects = [GObject, MainLoop]
 __all__ = objects + methods + constants + enums


### PR DESCRIPTION
Instead of idle_add'ing the check_if_ran_once call
back at the end of each StatusChecker method call
to exit the main loop and exit the service, add a
default timeout, after which the loop/service quits.
And reset the timeout after any activity.

This avoids starting/stopping rhsm_d service as often,
while also providing a way to automatically shut it down
after a timeout.

Make watchdog into a context manager

Something running in the watchdog() context will
not cause a timeout, but an idle process will
timeout in 240 seconds.

Get rid of StatusChecker.has_run attribute, we don't use
it anymore.

Add DBus Introspectable and Properties to default
dbus policy context for subscription-manager
(though note our object has no properties at the momemnt).