### PR TITLE
1376014: Clear activation key list when checkbox unchecked

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -1870,6 +1870,7 @@ class ChooseServerScreen(Screen):
 
         else:
             self.emit('move-to-screen', CREDENTIALS_PAGE)
+            self.info.set_property('activation-keys', None)
             return True
 
     def set_server_entry(self, hostname, port, prefix):


### PR DESCRIPTION
When the user attempted to register with an activation key and
 got a failure they could back out to the first screen. If they
 then proceeded without an activation key the remnant of the
 first attempt would confuse the logic.