### PR TITLE
1163968: Use macro for service restart

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -546,9 +546,7 @@ rm -rf %{buildroot}
 
 %post
 %if %use_systemd
-    /bin/systemctl enable rhsmcertd.service >/dev/null 2>&1 || :
-    /bin/systemctl daemon-reload >/dev/null 2>&1 || :
-    /bin/systemctl try-restart rhsmcertd.service >/dev/null 2>&1 || :
+    %systemd_post rhsmcertd.service
 %else
     chkconfig --add rhsmcertd
 %endif


### PR DESCRIPTION
Also removed the rhsmcertd enable command. Proper way
is for the release team to add it to the preset file.

BZ created for that to happen.