### PR TITLE
1367657: Properly escape gui error/info messages

### DIFF
--- a/src/subscription_manager/gui/utils.py
+++ b/src/subscription_manager/gui/utils.py
@@ -139,7 +139,7 @@ def format_exception(e, msg, format_msg=True, log_msg=None):
         # Get the class instance of the exception
         e = e[1]
     message = None
-    exception_mapper = ExceptionMapper()
+    exception_mapper = GuiExceptionMapper()
     mapped_message = exception_mapper.get_message(e)
     if mapped_message:
         message = format_mapped_message(e, msg, mapped_message, format_msg=format_msg)
@@ -319,3 +319,9 @@ class AsyncWidgetUpdater(object):
         threading.Thread(target=self.worker, name="AsyncWidgetUpdaterThread",
                          args=(widget_update, backend_method, args,
                                kwargs, exception_msg, callback)).start()
+
+
+class GuiExceptionMapper(ExceptionMapper):
+
+    def format_restlib_exception(self, restlib_exception, message_template):
+        return ga_GObject.markup_escape_text(restlib_exception.msg)

--- a/test/test_gui_utils.py
+++ b/test/test_gui_utils.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     import unittest
 
+from rhsm.connection import RestlibException
 from subscription_manager.ga import Gtk as ga_Gtk
 from subscription_manager.gui import utils
 from subscription_manager.gui import storage
@@ -94,3 +95,13 @@ class TestGatherGroup(unittest.TestCase):
             m = r.get_model()
             names.add(m.get_value(m.get_iter(r.get_path()), 0))
         self.assertEqual(names, set(['root', 'child-1', 'child-2', 'grandchild-1']))
+
+
+class TestGuiExceptionMapper(unittest.TestCase):
+    def test_restlib_exception_with_markup(self):
+        exception_mapper = utils.GuiExceptionMapper()
+        unescaped_input = '<a=3>&'
+        bad_restlib_exception = RestlibException(404, unescaped_input)
+        expected_output = '&lt;a=3&gt;&amp;'
+        actual_output = exception_mapper.get_message(bad_restlib_exception)
+        self.assertEqual(expected_output, actual_output)


### PR DESCRIPTION
When candlepin returns an error message that includes characters often found in markup (like '<>' for example) our gui error and info dialogs fail as GTK tries to parse those items as markup. These small changes ensure we are escaping our info and error messages properly to avoid displaying empty dialog boxes.