### PR TITLE
1443554: Clicking at Help->Getting Started opens yelp.

### DIFF
--- a/src/subscription_manager/ga_impls/ga_gtk2/Gtk.py
+++ b/src/subscription_manager/ga_impls/ga_gtk2/Gtk.py
@@ -36,6 +36,7 @@ from gtk import main_iteration
 from gtk import main_quit
 from gtk import check_version
 from gtk import window_set_default_icon_name
+from gtk import show_uri as _show_uri
 
 # gtk2 (or more specifically, pygtk2) provided all of it's enums and
 # constants in the top level 'gtk' module. Gtk3 (or more specifically, gobject
@@ -126,6 +127,11 @@ class GaWindow(Window):
 Window = GaWindow
 
 
+def show_uri(screen, uri, timestamp):
+    """Gtk2 version requires the third parameter to be int type"""
+    return _show_uri(screen, uri, int(timestamp))
+
+
 # Attempt to keep the list of faux Gtk 3 names we are
 # providing to a min.
 constants = [STOCK_APPLY, STOCK_CANCEL, STOCK_REMOVE, STOCK_YES]
@@ -142,6 +148,6 @@ widgets = [AboutDialog, Adjustment, Builder, Button, Calendar, CellRendererPixbu
            RadioButton, SpinButton, TextBuffer, TreeStore, TreeView, TreeViewColumn,
            VBox, Viewport, Window]
 
-methods = [check_version, events_pending, main, main_iteration, main_quit]
+methods = [check_version, events_pending, main, main_iteration, main_quit, show_uri]
 
 __all__ = widgets + constants + methods + enums

--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -23,7 +23,6 @@ import subscription_manager.injection as inj
 import gettext
 import locale
 import logging
-import subprocess
 import urllib2
 import webbrowser
 import os
@@ -521,10 +520,8 @@ class MainWindow(widgets.SubmanBaseWidget):
 
     def _getting_started_item_clicked(self, widget):
         try:
-            # unfortunately, Gtk.show_uri does not work in RHEL 5
-            DEVNULL = open(os.devnull, 'w')
-            subprocess.call(["gnome-open", "ghelp:subscription-manager"],
-                            stderr=DEVNULL)
+            # try to open documentation in yelp
+            ga_Gtk.show_uri(None, 'ghelp:subscription-manager', time.time())
         except Exception, e:
             # if we can't open it, it's probably because the user didn't
             # install the docs, or yelp. no need to bother them.


### PR DESCRIPTION
Bug fix for this bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1443554

Note: it will work at RHEL7/Fedora as well at RHEL6, because xdg-utils RPM package is installed there due to dependencies.