### PR TITLE
Use patch for mocking loggers and show_error_window

### DIFF
--- a/test/fixture.py
+++ b/test/fixture.py
@@ -91,6 +91,9 @@ class FakeLogger:
     def info(self, buf, *args, **kwargs):
         self.msg = buf
 
+    def warning(self, buf, *args, **kwargs):
+        self.msg = buf
+
 
 class FakeException(Exception):
     def __init__(self, msg=None):

--- a/test/test_handle_gui_exception.py
+++ b/test/test_handle_gui_exception.py
@@ -2,6 +2,7 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
+from mock import patch
 
 import socket
 from rhsm.https import ssl
@@ -17,6 +18,8 @@ class FakeErrorWindow:
         self.msg = msg
 
 
+@patch('subscription_manager.gui.utils.log', FakeLogger())
+@patch('subscription_manager.gui.utils.show_error_window', FakeErrorWindow)
 class HandleGuiExceptionTests(unittest.TestCase):
 
     # we are going with "hge" for handle_gui_exception
@@ -27,9 +30,6 @@ class HandleGuiExceptionTests(unittest.TestCase):
         self.msg_with_url = "https://www.example.com"
         self.msg_with_url_and_formatting = "https://www.example.com %s"
         self.msg_with_markup = """<span foreground="blue" size="100">Blue text</span> is <i>cool</i>!"""
-        utils.log = FakeLogger()
-        utils.show_error_window = FakeErrorWindow
-        # set a mock logger
 
     def test_hge(self):
         e = FakeException()

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1504,7 +1504,6 @@ class HandleExceptionTests(unittest.TestCase):
     def setUp(self):
         self.msg = "some thing to log home about"
         self.formatted_msg = "some thing else like: %s"
-        managercli.log = FakeLogger()
 
     def test_he(self):
         e = FakeException()
@@ -1521,6 +1520,7 @@ class HandleExceptionTests(unittest.TestCase):
         except SystemExit, e:
             self.assertEquals(e.code, os.EX_SOFTWARE)
 
+    @patch('subscription_manager.managercli.log', FakeLogger())
     def test_he_socket_error(self):
         # these error messages are bare strings, so we need to update the tests
         # if those messages change


### PR DESCRIPTION
This reduces pollution of test environments that was causing PR test
failures seen first in #1589.

`test/test_managercli.py` was the actual culprit.

I went ahead and fixed `test/test_handle_gui_exception.py` while I was
at it.

Also, I went ahead and added the `warning` method to `FakeLogger`.