### PR TITLE
1334916: Update logging configuration to read from rhsm.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,6 @@ install-conf:
 	install -d $(PREFIX)/etc/security/console.apps
 	install -m 644 etc-conf/rhsm.conf $(PREFIX)/etc/rhsm/
 	install -m 644 etc-conf/logrotate.conf $(PREFIX)/etc/logrotate.d/subscription-manager
-	install -m 644 etc-conf/logging.conf $(PREFIX)/etc/rhsm/logging.conf
 	install -m 644 etc-conf/subscription-manager.completion.sh $(PREFIX)/etc/bash_completion.d/subscription-manager
 	install -m 644 etc-conf/rct.completion.sh $(PREFIX)/etc/bash_completion.d/rct
 	install -m 644 etc-conf/rhsm-debug.completion.sh $(PREFIX)/etc/bash_completion.d/rhsm-debug

--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -67,4 +67,11 @@ certCheckInterval = 240
 # Interval to run auto-attach (in minutes):
 autoAttachInterval = 1440
 
-
+[logging]
+default_log_level = DEBUG
+# subscription_manager = DEBUG
+# subscription_manager.managercli = DEBUG
+# rhsm = DEBUG
+# rhsm.connection = DEBUG
+# rhsm-app = DEBUG
+# rhsm-app.rhsmd = DEBUG

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -1137,7 +1137,7 @@ command in the format
 .I --section.parameter=value
 , where
 .I section
-is the configuration section in the file: server, rhsm, or rhsmcertd.
+is the configuration section in the file: server, rhsm, rhsmcertd or logging.
 
 .PP
 For example, to change the hostname of the subscription management service host:
@@ -1147,6 +1147,40 @@ For example, to change the hostname of the subscription management service host:
 subscription-manager config --server.hostname=myserver.example.com
 .fi
 .RE
+
+.PP
+The entries in the
+.B logging
+section are somewhat special.
+The keys in this section are a name of a logger.
+The values are the logging level.
+.PP
+Valid levels are one of:
+.B DEBUG
+,
+.B INFO
+,
+.B WARNING
+,
+.B ERROR
+, or
+.B CRITICAL
+.
+.PP
+Valid logger names are the full module path of any Subscription Manager module.
+For example:
+.B subscription_manager
+or
+subscription_manager.managercli
+
+.PP
+There are three main top-level loggers: subscription_manager, rhsm, and rhsm-app.
+All logger names begin with one of the above.
+
+.PP
+To set the default log level for all loggers (that are not otherwise set in the logging section), edit the
+.B default_log_level
+key in /etc/rhsm/rhsm.conf
 
 
 .SS UPDATING FACTS

--- a/src/subscription_manager/action_client.py
+++ b/src/subscription_manager/action_client.py
@@ -30,7 +30,7 @@ from subscription_manager.installedproductslib import InstalledProductsActionInv
 from subscription_manager.content_action_client import ContentActionClient
 
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 _ = gettext.gettext
 

--- a/src/subscription_manager/base_action_client.py
+++ b/src/subscription_manager/base_action_client.py
@@ -19,7 +19,7 @@ from subscription_manager import injection as inj
 
 from rhsm.connection import GoneException, ExpiredIdentityCertException
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class BaseActionClient(object):

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -34,7 +34,7 @@ from subscription_manager.jsonwrapper import PoolWrapper
 from rhsm import ourjson as json
 
 _ = gettext.gettext
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 PACKAGES_RESOURCE = "packages"
 

--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -27,7 +27,7 @@ from subscription_manager import utils
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 FUTURE_SUBSCRIBED = "future_subscribed"
 SUBSCRIBED = "subscribed"

--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -23,7 +23,7 @@ from rhsm.certificate import Key, create_from_file
 from rhsm.config import initConfig
 from subscription_manager.injection import require, ENT_DIR
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 _ = gettext.gettext
 

--- a/src/subscription_manager/certlib.py
+++ b/src/subscription_manager/certlib.py
@@ -3,7 +3,7 @@ import logging
 
 from subscription_manager import injection as inj
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class Locker(object):

