### PR TITLE
1360909: The refresh command now requests entitlement cert regeneration

### DIFF
--- a/src/subscription_manager/ga_loader.py
+++ b/src/subscription_manager/ga_loader.py
@@ -237,8 +237,7 @@ def init_ga(gtk_version=None):
         else:
             gtk_version_from_build = "3"
         if gtk_version_from_environ is None:
-            warnings.warn("GTK_VERSION is unset in version.py.  Using GTK %s"
-                          % gtk_version_from_build)
+            warnings.warn("GTK_VERSION is unset in version.py.  Using GTK %s" % gtk_version_from_build)
 
     GTK_VERSION = gtk_version_from_environ or gtk_version or gtk_version_from_build \
         or DEFAULT_GTK_VERSION

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -642,6 +642,12 @@ class RefreshCommand(CliCommand):
     def _do_command(self):
         self.assert_should_be_registered()
         try:
+            # get current consumer identity
+            identity = inj.require(inj.IDENTITY)
+
+            # Force a regen of the entitlement certs for this consumer
+            self.cp.regenEntitlementCertificates(identity.uuid, True)
+
             self.entcertlib.update()
             log.info("Refreshed local data")
             print (_("All local data refreshed"))


### PR DESCRIPTION
- When the refresh command is issued on the CLI, subman will request
  entitlement certificate regeneration (lazily) for the active consumer