### PR TITLE
1428435: Make release set/unset regenerate repos

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1456,9 +1456,12 @@ class ReleaseCommand(CliCommand):
 
         self.assert_should_be_registered()
 
+        repo_action_invoker = RepoActionInvoker()
+
         if self.options.unset:
             self.cp.updateConsumer(self.identity.uuid,
                         release="")
+            repo_action_invoker.update()
             print _("Release preference has been unset")
         elif self.options.release is not None:
             # check first if the server supports releases
@@ -1471,6 +1474,7 @@ class ReleaseCommand(CliCommand):
                 system_exit(os.EX_DATAERR, _("No releases match '%s'.  "
                                  "Consult 'release --list' for a full listing.")
                                  % self.options.release)
+            repo_action_invoker.update()
             print _("Release set to: %s") % self.options.release
         elif self.options.list:
             self._get_consumer_release()

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1282,6 +1282,25 @@ class TestReleaseCommand(TestCliProxyCommand):
             self.assertEquals(proxy_host, self.cc.proxy_hostname)
             self.assertEquals(int(proxy_port), self.cc.proxy_port)
 
+    def test_release_set_updates_repos(self):
+        mock_repo_invoker = Mock()
+        with patch.object(managercli, 'RepoActionInvoker', Mock(return_value=mock_repo_invoker)):
+            with patch.object(managercli.ReleaseBackend, 'get_releases', Mock(return_value=['7.2'])):
+                with patch.object(managercli.ReleaseCommand, '_get_consumer_release'):
+                    self.cc.main(['--set=7.2'])
+                    self._orig_do_command()
+
+                    mock_repo_invoker.update.assert_called_with()
+
+    def test_release_unset_updates_repos(self):
+        mock_repo_invoker = Mock()
+        with patch.object(managercli, 'RepoActionInvoker', Mock(return_value=mock_repo_invoker)):
+            with patch.object(managercli.ReleaseCommand, '_get_consumer_release'):
+                self.cc.main(['--unset'])
+                self._orig_do_command()
+
+                mock_repo_invoker.update.assert_called_with()
+
 
 class TestVersionCommand(TestCliCommand):
     command_class = managercli.VersionCommand


### PR DESCRIPTION
Previously we were relying on subsequent yum commands to regenerate
redhat.repo, but this is problematic because if the lock can't be
acquired, due to behavior introduced in f9715503 (bz 1224806), the repo
is simply left alone.

This change makes it so that the release command is responsible for
updating the repo. Furthermore, the release command will block if the
lock is held, until it can be acquired (with default timeout, this
should be no longer than 3 minutes).