### PR TITLE
1382355: Don't swallow CLI autoattach exceptions

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -201,6 +201,7 @@ def autosubscribe(cp, consumer_uuid, service_level=None):
     except Exception, e:
         log.warning("Error during auto-attach.")
         log.exception(e)
+        raise
 
 
 def show_autosubscribe_output(uep):


### PR DESCRIPTION
This affects two CLI commands:

 - register with --autoattach which now will report server exceptions
   on stdout and will raise other exceptions during auto-attach
 - attach with --auto will now raise all exceptions during auto-attach

In the testing I did of the change, the behavior of subscription-manager
register command is different in *output only*, but attach exits early
if auto-attach fails (entitlement certs aren't updated and certification
is *not* re-checked), which I think is valid behavior.