### PR TITLE
 1444714: Error reading system DMI information

### DIFF
--- a/src/rhsmlib/facts/dmiinfo.py
+++ b/src/rhsmlib/facts/dmiinfo.py
@@ -68,7 +68,11 @@ class DmiFirmwareInfoCollector(collector.FactsCollector):
 
         dmiinfo = {}
         try:
-            self.use_dump_file(dmidecode)
+            # When alternative memory device file was specified for this class, then
+            # try to use it. Otherwise current device file will be used.
+            if self.dump_file is not None:
+                self.use_dump_file(dmidecode)
+            log.info("Using dmidecode dump file: %s" % dmidecode.get_dev())
             dmi_data = {
                 "dmi.bios.": self._read_dmi(dmidecode.bios),
                 "dmi.processor.": self._read_dmi(dmidecode.processor),


### PR DESCRIPTION
* When DMI dump_file was not specified, then it tried to use
  this default value (None) as dump file (dmidecode.set_dev()).
  It raises exception visible in log rhsm.log file.
* This bug fix uses current dmidecode dump file (usually
  /dev/mem), when dump file wasn't specified.
* Note: `subscription-manager facts --list | grep dmi` returns something again.
* Bugzilla report: https://bugzilla.redhat.com/show_bug.cgi?id=1444714
