### PR TITLE
1426357: Fix DBus register service configuration issue.

### DIFF
--- a/src/subscription_manager/cp_provider.py
+++ b/src/subscription_manager/cp_provider.py
@@ -52,8 +52,8 @@ class CPProvider(object):
                 proxy_port_arg=None,
                 proxy_user_arg=None,
                 proxy_password_arg=None,
-                no_proxy_arg=None):
-
+                no_proxy_arg=None,
+                restlib_class=connection.Restlib):
         self.cert_file = ConsumerIdentity.certpath()
         self.key_file = ConsumerIdentity.keypath()
 
@@ -67,6 +67,7 @@ class CPProvider(object):
         self.proxy_user = proxy_user_arg
         self.proxy_password = proxy_password_arg
         self.no_proxy = no_proxy_arg
+        self.restlib_class = restlib_class
         self.clean()
 
     # Set username and password used for basic_auth without
@@ -103,7 +104,8 @@ class CPProvider(object):
                     proxy_password=self.proxy_password,
                     cert_file=self.cert_file, key_file=self.key_file,
                     correlation_id=self.correlation_id,
-                    no_proxy=self.no_proxy)
+                    no_proxy=self.no_proxy,
+                    restlib_class=self.restlib_class)
         return self.consumer_auth_cp
 
     def get_basic_auth_cp(self):
@@ -119,7 +121,8 @@ class CPProvider(object):
                     username=self.username,
                     password=self.password,
                     correlation_id=self.correlation_id,
-                    no_proxy=self.no_proxy)
+                    no_proxy=self.no_proxy,
+                    restlib_class=self.restlib_class)
         return self.basic_auth_cp
 
     def get_no_auth_cp(self):
@@ -133,7 +136,8 @@ class CPProvider(object):
                     proxy_user=self.proxy_user,
                     proxy_password=self.proxy_password,
                     correlation_id=self.correlation_id,
-                    no_proxy=self.no_proxy)
+                    no_proxy=self.no_proxy,
+                    restlib_class=self.restlib_class)
         return self.no_auth_cp
 
     def get_content_connection(self):

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -53,6 +53,7 @@ proxy_hostname = notaproxy.grimlock.usersys.redhat.com
 proxy_port = 3128
 proxy_user = proxy_user
 proxy_password = proxy_password
+no_proxy =
 
 [rhsm]
 baseurl= https://content.example.com
@@ -119,7 +120,7 @@ class StubConfig(config.RhsmConfigParser):
 def stubInitConfig():
     return StubConfig()
 
-# create a global CFG object,then replace it with out own that candlepin
+# create a global CFG object,then replace it with our own that candlepin
 # read from a stringio
 config.initConfig(config_file="test/rhsm.conf")
 config.CFG = StubConfig()
@@ -596,7 +597,10 @@ class StubCPProvider(object):
         proxy_hostname_arg=None,
         proxy_port_arg=None,
         proxy_user_arg=None,
-        proxy_password_arg=None):
+        proxy_password_arg=None,
+        no_proxy_arg=None,
+        correlation_id=None,
+        restlib_class=None):
         pass
 
     def set_content_connection_info(self, cdn_hostname=None, cdn_port=None):


### PR DESCRIPTION
The DBus registration service had an error where it did not consult the
settings in rhsm.conf when attempting to register.  Any settings not
specified explicitly in the options hash were set to application
defaults.