### PR TITLE
1368362: Do not display logging config error on upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ install-conf:
 	install -d $(PREFIX)/etc/rhsm/facts
 	install -d $(PREFIX)/etc/security/console.apps
 	install -m 644 etc-conf/rhsm.conf $(PREFIX)/etc/rhsm/
+	install -T etc-conf/logging.conf $(PREFIX)/etc/rhsm/logging.conf
 	install -m 644 etc-conf/logrotate.conf $(PREFIX)/etc/logrotate.d/subscription-manager
 	install -m 644 etc-conf/subscription-manager.completion.sh $(PREFIX)/etc/bash_completion.d/subscription-manager
 	install -m 644 etc-conf/rct.completion.sh $(PREFIX)/etc/bash_completion.d/rct

--- a/etc-conf/logging.conf
+++ b/etc-conf/logging.conf
@@ -1,3 +1,6 @@
+# This file is no longer used and will be removed in a future version.
+# Any changes here will be ignored.
+# Please see `man rhsm.conf` for new logging config information.
 [loggers]
 keys=root,rhsm-app,rhsm,subscription_manager,py.warnings
 
@@ -72,4 +75,3 @@ class=subscription_manager.logutil.SubmanDebugHandler
 level=DEBUG
 formatter=subman_debug
 args=()
-

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -340,6 +340,7 @@ rm -rf %{buildroot}
 %attr(755,root,root) %dir %{_sysconfdir}/rhsm
 %attr(755,root,root) %dir %{_sysconfdir}/rhsm/facts
 %attr(644,root,root) %config(noreplace) %{_sysconfdir}/rhsm/rhsm.conf
+%config %attr(644,root,root) %{_sysconfdir}/rhsm/logging.conf
 
 %config(noreplace) %{_sysconfdir}/dbus-1/system.d/com.redhat.SubscriptionManager.conf
 


### PR DESCRIPTION
On upgrade of subman from a version older than (7218097e03b9255e74c41e13772698fc52f92ec6)
to any version newer than or equal to the aforementioned hash ^, an error message regarding failure to find section named 'formatters' is displayed.

The reason for this - and consequently for the fix itself - is during upgrade old subscription-manager plugins are run which look for the logging.conf file that was previously erased from the spec file and Makefile. This would cause a deletion of this file on the filesystem of the upgrading host. When the old plugin attempted to read this file, and found it missing, it fails and prints the exeception to stdout (which is what we see in the referenced bz 1368362).

The fix is to leave the now defunct logging.conf file (as well as a nice comment telling people who might be using it to look toward the new bits) so that the old code running during upgrade doesn't fail.