### PR TITLE
Add support for rct cat-manifest to print virt_limit attribute

### DIFF
--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -237,6 +237,15 @@ class CatManifestCommand(RCTManifestCommand):
             to_print.append((_("Contract"), get_value(data, "pool.contractNumber")))
             to_print.append((_("Order"), get_value(data, "pool.orderNumber")))
             to_print.append((_("Account"), get_value(data, "pool.accountNumber")))
+            virt_limit = self._get_product_attribute("virt_limit", data)
+            to_print.append((_("Virt Limit"), virt_limit))
+            if virt_limit == 0:
+                require_virt_who = False
+            elif virt_limit is None:
+                require_virt_who = False
+            else:
+                require_virt_who = True
+            to_print.append((_("Requires Virt-who"), require_virt_who))
 
             entitlement_file = os.path.join("export", "entitlements", "%s.json" % data["id"])
             to_print.append((_("Entitlement File"), entitlement_file))


### PR DESCRIPTION
Add support for rct cat-manifest to print virt_limit attribute. This attribute helps the user determine if virt-who is required. 

Additionally, output a new 'Requires virt-who field' set to 

- **False** - if VIRT_LIMIT attribute == 0 or is nil/None
- **True** - otherwise

Example output:

~~~
        Name: Red Hat Enterprise Linux Server, Premium (4 sockets) (Unlimited guests)
        Quantity: 50
        Created: 2015-09-07T10:51:26.000+0000
        Start Date: 2015-08-26T04:00:00.000+0000
        End Date: 2016-08-26T03:59:59.000+0000
        Service Level: Premium
        Service Type: L1-L3
        Architectures: x86_64,ppc64le,ppc64,ia64,ppc,x86,s390,s390x
        SKU: *****
        Contract: *****
        Order: *****
        Account: *****
        Virt Limit: unlimited
        Requires Virt-who: True
~~~