--- a/src/subscription_manager/content_action_client.py
+++ b/src/subscription_manager/content_action_client.py
@@ -22,7 +22,7 @@ from subscription_manager.model.ent_cert import EntitlementDirEntitlementSource
 
 import subscription_manager.injection as inj
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class ContentPluginActionReport(certlib.ActionReport):

--- a/src/subscription_manager/cpuinfo.py
+++ b/src/subscription_manager/cpuinfo.py
@@ -104,7 +104,7 @@ import os
 # stepping    : 7
 # microcode   : 0x710
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class DefaultCpuFields(object):

--- a/src/subscription_manager/dbus_interface.py
+++ b/src/subscription_manager/dbus_interface.py
@@ -18,7 +18,7 @@ import inspect
 import logging
 import subscription_manager.injection as inj
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class DbusIface(object):

--- a/src/subscription_manager/dmiinfo.py
+++ b/src/subscription_manager/dmiinfo.py
@@ -20,7 +20,7 @@ import dmidecode
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class DmiFirmwareInfoProvider(object):

--- a/src/subscription_manager/entbranding.py
+++ b/src/subscription_manager/entbranding.py
@@ -19,7 +19,7 @@
 
 import logging
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class BrandsInstaller(object):

--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -29,7 +29,7 @@ from subscription_manager import rhelentbranding
 import subscription_manager.injection as inj
 
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 _ = gettext.gettext
 

--- a/src/subscription_manager/factlib.py
+++ b/src/subscription_manager/factlib.py
@@ -23,7 +23,7 @@ from subscription_manager import injection as inj
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 # FactsActionInvoker has a Facts

--- a/src/subscription_manager/facts.py
+++ b/src/subscription_manager/facts.py
@@ -26,7 +26,7 @@ from rhsm import ourjson as json
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 # Hardcoded value for the version of certificates this version of the client
 # prefers:

--- a/src/subscription_manager/ga_loader.py
+++ b/src/subscription_manager/ga_loader.py
@@ -18,7 +18,7 @@ import os
 import sys
 
 import logging
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 from subscription_manager import version
 

--- a/src/subscription_manager/gui/allsubs.py
+++ b/src/subscription_manager/gui/allsubs.py
@@ -34,7 +34,7 @@ from subscription_manager.managerlib import allows_multi_entitlement, valid_quan
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class AllSubscriptionsTab(widgets.SubscriptionManagerTab):

--- a/src/subscription_manager/gui/autobind.py
+++ b/src/subscription_manager/gui/autobind.py
@@ -20,7 +20,7 @@ import logging
 import gettext
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class DryRunResult(object):

--- a/src/subscription_manager/gui/factsgui.py
+++ b/src/subscription_manager/gui/factsgui.py
@@ -24,7 +24,7 @@ from subscription_manager import injection as inj
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class SystemFactsDialog(widgets.SubmanBaseWidget):

--- a/src/subscription_manager/gui/filter.py
+++ b/src/subscription_manager/gui/filter.py
@@ -21,7 +21,7 @@ from subscription_manager.gui import widgets
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class Filters(object):

--- a/src/subscription_manager/gui/firstboot/rhsm_login.py
+++ b/src/subscription_manager/gui/firstboot/rhsm_login.py
@@ -19,7 +19,7 @@ import rhsm
 from subscription_manager import logutil
 logutil.init_logger()
 
-log = logging.getLogger("rhsm-app." + __name__)
+log = logging.getLogger(__name__)
 
 # neuter linkify in firstboot
 from subscription_manager.gui.utils import running_as_firstboot

--- a/src/subscription_manager/gui/importsub.py
+++ b/src/subscription_manager/gui/importsub.py
@@ -23,7 +23,7 @@ from subscription_manager.gui import messageWindow
 from subscription_manager.gui.utils import show_error_window
 from subscription_manager.managerlib import ImportFileExtractor
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 _ = gettext.gettext
 

