### PR TITLE
Add missing Requires and BuildRequires needed by F25.

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -94,6 +94,7 @@ Requires:  python-dateutil
 %if %use_gtk3
 Requires: gobject-introspection
 Requires: pygobject3-base
+Requires: dbus-glib
 %else
 %if 0%{?sles_version}
 Requires:  python-gobject2
@@ -142,6 +143,7 @@ BuildRequires: gtk3-devel
 %else
 BuildRequires: gtk2-devel
 %endif
+BuildRequires: dbus-glib-devel
 %if %use_systemd
 # We need the systemd RPM macros
 BuildRequires: systemd


### PR DESCRIPTION
Fixes issue revealed doing build for Fedora 25:

```
+ make -f Makefile VERSION=1.18.6-1.fc26 'CFLAGS=-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic' 'LDFLAGS=-Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld' OS_DIST=.fc26 GTK_VERSION=3
cc -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld `pkg-config --cflags --libs glib-2.0` src/daemons/rhsmcertd.c -o bin/rhsmcertd
cc -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld `pkg-config --cflags --libs "gtk+-3.0 libnotify gconf-2.0 dbus-glib-1"` src/rhsm_icon/rhsm_icon.c -o bin/rhsm-icon
Package dbus-glib-1 was not found in the pkg-config search path.
Perhaps you should add the directory containing `dbus-glib-1.pc'
to the PKG_CONFIG_PATH environment variable
No package 'dbus-glib-1' found
src/rhsm_icon/rhsm_icon.c:26:18: fatal error: glib.h: No such file or directory
#include <glib.h>
                  ^
compilation terminated.
```