### PR TITLE
1438869: Clear dmidecode warnings

### DIFF
--- a/src/rhsmlib/facts/dmiinfo.py
+++ b/src/rhsmlib/facts/dmiinfo.py
@@ -36,6 +36,10 @@ _ = gettext.gettext
 FIRMWARE_DUMP_FILENAME = "dmi.dump"
 
 
+def clear_warnings():
+    dmidecode.clear_warnings()
+
+
 class DmiFirmwareInfoCollector(collector.FactsCollector):
     def __init__(self, prefix=None, testing=None, collected_hw_info=None):
         super(DmiFirmwareInfoCollector, self).__init__(
@@ -85,6 +89,8 @@ class DmiFirmwareInfoCollector(collector.FactsCollector):
         except Exception as e:
             log.warn(_("Error reading system DMI information: %s"), e)
 
+        self.log_warnings()
+
         return dmiinfo
 
     def _read_dmi(self, func):
@@ -117,3 +123,9 @@ class DmiFirmwareInfoCollector(collector.FactsCollector):
             ddict['dmi.meta.cpu_socket_count'] = str(len(self._socket_designation))
 
         return ddict
+
+    def log_warnings(self):
+        dmiwarnings = dmidecode.get_warnings()
+        if dmiwarnings:
+            log.warn(_("Error reading system DMI information: %s"), dmiwarnings)
+            dmidecode.clear_warnings()

--- a/src/rhsmlib/facts/firmware_info.py
+++ b/src/rhsmlib/facts/firmware_info.py
@@ -95,6 +95,8 @@ def get_firmware_collector(arch, prefix=None, testing=None,
 
     if arch in ARCHES_WITHOUT_DMI:
         log.debug("Not looking for DMI info since it is not available on '%s'" % arch)
+        if dmiinfo:
+            dmiinfo.clear_warnings()
         firmware_provider_class = NullFirmwareInfoCollector
     else:
         if dmiinfo:


### PR DESCRIPTION
There are two cases where we need to clear the warnings:

1. Non-blacklisted platforms, where this change restores old behavior of
   logging the warnings if they are present.
2. Blacklisted platforms, where we don't even attempt to use dmidecode,
   even though it is imported, where this change blindly clears the
   warnings.