### PR TITLE
Check for None before decoding alt subject name

### DIFF
--- a/python-rhsm/src/rhsm/certificate2.py
+++ b/python-rhsm/src/rhsm/certificate2.py
@@ -118,7 +118,11 @@ class _CertFactory(object):
             return self._create_v1_prod_cert(version, extensions, x509, path)
 
     def _read_alt_name(self, x509):
-        return x509.get_extension(name='subjectAltName').decode('utf-8')
+        alt_name = x509.get_extension(name='subjectAltName')
+        if alt_name is None:
+            return None
+        else:
+            return alt_name.decode('utf-8')
 
     def _read_issuer(self, x509):
         return x509.get_issuer()


### PR DESCRIPTION
Looks like when F25 upgraded from python-rhsm 1.19.0 to 1.19.4, our tests started failing:

```
rhsm.https: DEBUG: Using standard libs to provide httplib and ssl
rhsm.certificate2: ERROR: 'NoneType' object has no attribute 'decode'
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/rhsm/certificate2.py", line 99, in _read_x509
    return self._create_v1_cert(version, extensions, x509, path)
  File "/usr/lib64/python2.7/site-packages/rhsm/certificate2.py", line 114, in _create_v1_cert
    return self._create_identity_cert(version, extensions, x509, path)
  File "/usr/lib64/python2.7/site-packages/rhsm/certificate2.py", line 137, in _create_identity_cert
    alt_name=self._read_alt_name(x509),
  File "/usr/lib64/python2.7/site-packages/rhsm/certificate2.py", line 121, in _read_alt_name
    return x509.get_extension(name='subjectAltName').decode('utf-8')
AttributeError: 'NoneType' object has no attribute 'decode'
```

Looks like the following change was introduced in that timeframe:

https://github.com/candlepin/python-rhsm/commit/f3164e32a5aae288a1ef73f3c16f46f60d0cb1b1#diff-b89afd85b4d5ab2767749c609cab6374R118

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1445511