### PR TITLE
1440922: Add a description of maxSplayMinutes to the rhsm.conf man page

### DIFF
--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -179,6 +179,10 @@ autoAttachInterval
 .RS 4
 The number of minutes between attempts to run auto\-attach on this consumer\&.
 .RE
+.PP
+maxSplayMinutes
+.RS 4
+The maximum number of minutes to offset the initial checks by. The initial checks are run 2 minutes plus a random number of seconds in the range [0, maxSplayMinutes * 60]. This is useful to reduce peak load on the Satellite or entitlement service used by a large number of machines. Increase this value on a number of systems to further decrease the peak load on the server.
 .SH "[LOGGING] OPTIONS"
 .PP
 default_log_level


### PR DESCRIPTION
Updates the man page for rhsm.conf to include the new maxSplayMinutes value used by rhsmcertd (that man page was already updated in the RFE PR #1577).