### PR TITLE
Add scripts for working with OBS

### DIFF
--- a/scripts/suse_build.sh
+++ b/scripts/suse_build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+. $(dirname "$BASH_SOURCE")/suse_functions.sh
+project_name="$1"
+shift
+
+if [ -z "$project_name" ]; then
+    echo "Usage: $0 {project_name} [args_for_osc_build]..."
+    exit 1
+fi
+
+prepare_obs "$project_name"
+cd "$OBS_DIR/$project_name/$package_name"
+
+osc build "$@"

--- a/scripts/suse_functions.sh
+++ b/scripts/suse_functions.sh
@@ -1,0 +1,35 @@
+OBS_DIR=${OBS_DIR:-~/obs}
+source_dir="$(pwd)"
+package_name="$(basename $(pwd))"
+prepare_obs() {
+    project_name="$1"
+
+    tempdir="$(mktemp -d)"
+    echo "Packaging sources w/ tito"
+    tito build --srpm --test -o "$tempdir"
+
+    if [ ! -d ~/obs ]; then
+        mkdir ~/obs
+    fi
+    pushd ~/obs
+
+    if [ ! -d "$project_name" ]; then
+        osc co "$project_name"
+        pushd "$project_name"
+    else
+        pushd "$project_name"
+        echo "Ensuring $project_name is up-to-date."
+        osc update
+    fi
+
+    pushd "$package_name"
+    echo "Removing any existing sources"
+    osc rm *
+    rpm2cpio "${tempdir}"/*.rpm | cpio -i
+    echo "Adding ${package_name}-rpmlintrc"
+    cp "${source_dir}/${package_name}-rpmlintrc" .
+
+    echo "Cleaning up tito tempdir"
+    rm -rf "${tempdir}"
+}
+

--- a/scripts/suse_upload.sh
+++ b/scripts/suse_upload.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+. $(dirname "$BASH_SOURCE")/suse_functions.sh
+project_name="$1"
+shift
+
+if [ -z "$project_name" ]; then
+    echo "Usage: $0 {project_name} [args_for_osc_commit]..."
+    exit 1
+fi
+
+prepare_obs "$project_name"
+cd "$OBS_DIR/$project_name/$package_name"
+
+osc add *
+osc commit "$@"


### PR DESCRIPTION
Two scripts: `scripts/suse_upload.sh` and `scripts/suse_build.sh`

The upload script prepares and uploads sources based on the currently
checked out HEAD, while build performs a local build with prepared
sources.

There is single mandatory arugment which is the name of the project to
work on. The project should be prepared in OBS ahead of running this
script. Any additional arguments are passed to the underlying `osc`
subcommand.

For the upload command, like `git`, omitting the commit message will
cause an editor to spawn, which is okay for interactive uses. For
automation, it is useful to specify the commit message with `-m`. See
`osc commit --help` for more details.

Example: `scripts/suse_upload.sh home:kahowell -m "Test commit"`

Example: `scripts/suse_build.sh home:kahowell openSUSE_Leap_42.2`

The scripts requires a login for the build service, tito, rpm2cpio, and
osc from http://download.opensuse.org/repositories/openSUSE:/Tools/

NOTE:
At this time, I needed to add "Prefer: sles-release" to get SLES builds
to work.

