### PR TITLE
1423013: Allow DBus calls to the com.redhat.RHSM1 interfaces

### DIFF
--- a/etc-conf/dbus/com.redhat.RHSM1.Facts.conf
+++ b/etc-conf/dbus/com.redhat.RHSM1.Facts.conf
@@ -8,6 +8,13 @@
     <policy user="root">
         <allow own="com.redhat.RHSM1.Facts"/>
 
+        <!--
+        Lock down the facts object to root access only since
+        some facts contain sensitive information (q.v. CVE-2016-4455)
+        -->
+        <allow send_destination="com.redhat.RHSM1.Facts"
+          send_interface="com.redhat.RHSM1.Facts"/>
+
         <!-- Basic D-Bus API stuff -->
         <allow send_destination="com.redhat.RHSM1.Facts"
             send_interface="org.freedesktop.DBus.Introspectable"/>
@@ -19,11 +26,6 @@
 
 
     <policy context="default">
-        <!-- TODO: make these read-only by default -->
-
-        <allow send_destination="com.redhat.RHSM1.Facts"
-          send_interface="com.redhat.RHSM1.Facts"/>
-
       <!-- Basic D-Bus API stuff -->
       <allow send_destination="com.redhat.RHSM1.Facts"
           send_interface="org.freedesktop.DBus.Introspectable"/>

--- a/etc-conf/dbus/com.redhat.RHSM1.conf
+++ b/etc-conf/dbus/com.redhat.RHSM1.conf
@@ -23,6 +23,12 @@
         <allow send_destination="com.redhat.RHSM1"
             send_interface="com.redhat.RHSM1"/>
 
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.Config"/>
+
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.RegisterServer"/>
+
         <!-- Basic D-Bus API stuff -->
         <allow send_destination="com.redhat.RHSM1"
             send_interface="org.freedesktop.DBus.Introspectable"/>


### PR DESCRIPTION
This patch allows users to actually call the DBus interfaces we expose.  Testing it is a bit annoying, but basically, you would install the old version and run

```
$ sudo dbus-send --system --print-reply --dest=com.redhat.RHSM1 '/com/redhat/RHSM1/Config' com.redhat.RHSM1.Config.GetAll
```

And get an error.

If you apply this patch, running the same command will return the current subscription-manager configuration.
