### PR TITLE
1445387: Set locale fact to Unknown if value cannot be determined

### DIFF
--- a/src/rhsmlib/facts/host_collector.py
+++ b/src/rhsmlib/facts/host_collector.py
@@ -67,7 +67,10 @@ class HostCollector(collector.FactsCollector):
         host_facts.update(firmware_info_dict)
 
         locale_info = {}
-        locale_info['system.default_locale'] = ".".join(locale.getdefaultlocale())
+        effective_locale = 'Unknown'
+        if locale.getdefaultlocale()[0] is not None:
+            effective_locale = ".".join(filter(None, locale.getdefaultlocale()))
+        locale_info['system.default_locale'] = effective_locale
         host_facts.update(locale_info)
 
         # Now, munging, kluges, special cases, etc

--- a/test/rhsmlib_test/test_host_collector.py
+++ b/test/rhsmlib_test/test_host_collector.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import mock
+
+from rhsmlib.facts import host_collector
+
+
+class HostCollectorTest(unittest.TestCase):
+
+    @mock.patch('locale.getdefaultlocale')
+    def test_unknown_locale(self, mock_locale):
+        collector = host_collector.HostCollector()
+        mock_locale.return_value = (None, None)
+        facts = collector.get_all()
+
+        self.assertTrue(isinstance(facts, dict))
+        self.assertEquals(facts['system.default_locale'], 'Unknown')
+
+    @mock.patch('locale.getdefaultlocale')
+    def test_en_us_utf8_locale(self, mock_locale):
+        collector = host_collector.HostCollector()
+        mock_locale.return_value = ('en_US', 'UTF-8')
+        facts = collector.get_all()
+
+        self.assertTrue(isinstance(facts, dict))
+        self.assertEquals(facts['system.default_locale'], 'en_US.UTF-8')
+
+    @mock.patch('locale.getdefaultlocale')
+    def test_en_us_no_encoding_locale(self, mock_locale):
+        collector = host_collector.HostCollector()
+        mock_locale.return_value = ('en_US', None)
+        facts = collector.get_all()
+
+        self.assertTrue(isinstance(facts, dict))
+        self.assertEquals(facts['system.default_locale'], 'en_US')


### PR DESCRIPTION
That is if the language code from `getdefaultlocale`[1] is `None`, then
special case this as 'Unknown'.

[1]: https://docs.python.org/2/library/locale.html#locale.getdefaultlocale