### PR TITLE
Add tests for zypper functionality

### DIFF
--- a/playpen/noserc.ci
+++ b/playpen/noserc.ci
@@ -7,3 +7,4 @@ cover-html=True
 cover-xml=True
 cover-erase=True
 with-xunit=True
+attr=!zypper

--- a/playpen/noserc.dev
+++ b/playpen/noserc.dev
@@ -2,3 +2,4 @@
 with-xvfb=True
 with-randomly=True
 with-yanc=True
+attr=!zypper

--- a/playpen/noserc.zypper
+++ b/playpen/noserc.zypper
@@ -1,0 +1,3 @@
+[nosetests]
+with-xunit=True
+attr=zypper

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,4 @@ cover-html=True
 # to load modules that would have that name, and seems to ignore 'ignore-files'
 # Workaround for nose/ga/pygobject issues introduced with pygobject3-3.14
 exclude=.*ga_impls.*
+attr=!zypper

--- a/test/zypper_test/test_productidplugin.py
+++ b/test/zypper_test/test_productidplugin.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+import glob
+import os
+import subprocess
+import time
+
+from nose.plugins.attrib import attr
+
+
+@attr('zypper')
+class TestProductIdPlugin(TestCase):
+    def setUp(self):
+        # remove all product certs
+        subprocess.call('rm -rf /etc/pki/product/*.pem', shell=True)
+        missing = []
+        for name in ['RHSM_USER', 'RHSM_PASSWORD', 'RHSM_URL', 'RHSM_POOL', 'RHSM_TEST_REPO', 'RHSM_TEST_PACKAGE']:
+            if name not in os.environ:
+                missing.append(name)
+        if missing:
+            raise EnvironmentError('Missing {0} environment variables'.format(str(missing)))
+
+    def test_updates_products_after_install(self):
+        subprocess.call('subscription-manager register --username={RHSM_USER} --password={RHSM_PASSWORD} --serverurl={RHSM_URL}'.format(**os.environ), shell=True)
+        subprocess.call('subscription-manager attach --pool={RHSM_POOL}'.format(**os.environ), shell=True)
+        subprocess.check_call('subscription-manager repos --enable={RHSM_TEST_REPO}'.format(**os.environ), shell=True)
+
+        # remove our test package if it exists
+        subprocess.call('zypper --non-interactive rm {RHSM_TEST_PACKAGE}'.format(**os.environ), shell=True)
+
+        # install test package
+        subprocess.check_call('zypper --non-interactive --no-gpg-checks in {RHSM_TEST_PACKAGE}'.format(**os.environ), shell=True)
+        time.sleep(5)  # give the productid process a little time to work its magic
+
+        self.assertTrue(len(glob.glob('/etc/pki/product/*.pem')) > 0, 'Missing product cert(s)')

--- a/test/zypper_test/test_serviceplugin.py
+++ b/test/zypper_test/test_serviceplugin.py
@@ -1,0 +1,54 @@
+from ConfigParser import ConfigParser
+from unittest import TestCase
+import os
+import subprocess
+import tempfile
+
+from nose.plugins.attrib import attr
+
+
+@attr('zypper')
+class TestServicePlugin(TestCase):
+    def setUp(self):
+        missing = []
+        for name in ['RHSM_USER', 'RHSM_PASSWORD', 'RHSM_URL', 'RHSM_POOL', 'RHSM_TEST_REPO', 'RHSM_TEST_PACKAGE']:
+            if name not in os.environ:
+                missing.append(name)
+        if missing:
+            raise EnvironmentError('Missing {0} environment variables'.format(str(missing)))
+
+        # start in a non-registered state
+        subprocess.call('subscription-manager unregister', shell=True)
+
+    def has_subman_repos(self):
+        repos = ConfigParser()
+        with tempfile.NamedTemporaryFile(suffix='.repo') as repofile:
+            subprocess.call('zypper lr -e {0}'.format(repofile.name), shell=True)
+            repos.read(repofile.name)
+        for repo in repos.sections():
+            repo_info = dict(repos.items(repo))
+            service = repo_info.get('service', None)
+            if service == 'subscription-manager':
+                return True
+        return False
+
+    def test_provides_no_subman_repos_if_unregistered(self):
+        self.assertFalse(self.has_subman_repos())
+
+    def test_provides_subman_repos_if_registered_and_subscribed(self):
+        subprocess.call('subscription-manager register --username={RHSM_USER} --password={RHSM_PASSWORD} --serverurl={RHSM_URL}'.format(**os.environ), shell=True)
+        subprocess.call('subscription-manager attach --pool={RHSM_POOL}'.format(**os.environ), shell=True)
+        self.assertTrue(self.has_subman_repos())
+
+    def test_can_download_rpm(self):
+        subprocess.check_call('subscription-manager register --username={RHSM_USER} --password={RHSM_PASSWORD} --serverurl={RHSM_URL}'.format(**os.environ), shell=True)
+        subprocess.check_call('subscription-manager attach --pool={RHSM_POOL}'.format(**os.environ), shell=True)
+        subprocess.check_call('subscription-manager repos --enable={RHSM_TEST_REPO}'.format(**os.environ), shell=True)
+
+        # remove cached subman packages
+        subprocess.call('rm -rf /var/cache/zypp/packages/subscription-manager*', shell=True)
+        # remove test package if installed
+        subprocess.call('zypper --non-interactive rm {RHSM_TEST_PACKAGE}'.format(**os.environ), shell=True)
+        subprocess.call('zypper --non-interactive --no-gpg-checks in --download-only {RHSM_TEST_PACKAGE}'.format(**os.environ), shell=True)
+
+        subprocess.check_call('test "$(find /var/cache/zypp/packages/ -name \'{RHSM_TEST_PACKAGE}*.rpm\' | wc -l)" -gt 0'.format(**os.environ), shell=True)


### PR DESCRIPTION
They are not invoked by default. Using the nose attribute plugin, they
are marked as "zypper" tests, and I altered noserc files to ignore these
(except for noserc.zypper, which can be used to run these explicitly).