--- a/src/subscription_manager/gui/installedtab.py
+++ b/src/subscription_manager/gui/installedtab.py
@@ -28,7 +28,7 @@ from subscription_manager.ga import Gtk as ga_Gtk
 from subscription_manager.ga import GdkPixbuf as ga_GdkPixbuf
 import os
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 _ = gettext.gettext
 

--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -68,7 +68,7 @@ gettext.textdomain("rhsm")
 #Gtk.glade.bindtextdomain("rhsm")
 #Gtk.Window.set_default_icon_name("subscription-manager")
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 cfg = config.initConfig()
 

--- a/src/subscription_manager/gui/networkConfig.py
+++ b/src/subscription_manager/gui/networkConfig.py
@@ -38,7 +38,7 @@ _ = gettext.gettext
 
 DIR = os.path.dirname(__file__)
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class NetworkConfigDialog(widgets.SubmanBaseWidget):

--- a/src/subscription_manager/gui/preferences.py
+++ b/src/subscription_manager/gui/preferences.py
@@ -24,7 +24,7 @@ from subscription_manager import release
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class PreferencesDialog(widgets.SubmanBaseWidget):

--- a/src/subscription_manager/gui/redeem.py
+++ b/src/subscription_manager/gui/redeem.py
@@ -22,7 +22,7 @@ from subscription_manager.injection import IDENTITY, require
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class RedeemDialog(widgets.SubmanBaseWidget):

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -50,7 +50,7 @@ _ = lambda x: gettext.ldgettext("rhsm", x)
 
 gettext.textdomain("rhsm")
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 CFG = config.initConfig()
 

--- a/src/subscription_manager/gui/reposgui.py
+++ b/src/subscription_manager/gui/reposgui.py
@@ -36,7 +36,7 @@ from subscription_manager.overrides import Override
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 cfg = rhsm.config.initConfig()
 

--- a/src/subscription_manager/gui/storage.py
+++ b/src/subscription_manager/gui/storage.py
@@ -21,8 +21,7 @@ from subscription_manager.ga import Gtk as ga_Gtk
 class MappedStore(object):
     def __init__(self, type_map):
         self.type_index = {}
-        self.log = logging.getLogger('rhsm-app.' + __name__ +
-                                     self.__class__.__name__)
+        self.log = logging.getLogger(__name__ + self.__class__.__name__)
 
         # Enumerate the keys and store the int index
         for i, type_key in enumerate(type_map.iterkeys()):
@@ -87,8 +86,7 @@ class MappedListStore(MappedStore, ga_Gtk.ListStore):
 
 class MappedTreeStore(MappedStore, ga_Gtk.TreeStore):
     def __init__(self, type_map):
-        self.log = logging.getLogger('rhsm-app.' + __name__ +
-                                     self.__class__.__name__)
+        self.log = logging.getLogger(__name__ + self.__class__.__name__)
         # FIXME: How does this work? .values() is not sorted, so could change?
         MappedStore.__init__(self, type_map)
         ga_Gtk.TreeStore.__init__(self, *type_map.values())

--- a/src/subscription_manager/gui/utils.py
+++ b/src/subscription_manager/gui/utils.py
@@ -27,7 +27,7 @@ from subscription_manager.exceptions import ExceptionMapper
 import rhsm.connection as connection
 from subscription_manager.gui import messageWindow
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 # we need gtk 2.18+ to do the right markup in linkify
 MIN_GTK_MAJOR = 2

--- a/src/subscription_manager/gui/widgets.py
+++ b/src/subscription_manager/gui/widgets.py
@@ -48,7 +48,7 @@ GLADE_SUFFIX = "glade"
 WARNING_COLOR = '#FFFB82'
 EXPIRED_COLOR = '#FFAF99'
 
-log = logging.getLogger("rhsm-app." + __name__)
+log = logging.getLogger(__name__)
 # Some versions of gtk has incorrect translations for the calendar widget
 # and gtk itself complains about this with errors like:
 #
