### PR TITLE
1266935: Turn sub-man logging to INFO level.

### DIFF
--- a/etc-conf/logging.conf
+++ b/etc-conf/logging.conf
@@ -60,7 +60,7 @@ args=(('/dev/log',))
 
 [handler_rhsm_log]
 class=subscription_manager.logutil.RHSMLogHandler
-level=DEBUG
+level=INFO
 formatter=rhsm_log
 # logfilepath is '/var/log/rhsm/rhsm.log' by default
 # To change it, replace '%(logfilepath)s' with the path to the desired log file.


### PR DESCRIPTION
Leave the console handler (SubmanDebugHandler) untouched since we want debug logging when it is enabled.