### PR TITLE
1261215: Fix frozen progress bars

### DIFF
--- a/src/subscription_manager/gui/installedtab.py
+++ b/src/subscription_manager/gui/installedtab.py
@@ -108,6 +108,8 @@ class InstalledProductsTab(widgets.SubscriptionManagerTab):
             "on_register_button_clicked": parent._register_item_clicked,
         })
 
+        self._entries = []
+
     def _calc_subs_providing(self, product_id, compliant_range):
         """
         Calculates the relevant contract IDs and subscription names which are
@@ -138,8 +140,8 @@ class InstalledProductsTab(widgets.SubscriptionManagerTab):
 
         return contract_ids, sub_names
 
-    def update_products(self):
-        self.store.clear()
+    def update(self):
+        entries = []
         range_calculator = inj.require(inj.PRODUCT_DATE_RANGE_CALCULATOR,
                 self.backend.cp_provider.get_consumer_auth_cp())
         for product_cert in self.product_dir.list():
@@ -218,14 +220,20 @@ class InstalledProductsTab(widgets.SubscriptionManagerTab):
                     entry['image'] = self._render_icon('red')
                     entry['status'] = _('Not Subscribed')
                     entry['validity_note'] = _("Not Subscribed")
+                entries.append(entry)
+        self._entries = entries
 
-                # FIXME
-                # TODO: fix mapped stores
-                self.store.add_map(entry)
+    def refresh(self):
+        self.store.clear()
+        for entry in self._entries:
+            # FIXME
+            # TODO: fix mapped stores
+            self.store.add_map(entry)
         # 811340: Select the first product in My Installed Products
         # table by default.
         selection = self.top_view.get_selection()
         selection.select_path(0)
+        self._set_validity_status()
 
     def _render_icon(self, icon_id):
         try:
@@ -286,7 +294,6 @@ class InstalledProductsTab(widgets.SubscriptionManagerTab):
 
     def _set_validity_status(self):
         """ Updates the entitlement validity status portion of the UI. """
-
         if ClassicCheck().is_registered_with_classic():
             self._set_status_icons(VALID_STATUS)
             self.subscription_status_label.set_text(
@@ -339,9 +346,6 @@ class InstalledProductsTab(widgets.SubscriptionManagerTab):
     def set_registered(self, is_registered):
         self.update_certificates_button.set_property('visible', is_registered)
         self.register_button.set_property('visible', not is_registered)
-
-    def refresh(self):
-        self._set_validity_status()
 
     def rreplace(self, s, old, new, occurrence):
         li = s.rsplit(old, occurrence)

--- a/src/subscription_manager/gui/mysubstab.py
+++ b/src/subscription_manager/gui/mysubstab.py
@@ -169,11 +169,14 @@ class MySubscriptionsTab(widgets.SubscriptionManagerTab):
                 self.content.get_toplevel())
         prompt.connect('response', self._on_unsubscribe_prompt_response, selection)
 
-    def update_subscriptions(self, update_dbus=True):
-        """
-        Pulls the entitlement certificates and updates the subscription model.
-        """
+    def update_subscriptions(self, update_dbus=True, update_gui=True):
         self.pooltype_cache.update()
+        if update_gui:
+            self.refresh()
+        if update_dbus:
+            inj.require(inj.DBUS_IFACE).update()
+
+    def refresh(self):
         sorter = EntitlementCertStackingGroupSorter(self.entitlement_dir.list())
         self.store.clear()
 
@@ -183,8 +186,6 @@ class MySubscriptionsTab(widgets.SubscriptionManagerTab):
 
         self.top_view.expand_all()
         self._stripe_rows(None, self.store)
-        if update_dbus:
-            inj.require(inj.DBUS_IFACE).update()
         self.unsubscribe_button.set_property('sensitive', False)
         # 841396: Select first item in My Subscriptions table by default
         selection = self.top_view.get_selection()

--- a/test/test_managergui.py
+++ b/test/test_managergui.py
@@ -1,8 +1,3 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
 from fixture import SubManFixture
 import mock
 
@@ -23,7 +18,7 @@ class TestManagerGuiMainWindow(SubManFixture):
                               prod_dir=stubs.StubProductDirectory([]))
 
 
-class TestRegisterScreen(unittest.TestCase):
+class TestRegisterScreen(SubManFixture):
     def test_register_screen(self):
         registergui.RegisterDialog(stubs.StubBackend())
 


### PR DESCRIPTION
Fixed by moving the blocking calls to candlepin to separate threads. One
small downside to this is that more GUI updates happen asynchronously,
and thus this _might_ be harder to test/verify. We can possibly fix that
without reverting this fix by having the registergui hang around a
little longer if necessary.

This is by no means comprehensive for fixing usage of HTTP calls on the
main thread in subscription-manager-gui...
