### PR TITLE
1185914: migrate - handle legacy services/packages

### DIFF
--- a/etc-conf/rhn-migrate-classic-to-rhsm.completion.sh
+++ b/etc-conf/rhn-migrate-classic-to-rhsm.completion.sh
@@ -11,7 +11,7 @@ _rhn-migrate-classic-to-rhsm()
 	first="${COMP_WORDS[1]}"
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	opts="-h --help --environment -f --force -n --no-auto --no-proxy --org -s --servicelevel --legacy-user --legacy-password --destination-url --destination-user --destination-password --activation-key --keep"
+	opts="-h --help --environment -f --force -n --no-auto --no-proxy --org -s --servicelevel --legacy-user --legacy-password --destination-url --destination-user --destination-password --activation-key --keep --remove-rhn-packages"
 
 	case "${cur}" in
 		-*)


### PR DESCRIPTION
Note that once `--remove-rhn-packages` is used, the script fails to
function as it depends on up2date_client provided by rhn-client-tools.

Aside from general feedback, I'm also looking for feedback specifically on the package list in `LEGACY_PACKAGES` and the legacy service list in `LEGACY_DAEMONS`: are they exhaustive? Any problems with handling any of those as implemented?