### PR TITLE
1390549: Force input prompts to use stdout

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -25,6 +25,7 @@ import logging
 from optparse import OptionValueError
 import os
 import re
+import readline
 import socket
 import sys
 from time import localtime, strftime, strptime
@@ -576,6 +577,7 @@ class UserPassCommand(CliCommand):
         """
         while not username:
             username = raw_input(_("Username: "))
+            readline.clear_history()
         while not password:
             password = getpass.getpass(_("Password: "))
         return (username.strip(), password.strip())
@@ -614,6 +616,7 @@ class OrgCommand(UserPassCommand):
     def _get_org(org):
         while not org:
             org = raw_input(_("Organization: "))
+            readline.clear_history()
         return org
 
     @property
@@ -1224,7 +1227,9 @@ class RegisterCommand(UserPassCommand):
         """
         By breaking this code out, we can write cleaner tests
         """
-        return raw_input(_("Environment: ")).strip() or self._prompt_for_environment()
+        environment = raw_input(_("Environment: ")).strip()
+        readline.clear_history()
+        return environment or self._prompt_for_environment()
 
     def _get_environment_id(self, cp, owner_key, environment_name):
         # If none specified on CLI and the server doesn't support environments,
@@ -1287,6 +1292,7 @@ class RegisterCommand(UserPassCommand):
         owner_key = None
         while not owner_key:
             owner_key = raw_input(_("Organization: "))
+            readline.clear_history()
         return owner_key
 
 

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -20,6 +20,7 @@ import libxml2
 import logging
 import os
 import re
+import readline
 import shutil
 import subprocess
 import sys
@@ -116,6 +117,7 @@ class Menu(object):
         while True:
             self.display()
             selection = raw_input("? ").strip()
+            readline.clear_history()
             try:
                 return self._get_item(selection)
             except InvalidChoiceError:
@@ -183,6 +185,7 @@ class MigrationEngine(object):
     def authenticate(self, username, password, user_prompt, pw_prompt):
         if not username:
             username = raw_input(user_prompt).strip()
+            readline.clear_history()
 
         if not password:
             password = getpass.getpass(prompt=pw_prompt)
@@ -304,6 +307,7 @@ class MigrationEngine(object):
                 org_input = owner_list[0]['key']
             else:
                 org_input = raw_input(_("Org: ")).strip()
+                readline.clear_history()
 
             org = None
             for owner_data in owner_list:
@@ -333,6 +337,7 @@ class MigrationEngine(object):
                 env_input = environment_list[0]['name']
             else:
                 env_input = raw_input(_("Environment: ")).strip()
+                readline.clear_history()
 
             for env_data in environment_list:
                 # See BZ #978001


### PR DESCRIPTION
Related to [python issue 1927](http://bugs.python.org/issue1927),
workaround is to import readline. When readline is imported, it causes
raw_input to always use stdout for the prompt.

Since adding readline causes additional behaviors, I also added
`readline.clear_history` after every raw_input() to reduce funtionality
change (we can always remove later).