### PR TITLE
1402009: Unset TERM inside subscription-manager

### DIFF
--- a/bin/subscription-manager
+++ b/bin/subscription-manager
@@ -26,6 +26,10 @@ sys.setdefaultencoding('utf-8')
 import site
 import os
 
+# work around for https://bugzilla.redhat.com/show_bug.cgi?id=1402009
+if 'TERM' in os.environ:
+    del os.environ['TERM']
+
 
 def system_exit(code, msgs=None):
     "Exit with a code and optional message(s). Saved a few lines of code."


### PR DESCRIPTION
Otherwise since #1513 (fix for BZ#1390549), with certain configurations,
`import readline` outputs extra characters.