### PR TITLE
Change method signature for Anaconda addon (#1362138)

### DIFF
--- a/src/initial-setup/com_redhat_subscription_manager/ks/rhsm_ks.py
+++ b/src/initial-setup/com_redhat_subscription_manager/ks/rhsm_ks.py
@@ -146,15 +146,15 @@ class RHSMAddonData(AddonData):
     def __str__(self):
         return "%%addon %s %s\n%s%%end\n" % (self.name, self.header_args, self.content)
 
-    def setup(self, storage, ksdata, instclass):
+    def setup(self, storage, ksdata, instclass, payload):
         """Make the changes to the install system.
 
            This method is called before the installation
            is started and directly from spokes. It must be possible
            to call it multiple times without breaking the environment."""
-        AddonData.setup(self, storage, ksdata, instclass)
+        pass
 
-    def execute(self, storage, ksdata, instClass, users):
+    def execute(self, storage, ksdata, instClass, users, payload):
 
         """Make the changes to the underlying system.
 


### PR DESCRIPTION
``setup()`` and ``execute()`` methods now have ``payload`` class accessible for addons.

These methods were changed in *anaconda-21.48.22.67* for RHEL-7 and *anaconda-25.9* for Rawhide (for the next Fedora 25).

Also removing the ``AddonData.setup()``. The parent's ``setup()`` method should not be called. It's placeholder for overriding only.

*Resolves: rhbz#1362138*

Reported-by: Michal Kovarik ``<mkovarik@redhat.com>``