### PR TITLE
1389559: Parse log levels properly from config

### DIFF
--- a/src/subscription_manager/logutil.py
+++ b/src/subscription_manager/logutil.py
@@ -145,7 +145,7 @@ def init_logger():
         logger = logging.getLogger(root_namespace)
         logger.addHandler(_get_default_rhsm_log_handler())
         logger.addHandler(_get_default_subman_debug_handler())
-        logger.setLevel(default_log_level)
+        logger.setLevel(getattr(logging, default_log_level.strip()))
 
     for logger_name, logging_level in config.items('logging'):
         logger_name = logger_name.strip()
@@ -156,7 +156,7 @@ def init_logger():
             # default_log_level
             continue
         logger = logging.getLogger(logger_name)
-        logger.setLevel(logging_level)
+        logger.setLevel(getattr(logging, logging_level.strip()))
 
     if not log:
         log = logging.getLogger(__name__)

--- a/test/test_logutil.py
+++ b/test/test_logutil.py
@@ -64,9 +64,9 @@ class TestLogutil(fixture.SubManFixture):
 
     def test_set_valid_logger_level(self):
         logging_conf = [
-            ('subscription_manager.managercli', logging.ERROR),
-            ('rhsm', logging.WARNING),
-            ('rhsm-app', logging.CRITICAL),
+            ('subscription_manager.managercli', "ERROR"),
+            ('rhsm', "WARNING"),
+            ('rhsm-app', "CRITICAL"),
             ('rhsm-app.rhsmd', "DEBUG")
         ]
 


### PR DESCRIPTION
In 2.7, `setLevel` seems to handle this for us, but in 2.6, the level is
blindly set, which leads to the logger misbehaving (since strings are
effectively a higher value than the highest logging level, CRITICAL, a
number, we saw no output).