### PR TITLE
1046132: rhsm_icon uses status from check_status

### DIFF
--- a/src/daemons/rhsm_d.py
+++ b/src/daemons/rhsm_d.py
@@ -170,17 +170,15 @@ class StatusChecker(dbus.service.Object):
                  2 if close to expiry
         """
         log.debug("D-Bus interface com.redhat.SubscriptionManager.EntitlementStatus.check_status called")
-        # If check status is called, fire signal whether the status changed or not.
-        # This is to ensure we get an icon at boot time. If we are going to fetch the status,
-        # might as well update the cache.
-        ret = check_status(self.force_signal)
-        debug("Fire status signal")
-        self.entitlement_status_changed(ret)
-        self.rhsm_icon_cache.data = ret
+        status = check_status(self.force_signal)
+        if (status != self.rhsm_icon_cache._read_cache()):
+            debug("Validity status changed, fire signal in check_status")
+            self.entitlement_status_changed(status)
+        self.rhsm_icon_cache.data = status
         self.rhsm_icon_cache.write_cache()
         self.has_run = True
         self.watchdog()
-        return ret
+        return status
 
     @dbus.service.method(
             dbus_interface="com.redhat.SubscriptionManager.EntitlementStatus",

--- a/src/rhsm_icon/rhsm_icon.c
+++ b/src/rhsm_icon/rhsm_icon.c
@@ -285,6 +285,7 @@ display_icon (Context * context, StatusType status_type)
 static void
 alter_icon (Context * context, StatusType status_type)
 {
+	g_debug ("alter_icon status_type: %i\n", status_type);
 	context->show_registration = status_type == RHSM_REGISTRATION_REQUIRED;
 	if ((status_type != RHN_CLASSIC) && (status_type != RHSM_VALID)) {
 		display_icon (context, status_type);
@@ -341,10 +342,10 @@ check_status (Context * context)
 				 force_icon);
 			exit (1);
 		}
-		alter_icon (context, status_type);
 	} else {
 		status_type = check_status_over_dbus (context);
 	}
+	alter_icon (context, status_type);
 	return true;
 }
 


### PR DESCRIPTION
This changes rhsm_icon.c to use the entitlement
status returned from it's call to 'check_status'
dbus method for the intial_check and daily checks.

Previously, the status returned from 'check_status'
was ignored, instead being triggered by the
'entitlement_status_changed' dbus signal. However,
rhsm_d.py was prone to emitting this too often
because of multiple bugs that are now fixed.
See commit 35aa7e7eba82f601504bb64ab56aebe6dee4e786.

Since rhsm_icons display_icon knows how to handle
a RHSM_VALID state (ie, don't do anything), we can
pass any entitlement status to it, instead of waiting
for a entitlement_status_changed signal.

The 'check_status' dbus method now only emits a
entitlement_status_changed signal if the current status
is different than the last know status.