### PR TITLE
1426685: Bug fix: subman doesn't log errors when repository enabling failed

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2142,6 +2142,7 @@ class ReposCommand(CliCommand):
                 rc = 1
                 print _("Error: '%s' does not match a valid repository ID. "
                         "Use \"subscription-manager repos --list\" to see valid repositories.") % repoid
+                log.warning("'%s' does not match a valid repository ID." % repoid)
 
             # Overwrite repo if it's already in the dict, we want the last
             # match to be the one sent to server.


### PR DESCRIPTION
Bug fix for following bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1426685

I can confirm that subscription-manager already returns non-zero exit code in this case.

I'm not sure about log level severity now. May be log.warning() would be enough.