### PR TITLE
Fix breakage caused by API changes in Flake8 3.x

### DIFF
--- a/build_ext/PKG-INFO
+++ b/build_ext/PKG-INFO
@@ -1,0 +1,4 @@
+Metadata-Version: 1.1
+Name: build_ext
+Version: 1.0
+Summary: Custom subscription-manager Flake8 checks

--- a/build_ext/entry_points.txt
+++ b/build_ext/entry_points.txt
@@ -1,0 +1,2 @@
+[flake8.extension]
+X = build_ext.lint:AstChecker

--- a/setup.py
+++ b/setup.py
@@ -251,7 +251,7 @@ cmdclass = {
     'lint': lint.Lint,
     'lint_glade': lint.GladeLint,
     'lint_rpm': lint.RpmLint,
-    'flake8': lint.PluginLoadingFlake8Command
+    'flake8': lint.PluginLoadingFlake8
 }
 
 transforms = [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@ coverage
 polib
 pep8==1.5.7
 pyflakes
-flake8
+flake8==3.0.2
 freezegun
 simplejson
 mock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,5 +11,5 @@ freezegun
 simplejson
 mock
 Sphinx
-git+https://github.com/alikins/pyqver.git#egg=pyqver
+# git+https://github.com/alikins/pyqver.git#egg=pyqver
 git+https://github.com/awood/nose-xvfb.git#egg=nose-xvfb


### PR DESCRIPTION
Flake8 3.x changed the way it loads plugins.  Before we were
piggy-backing on PEP8's plugin loading functionality, but that doesn't
work in the 3.x world.  This patch loads our plugins as a "virtual"
Python egg with an entry point defined for "flake8.extensions."