### PR TITLE
1176219: Treat port as integer for GUI conn test

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -1836,7 +1836,7 @@ class ChooseServerScreen(Screen):
             self.reset_resolver()
 
             try:
-                conn = UEPConnection(hostname, port, prefix)
+                conn = UEPConnection(hostname, int(port), prefix)
                 if not is_valid_server_info(conn):
                     self.emit('register-error',
                               _("Unable to reach the server at %s:%s%s") %


### PR DESCRIPTION
Fix for a bug I introduced w/ #1486.