### PR TITLE
Add Update subscriptions pools API call

### DIFF
--- a/python-rhsm/src/rhsm/connection.py
+++ b/python-rhsm/src/rhsm/connection.py
@@ -1405,6 +1405,20 @@ class UEPConnection:
         results = self.conn.request_get(method)
         return results
 
+    def updateSubscriptionList(self, owner_key, auto_create_owner=None, lazy_regen=None):
+        """
+        Update subscriptions for a particular owner.
+        """
+        method = "/owners/%s/subscriptions?" % self.sanitize(owner_key)
+
+        if auto_create_owner is not None:
+            method += "&auto_create_owner=%s" % bool(auto_create_owner).lower()
+        if lazy_regen is not None:
+            method += "&lazy_regen=%s" % bool(lazy_regen).lower()
+
+        results = self.conn.request_put(method)
+        return results
+
     def getJob(self, job_id):
         """
         Returns the status of a candlepin job.


### PR DESCRIPTION
Adding a call to Candlepin API
`HTTP PUT /owners/<owner_key>/subscriptions`
with optional parameters `auto_create_owner` and `lazy_regen`

Cite from API documentation [[ref]](http://www.candlepinproject.org/swagger/?url=candlepin/swagger-2.0.25.json#!/owners/refreshPools):
_Tickle an owner to have all of their entitlement pools synced with their subscriptions._

We're using this call in our app (Red Hat Ethel) and since we use `python-rhsm` for every other request to Candlepin, it would be nice to have this one also covered in there (`python-rhsm` can track future API changes better than we can)