### PR TITLE
1366301: Entitlement regeneration failure no longer aborts refresh

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -646,9 +646,13 @@ class RefreshCommand(CliCommand):
             identity = inj.require(inj.IDENTITY)
 
             # Force a regen of the entitlement certs for this consumer
-            self.cp.regenEntitlementCertificates(identity.uuid, True)
+            # TODO: Eventually migrate this to capability recognition. Currently it will silently return
+            #   false if an error occurs
+            if not self.cp.regenEntitlementCertificates(identity.uuid, True):
+                log.debug("Warning: Unable to refresh entitlement certificates; service likely unavailable")
 
             self.entcertlib.update()
+
             log.info("Refreshed local data")
             print (_("All local data refreshed"))
         except connection.RestlibException, re:


### PR DESCRIPTION
- Service unavailable errors will no longer raise an exception
  whilst running the refresh command