### PR TITLE
1401394: Collect fqdn via `hostname -f`

### DIFF
--- a/src/subscription_manager/hwprobe.py
+++ b/src/subscription_manager/hwprobe.py
@@ -617,7 +617,7 @@ class Hardware:
         try:
             host = socket.gethostname()
             self.netinfo['network.hostname'] = host
-            fqdn = socket.getfqdn()
+            fqdn = self._get_output('hostname', '-f')
             self.netinfo['network.fqdn'] = fqdn
 
             try:
@@ -804,13 +804,13 @@ class Hardware:
         self.allhw.update(virt_dict)
         return virt_dict
 
-    def _get_output(self, cmd):
-        log.debug("Running '%s'" % cmd)
-        process = Popen([cmd], stdout=PIPE, stderr=PIPE)
+    def _get_output(self, cmd, *args):
+        log.debug("Running '%s'" % " ".join([cmd] + list(args)))
+        process = Popen([cmd] + list(args), stdout=PIPE, stderr=PIPE)
         (std_output, std_error) = process.communicate()
 
-        log.debug("%s stdout: %s" % (cmd, std_output))
-        log.debug("%s stderr: %s" % (cmd, std_error))
+        log.debug("%s stdout: %s" % (" ".join([cmd] + list(args)), std_output))
+        log.debug("%s stderr: %s" % (" ".join([cmd] + list(args)), std_error))
 
         output = std_output.strip()
 


### PR DESCRIPTION
`socket.getfqdn()` and `hostname -f` give different results when ipv4
and ipv6 dns entries differ. `hostname -f` appears to prefer ipv4 while
`socket.getfqdn()` prefers ipv6.

By changing to `hostname -f`, we can at least stay consistent with
puppet fact collection (on my machine, `fqdn.rb` uses `hostname -f` at
this time at least).