### PR TITLE
1360427: Show error if browser is not detected

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -46,6 +46,7 @@ from subscription_manager.gui import messageWindow
 from subscription_manager.gui import networkConfig
 from subscription_manager.gui import redeem
 from subscription_manager.gui import registergui
+from subscription_manager.gui import utils
 from subscription_manager.gui import widgets
 
 from subscription_manager.gui.about import AboutDialog
@@ -73,6 +74,22 @@ cfg = config.initConfig()
 
 ONLINE_DOC_URL_TEMPLATE = "https://access.redhat.com/knowledge/docs/Red_Hat_Subscription_Management/?locale=%s"
 ONLINE_DOC_FALLBACK_URL = "https://access.redhat.com/knowledge/docs/Red_Hat_Subscription_Management/"
+
+# every GUI browser from https://docs.python.org/2/library/webbrowser.html with updates within last 2 years of writing
+PREFERRED_BROWSERS = [
+    "mozilla",
+    "firefox",
+    "epiphany",
+    "konqueror",
+    "opera",
+    "google-chrome",
+    "chrome",
+    "chromium",
+    "chromium-browser",
+]
+
+# inform user of the URL in case our detection is outdated
+NO_BROWSER_MESSAGE = _("Browser not detected. Documentation URL is %s.")
 
 
 class Backend(object):
@@ -486,7 +503,17 @@ class MainWindow(widgets.SubmanBaseWidget):
         about.show()
 
     def _online_docs_item_clicked(self, widget):
-        webbrowser.open_new(self._get_online_doc_url())
+        browser = None
+        for possible_browser in PREFERRED_BROWSERS:
+            try:
+                browser = webbrowser.get(possible_browser)
+                break
+            except webbrowser.Error:
+                pass
+        if browser is None:
+            utils.show_error_window(NO_BROWSER_MESSAGE % (self._get_online_doc_url()))
+        else:
+            webbrowser.open_new(self._get_online_doc_url())
 
     def _quit_item_clicked(self):
         self.hide()


### PR DESCRIPTION
This prevents weird behavior, like having gedit show raw HTML. Instead,
we show an error with the URL, so that the user can do something useful
with it.

The browser detection has the potential to be outdated if a new browser
is released, but as long as the user has at least one of the coded
browsers present, it should respect their default browser, and
otherwise, they can copy the URL from the error dialog.
