### PR TITLE
1434860: Only log correlation ID for specified cmd

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -313,7 +313,6 @@ class CliCommand(AbstractCLICommand):
         self.identity = inj.require(inj.IDENTITY)
 
         self.correlation_id = generate_correlation_id()
-        self.log.info("X-Correlation-ID: %s", self.correlation_id)
 
     def _get_logger(self):
         return logging.getLogger('rhsm-app.%s.%s' % (self.__module__, self.__class__.__name__))
@@ -498,6 +497,7 @@ class CliCommand(AbstractCLICommand):
 
         self.cp_provider = inj.require(inj.CP_PROVIDER)
         self.cp_provider.set_connection_info(**connection_info)
+        self.log.info("X-Correlation-ID: %s", self.correlation_id)
         self.cp_provider.set_correlation_id(self.correlation_id)
 
         self.log_client_version()


### PR DESCRIPTION
Necessary because all of the command classes are initialized in the flow
of subscription-manager commands, we only care about the correlation ID
from the one that actually runs.