### PR TITLE
Add support to list future subscription pools

### DIFF
--- a/python-rhsm/src/rhsm/connection.py
+++ b/python-rhsm/src/rhsm/connection.py
@@ -1187,7 +1187,7 @@ class UEPConnection:
 
         return self.conn.request_put(method)
 
-    def getPoolsList(self, consumer=None, listAll=False, active_on=None, owner=None, filter_string=None):
+    def getPoolsList(self, consumer=None, listAll=False, active_on=None, owner=None, filter_string=None, future=None):
         """
         List pools for a given consumer or owner.
 
@@ -1210,6 +1210,8 @@ class UEPConnection:
 
         if listAll:
             method = "%s&listall=true" % method
+        if future in ('add', 'only'):
+            method = "%s&%s_future=true" % (method, future)
         if active_on:
             method = "%s&activeon=%s" % (method,
                     self.sanitize(active_on.isoformat(), plus=True))


### PR DESCRIPTION
Implementing API addition based on [Candlepin bug 1414426](https://bugzilla.redhat.com/show_bug.cgi?id=1414426) and [API spec](http://www.candlepinproject.org/swagger/?url=candlepin/swagger-2.0.25.json#!/owners/listPools). This functionality is available since Candlepin 2.0.24 (backported to the 0.9.51.21)

It allows user to list future pools via `getPoolsList()` method of the `UEPConnection` class. This PR is introducing a new parameter `future`, which can be either `None`, `"add"` or `"only"` according to how the future pools should be listed.

Possible values:
- `None` - there's no change in behavior.
- `'add'` - the `add_future=true` param is added to the GET call.
- `'only'` - API is called with `only_future=true` param in the query.

This work flow is using rather one param than two separate (used by API). I've favored this way because `only_future` and `add_future` flags are mutually exclusive, when it comes to it's behavior. If it should be rewritten to fully respect the original API call, please let me know. If any test or documentation should be updated according to this change, let me know as well.

Resubmitting [PR \#200](https://github.com/candlepin/python-rhsm/pull/200) from `candlepin/python-rhsm`