### PR TITLE
1438552: Allows releases to be listed through a proxy

### DIFF
--- a/python-rhsm/src/rhsm/connection.py
+++ b/python-rhsm/src/rhsm/connection.py
@@ -287,7 +287,7 @@ class ContentConnection(object):
             proxy_headers = {'User-Agent': self.user_agent}
             if self.proxy_user and self.proxy_password:
                 proxy_headers['Proxy-Authorization'] = _encode_auth(self.proxy_user, self.proxy_password)
-            conn = httplib.HTTPSConnection(self.proxy_host, self.proxy_port, context=context, timeout=self.timeout)
+            conn = httplib.HTTPSConnection(self.proxy_hostname, self.proxy_port, context=context, timeout=self.timeout)
             conn.set_tunnel(self.host, safe_int(self.ssl_port), proxy_headers)
         else:
             conn = httplib.HTTPSConnection(self.host, self.ssl_port, context=context, timeout=self.timeout)


### PR DESCRIPTION
This regression amounts to a typo.
Changes 'proxy_host' to 'proxy_hostname' in the problem area.