### PR TITLE
remove nose-machineout

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
 yanc
 nose-randomly
 xtraceback
-git+git://github.com/nvie/nose-machineout.git#egg=nose_machineout


### PR DESCRIPTION
seems to be a plugin that lets users run nose tests in vim.
not sure if any one does this anymore in the team, and the repository has been removed, so removing this entirely.