### PR TITLE
Flag interior string formatting for the gettext method

### DIFF
--- a/src/rhsm_debug/debug_commands.py
+++ b/src/rhsm_debug/debug_commands.py
@@ -91,7 +91,7 @@ class SystemCommand(CliCommand):
             if not self._dirs_on_same_device(self.assemble_path, self.options.destination):
                 msg = _("To use the no-archive option, the destination directory '%s' "
                         "must exist on the same file system as the "
-                        "data assembly directory '%s'." % (self.options.destination, self.assemble_path))
+                        "data assembly directory '%s'.") % (self.options.destination, self.assemble_path)
                 raise InvalidCLIOptionError(msg)
         # In case folks are using this in a script
         if self.options.placeholder_for_subscriptions_option:

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1110,7 +1110,7 @@ class RegisterCommand(UserPassCommand):
 
                 if consumer.get('type', {}).get('manifest', {}):
                     log.error("registration attempted with consumerid = Subscription Management Application's uuid: %s" % self.options.consumerid)
-                    system_exit(os.EX_USAGE, _("Error: Cannot register with an ID of a Subscription Management Application: %s" % self.options.consumerid))
+                    system_exit(os.EX_USAGE, _("Error: Cannot register with an ID of a Subscription Management Application: %s") % self.options.consumerid)
 
             else:
                 owner_key = self._determine_owner_key(admin_cp)

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -362,7 +362,7 @@ class MigrationEngine(object):
             rpc_session.system.getDetails(session_key, self.system_id)
         except Exception, e:
             log.exception(e)
-            system_exit(1, _("You do not have access to system %s.  " % self.system_id) + SEE_LOG_FILE)
+            system_exit(1, _("You do not have access to system %s.  ") % self.system_id + SEE_LOG_FILE)
 
     def resolve_base_channel(self, label, rpc_session, session_key):
         try:


### PR DESCRIPTION
Good: _("Hello %s") % name
Bad: _("Hello %s" % name)

The "bad" example doesn't work correctly because the key gettext tries
to lookup isn't constant.  The key varies based on the value of name.