### PR TITLE
Address code paths with Coverity FORWARD_NULL

### DIFF
--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -705,7 +705,7 @@ class ImportFileExtractor(object):
         return key_content
 
     def get_cert_content(self):
-        cert_content = None
+        cert_content = ''
         if self._CERT_DICT_TAG in self.parts:
             cert_content = self.parts[self._CERT_DICT_TAG]
         if self._ENT_DICT_TAG in self.parts:

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -180,7 +180,7 @@ class YumReleaseverSource(object):
         #       so a new created YumReleaseverSource needs to be created when
         #       you think there may be a new release set. We assume it will be
         #       the same for the lifetime of a RepoUpdateActionCommand
-        if not self.is_set(result):
+        if not self.is_set(result) or result is None:
             # we got a result indicating we don't know the release, use the
             # default. This could be server error or just an "unset" release.
             self._expansion = self.default


### PR DESCRIPTION
Both issues are arguably valid, but errors are handled
elsewhere in the code:

 - `repolib.py`: `is_set` checks for `None` explicitly.
 - `managerlib.py`: `verify_valid_entitlement` checks for `None`.