### PR TITLE
1429505: Facts dbus service does not start properly due to timeout.

### DIFF
--- a/etc-conf/dbus/rhsm-facts.service
+++ b/etc-conf/dbus/rhsm-facts.service
@@ -4,7 +4,7 @@ After=syslog.target network.target
 
 [Service]
 Type=dbus
-BusName=com.redhat.Subscriptions1.Facts
+BusName=com.redhat.RHSM1.Facts
 ExecStart=/usr/libexec/rhsm-facts-service
 
 [Install]

--- a/scripts/smoke_dbus.sh
+++ b/scripts/smoke_dbus.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-FACTS="com.redhat.Subscriptions1.Facts"
-FACTS_PATH="/com/redhat/Subscriptions1/Facts/Host"
-FACTS_INTF="com.redhat.Subscriptions1.Facts"
+FACTS="com.redhat.RHSM1.Facts"
+FACTS_PATH="/com/redhat/RHSM1/Facts/Host"
+FACTS_INTF="com.redhat.RHSM1.Facts"
 PROPS_INTF="org.freedesktop.DBus.Properties"
 INTRO_INTF="org.freedesktop.DBus.Introspectable"
 
 busctl | grep 'rhsm'
 busctl status "${FACTS}"
 
-pkaction | grep 'Subscriptions1'
+pkaction | grep 'RHSM1'
 
 busctl tree "${FACTS}"
 SERVICE="${FACTS}"


### PR DESCRIPTION
BusName defined in .service file has to the be same as bus name
used and asquired by rhsm-fact-service. More details are here:

https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=