### PR TITLE
1429657: Remove catch-all on register --force

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1095,19 +1095,16 @@ class RegisterCommand(UserPassCommand):
             consumername = socket.gethostname()
 
         if self.is_registered() and self.options.force:
-            # First let's try to un-register previous consumer. This may fail
-            # if consumer has already been deleted so we will continue even if
-            # errors are encountered.
+            # First let's try to un-register previous consumer; if this fails
+            # we'll let the error bubble up, so that we don't blindly re-register.
+            # managerlib.unregister handles the special case that the consumer has already been removed.
             old_uuid = self.identity.uuid
-            try:
-                managerlib.unregister(self.cp, old_uuid)
-                self.entitlement_dir.__init__()
-                self.product_dir.__init__()
-                log.info("--force specified, unregistered old consumer: %s" % old_uuid)
-                print(_("The system with UUID %s has been unregistered") % old_uuid)
-            except Exception, e:
-                log.error("Unable to unregister consumer: %s" % old_uuid)
-                log.exception(e)
+
+            managerlib.unregister(self.cp, old_uuid)
+            self.entitlement_dir.__init__()
+            self.product_dir.__init__()
+            log.info("--force specified, unregistered old consumer: %s" % old_uuid)
+            print(_("The system with UUID %s has been unregistered") % old_uuid)
 
         self.cp_provider.clean()
 


### PR DESCRIPTION
At the time the catch-all was put into place, it seems it was being used
to handle the 410 Gone, but as of 5c48d059, it is handled in
`managerlib.unregister`, so the catch-all is now unnecessary, and
causing the register to proceed regardless of whether an unregister was
successful.

This change makes it so that `subscription-manager register --force`
behaves much more like `subscription manager unregister &&
subscription-manager register`, in that if there is a failure to
communicate with the server during the unregister, then the register
will not occur (we'll exit with an error code instead).

This prevents some cases where a consumer is registered twice (thus
effectively losing the original consumer, since it is deleted locally,
but remains server-side).