### PR TITLE
1435013: Add splay option to rhsmcertd, randomize over interval

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -69,9 +69,8 @@ pluginConfDir = /etc/rhsm/pluginconf.d
 certCheckInterval = 240
 # Interval to run auto-attach (in minutes):
 autoAttachInterval = 1440
-# Max number of minutes to offset initial checks by
-# Useful for reducing peak load on the entitlement server
-maxSplayMinutes = 10
+# If set to zero, the checks done by the rhsmcertd daemon will not be splayed (randomly offset)
+splay = 1
 
 [logging]
 default_log_level = INFO

--- a/etc-conf/rhsmcertd.completion.sh
+++ b/etc-conf/rhsmcertd.completion.sh
@@ -11,7 +11,7 @@ _rhsmcertd()
 	first="${COMP_WORDS[1]}"
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	opts="-h --help -c --cert-check-interval --cert-interval -d --debug --heal-interval -i --auto-attach-interval -n --now -m --max-splay-minutes"
+	opts="-h --help -c --cert-check-interval --cert-interval -d --debug --heal-interval -i --auto-attach-interval -n --now -s --no-splay"
 
 	case "${cur}" in
 		-*)

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -180,9 +180,11 @@ autoAttachInterval
 The number of minutes between attempts to run auto\-attach on this consumer\&.
 .RE
 .PP
-maxSplayMinutes
+splay
 .RS 4
-The maximum number of minutes to offset the initial checks by. The initial checks are run 2 minutes plus a random number of seconds in the range [0, maxSplayMinutes * 60]. This is useful to reduce peak load on the Satellite or entitlement service used by a large number of machines. Increase this value on a number of systems to further decrease the peak load on the server.
+1 to enable splay. 0 to disable splay. If enabled, this feature delays the initial auto attach and cert check by an amount between 0 seconds and the interval given for the action being delayed. For example if the
+.B certCheckInterval
+were set to 3 minutes, the initial cert check would begin somewhere between 2 minutes after start up (minimum delay) and 5 minutes after start up. This is useful to reduce peak load on the Satellite or entitlement service used by a large number of machines.
 .SH "[LOGGING] OPTIONS"
 .PP
 default_log_level

--- a/man/rhsmcertd.8
+++ b/man/rhsmcertd.8
@@ -3,7 +3,7 @@
 rhsmcertd \- Periodically scans and updates the entitlement certificates on a registered system.
 
 .SH SYNOPSIS
-rhsmcertd [--cert-check-interval=MINUTES] [--auto-attach-interval=MINUTES] [--max-splay-minutes=MINUTES] [--now] [--debug] [--help]
+rhsmcertd [--cert-check-interval=MINUTES] [--auto-attach-interval=MINUTES] [--no-splay] [--now] [--debug] [--help]
 
 .PP
 .I Deprecated usage
@@ -21,7 +21,7 @@ When subscriptions are applied to a system or when new subscriptions are availab
 process runs periodically to check for changes in the subscriptions available to a machine by updating the entitlement certificates installed on the machine and by installing new entitlement certificates as they're available.
 
 .PP
-At a defined interval, the process checks with the subscription management service to see if any new subscriptions are available to the system. If there are, it pulls in the associated subscription certificates. If any subscriptions have expired and new subscriptions are available, then the \fBrhsmcertd\fP process will automatically request those subscriptions. By default, the initial checks run are delayed by a random amount of minutes in the range [0,10]. The upper limit of this random delay is configurable with the \fBmax-splay-minutes\fP on the command line or by setting the \fBmaxSplayMinutes\fP option in \fB/etc/rhsm/rhsm.conf\fP
+At a defined interval, the process checks with the subscription management service to see if any new subscriptions are available to the system. If there are, it pulls in the associated subscription certificates. If any subscriptions have expired and new subscriptions are available, then the \fBrhsmcertd\fP process will automatically request those subscriptions. By default, the initial auto-attach is delayed by a random amount of seconds from zero to the \fBautoAttachInterval\fP. The initial cert check is delayed by a random amount of seconds from zero to \fBcertCheckInterval\fP.
 
 .PP
 This \fBrhsmcertd\fP process invokes the
@@ -62,10 +62,10 @@ Resets the interval for checking for and replacing expired subscriptions. This v
 file are used (unless the argument is passed again).
 
 .TP
-.B -m, --max-splay-minutes=MINUTES
-Sets the maximum time to offset the checks done by this tool. This value is in minutes. The default value is 10. It may be useful in large deployments to increase this value to reduce peak load on the entitlement server these systems are registered to. Setting this value to 0 effectively turns off this feature. This interval is in effect until the daemon restarts, and then the values in the
+.B -s, --no-splay
+If present this option disables the splay feature entirely. When not present the value of "splay" from the
 .B /etc/rhsm/rhsm.conf
-file are used (unless the argument is passed again).
+file is used to determine whether the splay feature is on ("1") or off ("0").
 
 .SH USAGE EXAMPLES
 .TP


### PR DESCRIPTION
This is a second implementation of the splay feature added to
rhsmcertd. This adds a 'splay' option. The new option is a bool
and can be set in the rhsm.conf and disabled via the new
'--no-splay' cli option. With this feature enabled, a random
offset in seconds is chosen for both cert checks and auto attaches.
There are different offsets chosen for each type of check.
The offsets chosen will always be from 0 to the interval amount
of time. For example, if the autoAttachInterval is set to 60
seconds, the offset for splay will be between 0 and 60 seconds.
Both initial checks will be delayed by the chosen amount. After
the initial delay, the checks will be performed on the intervals
set in the config (or on the cli). In this way, the peak load on
the server that a series of systems are all checking in to can be
diffused or spread out over the intervals.