### PR TITLE
1311935: Emit register-message for user errors

### DIFF
--- a/src/subscription_manager/gui/firstboot/rhsm_login.py
+++ b/src/subscription_manager/gui/firstboot/rhsm_login.py
@@ -139,6 +139,7 @@ class moduleClass(module.Module, object):
 
         self.register_widget.connect('finished', self.on_finished)
         self.register_widget.connect('register-error', self.on_register_error)
+        self.register_widget.connect('register-message', self.on_register_message)
 
         # In firstboot, we leverage the RHN setup proxy settings already
         # presented to the user, so hide the choose server screen's proxy
@@ -216,6 +217,10 @@ class moduleClass(module.Module, object):
         identity = inj.require(inj.IDENTITY)
         return not identity.is_valid()
 
+    def on_register_message(self, obj, msg, message_type=None):
+        message_type = message_type or ga_Gtk.MessageType.ERROR
+        self.error_dialog(msg, message_type=message_type)
+
     def on_register_error(self, obj, msg, exc_list):
         self.page_status = constants.RESULT_FAILURE
 
@@ -243,8 +248,9 @@ class moduleClass(module.Module, object):
         message = format_exception(exc_info, msg)
         self.error_dialog(message)
 
-    def error_dialog(self, text):
-        dlg = ga_Gtk.MessageDialog(None, 0, ga_Gtk.MessageType.ERROR,
+    def error_dialog(self, text, message_type=None):
+        message_type = message_type or ga_Gtk.MessageType.ERROR
+        dlg = ga_Gtk.MessageDialog(None, 0, message_type,
                                    ga_Gtk.ButtonsType.OK, text)
         dlg.set_markup(text)
         dlg.set_skip_taskbar_hint(True)

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -1528,7 +1528,7 @@ class CredentialsScreen(Screen):
     def _validate_consumername(self, consumername):
         if not consumername:
             # TODO: register state to signal
-            self.emit('register-error',
+            self.emit('register-message',
                       _("You must enter a system name."),
                       ga_Gtk.MessageType.ERROR)
 
@@ -1539,7 +1539,7 @@ class CredentialsScreen(Screen):
     def _validate_account(self):
         # validate / check user name
         if self.account_login.get_text().strip() == "":
-            self.emit('register-error',
+            self.emit('register-message',
                       _("You must enter a login."),
                       ga_Gtk.MessageType.ERROR)
 
@@ -1547,7 +1547,7 @@ class CredentialsScreen(Screen):
             return False
 
         if self.account_password.get_text().strip() == "":
-            self.emit('register-error',
+            self.emit('register-message',
                       _("You must enter a password."),
                       ga_Gtk.MessageType.ERROR)
 
@@ -1649,7 +1649,7 @@ class ActivationKeyScreen(Screen):
 
     def _validate_owner_key(self, owner_key):
         if not owner_key:
-            self.emit('register-error',
+            self.emit('register-message',
                       _("You must enter an organization."),
                       ga_Gtk.MessageType.ERROR)
 
@@ -1659,7 +1659,7 @@ class ActivationKeyScreen(Screen):
 
     def _validate_activation_keys(self, activation_keys):
         if not activation_keys:
-            self.emit('register-error',
+            self.emit('register-message',
                       _("You must enter an activation key."),
                       ga_Gtk.MessageType.ERROR)
 
@@ -1669,7 +1669,7 @@ class ActivationKeyScreen(Screen):
 
     def _validate_consumername(self, consumername):
         if not consumername:
-            self.emit('register-error',
+            self.emit('register-message',
                       _("You must enter a system name."),
                       ga_Gtk.MessageType.ERROR)
 


### PR DESCRIPTION
The wrong args were getting passed along with the register-error signal. As it turns out we need not emit the register-error signal in the places updated by this PR at all. Instead we can have the desired effect simply by emitting a register-message signal and fixing up rhsm_login to handle those signals (in this case we just display a message dialog box with the appropriate message type).