### PR TITLE
Add zypper repo logic, service plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,8 @@ YUM_PLUGINS_SRC_DIR := src/plugins
 INSTALL_DNF_PLUGINS ?= false
 DNF_PLUGINS_SRC_DIR := src/plugins
 
+INSTALL_ZYPPER_PLUGINS ?= false
+
 # sets a version that is more or less latest tag plus commit sha
 VERSION ?= $(shell git describe | awk ' { sub(/subscription-manager-/,"")};1' )
 
@@ -181,6 +183,13 @@ install-plugins:
 		install -d $(PREFIX)/usr/lib/yum-plugins/ ; \
 		install -m 644 -p src/plugins/*.py $(PREFIX)/usr/lib/yum-plugins/ ; \
 		install -m 644 etc-conf/plugin/*.conf $(PREFIX)/etc/yum/pluginconf.d/ ; \
+	fi;
+
+	if [ "$(INSTALL_ZYPPER_PLUGINS)" = "true" ] ; then \
+	  echo "Installing zypper plugins" ; \
+		install -d $(PREFIX)/etc/rhsm/zypper.repos.d ; \
+		install -d $(PREFIX)/usr/lib/zypp/plugins/services ; \
+		install -m 755 -p src/zypper/services/* $(PREFIX)/usr/lib/zypp/plugins/services ; \
 	fi;
 
 	if [ "$(INSTALL_DNF_PLUGINS)" = "true" ] ; then \

--- a/rpmlint.config
+++ b/rpmlint.config
@@ -2,6 +2,8 @@
 addFilter('invalid-url')
 # all yum plugins seem to hardcode paths
 addFilter("hardcoded-library-path .*lib/yum-plugins/.*")
+# filter out zypper plugins too!
+addFilter("hardcoded-library-path .*lib/zypp/plugins/.*")
 #sytemd tmpfiles are in /usr/lib
 addFilter("hardcoded-library-path .*lib/tmpfiles.d/.*")
 

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -29,6 +29,8 @@ from subscription_manager.cache import OverrideStatusCache, WrittenOverrideCache
 from subscription_manager import utils
 from subscription_manager import model
 from subscription_manager.model import ent_cert
+from urllib import urlencode
+from urlparse import parse_qs, urlparse, urlunparse
 
 from rhsm.config import initConfig, in_container
 
@@ -43,6 +45,8 @@ log = logging.getLogger(__name__)
 conf = config.Config(initConfig())
 
 ALLOWED_CONTENT_TYPES = ["yum"]
+
+ZYPPER_REPO_DIR = '/etc/rhsm/zypper.repos.d'
 
 _ = gettext.gettext
 
@@ -201,6 +205,9 @@ class RepoUpdateActionCommand(object):
         - yum config
         - manual changes made to "redhat.repo".
 
+    If the system in question has a zypper repo directory, will also generate
+    zypper repo config.
+
     Returns an RepoActionReport.
     """
     def __init__(self, cache_only=False, apply_overrides=True):
@@ -267,6 +274,9 @@ class RepoUpdateActionCommand(object):
     def perform(self):
         # Load the RepoFile from disk, this contains all our managed yum repo sections:
         repo_file = RepoFile()
+        zypper_repo_file = None
+        if os.path.exists(ZYPPER_REPO_DIR):
+            zypper_repo_file = ZypperRepoFile()
 
         # the [rhsm] manage_repos can be overridden to disable generation of the
         # redhat.repo file:
@@ -280,6 +290,8 @@ class RepoUpdateActionCommand(object):
             return 0
 
         repo_file.read()
+        if zypper_repo_file:
+            zypper_repo_file.read()
         valid = set()
 
         # Iterate content from entitlement certs, and create/delete each section
@@ -296,19 +308,78 @@ class RepoUpdateActionCommand(object):
                 repo_file.update(existing)
                 self.report_update(existing)
 
+            if zypper_repo_file:  # no reporting for zypper, already reported for yum
+                zypper_cont = self._zypper_content(cont)
+                existing = zypper_repo_file.section(zypper_cont.id)
+                if existing is None:
+                    zypper_repo_file.add(zypper_cont)
+                else:
+                    zypper_repo_file.update(zypper_cont)
+
         for section in repo_file.sections():
             if section not in valid:
                 self.report_delete(section)
                 repo_file.delete(section)
+                if zypper_repo_file:
+                    zypper_repo_file.delete(section)
 
         # Write new RepoFile to disk:
         repo_file.write()
+        if zypper_repo_file:
+            zypper_repo_file.write()
         if self.override_supported:
             # Update with the values we just wrote
             self.written_overrides.overrides = self.overrides
             self.written_overrides.write_cache()
         log.info("repos updated: %s" % self.report)
         return self.report
+
+    def _zypper_content(self, content):
+        zypper_cont = content.copy()
+        sslverify = zypper_cont['sslverify']
+        sslcacert = zypper_cont['sslcacert']
+        sslclientkey = zypper_cont['sslclientkey']
+        sslclientcert = zypper_cont['sslclientcert']
+        proxy = zypper_cont['proxy']
+        proxy_username = zypper_cont['proxy_username']
+        proxy_password = zypper_cont['proxy_password']
+
+        del zypper_cont['sslverify']
+        del zypper_cont['sslcacert']
+        del zypper_cont['sslclientkey']
+        del zypper_cont['sslclientcert']
+        del zypper_cont['proxy']
+        del zypper_cont['proxy_username']
+        del zypper_cont['proxy_password']
+        # NOTE looks like metadata_expire and ui_repoid_vars are ignored by zypper
+
+        # clean up data for zypper
+        if zypper_cont['gpgkey'] in ['https://', 'http://']:
+            del zypper_cont['gpgkey']
+
+        baseurl = zypper_cont['baseurl']
+        parsed = urlparse(baseurl)
+        zypper_query_args = parse_qs(parsed.query)
+        if sslverify and sslverify in ['1']:
+            zypper_query_args['ssl_verify'] = 'host'
+        if sslcacert:
+            zypper_query_args['ssl_capath'] = os.path.dirname(sslcacert)
+        if sslclientkey:
+            zypper_query_args['ssl_clientkey'] = sslclientkey
+        if sslclientcert:
+            zypper_query_args['ssl_clientcert'] = sslclientcert
+        if proxy:
+            zypper_query_args['proxy'] = proxy
+        if proxy_username:
+            zypper_query_args['proxyuser'] = proxy_username
+        if proxy_password:
+            zypper_query_args['proxypass'] = proxy_password
+        zypper_query = urlencode(zypper_query_args)
+
+        new_url = urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, zypper_query, parsed.fragment))
+        zypper_cont['baseurl'] = new_url
+
+        return zypper_cont
 
     def get_unique_content(self):
         # FIXME Shouldn't this skip all of the repo updating?
@@ -526,6 +597,12 @@ class Repo(dict):
         for k, (_m, d) in self.PROPERTIES.items():
             if k not in self.keys():
                 self[k] = d
+
+    def copy(self):
+        new_repo = Repo(self.id)
+        for key, value in self.items():
+            new_repo[key] = value
+        return new_repo
 
     @classmethod
     def from_ent_cert_content(cls, content, baseurl, ca_cert, release_source):
@@ -804,4 +881,26 @@ class RepoFile(ConfigParser):
         s.append('# a "yum repolist" to refresh available repos')
         s.append('#')
         f.write('\n'.join(s))
+        f.close()
+
+
+class ZypperRepoFile(RepoFile):
+
+    PATH = 'etc/rhsm/zypper.repos.d'
+
+    def create(self):
+        if self.path_exists(self.path) or not self.manage_repos:
+            return
+        f = open(self.path, 'w')
+        f.write("""#
+# Certificate-Based Repositories')
+# Managed by (rhsm) subscription-manager')
+#')
+# *** This file is auto-generated.  Changes made here will be over-written. ***')
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***')
+#')
+# If this file is empty and this system is subscribed consider ')
+# a "zypper lr" to refresh available repos')
+#
+""")
         f.close()

--- a/src/zypper/services/subscription-manager
+++ b/src/zypper/services/subscription-manager
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+import os
+import sys
+
+from subscription_manager import injection as inj
+from subscription_manager.repolib import RepoActionInvoker, ZYPPER_REPO_DIR
+from subscription_manager.certlib import Locker
+from subscription_manager.injectioninit import init_dep_injection
+from subscription_manager import logutil
+from rhsm import connection
+from rhsm import config
+
+expired_warning = \
+"""
+*** WARNING ***
+The subscription for following product(s) has expired:
+%s
+You no longer have access to the repositories that provide these products.  It is important that you apply an active subscription in order to resume access to security and other critical updates. If you don't have other active subscriptions, you can renew the expired subscription.  """
+
+not_registered_warning = \
+"This system is not registered with an entitlement server. You can use subscription-manager to register."
+
+no_subs_warning = \
+"This system is registered with an entitlement server, but is not receiving updates. You can use subscription-manager to assign subscriptions."
+
+no_subs_container_warning = \
+"This system is not receiving updates. You can use subscription-manager on the host to register and assign subscriptions."
+
+
+# If running from the zypper plugin, we want to avoid blocking
+# zypper forever on locks created by other rhsm processes. We try
+# to acquire the lock before potentially updating redhat.repo, but
+# if we can't, the plugin will fail back to not updating it.
+# So this class provides a Locker uses the default ACTION_LOCK,
+# but if it would have to wait for it, it decides to do nothing
+# instead.
+class RepoLocker(Locker):
+    def run(self, action):
+        # lock.acquire will return False if it would block
+        # NOTE: acquire can return None, True, or False
+        #       with different meanings.
+        nonblocking = self.lock.acquire(blocking=False)
+        if nonblocking is False:
+            # Could try to grab the pid for the log message, but it's a bit of a race.
+            sys.stderr.write("Another process has the cert lock. We will not attempt to update certs or repos.")
+            sys.stderr.write("\n")
+            return 0
+        try:
+            return action()
+        finally:
+            self.lock.release()
+
+
+class ZypperService(object):
+    def __init__(self):
+        logutil.init_logger()
+        init_dep_injection()
+        self.is_root = os.getuid() == 0
+
+    def main(self):
+        self.update()
+        self.warn_or_give_usage_message()
+        self.warn_expired()
+        self.print_zypper_repos()
+
+    def update(self):
+        """ update entitlement certificates """
+        if not self.is_root:
+            sys.stderr.write('Not root, Subscription Management repositories not updated')
+            sys.stderr.write("\n")
+            return
+        sys.stderr.write('Updating Subscription Management repositories.')
+        sys.stderr.write("\n")
+
+        # XXX: Importing inline as you must be root to read the config file
+
+        from subscription_manager.identity import ConsumerIdentity
+
+        cert_file = ConsumerIdentity.certpath()
+        key_file = ConsumerIdentity.keypath()
+
+        connection.UEPConnection(cert_file=cert_file, key_file=key_file)
+
+        rl = RepoActionInvoker(cache_only=False, locker=RepoLocker())
+        rl.update()
+
+    def warn_expired(self):
+        """ display warning for expired entitlements """
+        ent_dir = inj.require(inj.ENT_DIR)
+        products = set()
+        for cert in ent_dir.list_expired():
+            for p in cert.products:
+                m = '  - %s' % p.name
+                products.add(m)
+        if products:
+            msg = expired_warning % '\n'.join(sorted(products))
+            sys.stderr.write(msg)
+            sys.stderr.write("\n")
+
+    def warn_or_give_usage_message(self):
+        """ either output a warning, or a usage message """
+        msg = ""
+        if not self.is_root:
+            return
+        try:
+            identity = inj.require(inj.IDENTITY)
+            ent_dir = inj.require(inj.ENT_DIR)
+            # Don't warn people to register if we see entitelements, but no identity:
+            if not identity.is_valid() and len(ent_dir.list_valid()) == 0:
+                msg = not_registered_warning
+            elif len(ent_dir.list_valid()) == 0:
+                msg = no_subs_warning
+            if config.in_container() and len(ent_dir.list_valid()) == 0:
+                msg = no_subs_container_warning
+
+        finally:
+            if msg:
+                conduit.stderr(msg)
+
+    def print_zypper_repos(self):
+        filenames = []
+        try:
+            filenames = os.listdir(ZYPPER_REPO_DIR)
+        except OSError:
+            pass
+        for filename in filenames:
+            with open(os.path.join(ZYPPER_REPO_DIR, filename)) as repo:
+                print(repo.read())
+
+if __name__ == '__main__':
+    service = ZypperService()
+    service.main()
+
+    # suppress python-dmidecode warnings
+    # TODO do this elsewhere?
+    try:
+        import dmidecode
+        dmidecode.clear_warnings()
+    except ImportError:
+        pass

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -52,6 +52,12 @@
 # makefile defaults to INSTALL_YUM_PLUGIN=true
 %define install_yum_plugins INSTALL_YUM_PLUGINS=true
 
+%if 0%{?suse_version}
+%define install_zypper_plugins INSTALL_ZYPPER_PLUGINS=true
+%else
+%define install_zypper_plugins INSTALL_ZYPPER_PLUGINS=false
+%endif
+
 # makefile defaults to INSTALL_DNF_PLUGIN=false
 %if %{use_dnf}
 %define install_dnf_plugins INSTALL_DNF_PLUGINS=true
@@ -120,6 +126,7 @@ Requires: pygobject3-base
 %else
 %if 0%{?suse_version}
 Requires:  python-gobject2
+Requires:  libzypp
 %else
 Requires:  pygobject2
 %endif
@@ -167,6 +174,7 @@ BuildRequires: scrollkeeper
 BuildRequires: gconf2-devel
 BuildRequires: dbus-1-glib-devel
 BuildRequires: update-desktop-files
+BuildRequires: libzypp
 %else
 BuildRequires: GConf2-devel
 BuildRequires: dbus-glib-devel
@@ -325,6 +333,7 @@ make -f Makefile install VERSION=%{version}-%{release} \
     OS_VERSION=%{?fedora}%{?rhel}%{?suse_version} OS_DIST=%{dist} \
     %{?install_ostree} %{?post_boot_tool} %{?gtk_version} \
     %{?install_yum_plugins} %{?install_dnf_plugins} \
+    %{?install_zypper_plugins} \
     %{?with_systemd}
 
 %if 0%{?suse_version}
@@ -406,6 +415,9 @@ rm -rf %{buildroot}
 %attr(755,root,root) %dir %{_sysconfdir}/pki/entitlement
 %attr(755,root,root) %dir %{_sysconfdir}/rhsm
 %attr(755,root,root) %dir %{_sysconfdir}/rhsm/facts
+%if 0%{?suse_version}
+%attr(755,root,root) %dir %{_sysconfdir}/rhsm/zypper.repos.d
+%endif
 %attr(644,root,root) %config(noreplace) %{_sysconfdir}/rhsm/rhsm.conf
 %config %attr(644,root,root) %{_sysconfdir}/rhsm/logging.conf
 
@@ -473,6 +485,11 @@ rm -rf %{buildroot}
 %{_prefix}/lib/yum-plugins/subscription-manager.py*
 %{_prefix}/lib/yum-plugins/product-id.py*
 %{_prefix}/lib/yum-plugins/search-disabled-repos.py*
+
+# zypper plugins
+%if 0%{?suse_version}
+%{_prefix}/lib/zypp/plugins/services/subscription-manager
+%endif
 
 # rhsmlib
 %dir %{python_sitelib}/rhsmlib


### PR DESCRIPTION
Testing
-------
 - On any machine, with this version of subman installed, create `/etc/rhsm/zypper.repos.d`.
 - Observe that when repos update, it adds a zypper variant of `redhat.repo`.
 - Observe that `src/zypper/services/subscription-manager` prints the above zypper repo on stdout.
 - To see full functionality, can build, install, register on an opensuse machine, and observe that subman-repos are added (ex. `zypper lr`).