@@ -114,8 +114,7 @@ class BuilderFileBasedWidget(FileBasedGui):
         The initial_widget_names is a list of widgets to pull in as instance
         variables.
         """
-        self.log = logging.getLogger('rhsm-app.' + __name__ +
-                                     '.' + self.__class__.__name__)
+        self.log = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
         self.builder = ga_Gtk.Builder()
 
@@ -135,8 +134,7 @@ class SubmanBaseWidget(ga_GObject.GObject):
         ga_GObject.GObject.__init__(self)
         self.gui = self._gui_factory()
         self.pull_widgets(self.gui, self.widget_names)
-        self.log = logging.getLogger('rhsm-app.' + __name__ +
-                                     '.' + self.__class__.__name__)
+        self.log = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
     def _gui_factory(self):
         gui = BuilderFileBasedWidget.from_file(self.gui_file)

--- a/src/subscription_manager/healinglib.py
+++ b/src/subscription_manager/healinglib.py
@@ -22,7 +22,7 @@ from subscription_manager import certlib
 from subscription_manager import entcertlib
 from subscription_manager import injection as inj
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class HealingActionInvoker(certlib.BaseActionInvoker):

--- a/src/subscription_manager/hwprobe.py
+++ b/src/subscription_manager/hwprobe.py
@@ -32,7 +32,7 @@ from subscription_manager import cpuinfo
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 # Exception classes used by this module.

--- a/src/subscription_manager/identity.py
+++ b/src/subscription_manager/identity.py
@@ -22,7 +22,7 @@ from subscription_manager.certdirectory import Path
 
 CFG = initConfig()
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class ConsumerIdentity:

--- a/src/subscription_manager/identitycertlib.py
+++ b/src/subscription_manager/identitycertlib.py
@@ -19,7 +19,7 @@ import logging
 from subscription_manager import certlib
 from subscription_manager import injection as inj
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class IdentityCertActionInvoker(certlib.BaseActionInvoker):

--- a/src/subscription_manager/isodate.py
+++ b/src/subscription_manager/isodate.py
@@ -19,7 +19,7 @@
 import dateutil.parser
 import logging
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 def _parse_date_dateutil(date):

--- a/src/subscription_manager/lock.py
+++ b/src/subscription_manager/lock.py
@@ -25,7 +25,7 @@ import time
 LOCK_WAIT_DURATION = 0.5
 
 import logging
-log = logging.getLogger("rhsm-app." + __name__)
+log = logging.getLogger(__name__)
 
 
 class LockFile(object):

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -62,7 +62,7 @@ from subscription_manager.printing_utils import columnize, format_name, \
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 cfg = rhsm.config.initConfig()
 

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -45,7 +45,7 @@ from subscription_manager import utils
 from subscription_manager.identity import ConsumerIdentity
 from dateutil.tz import tzlocal
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 _ = gettext.gettext
 

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -62,7 +62,7 @@ except ImportError:
     def getChannels():
         raise NotImplementedError(_("Could not find up2date_client.rhnChannel module!"))
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 SEE_LOG_FILE = _(u"See /var/log/rhsm/rhsm.log for more details.")
 

--- a/src/subscription_manager/model/__init__.py
+++ b/src/subscription_manager/model/__init__.py
@@ -15,7 +15,7 @@
 
 import logging
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 # These containerish iterables could share a
 # base class, though, it should probably just

--- a/src/subscription_manager/overrides.py
+++ b/src/subscription_manager/overrides.py
@@ -18,7 +18,7 @@ from subscription_manager.repolib import RepoActionInvoker
 
 import logging
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 # Module for manipulating content overrides
 

--- a/src/subscription_manager/plugin/container.py
+++ b/src/subscription_manager/plugin/container.py
@@ -24,7 +24,7 @@ import shutil
 from subscription_manager import certlib
 from subscription_manager.model import find_content
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 _ = gettext.gettext
 

--- a/src/subscription_manager/plugin/ostree/action_invoker.py
+++ b/src/subscription_manager/plugin/ostree/action_invoker.py
@@ -24,7 +24,7 @@ from subscription_manager.model import find_content
 from subscription_manager.plugin.ostree import model
 
 # plugins get
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 _ = gettext.gettext
 

--- a/src/subscription_manager/plugin/ostree/config.py
+++ b/src/subscription_manager/plugin/ostree/config.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     pass
 
-log = logging.getLogger("rhsm-app." + __name__)
+log = logging.getLogger(__name__)
 
 CFG = config.initConfig()
 

--- a/src/subscription_manager/plugin/ostree/model.py
+++ b/src/subscription_manager/plugin/ostree/model.py
@@ -32,7 +32,7 @@ OSTREE_REPORT_TEMPLATE = """remote \"{self.name}\"
 \ttls-client-key-path: {self.tls_client_key_path}
 \ttls-ca-path: {self.tls_ca_path}"""
 
-log = logging.getLogger("rhsm-app." + __name__)
+log = logging.getLogger(__name__)
 
 
 class OstreeContentError(Exception):

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -47,7 +47,7 @@ DEFAULT_CONF_PATH = "/etc/rhsm/pluginconf.d/"
 
 cfg = initConfig()
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 _ = gettext.gettext
 
@@ -158,7 +158,7 @@ class BaseConduit(object):
             self._conf = clazz.conf
 
         # maybe useful to have a per conduit/per plugin logger space
-        self.log = logging.getLogger("rhsm-app." + clazz.__name__)
+        self.log = logging.getLogger(clazz.__name__)
 
     def conf_string(self, section, option, default=None):
         """get string from plugin config

