### PR TITLE
1331739: Validate repo-override --remove non-empty [squashed]

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2557,9 +2557,11 @@ class OverrideCommand(CliCommand):
     def _colon_split(self, option, opt_str, value, parser):
         if parser.values.additions is None:
             parser.values.additions = {}
+        if value.strip() == '':
+            raise OptionValueError(_("You must specify an override in the form of \"name:value\" with --add."))
 
         k, colon, v = value.partition(':')
-        if not v:
+        if not v or not k:
             raise OptionValueError(_("--add arguments should be in the form of \"name:value\""))
 
         parser.values.additions[k] = v
@@ -2575,6 +2577,10 @@ class OverrideCommand(CliCommand):
         if self.options.repos and not (self.options.list or self.options.additions or
                                        self.options.removals or self.options.remove_all):
             system_exit(os.EX_USAGE, _("Error: The --repo option must be used with --list or --add or --remove."))
+        if self.options.removals:
+            stripped_removals = [removal.strip() for removal in self.options.removals]
+            if '' in stripped_removals:
+                system_exit(os.EX_USAGE, _("Error: You must specify an override name with --remove."))
         # If no relevant options were given, just show a list
         if not (self.options.repos or self.options.additions or
                 self.options.removals or self.options.remove_all or self.options.list):

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1325,6 +1325,21 @@ class TestOverrideCommand(TestCliProxyCommand):
         self.assertEquals(self.cc.options.additions, {'a': 'b'})
         self.assertEquals(self.cc.options.removals, ['a'])
 
+    def test_remove_empty_arg(self):
+        self._test_exception(["--repo", "x", "--remove", ""])
+
+    def test_remove_multiple_args_empty_arg(self):
+        self._test_exception(["--repo", "x", "--remove", "foo", "--remove", ""])
+
+    def test_add_empty_arg(self):
+        self.assertRaises(SystemExit, self.cc.main, ["--repo", "x", "--add", ""])
+
+    def test_add_empty_name(self):
+        self.assertRaises(SystemExit, self.cc.main, ["--repo", "x", "--add", ":foo"])
+
+    def test_add_multiple_args_empty_arg(self):
+        self.assertRaises(SystemExit, self.cc.main, ["--repo", "x", "--add", "foo:bar", "--add", ""])
+
     def test_list_and_remove_all_work_with_repos(self):
         self.cc.main(["--repo", "x", "--list"])
         self.cc._validate_options()


### PR DESCRIPTION
Same as #1470, except squashed.