### PR TITLE
1427069: Prioritize content from Basic entitlements

### DIFF
--- a/python-rhsm/src/rhsm/certificate2.py
+++ b/python-rhsm/src/rhsm/certificate2.py
@@ -45,6 +45,8 @@ PRODUCT_CERT = 1
 ENTITLEMENT_CERT = 2
 IDENTITY_CERT = 3
 
+CONTENT_ACCESS_CERT_TYPE = "OrgLevel"
+
 
 class _CertFactory(object):
     """

--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -18,6 +18,7 @@ import logging
 import socket
 
 from rhsm.certificate import Key, create_from_pem
+from rhsm.certificate2 import CONTENT_ACCESS_CERT_TYPE
 
 from subscription_manager.certdirectory import Writer
 from subscription_manager import certlib
@@ -31,7 +32,6 @@ log = logging.getLogger(__name__)
 _ = gettext.gettext
 
 CONTENT_ACCESS_CERT_CAPABILITY = "org_level_content_access"
-CONTENT_ACCESS_CERT_TYPE = "OrgLevel"
 
 
 class EntCertActionInvoker(certlib.BaseActionInvoker):

--- a/src/subscription_manager/model/ent_cert.py
+++ b/src/subscription_manager/model/ent_cert.py
@@ -48,7 +48,7 @@ class EntitlementCertEntitlement(Entitlement):
 
         # create a :EntitlementCertEntitlement with a EntitledContents
         # as the content Iterables
-        ent_cert_ent = cls(content_set)
+        ent_cert_ent = cls(content_set, ent_cert.entitlement_type)
 
         # could populate more info here, but
         # we don't actually seem to use it anywhere


### PR DESCRIPTION
Had to move the constant CONTENT_ACCESS_CERT_TYPE to prevent a circular
dependency.

How to test: see the bug in bugzilla or the unit test changes.