### PR TITLE
Awood/unittest2

### DIFF
--- a/test-requirements-2.6.txt
+++ b/test-requirements-2.6.txt
@@ -1,0 +1,2 @@
+-r test-requirements.txt
+unittest2

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -2,10 +2,15 @@ import difflib
 import locale
 import os
 import pprint
-import unittest
 import sys
 import StringIO
 import tempfile
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
 
 # just log py.warnings (and pygtk warnings in particular)
 import logging

--- a/test/test_about.py
+++ b/test/test_about.py
@@ -13,7 +13,10 @@
 # in this software or its documentation.
 #
 
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import mock
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -16,6 +16,7 @@ from subscription_manager import api
 from subscription_manager.repolib import Repo
 
 from fixture import SubManFixture
+from stubs import StubUEP
 
 
 class ApiVersionTest(SubManFixture):
@@ -34,6 +35,10 @@ class RepoApiTest(SubManFixture):
         repo_file_patcher = patch("subscription_manager.api.repos.RepoFile", autospec=True)
         self.repo_file = repo_file_patcher.start()
         self.addCleanup(repo_file_patcher.stop)
+
+        uep_patcher = patch("rhsm.connection.UEPConnection", new=StubUEP)
+        self.stub_uep = uep_patcher.start()
+        self.addCleanup(uep_patcher.stop)
 
     def test_disable_repo(self):
         repo_settings = {

--- a/test/test_branding.py
+++ b/test/test_branding.py
@@ -12,9 +12,10 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from subscription_manager.branding import Branding
 #from subscription_manager.managerlib import configure_i18n

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -10,10 +10,13 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import os
 import logging
-import unittest
 import random
 import shutil
 import socket

--- a/test/test_catcert_command.py
+++ b/test/test_catcert_command.py
@@ -12,7 +12,10 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import certdata
 from fixture import Capture, SubManFixture

--- a/test/test_certdirectory.py
+++ b/test/test_certdirectory.py
@@ -12,9 +12,12 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import tempfile
-import unittest
 import os
 
 from mock import patch, MagicMock

--- a/test/test_certificate.py
+++ b/test/test_certificate.py
@@ -12,10 +12,12 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from datetime import datetime, timedelta
-import unittest
-
 
 # TODO: move to python-rhsm test suite?
 

--- a/test/test_contract_selection_gui.py
+++ b/test/test_contract_selection_gui.py
@@ -1,4 +1,8 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
 import datetime
 from dateutil.tz import tzutc
 

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -10,8 +10,11 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
-import unittest
 from subscription_manager.exceptions import ExceptionMapper
 from rhsm.connection import RestlibException
 

--- a/test/test_format_time.py
+++ b/test/test_format_time.py
@@ -1,4 +1,8 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
 import locale
 import sys
 

--- a/test/test_gui_utils.py
+++ b/test/test_gui_utils.py
@@ -1,5 +1,7 @@
-import unittest
-
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from subscription_manager.ga import Gtk as ga_Gtk
 from subscription_manager.gui import utils

--- a/test/test_handle_gui_exception.py
+++ b/test/test_handle_gui_exception.py
@@ -1,4 +1,8 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
 import socket
 from M2Crypto import SSL
 

--- a/test/test_hw.py
+++ b/test/test_hw.py
@@ -11,9 +11,10 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-
-import unittest
-
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import cStringIO
 

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -1,4 +1,7 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from subscription_manager.i18n import configure_i18n
 

--- a/test/test_i18n_optparse.py
+++ b/test/test_i18n_optparse.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
 import optparse
 
 from subscription_manager import i18n_optparse

--- a/test/test_isodate.py
+++ b/test/test_isodate.py
@@ -12,11 +12,13 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import datetime
 import time
-import unittest
-
 from subscription_manager import isodate
 from dateutil.tz import tzlocal
 

--- a/test/test_jsonwrapper.py
+++ b/test/test_jsonwrapper.py
@@ -11,8 +11,11 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
-import unittest
 from modelhelpers import create_pool, create_attribute_list
 from subscription_manager.jsonwrapper import PoolWrapper
 

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -12,7 +12,10 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from subscription_manager import listing
 

--- a/test/test_lock.py
+++ b/test/test_lock.py
@@ -1,10 +1,14 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
 import os
 import subprocess
 import sys
 import tempfile
 import threading
 import time
-import unittest
 
 from nose import SkipTest
 

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
 from datetime import datetime, timedelta
-import unittest
 import re
 import sys
 import socket

--- a/test/test_managergui.py
+++ b/test/test_managergui.py
@@ -1,4 +1,7 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from fixture import SubManFixture
 import mock

--- a/test/test_managerlib.py
+++ b/test/test_managerlib.py
@@ -12,9 +12,12 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from datetime import datetime, timedelta
-import unittest
 import os
 
 from stubs import StubCertificateDirectory, StubProductCertificate, \

--- a/test/test_migration.py
+++ b/test/test_migration.py
@@ -11,12 +11,15 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import os
 import re
 import StringIO
 import stubs
-import unittest
 
 from mock import patch, NonCallableMock, MagicMock, Mock, call
 from M2Crypto import SSL

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -12,11 +12,13 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import os
 import mock
-import unittest
 
 from StringIO import StringIO
 

--- a/test/test_po_files.py
+++ b/test/test_po_files.py
@@ -1,6 +1,9 @@
-import gettext
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
+import gettext
 import fixture
 
 from subscription_manager import managercli

--- a/test/test_productid.py
+++ b/test/test_productid.py
@@ -1,8 +1,12 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
 import os
 import shutil
 import tempfile
 import types
-import unittest
 
 import yum
 

--- a/test/test_progress_gui.py
+++ b/test/test_progress_gui.py
@@ -1,4 +1,7 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from subscription_manager.gui import progress
 

--- a/test/test_rct_cert_command.py
+++ b/test/test_rct_cert_command.py
@@ -12,8 +12,10 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from mock import patch
 from rhsm.certificate import CertificateException

--- a/test/test_rct_manifest_command.py
+++ b/test/test_rct_manifest_command.py
@@ -12,6 +12,10 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from cStringIO import StringIO
 import errno
@@ -19,7 +23,6 @@ import mock
 import os
 import shutil
 import tempfile
-import unittest
 import zipfile
 from zipfile import ZipFile
 

--- a/test/test_reasons.py
+++ b/test/test_reasons.py
@@ -11,10 +11,13 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from stubs import StubEntitlementCertificate, StubProduct
 from mock import Mock
-import unittest
 from subscription_manager.reasons import Reasons
 
 INST_PID_1 = "100000000000002"  # awesomeos 64

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -13,15 +13,18 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import re
-import unittest
+import fixture
 
 from iniparse import RawConfigParser, SafeConfigParser
 from mock import Mock, patch
 from StringIO import StringIO
 
-import fixture
 from stubs import StubCertificateDirectory, StubProductCertificate, \
         StubProduct, StubEntitlementCertificate, StubContent, \
         StubProductDirectory, StubConsumerIdentity, StubEntitlementDirectory

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -11,8 +11,10 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from subscription_manager.gui.storage import MappedTreeStore, MappedListStore
 

--- a/test/test_widgets.py
+++ b/test/test_widgets.py
@@ -11,8 +11,10 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 #from gi.repository import Gtk
 from datetime import datetime, timedelta


### PR DESCRIPTION
We need to use unittest2 now because unittest in Python 2.6 doesn't offer the `addCleanUp` method which will run a function *even if an exception is thrown in setUp*.  In order to prevent polluting the test environment, we need to always *unpatch* a patched class or object.