### PR TITLE
1423443: Handle IndexError during m2crypto request

### DIFF
--- a/python-rhsm/test/unit/connection-tests.py
+++ b/python-rhsm/test/unit/connection-tests.py
@@ -15,7 +15,10 @@
 #
 import datetime
 import locale
+import socket
 import unittest
+
+from nose.plugins.skip import SkipTest
 
 from rhsm.connection import UEPConnection, Restlib, ConnectionException, ConnectionSetupException, \
         BadCertificateException, RestlibException, GoneException, NetworkException, \
@@ -592,3 +595,18 @@ class DatetimeFormattingTests(unittest.TestCase):
         self.cp.conn = Mock()
         self.cp.getAccessibleContent(consumerId='bob', if_modified_since=datetime.datetime.fromtimestamp(timestamp))
         self.cp.conn.request_get.assert_called_with('/consumers/bob/accessible_content', headers=expected_headers)
+
+
+class M2CryptoHttpTests(unittest.TestCase):
+    def test_index_error_handled(self):
+        try:
+            from rhsm import m2cryptohttp
+
+            conn = m2cryptohttp.HTTPSConnection('example.com', 443)
+            mock_connection = Mock()
+            mock_connection.request.side_effect=IndexError
+            with patch.object(conn, '_connection', mock_connection):
+                self.assertRaises(socket.error, conn.request, '/foo', '/bar')
+
+        except ImportError:
+            raise SkipTest('m2crypto not supported on python3')


### PR DESCRIPTION
Looks like this happens because the httplib code that handles
socket.error expects socket.error to be in a certain state. I'm guessing
this occurs when the socket.error raised is initialized with a string,
rather than a code and string.

Anyways, this will handle the case specially by having the m2crypto
wrapper detect IndexError explicitly, and raise a socket.error. Even
though there's a risk that the IndexError is raised internally for some
other reason, it seems harmless to simply map any IndexError encountered
in an m2crypto request to a socket.error.