### PR TITLE
Removes debug print statments from cpuinfo

### DIFF
--- a/src/subscription_manager/cpuinfo.py
+++ b/src/subscription_manager/cpuinfo.py
@@ -469,8 +469,6 @@ class SystemCpuInfoFactory(object):
 
     @classmethod
     def from_uname_machine(cls, uname_machine, prefix=None):
-        print 'fum', prefix
-        print 'uname_machine', uname_machine
         if uname_machine not in SystemCpuInfoFactory.uname_to_cpuinfo:
             # er?
             raise NotImplementedError


### PR DESCRIPTION
This PR removes two lines of debug print statements that were added by 80eb39098c6f7721f747415762cb3ebd381840c0