### PR TITLE
1308732: Leave hw fact virt.uuid unset if unknown

### DIFF
--- a/src/subscription_manager/hwprobe.py
+++ b/src/subscription_manager/hwprobe.py
@@ -820,8 +820,6 @@ class Hardware:
         """
         no_uuid_platforms = ['powervm_lx86', 'xen-dom0', 'ibm_systemz']
 
-        self.allhw['virt.uuid'] = 'Unknown'
-
         try:
             for v in no_uuid_platforms:
                 if self.allhw['virt.host_type'].find(v) > -1:

--- a/test/test_hw.py
+++ b/test/test_hw.py
@@ -302,6 +302,36 @@ class HardwareProbeTests(fixture.SubManFixture):
         self.assertEquals(hw.get_release_info(), {'distribution.version': '42', 'distribution.name': 'Awesome OS',
             'distribution.id': 'Go4It', 'distribution.version.modifier': 'be:ta'})
 
+    def test_default_virt_uuid_physical(self):
+        """Check that physical systems dont set an 'Unknown' virt.uuid."""
+        reload(hwprobe)
+        hw = hwprobe.Hardware()
+        hw.allhw['virt.host_type'] = 'Not Applicable'
+        hw.allhw['virt.is_guest'] = False
+        hw.get_virt_uuid()
+        self.assertFalse('virt.uuid' in hw.allhw)
+
+    def test_default_virt_uuid_guest_no_uuid(self):
+        """Check that virt guest systems dont set an 'Unknown' virt.uuid if not found."""
+        reload(hwprobe)
+        hw = hwprobe.Hardware()
+        hw.allhw['virt.host_type'] = 'kvm'
+        hw.allhw['virt.is_guest'] = True
+        hw.get_virt_uuid()
+        self.assertFalse('virt.uuid' in hw.allhw)
+
+    def test_default_virt_uuid_guest_with_uuid(self):
+        """Check that virt guest systems dont set an 'Unknown' virt.uuid if virt.uuid is found."""
+        reload(hwprobe)
+        hw = hwprobe.Hardware()
+        hw.allhw['virt.host_type'] = 'kvm'
+        hw.allhw['virt.is_guest'] = True
+        fake_virt_uuid = 'this-is-a-weird-uuid'
+        hw.allhw['dmi.system.uuid'] = fake_virt_uuid
+        hw.get_virt_uuid()
+        self.assertTrue('virt.uuid' in hw.allhw)
+        self.assertEquals(fake_virt_uuid, hw.allhw['virt.uuid'])
+
     def test_get_arch(self):
         reload(hwprobe)
         hw = hwprobe.Hardware()


### PR DESCRIPTION
f8416137a3b426aa54608116e005df7273abfada changed virt.uuid
fact collection so that it starts with a default value of
'Unknown' where previously the virt.uuid fact wouldn't
be created (no 'hw.allhw['virt.uuid'] entry). That
was reasonable and expected so change back to that
behavior.