### PR TITLE
1403387: Fix proxy conn test short-circuit

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -315,7 +315,7 @@ class CliCommand(AbstractCLICommand):
 
     def test_proxy_connection(self):
         result = None
-        if not self.proxy_hostname or cfg.get("server", "proxy_hostname"):
+        if not self.proxy_hostname and not cfg.get("server", "proxy_hostname"):
             return True
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)


### PR DESCRIPTION
There is a short-circuit to return True (as if the proxy
connection test had passed) if there is no proxy configuration
from either the cli or the rhsm config file.

This fix ensures that this short-circuit check for the absence of
config info.