### PR TITLE
1176219: Error out if bad proxy settings detected

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -1836,7 +1836,8 @@ class ChooseServerScreen(Screen):
             self.reset_resolver()
 
             try:
-                if not is_valid_server_info(hostname, port, prefix):
+                conn = UEPConnection(hostname, port, prefix)
+                if not is_valid_server_info(conn):
                     self.emit('register-error',
                               _("Unable to reach the server at %s:%s%s") %
                                 (hostname, port, prefix),


### PR DESCRIPTION
Improves upon changes in 7ce6801fc1cc38edcdeb75dfb5f0d1f8a6398c68

 - make is_valid_server_info handle proxy settings
 - detect 407 (proxy auth) http errors in is_valid_server_info
 - treat exceptions during test_proxy_connection as failures