### PR TITLE
1433479: rhsmcertd - check connection before lock

### DIFF
--- a/src/daemons/rhsmcertd-worker.py
+++ b/src/daemons/rhsmcertd-worker.py
@@ -57,6 +57,9 @@ def main(options, log):
         sys.exit(-1)
     print _('Updating entitlement certificates & repositories')
 
+    cp = cp_provider.get_consumer_auth_cp()
+    cp.supports_resource(None)  # pre-load supported resources; serves as a way of failing before locking the repos
+
     try:
         if options.autoheal:
             actionclient = action_client.HealingActionClient()


### PR DESCRIPTION
The first thing that rhsmcertd-worker does is write a lock
(/var/run/rhsm/cert.pid), this means that if rhsmcertd-worker cannot
communicate with the server(ex. if rhsm.conf *does not* contain
necessary proxy info), but subscription-manager does (ex. proxy
configured in the command or environment), then the timeout must occur
before actions that require the lock can complete.

This patch fixes it by having rhsmcertd-worker pre-load the capabilities
thus, raising an exception if a connection cannot be established,
*before* acquiring the lock.