### PR TITLE
1290885: Display formatted error if no DISPLAY exists.

### DIFF
--- a/bin/subscription-manager-gui
+++ b/bin/subscription-manager-gui
@@ -104,14 +104,14 @@ _LIBPATH = "/usr/share/rhsm"
 if _LIBPATH not in sys.path:
     sys.path.append(_LIBPATH)
 
-
-from subscription_manager import ga_loader
-ga_loader.init_ga()
-
-from subscription_manager.ga import Gtk as ga_Gtk
-from subscription_manager.ga import gtk_compat
-
-gtk_compat.threads_init()
+try:
+    from subscription_manager import ga_loader
+    ga_loader.init_ga()
+    from subscription_manager.ga import Gtk as ga_Gtk
+    from subscription_manager.ga import gtk_compat
+    gtk_compat.threads_init()
+except RuntimeError, e:
+    system_exit(2, "Unable to start.  Error: %s" % e)
 
 # quick check to see if you are a super-user.
 if os.getuid() != 0:


### PR DESCRIPTION
It would be nice to log the exception, but adding the `log.exception(e)` line results in the complaint `No handlers could be found for logger "rhsm-app.subscription-manager-gui"`.  I presume this is because `logutil.init_logger()` hasn't been called yet.  @alikins Can you confirm?