### PR TITLE
1441698: Install missing rpm package with fonts.

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -177,8 +177,10 @@ Requires: %{name} = %{version}-%{release}
 %if %use_gtk3
 Requires: pygobject3
 Requires: gtk3
+Requires: abattis-cantarell-fonts
 %else
 Requires: pygtk2 pygtk2-libglade
+Requires: dejavu-sans-fonts
 %endif
 Requires: usermode-gtk
 Requires: dbus-x11


### PR DESCRIPTION
This small change of RPM spec adds dependencies to:
* Cantarella font RPM when gtk3 is used (RHEL7)
* Dejavu-Sans font RPM when gtk2 is used (RHEL6)