### PR TITLE
1438561: Do not use D-Bus for facts collection

### DIFF
--- a/src/rhsmlib/dbus/facts/constants.py
+++ b/src/rhsmlib/dbus/facts/constants.py
@@ -34,5 +34,3 @@ FACTS_DBUS_PATH = constants.ROOT_DBUS_PATH + '/' + SUB_SERVICE_NAME
 
 FACTS_VERSION = "1.1e1"
 FACTS_NAME = "Red Hat Subscription Manager facts."
-
-CERT_VERSION = "3.2"

--- a/src/rhsmlib/facts/all.py
+++ b/src/rhsmlib/facts/all.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+from rhsmlib.facts import collector
+from rhsmlib.facts import custom
+from rhsmlib.facts import host_collector
+from rhsmlib.facts import hwprobe
+
+
+class AllFactsCollector(collector.FactsCollector):
+    def __init__(self):
+        self.collectors = [
+            host_collector.HostCollector(),
+            hwprobe.HardwareCollector(),
+            custom.CustomFactsCollector(),
+            collector.StaticFactsCollector(),
+        ]
+
+    def get_all(self):
+        results = {}
+        for fact_collector in self.collectors:
+            results.update(fact_collector.get_all())
+        return results

--- a/src/rhsmlib/facts/collector.py
+++ b/src/rhsmlib/facts/collector.py
@@ -102,9 +102,12 @@ class FactsCollector(object):
 
 
 class StaticFactsCollector(FactsCollector):
-    def __init__(self, static_facts, **kwargs):
+    def __init__(self, static_facts=None, **kwargs):
         super(FactsCollector, self).__init__(**kwargs)
+        if static_facts is None:
+            static_facts = {}
         self.static_facts = static_facts
+        self.static_facts.setdefault("system.certificate_version", "3.2")
 
     def get_all(self):
         return self.static_facts

--- a/src/rhsmlib/facts/custom.py
+++ b/src/rhsmlib/facts/custom.py
@@ -15,6 +15,8 @@ import os
 import glob
 import logging
 
+import rhsm.config
+
 from rhsm import ourjson
 from rhsmlib.facts.collector import FactsCollector
 
@@ -103,6 +105,10 @@ class CustomFactsCollector(FactsCollector):
             collected_hw_info=collected_hw_info
         )
         self.path_and_globs = path_and_globs
+        if path_and_globs is None:
+            self.path_and_globs = [
+                (os.path.join(rhsm.config.DEFAULT_CONFIG_DIR, 'facts'), '*.facts')
+            ]
         self.facts_directories = CustomFactsDirectories(self.path_and_globs)
 
     def get_all(self):

--- a/src/subscription_manager/facts.py
+++ b/src/subscription_manager/facts.py
@@ -20,7 +20,7 @@ from subscription_manager.injection import PLUGIN_MANAGER, require
 from subscription_manager.cache import CacheManager
 from rhsm import ourjson as json
 
-from rhsmlib.dbus.facts import FactsClient
+from rhsmlib.facts.all import AllFactsCollector
 
 _ = gettext.gettext
 log = logging.getLogger(__name__)
@@ -75,8 +75,8 @@ class Facts(CacheManager):
 
     def get_facts(self, refresh=False):
         if ((len(self.facts) == 0) or refresh):
-            facts_dbus_client = FactsClient()
-            facts = facts_dbus_client.GetFacts()
+            collector = AllFactsCollector()
+            facts = collector.get_all()
             self.plugin_manager.run('post_facts_collection', facts=facts)
             self.facts = facts
         return self.facts

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -1999,7 +1999,7 @@ class AsyncBackend(object):
             #
             # Behing a 'gather system info' screen?
             #  get installed prods
-            #  get facts (local collection or facts dbus service)
+            #  get facts (local collection or facts service)
             #
             # run pre_register plugin (in main?)
             # ACTUALLY REGISTER (the network call)
@@ -2025,9 +2025,7 @@ class AsyncBackend(object):
             # Note: for now, this is blocking. Maybe we should do it
             #       in the gui mainthread async and pass it in?
 
-            log.debug("about to dbus GetFacts")
             facts_dict = facts.get_facts()
-            log.debug("finished doing dbus GetFacts")
 
             # TODO: We end up calling plugins from threads, which is a little weird.
             #       Seems like a reasonable place to go back to main thread, run the

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1120,7 +1120,6 @@ class RegisterCommand(UserPassCommand):
 
         self.cp_provider.clean()
 
-        # A proxy to the dbus service
         facts = inj.require(inj.FACTS)
 
         # Proceed with new registration:


### PR DESCRIPTION
Instead, we use the same underlying service, which is also exposed via
D-Bus.

This involved refactoring the aggregation into a separate service -
`AllFactsCollector`, and then using that to implement `AllFacts`.

I also moved the default configuration of the collectors into their
classes.

Also, I removed now outdated comments and logging that suggested we are
using D-Bus for facts collection.