### PR TITLE
1388207: show Derived Provided Products for products that have them

### DIFF
--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -271,7 +271,7 @@ class CatManifestCommand(RCTManifestCommand):
             self._print_section(_("Provided Products:"), sorted(to_print), 2, False)
 
             # Get the derived provided Products (if available)
-            if data["pool"]["derivedProvidedProducts"]:
+            if "derivedProvidedProducts" in data["pool"]:
                 to_print = [(int(pp["productId"]), pp["productName"]) for pp in data["pool"]["derivedProvidedProducts"]]
                 self._print_section(_("Derived Products:"), sorted(to_print), 2, False)
 

--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -270,6 +270,11 @@ class CatManifestCommand(RCTManifestCommand):
 
             self._print_section(_("Provided Products:"), sorted(to_print), 2, False)
 
+            # Get the derived provided Products (if available)
+            if data["pool"]["derivedProvidedProducts"]:
+                to_print = [(int(pp["productId"]), pp["productName"]) for pp in data["pool"]["derivedProvidedProducts"]]
+                self._print_section(_("Derived Products:"), sorted(to_print), 2, False)
+
             # Get the Content Sets
             if not self.options.no_content:
                 to_print = [[item.url] for item in cert.content]


### PR DESCRIPTION
Expands the rct command to show which products are provided for subscription types that have derived products

~~~
Subscription:
        Name: Red Hat Enterprise Linux for Virtual Datacenters, Premium
        Quantity: 19
        Created: 2016-07-14T16:44:20.000+0000
        Start Date: 2015-02-28T05:00:00.000+0000
        End Date: 2018-02-28T04:59:59.000+0000
        Service Level: Premium
        Service Type: L1-L3
        Architectures: 
        SKU: RH00001F3
        Contract: [REDACTED]
        Order: [REDACTED]
        Account: [REDACTED]
        Virt Limit: unlimited
        Requires Virt-who: True
        Entitlement File: export/entitlements/8a85f98b55e3a2d30155ea4b70b16c4e.json
        Certificate File: export/entitlement_certificates/5189219367084232490.pem
        Certificate Version: 3.2
        Provided Products:
        Derived Products:
                69: Red Hat Enterprise Linux Server
                70: Red Hat Enterprise Linux Server - Extended Update Support
                84: Red Hat Enterprise Linux High Availability (for RHEL Server) - Extended Update Support
                86: Red Hat Enterprise Linux Load Balancer (for RHEL Server) - Extended Update Support
                91: Red Hat Enterprise Linux Resilient Storage (for RHEL Server) - Extended Update Support
                93: Red Hat Enterprise Linux Scalable File System (for RHEL Server) - Extended Update Support
                127: Red Hat S-JIS Support (for RHEL Server) - Extended Update Support
                133: Red Hat Enterprise Linux High Performance Networking (for RHEL Server) - Extended Update Support
                176: Red Hat Developer Toolset (for RHEL Server)
                180: Red Hat Beta
                182: Red Hat EUCJP Support (for RHEL Server) - Extended Update Support
                201: Red Hat Software Collections (for RHEL Server)

~~~