### PR TITLE
1425438: Hide content access certs from list cmd

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -40,7 +40,7 @@ from rhsm.utils import remove_scheme, ServerUrlParseError
 from rhsm.certificate import GMT
 
 from subscription_manager.branding import get_branding
-from subscription_manager.entcertlib import EntCertActionInvoker, CONTENT_ACCESS_CERT_CAPABILITY
+from subscription_manager.entcertlib import EntCertActionInvoker, CONTENT_ACCESS_CERT_CAPABILITY, CONTENT_ACCESS_CERT_TYPE
 from subscription_manager.action_client import ActionClient, UnregisterActionClient
 from subscription_manager.cert_sorter import ComplianceManager, FUTURE_SUBSCRIBED, \
         SUBSCRIBED, NOT_SUBSCRIBED, EXPIRED, PARTIALLY_SUBSCRIBED, UNKNOWN
@@ -2445,6 +2445,10 @@ class ListCommand(CliCommand):
         # list all certificates that have not yet expired, even those
         # that are not yet active.
         certs = self.entitlement_dir.list()
+
+        # filter out content access certs
+        certs = [cert for cert in certs if cert.entitlement_type != CONTENT_ACCESS_CERT_TYPE]
+
         cert_filter = EntitlementCertificateFilter(filter_string=filter_string, service_level=service_level)
 
         if len(certs):

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -221,7 +221,7 @@ class StubEntitlementCertificate(EntitlementCertificate):
 
     def __init__(self, product, provided_products=None, start_date=None, end_date=None,
             content=None, quantity=1, stacking_id=None, sockets=2, service_level=None,
-            ram=None, pool=None, ent_id=None):
+            ram=None, pool=None, ent_id=None, entitlement_type=None):
 
         # If we're given strings, create stub products for them:
         if isinstance(product, str):
@@ -272,9 +272,11 @@ class StubEntitlementCertificate(EntitlementCertificate):
         if ent_id:
             self.subject = {'CN': ent_id}
 
+        self._entitlement_type = entitlement_type or 'Basic'
+
     @property
     def entitlement_type(self):
-        return 'Basic'
+        return self._entitlement_type
 
     def delete(self):
         self.is_deleted = True


### PR DESCRIPTION
They're not associated to subscriptions as other entitlement certs are,
so we won't show them.