### PR TITLE
Csnyder/fix registration gui test

### DIFF
--- a/test/stubs.py
+++ b/test/stubs.py
@@ -571,9 +571,7 @@ class StubCertSorter(CertSorter):
 class StubCPProvider(object):
 
     def __init__(self):
-        self.consumer_auth_cp = StubUEP()
-        self.basic_auth_cp = StubUEP()
-        self.no_auth_cp = StubUEP()
+        self.set_connection_info()
         self.content_connection = StubContentConnection()
 
     def set_connection_info(self,
@@ -586,6 +584,9 @@ class StubCPProvider(object):
                 proxy_port_arg=None,
                 proxy_user_arg=None,
                 proxy_password_arg=None):
+
+        self.cert_file = StubConsumerIdentity.certpath()
+        self.key_file = StubConsumerIdentity.keypath()
         self.consumer_auth_cp = StubUEP()
         self.basic_auth_cp = StubUEP()
         self.no_auth_cp = StubUEP()

--- a/test/test_registrationgui.py
+++ b/test/test_registrationgui.py
@@ -1,5 +1,5 @@
 
-from mock import Mock
+from mock import Mock, patch
 
 from fixture import SubManFixture
 
@@ -203,9 +203,16 @@ class ChooseServerScreenTests(SubManFixture):
         self.assertTrue(self.screen.activation_key_checkbox.get_property('sensitive'))
         self.assertTrue(self.screen.activation_key_checkbox.get_property('active'))
 
-    def test__on_default_button_clicked(self):
+    @patch('subscription_manager.gui.registergui.config')
+    def test__on_default_button_clicked(self, config):
+        config.DEFAULT_HOSTNAME = "subscription.rhsm.redhat.com"
+        config.DEFAULT_PORT = '443'
+        config.DEFAULT_PREFIX = "/subscription"
+
         non_default = "foo.bar:8443/baz"
-        expected = "subscription.rhsm.redhat.com:443/subscription"
+        expected = "%s:%s%s" % (config.DEFAULT_HOSTNAME,
+            config.DEFAULT_PORT,
+            config.DEFAULT_PREFIX)
         self.screen.server_entry.set_text(non_default)
         self.screen._on_default_button_clicked(None)  # The widget param is not used
         result = self.screen.server_entry.get_text()


### PR DESCRIPTION
This PR fixes two issues with our tests.

The first is a fix for a test in test_registerationgui.py that needed some additional mocking to ensure we don't expect values from the real rhsm.config installed on the system.

The second is an update to StubCPProvider to provide two attributes that were used during another test (cert_file and key_file) that were causing a nasty traceback during test runs.

To verify the fixes here:
1) run the tests on master with a version of python-rhsm <= 1.15.4-1 installed
2) look for a traceback in the output as well as a test failure in test_registrationgui.test__on_default_button_clicked