### PR TITLE
1300259: Select service level label no longer overlaps dropdown box

### DIFF
--- a/src/subscription_manager/gui/data/glade/selectsla.glade
+++ b/src/subscription_manager/gui/data/glade/selectsla.glade
@@ -101,6 +101,7 @@
             <property name="use_markup">True</property>
             <property name="single_line_mode">True</property>
             <property name="max_width_chars">32</property>
+            <property name="width_request">520</property>
           </object>
           <packing>
             <property name="y_options">GTK_EXPAND</property>


### PR DESCRIPTION
Another one liner fix for a regression.

BZ here: https://bugzilla.redhat.com/show_bug.cgi?id=1300259