### PR TITLE
1315591: Catches exception and allows process to continue

### DIFF
--- a/src/subscription_manager/gui/widgets.py
+++ b/src/subscription_manager/gui/widgets.py
@@ -333,7 +333,11 @@ class SelectionWrapper(object):
         return self.tree_iter is not None
 
     def __getitem__(self, key):
-        return self.model.get_value(self.tree_iter, self.store[key])
+        try:
+            return self.model.get_value(self.tree_iter, self.store[key])
+        except TypeError, te:
+            log.warning('Invalid item request: %s', te)
+        return None
 
 
 class OverridesTable(object):


### PR DESCRIPTION
Ends up in odd state where the previous selection is not reachable.
Now the proper window with lack of connection information is
displayed.


To test you need to run 'sudo ifdown [eth0 or the like]' before you attempt an unbind.