### PR TITLE
1431659: Let rhsmcertd-worker clean up on SIGTERM

### DIFF
--- a/src/daemons/rhsmcertd-worker.py
+++ b/src/daemons/rhsmcertd-worker.py
@@ -16,6 +16,7 @@
 # in this software or its documentation.
 #
 
+import signal
 import sys
 import logging
 import dbus.mainloop.glib
@@ -42,9 +43,18 @@ import gettext
 _ = gettext.gettext
 
 
+def exit_on_signal(_signumber, _stackframe):
+    sys.exit(0)
+
+
 def main(options, log):
     # Set default mainloop
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+
+    # exit on SIGTERM, otherwise finally statements don't run (one explanation: http://stackoverflow.com/a/41840796)
+    # SIGTERM happens for example when systemd wants the service to stop
+    # without finally statements, we get confusing behavior (ex. see bz#1431659)
+    signal.signal(signal.SIGTERM, exit_on_signal)
 
     cp_provider = inj.require(inj.CP_PROVIDER)
     correlation_id = generate_correlation_id()


### PR DESCRIPTION
So it turns out that `systemd stop` will send SIGTERM initially; without
an appropriate signal handler set in python, it causes the process to
immediately terminate. This meant that even though we had `finally` blocks
that would release the acquired lock (`/var/run/rhsm/cert.pid`), those
`finally` blocks weren't being executed... The lock logic was robust
enough that it didn't seem to matter (on an attempt to lock it checks
the pid validity), but left the `cert.pid` file around when it *should*
have been cleaned up.

Signal explanation here: http://stackoverflow.com/a/41840796