### PR TITLE
Fix rhsmcertd status command on SLES11

### DIFF
--- a/etc-conf/rhsmcertd.init.d
+++ b/etc-conf/rhsmcertd.init.d
@@ -24,6 +24,13 @@ VENDOR=$( rpm --eval %_vendor )
 [ -f /etc/rc.d/init.d/functions ] && . /etc/rc.d/init.d/functions
 [ -f /etc/rc.status ] && . /etc/rc.status
 
+if [ ! -f /etc/rc.d/init.d/functions ]; then
+  status() {
+    /sbin/checkproc $PROG
+    rc_status -v
+  }
+fi
+
 BINDIR=/usr/bin
 PROG=rhsmcertd
 LOCK=/var/lock/subsys/$PROG


### PR DESCRIPTION
`/etc/rc.d/init.d/functions` does not exist on this configuration. We
are only using it to provide `status`, so I implemented a fallback which
uses idiomatic SUSE implementation.

Testing
-------
 - On a SLES11 machine with this version installed, see that `service rhsmcertd status` works (vs. not working without the change)