### PR TITLE
Account for keyboard interrupt

### DIFF
--- a/bin/subscription-manager-gui
+++ b/bin/subscription-manager-gui
@@ -39,7 +39,11 @@ import dbus.glib
 import dbus.exceptions
 import logging
 import gettext
+import signal
+
 _ = gettext.gettext
+
+signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 # Capture python (and pygtk) warnings that normally print to
 # stderr and log them.

--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -29,7 +29,6 @@ import webbrowser
 import os
 import socket
 
-
 import rhsm.config as config
 
 from subscription_manager.ga import Gtk as ga_Gtk


### PR DESCRIPTION
Confirmed on RHEL 7.2, RHEL 6.8 and Fedora 23.