### PR TITLE
1390712: Add --remove-rhn-packages to man pages

### DIFF
--- a/man/rhn-migrate-classic-to-rhsm.8
+++ b/man/rhn-migrate-classic-to-rhsm.8
@@ -21,7 +21,7 @@
 rhn-migrate-classic-to-rhsm \- Migrates a system profile from Red Hat Network Classic Hosted to Customer Portal Subscription Management (hosted) or Subscription Asset Manager (on-premise).
 
 .SH SYNOPSIS
-rhn-migrate-classic-to-rhsm [--force] | [--no-auto] [--keep] | [--servicelevel=SERVICE_LEVEL] | [--destination-url=URL] | [--legacy-user=LEGACY_USER] | [--legacy-password=LEGACY_PASSWORD] | [--destination-user=DESTINATION_USER] | [--destination-password=DESTINATION_PASSWORD] | [--org=ORG] | [--environment=ENVIRONMENT] | [--no-proxy] [--activation-key=ACTIVATION_KEY] | [--help]
+rhn-migrate-classic-to-rhsm [--force] | [--no-auto] [--keep] | [--servicelevel=SERVICE_LEVEL] | [--remove-rhn-packages] | [--destination-url=URL] | [--legacy-user=LEGACY_USER] | [--legacy-password=LEGACY_PASSWORD] | [--destination-user=DESTINATION_USER] | [--destination-password=DESTINATION_PASSWORD] | [--org=ORG] | [--environment=ENVIRONMENT] | [--no-proxy] [--activation-key=ACTIVATION_KEY] | [--help]
 
 .SH DESCRIPTION
 \fBrhn-migrate-classic-to-rhsm\fP migrates a system profile which is registered with Red Hat Network Classic to Customer Portal Subscription Management. This is intended for migrating from the host service, not for migrating from a Satellite system.
@@ -62,6 +62,27 @@ Deletes the system from Red Hat Network Classic and registers it to Customer Por
 .TP
 .B -s SERVICE_LEVEL, --servicelevel=SERVICE_LEVEL
 Sets a preferred service level for the system, such as premium or standard. This service-level preference is then used as one of the criteria for auto-attaching subscriptions to the system.
+
+.TP
+.B --remove-rhn-packages
+After unregistering from Red Hat Network Classic, remove legacy packages:
+\fBosad\fP,
+\fBrhn-check\fP,
+\fBrhn-client-tools\fP,
+\fBrhncfg\fP,
+\fBrhncfg-actions\fP,
+\fBrhncfg-client\fP,
+\fBrhncfg-management\fP,
+\fBrhn-setup\fP,
+\fBrhnpush\fP,
+\fBrhnsd\fP,
+\fBspacewalk-abrt\fP,
+\fBspacewalk-oscap\fP,
+\fByum-rhn-plugin\fP.
+Once unregistered from Red Hat Network Classic, they are no longer needed.
+Once packages are removed, subsequent attempts to migrate will be blocked with a message indicating
+"Perhaps this script was already executed with --remove-rhn-packages?".
+\fB--remove-rhn-packages\fP cannot be used with \fB--keep\fP, since it does not make sense to keep a system registered without the tooling.
 
 .TP
 .B --org=ORG
@@ -122,7 +143,10 @@ The migration process moves the system from the inventory in one subscription ma
 5. Unregister from Red Hat Network Classic.
 
 .IP
-6. Register with Customer Portal Subscription Management and auto-attach the best-matched subscriptions.
+6. Stop and disable legacy services: \fBosad\fP, \fBrhnsd\fP.
+
+.IP
+7. Register with Customer Portal Subscription Management and auto-attach the best-matched subscriptions.
 
 .PP
 After migration, the system facts maintained by Subscription Manager display what script was used for migration and what the previous system ID was.

--- a/man/sat5to6.8
+++ b/man/sat5to6.8
@@ -21,7 +21,7 @@
 sat5to6 \- Migrates a system profile from Red Hat Satellite v.5 to Red Hat Satellite v.6 as part of the Satellite Transition process.
 
 .SH SYNOPSIS
-sat5to6 [--destination-user=DESTINATION_USER] | [--destination-password=DESTINATION_PASSWORD] | [--destination-url=URL] | [--legacy-user=LEGACY_USER] | [--legacy-password=LEGACY_PASSWORD] | [--no-auto] | [--no-proxy] | [--registration-state=STATE] | [--servicelevel=SERVICE_LEVEL] | [--help]
+sat5to6 [--destination-user=DESTINATION_USER] | [--destination-password=DESTINATION_PASSWORD] | [--destination-url=URL] | [--legacy-user=LEGACY_USER] | [--legacy-password=LEGACY_PASSWORD] | [--no-auto] | [--no-proxy] | [--registration-state=STATE] | [--servicelevel=SERVICE_LEVEL] | [--remove-rhn-packages] | [--help]
 
 .SH DESCRIPTION
 \fBsat5to6\fP migrates a system profile which is registered to a Red Hat Satellite v.5 instance to a Red Hat Satellite v.6 instance.
@@ -64,6 +64,27 @@ Do not attempt to automatically attach subscriptions to the associated content-h
 .B -s SERVICE_LEVEL, --servicelevel=SERVICE_LEVEL
 Set a preferred service level for the system, such as premium or standard.
 This service level preference is then used as one of the criteria for autoattaching subscriptions to the system.
+
+.TP
+.B --remove-rhn-packages
+After unregistering from Satellite v.5, remove legacy packages:
+\fBosad\fP,
+\fBrhn-check\fP,
+\fBrhn-client-tools\fP,
+\fBrhncfg\fP,
+\fBrhncfg-actions\fP,
+\fBrhncfg-client\fP,
+\fBrhncfg-management\fP,
+\fBrhn-setup\fP,
+\fBrhnpush\fP,
+\fBrhnsd\fP,
+\fBspacewalk-abrt\fP,
+\fBspacewalk-oscap\fP,
+\fByum-rhn-plugin\fP.
+Once unregistered from Satellite v.5, they are no longer needed.
+Once packages are removed, subsequent attempts to migrate will be blocked with a message indicating
+"Perhaps this script was already executed with --remove-rhn-packages?".
+\fB--remove-rhn-packages\fP can only be used with \fB--registration-state=purge\fP, since it does not make sense to keep a system registered without the tooling.
 
 .TP
 .B --no-proxy
@@ -115,7 +136,10 @@ The script runs through these steps:
 5. Unregister (unless \fB--registration-state=keep\fP specified) from Satellite v.5
 
 .IP
-6. Register to Satellite v.6, connecting to the content-host UUID created as part of the transition process.
+6. Stop and disable legacy services: \fBosad\fP, \fBrhnsd\fP.
+
+.IP
+7. Register to Satellite v.6, connecting to the content-host UUID created as part of the transition process.
 Unless \fB--no-auto\fP is specified, autoattach the best-matched subscriptions.
 
 .PP


### PR DESCRIPTION
For both rhn-migrate-classic-to-rhsm and sat5to6.