--- a/src/subscription_manager/printing_utils.py
+++ b/src/subscription_manager/printing_utils.py
@@ -21,7 +21,7 @@ import logging
 from yum.i18n import utf8_width
 from subscription_manager.utils import get_terminal_width
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 _ = gettext.gettext
 

--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -37,7 +37,7 @@ import subscription_manager.injection as inj
 from rhsm import ourjson as json
 
 _ = gettext.gettext
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class DatabaseDirectory(Directory):

--- a/src/subscription_manager/release.py
+++ b/src/subscription_manager/release.py
@@ -31,7 +31,7 @@ from subscription_manager import rhelproduct
 
 _ = gettext.gettext
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 cfg = rhsm.config.initConfig()
 

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -37,7 +37,7 @@ from rhsm.config import initConfig
 from subscription_manager.certlib import ActionReport, BaseActionInvoker
 from subscription_manager.certdirectory import Path
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 CFG = initConfig()
 

--- a/src/subscription_manager/rhelentbranding.py
+++ b/src/subscription_manager/rhelentbranding.py
@@ -21,7 +21,7 @@ import logging
 from subscription_manager import injection as inj
 from subscription_manager import entbranding
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class RHELBrandsInstaller(entbranding.BrandsInstaller):

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -44,7 +44,7 @@ from rhsm.connection import UEPConnection, RestlibException, GoneException
 from rhsm.config import DEFAULT_PORT, DEFAULT_PREFIX, DEFAULT_HOSTNAME, \
     DEFAULT_CDN_HOSTNAME, DEFAULT_CDN_PORT, DEFAULT_CDN_PREFIX
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 _ = lambda x: gettext.ldgettext("rhsm", x)
 

--- a/src/subscription_manager/validity.py
+++ b/src/subscription_manager/validity.py
@@ -19,7 +19,7 @@ from rhsm.certificate import DateRange
 import subscription_manager.injection as inj
 from subscription_manager.isodate import parse_date
 
-log = logging.getLogger('rhsm-app.' + __name__)
+log = logging.getLogger(__name__)
 
 
 class ValidProductDateRangeCalculator(object):

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -340,7 +340,6 @@ rm -rf %{buildroot}
 %attr(755,root,root) %dir %{_sysconfdir}/rhsm
 %attr(755,root,root) %dir %{_sysconfdir}/rhsm/facts
 %attr(644,root,root) %config(noreplace) %{_sysconfdir}/rhsm/rhsm.conf
