### PR TITLE
1435771: Allow rhsm dbus services to log to the default rhsm.log

### DIFF
--- a/src/rhsmlib/dbus/service_wrapper.py
+++ b/src/rhsmlib/dbus/service_wrapper.py
@@ -18,6 +18,11 @@ import rhsmlib
 import logging
 
 from rhsmlib.dbus import server
+from subscription_manager import logutil
+
+# FIXME: Should this be logging to the same file from a different process?
+# rhsmd already does this but I'm unsure that is right. This has been added to satisfy BZ#1435771.
+logutil.init_logger()
 
 log = logging.getLogger(__name__)
 

--- a/src/rhsmlib/facts/custom.py
+++ b/src/rhsmlib/facts/custom.py
@@ -29,6 +29,9 @@ class CustomFacts(object):
     def from_json(cls, json_blob):
         custom_facts = cls
 
+        # Default to no facts collected
+        # See BZ#1435771
+        data = {}
         try:
             data = ourjson.loads(json_blob)
         except ValueError:

--- a/src/subscription_manager/logutil.py
+++ b/src/subscription_manager/logutil.py
@@ -24,7 +24,11 @@ LOG_FORMAT = u'%(asctime)s [%(levelname)s] %(cmd_name)s:%(process)d:' \
 _rhsm_log_handler = None
 _subman_debug_handler = None
 log = None
-ROOT_NAMESPACES = ['subscription_manager', 'rhsm', 'rhsm-app']
+ROOT_NAMESPACES = ['subscription_manager',
+                   'rhsm',
+                   'rhsm-app',
+                   'rhsmlib',
+                   ]
 
 
 # Don't need this for syslog


### PR DESCRIPTION
This commit also stops the facts service from failing in the event
there is malformed or empty custom facts file(s).
There is historical precedent for a different process, one other
than subscription-manager, writing to the default log file.
While I do not think this is the best thing to do, it is certainly
better than not logging at all.

Future work: Improve multiprocess logging for the rhsm ecosystem.