### PR TITLE
1421930: Force update of icon cache on install of subman gui

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -601,7 +601,8 @@ if [ $1 -eq 0 ] ; then
 fi
 
 %posttrans -n subscription-manager-gui
-gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
+touch --no-create %{_datadir}/icons/hicolor &>/dev/null
+gtk-update-icon-cache -f %{_datadir}/icons/hicolor &>/dev/null || :
 
 %changelog
 * Fri Jan 20 2017 Alex Wood <awood@redhat.com> 1.19.1-1


### PR DESCRIPTION
On install of subman gui, there are icons installed into the
hicolor theme. From what I've seen it seems that gtk (at least
the version of gtk in RHEL 6 at the time of writing this) will do
the following (with regards to retriving a given named icon):

1) Check if the folder /usr/share/icons/THEME_NAME has a cache

2) If there is a cache and it is valid, look for the named icon
   in the cache ONLY. (Meaning if the named icon is not in the
   cache, return the default icon).

3) If the cache is invalid or nonexistant, look for the icon by
   navigating through the filesystem (Descend into subdirs of
   /usr/share/icon/THEME_NAME to find the right icon).

In the bz this commit is meant to fix it seems that something is
causing the cache file to exist and be valid, but to not include
the subscription-manager icons (despite the icons being placed in
the appropriate location). The fix in this commit is simply to
force the cache to be updated posttransaction.

If something else is running after our posttrans script that is
overwriting our changes to the cache, there is not much we can do.