### PR TITLE
expand into directory matching the manifest

### DIFF
--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -314,9 +314,12 @@ class DumpManifestCommand(RCTManifestCommand):
         """
         Does the work that this command intends.
         """
-        if self.options.destination:
-            if self._extract(self.options.destination, self.options.overwrite_files):
-                print _("The manifest has been dumped to the %s directory") % self.options.destination
-        else:
-            if self._extract(os.getcwd(), self.options.overwrite_files):
-                print _("The manifest has been dumped to the current directory")
+        dest = self.options.destination
+
+        if not dest:
+            # default to the name of the manifest instead of the current
+            # working directory
+            dest = os.path.join(os.getcwd(), os.path.splitext(self._get_file_from_args())[0])
+
+        if self._extract(dest, self.options.overwrite_files):
+            print _("The manifest has been dumped to the %s directory") % dest


### PR DESCRIPTION
rct dump-manifest manifest.zip will dump the manifest into the current working directory. If you happen to do this in your home directory you lose track of the files quite easily. This PR changes the rct to default to creating a directory named after the manifest.

For example, given ```rct dump-manifest manifest.zip``` it will now create a ```manifest``` directory in your CWD and dump the contents in there. I realize there is an option for passing in the ```--destination``` but I always seem to run rct dump-manifest first losing track of the output.