-%config(noreplace) %attr(644,root,root) %{_sysconfdir}/rhsm/logging.conf
 
 %config(noreplace) %{_sysconfdir}/dbus-1/system.d/com.redhat.SubscriptionManager.conf
 

--- a/test/test_logutil.py
+++ b/test/test_logutil.py
@@ -1,13 +1,12 @@
 import logging
-import os
 
 import mock
 
 import fixture
 
-from subscription_manager import logutil
+import stubs
 
-TEST_LOG_CONFIG = os.path.join(os.path.dirname(__file__), "test-logging.conf")
+from subscription_manager import logutil
 
 
 # no NullHandler in 2.6, include our own
@@ -19,11 +18,15 @@ class NullHandler(logging.Handler):
 class TestLogutil(fixture.SubManFixture):
     def setUp(self):
         super(TestLogutil, self).setUp()
+        self.rhsm_config = stubs.StubConfig()
+        rhsm_patcher = mock.patch('rhsm.config')
+        self.rhsm_config_mock = rhsm_patcher.start()
+        self.rhsm_config_mock.initConfig.return_value = self.rhsm_config
+        self.addCleanup(rhsm_patcher.stop)
 
     def tearDown(self):
         self.remove_loggers()
         super(TestLogutil, self).tearDown()
-        mock.patch.stopall()
 
     def remove_loggers(self):
         logging.getLogger("subscription_manager").handlers = []
@@ -31,14 +34,6 @@ class TestLogutil(fixture.SubManFixture):
         logging.getLogger("rhsm-app").handlers = []
         logging.getLogger().handlers = []
 
-    def test_file_config(self):
-        logutil.file_config(logging_config=TEST_LOG_CONFIG)
-        sm_logger = logging.getLogger("subscription_manager")
-        rhsm_logger = logging.getLogger("rhsm")
-        self.assertEqual(sm_logger.getEffectiveLevel(), logging.DEBUG)
-        self.assertEqual(rhsm_logger.getEffectiveLevel(), logging.DEBUG)
-
-    @mock.patch.object(logutil, 'LOGGING_CONFIG', TEST_LOG_CONFIG)
     def test_log_init(self):
         logutil.init_logger()
         sm_logger = logging.getLogger("subscription_manager")
@@ -46,16 +41,53 @@ class TestLogutil(fixture.SubManFixture):
         self.assertEqual(sm_logger.getEffectiveLevel(), logging.DEBUG)
         self.assertEqual(rhsm_logger.getEffectiveLevel(), logging.DEBUG)
 
-    def test_file_config_debug(self):
-        with mock.patch.dict('os.environ', {'SUBMAN_DEBUG': '1'}):
-            logutil.file_config(logging_config=TEST_LOG_CONFIG)
-            debug_logger = logging.getLogger()
-            self.assertEqual(debug_logger.getEffectiveLevel(), logging.NOTSET)
+    def test_log_init_default_log_level(self):
+        self.rhsm_config.set("logging", "default_log_level", "WARNING")
 
-    @mock.patch.object(logutil, 'LOGGING_CONFIG', TEST_LOG_CONFIG)
+        logutil.init_logger()
+        sm_logger = logging.getLogger("subscription_manager")
+        rhsm_logger = logging.getLogger("rhsm-app")
+        self.assertEqual(sm_logger.getEffectiveLevel(), logging.WARNING)
+        self.assertEqual(rhsm_logger.getEffectiveLevel(), logging.WARNING)
+
     def test_init_logger_for_yum(self):
         logutil.init_logger_for_yum()
         sm_logger = logging.getLogger("subscription_manager")
         rhsm_logger = logging.getLogger("rhsm-app")
         self.assertFalse(sm_logger.propagate)
         self.assertFalse(rhsm_logger.propagate)
