### PR TITLE
1382897: Don't always reenable register menu item

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -387,7 +387,8 @@ class MainWindow(widgets.SubmanBaseWidget):
         registration_dialog.show()
 
     def _on_dialog_destroy(self, obj, widget):
-        if widget:
+        # bz#1382897 make sure register menu item is left in appropriate state
+        if (widget is not self.register_menu_item or not self.registered()) and widget:
             widget.set_sensitive(True)
         return False
 


### PR DESCRIPTION
Because we use the same registration dialog for both the menu item and
the register button on the install tab, we need to account for the menu
item in the destroy handler. Prior to this change, the handler
unconditionally (re)-enabled whatever the widget that triggered the
dialog was, which is wrong for the register menu item.