### PR TITLE
1357152: Print right dates on subscription-manager list --installed

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -240,8 +240,19 @@ def get_installed_product_status(product_directory, entitlement_directory, uep, 
     """
     product_status = []
 
-    calculator = inj.require(inj.PRODUCT_DATE_RANGE_CALCULATOR, uep)
+    # It is important to gather data from certificates of installed
+    # products at the first time: sorter = inj.require(inj.CERT_SORTER)
+    # Data are stored in cache (json file:
+    # /var/lib/rhsm/cache/installed_products.json)
+    # Calculator use this cache (json file) for assembling request
+    # sent to server. When following two lines of code are called in
+    # reverse order, then request can be incomplete and result
+    # needn't contain all data (especially startDate and endDate).
+
+    # FIXME: make following functions independent on order of calling
     sorter = inj.require(inj.CERT_SORTER)
+    calculator = inj.require(inj.PRODUCT_DATE_RANGE_CALCULATOR, uep)
+
     cert_filter = None
 
     if filter_string is not None:


### PR DESCRIPTION
Bug fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1357152

Right order of actions is IMHO following: gather information about products from product certificates and then ask server for validity of this information. More details in BZ.