### PR TITLE
1353662: Explicitly use ConsumerIdentity keypath and certpath methods

### DIFF
--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -807,8 +807,7 @@ def check_identity_cert_perms():
     Ensure the identity certs on this system have the correct permissions, and
     fix them if not.
     """
-    ident = require(IDENTITY)
-    certs = [ident.keypath(), ident.certpath()]
+    certs = [identity.ConsumerIdentity.keypath(), identity.ConsumerIdentity.certpath()]
     for cert in certs:
         if not os.path.exists(cert):
             # Only relevant if these files exist.


### PR DESCRIPTION
Dep injection was set to return an instance of Identity instead of the required ConsumerIdentity object.
This undoes the change to managerlib from the following commit:
https://github.com/candlepin/subscription-manager/commit/18310e65308fe562b04a4baddeb12bd50078460f