### PR TITLE
1426343: fixed rct to display cert without subjectAltName.

### DIFF
--- a/bin/rct
+++ b/bin/rct
@@ -20,7 +20,6 @@ if __name__ != '__main__':
 
 import sys
 sys.setdefaultencoding('utf-8')
-import site
 
 from subscription_manager.i18n import configure_i18n
 configure_i18n()
@@ -42,8 +41,8 @@ if __name__ == '__main__':
     try:
         sys.exit(abs(main() or 0))
     except SystemExit, e:
-        #this is a non-exceptional exception thrown by Python 2.4, just
-        #re-raise, bypassing handle_exception
+        # This is a non-exceptional exception thrown by Python 2.4, just
+        # re-raise, bypassing handle_exception
         try:
             sys.stdout.flush()
         except IOError:

--- a/python-rhsm/src/rhsm/certificate2.py
+++ b/python-rhsm/src/rhsm/certificate2.py
@@ -118,7 +118,14 @@ class _CertFactory(object):
             return self._create_v1_prod_cert(version, extensions, x509, path)
 
     def _read_alt_name(self, x509):
-        return x509.get_extension(name='subjectAltName').decode('utf-8')
+        """Try to read subjectAltName from certificate"""
+        alt_name = x509.get_extension(name='subjectAltName')
+        # When certificate does not include subjectAltName, then
+        # return emtpy string
+        if alt_name is None:
+            return ''
+        else:
+            return alt_name.decode('utf-8')
 
     def _read_issuer(self, x509):
         return x509.get_issuer()


### PR DESCRIPTION
When rct tried to display candlepin certificate (IMHO self-signed), then it was terminated with error described in this BZ bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1426343