### PR TITLE
Change the default ssl_verify_depth to be unset. Requires https://github.com/candlepin/python-rhsm/pull/166

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -15,8 +15,9 @@ port = 443
 insecure = 0
 
 # Set the depth of certs which should be checked
-# when validating a certificate
-ssl_verify_depth = 3
+# when validating a certificate.
+# If unset, use the system ssl implementation default (100).
+ssl_verify_depth =
 
 # an http proxy server to use
 proxy_hostname =


### PR DESCRIPTION
Instead of defaulting to 3, we default the config
value to be unset.

If the value is unset, python-rhsm will use the
default of the underlying ssl implementation.
With current implementation, that will be
100 (the openssl default).

