### PR TITLE
1390258: Validate --remove-rhn-packages conflicting options

### DIFF
--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -939,6 +939,12 @@ def validate_options(options):
         # TODO Need to explain why this restriction exists.
         system_exit(os.EX_USAGE, _("The --servicelevel and --no-auto options cannot be used together."))
 
+    if options.remove_legacy_packages and options.registration_state == 'keep' and not options.five_to_six:
+        system_exit(os.EX_USAGE, _("The --remove-rhn-packages and --keep options cannot be used together."))
+
+    if options.remove_legacy_packages and options.registration_state in ['keep', 'unentitle'] and options.five_to_six:
+        system_exit(os.EX_USAGE, _("The --remove-rhn-packages option must be used with --registration-state=purge."))
+
 
 def is_hosted():
     rhsmcfg = rhsm.config.initConfig()


### PR DESCRIPTION
For both the rhn-migrate-classic-to-rhsm and sat5to6 tools, disallow
states where the system should continue to use rhn packages (i.e. states
where the system is still registered).

For RHN/RHSM, the only state is keep, where migration is performed, but
no changes are made to the legacy registration.

For the Satellite case, this is either unentitle, where the system is
still registered to the Satellite instance, and keep, where the system
is registered and consuming.