### PR TITLE
1405314: Better output message, when subman gui is launched with non-root user

### DIFF
--- a/bin/subscription-manager-gui
+++ b/bin/subscription-manager-gui
@@ -108,6 +108,11 @@ _LIBPATH = "/usr/share/rhsm"
 if _LIBPATH not in sys.path:
     sys.path.append(_LIBPATH)
 
+# quick check to see if you are a super-user.
+if os.getuid() != 0:
+    sys.stderr.write('Error: must be root to execute\n')
+    sys.exit(8)
+
 try:
     from subscription_manager import ga_loader
     ga_loader.init_ga()
@@ -116,11 +121,6 @@ try:
     gtk_compat.threads_init()
 except RuntimeError, e:
     system_exit(2, "Unable to start.  Error: %s" % e)
-
-# quick check to see if you are a super-user.
-if os.getuid() != 0:
-    sys.stderr.write('Error: must be root to execute\n')
-    sys.exit(8)
 
 try:
     # this has to be done first thing due to module level translated vars.


### PR DESCRIPTION
When an unprivileged user tries to run `subscription-manger-gui` and consolehelper can not be executed due to missing X auth coockie, then user should be warned about it with correct output message: "Error: this command requires root access to execute". More information in [bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1405314).