+
+    def test_do_not_modify_root_logger(self):
+        root_handlers = logging.getLogger().handlers
+        logutil.init_logger()
+        self.assert_items_equals(logging.getLogger().handlers, root_handlers)
+
+    def test_set_valid_logger_level(self):
+        logging_conf = [
+            ('subscription_manager.managercli', logging.ERROR),
+            ('rhsm', logging.WARNING),
+            ('rhsm-app', logging.CRITICAL),
+            ('rhsm-app.rhsmd', "DEBUG")
+        ]
+
+        for logger_name, log_level in logging_conf:
+            self.rhsm_config.set('logging', logger_name, log_level)
+
+        logutil.init_logger()
+
+        for logger_name, log_level in logging_conf:
+            real_log_level = logging.getLogger(logger_name).getEffectiveLevel()
+            self.assertEqual(real_log_level, logging._checkLevel(log_level))
+
+    def test_set_invalid_logger_level(self):
+        test_logger_name = 'foobar'
+        initial_level = logging.ERROR
+        test_logger = logging.getLogger(test_logger_name)
+        test_logger.setLevel(initial_level)
+        config_level = logging.DEBUG
+        self.rhsm_config.set('logging', test_logger_name,
+                             config_level)
+
+        logutil.init_logger()
+
+        self.assertNotEqual(test_logger.getEffectiveLevel(), config_level)

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -935,7 +935,7 @@ class TestConfigCommand(TestCliCommand):
 
         baseurl = 'https://someserver.example.com/foo'
         self.cc.main(['--rhsm.baseurl', baseurl])
-        self.assertEquals(managercli.cfg.store['rhsm.baseurl'], baseurl)
+        self.assertEquals(managercli.cfg.store['rhsm']['baseurl'], baseurl)
 
     def test_remove_config_default(self):
         with Capture() as cap:

--- a/test/test_network_config_gui.py
+++ b/test/test_network_config_gui.py
@@ -67,7 +67,7 @@ class TestNetworkConfigDialog(SubManFixture):
         self.assertEquals(expected, actual)
 
     def test_network_cfg_set_initial_values(self):
-        self.stubConfig = stubs.StubConfig(config_file=stubs.test_config)
+        self.stubConfig = stubs.StubConfig()
         self.nc.set_initial_values()
 
     def test_network_cfg_write_values(self):
@@ -97,8 +97,8 @@ class TestNetworkConfigDialog(SubManFixture):
         self.nc.proxyPasswordEntry.set_text("redhatPass")
         self.nc.write_values()
 
-        actual_user = self.nc.cfg.store['server.proxy_user']
-        actual_password = self.nc.cfg.store['server.proxy_password']
+        actual_user = self.nc.cfg.store['server']['proxy_user']
+        actual_password = self.nc.cfg.store['server']['proxy_password']
         self.assertTrue(actual_user == "redhatUser")
         self.assertTrue(actual_password == "redhatPass")
 


### PR DESCRIPTION
## Please see the bz for a reproducer script to verify that this PR fixes the issue


The primary reason for these changes is to simplify logging config in subman (and friends) and especially **to not override the root logger**. This PR removes the usage of our logging.conf file. All logging configuration is now done in /etc/rhsm/rhsm.conf.

This PR looks for a section called 'logging'. There is a special key there ('default_log_level') that is used to set the log level of all subman and python-rhsm loggers if not specified elsewhere in the logging section. All other key=value in the logging section are logger_name=log_level (WARNING, DEBUG, etc..) where the logger_names are the python module name of the code that you'd like to change logging for. 

For example, if I'd like to see more logging info for the managercli module of subman I'd add the following to the logging section of rhsm.conf:
"""
subscription_manager.managercli=DEBUG
"""
Logging levels can be changed similarly for all loggers that are in any of the following namespaces:
'rhsm', 'subscription_manager' or 'rhsm-app'.

Please note: 'rhsm-app' is not a package or module anywhere it has been mostly removed and only lives on for those tools that are not subman nor are python-rhsm (for example rhsmd).

This PR requires this python-rhsm PR: https://github.com/candlepin/python-rhsm/pull/177


After review I'll squash the commits below into the first one.