### PR TITLE
1438869: Capture dmidecode errors at fact gathering

### DIFF
--- a/src/rhsmlib/facts/firmware_info.py
+++ b/src/rhsmlib/facts/firmware_info.py
@@ -95,8 +95,6 @@ def get_firmware_collector(arch, prefix=None, testing=None,
 
     if arch in ARCHES_WITHOUT_DMI:
         log.debug("Not looking for DMI info since it is not available on '%s'" % arch)
-        if dmiinfo:
-            dmiinfo.clear_warnings()
         firmware_provider_class = NullFirmwareInfoCollector
     else:
         if dmiinfo:


### PR DESCRIPTION
Previously tried to fix with #1584, but with that fix, only some of the
cases were covered. This change covers more cases by making `get_all`
responsible for importing dmidecode and then making sure any warnings
are cleared.

In this way, dmiinfo more fully encapsulates dmidecode, not even
exposing the module outside of that method (except to pass to other
helper functions).