### PR TITLE
Remove sys.path shenanigans that break yum imports.

### DIFF
--- a/build_ext/utils.py
+++ b/build_ext/utils.py
@@ -13,13 +13,8 @@
 # in this software or its documentation.
 import fnmatch
 import os
-import sys
 
 from distutils import cmd
-
-# Force python parser since we can't hook into the C implementation
-sys.modules['_elementtree'] = None
-import xml.etree.ElementTree as ET  # noqa
 
 
 def memoize(f):


### PR DESCRIPTION
This code was originally added to augment the built-in Python XML parser
so that it would report line numbers.  Eventually, I determined that the
built-in parser wouldn't cut it and switched to LXML but forgot to
remove this code.  This snippet breaks yum because yum is explicitly
attempting to import the C implementation.