### PR TITLE
1424614: add support to rct to print contentAccessMode attribute

### DIFF
--- a/man/rct.8
+++ b/man/rct.8
@@ -301,6 +301,7 @@ General:
 Consumer:
     Name: server.example.com
     UUID:
+    Content Access Mode: entitlement
     Type: system
 
 Subscriptions:

--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -206,6 +206,11 @@ class CatManifestCommand(RCTManifestCommand):
         to_print = []
         to_print.append((_("Name"), get_value(data, "name")))
         to_print.append((_("UUID"), get_value(data, "uuid")))
+        # contentAccessMode is entitlement if null, blank or non-present
+        contentAccessMode = 'entitlement'
+        if "contentAccessMode" in data and data["contentAccessMode"] == 'org_environment':
+            contentAccessMode = 'org_environment'
+        to_print.append((_("Content Access Mode"), contentAccessMode))
         to_print.append((_("Type"), get_value(data, "type.label")))
         self._print_section(_("Consumer:"), to_print)
 

--- a/test/manifestdata.py
+++ b/test/manifestdata.py
@@ -12,6 +12,7 @@ General:
 Consumer:
 \tName: sam_org
 \tUUID: ba5ac769-207e-421c-bfd2-a23c767114af
+\tContent Access Mode: entitlement
 \tType: sam
 
 Subscription:


### PR DESCRIPTION
With this PR, rct now shows the Content Access Mode of a manifest

~~~
rct cat-manifest /tmp/manifest.zip

+-------------------------------------------+
        Manifest
+-------------------------------------------+

General:
        Server: 
        Server Version: 0.9.51.21-1
        Date Created: 2017-03-20T17:02:55.850+0000
        Creator: candlepin_admin

Consumer:
        Name: ExampleCorp
        UUID: c319a1d8-4b30-44cd-b2cf-2ccba4b9a8db
        Content Access Mode: org_environment
        Type: satellite


~~~

It is assumed that if the  `contentAccessMode` attribute in `consumer.json` is null, blank, or not present (as it would be on older manifests), that the Content Access Mode is `entitlement` unless it is explicitly set to `org_environment`