### PR TITLE
Use socket.getfqdn() instead of gethostname().

### DIFF
--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -224,6 +224,6 @@ class DomainSocketRegisterDBusObject(base_object.BaseObject):
             raise exceptions.Failed(msg=error_msg)
 
         if 'name' not in options:
-            options['name'] = socket.gethostname()
+            options['name'] = socket.getfqdn()
 
         return options

--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -573,7 +573,7 @@ class HardwareCollector(collector.FactsCollector):
     def get_network_info(self):
         netinfo = {}
         try:
-            host = socket.gethostname()
+            host = socket.getfqdn()
             netinfo['network.hostname'] = host
 
             try:

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -1581,7 +1581,7 @@ class CredentialsScreen(Screen):
 
     def _initialize_consumer_name(self):
         if not self.consumer_name.get_text():
-            self.consumer_name.set_text(socket.gethostname())
+            self.consumer_name.set_text(socket.getfqdn())
 
     def _validate_consumername(self, consumername):
         if not consumername:
@@ -1679,7 +1679,7 @@ class ActivationKeyScreen(Screen):
 
     def _initialize_consumer_name(self):
         if not self.consumer_entry.get_text():
-            self.consumer_entry.set_text(socket.gethostname())
+            self.consumer_entry.set_text(socket.getfqdn())
 
     def apply(self):
         self.stay()

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1115,7 +1115,7 @@ class RegisterCommand(UserPassCommand):
         # Set consumer's name to hostname by default:
         consumername = self.options.consumername
         if consumername is None:
-            consumername = socket.gethostname()
+            consumername = socket.getfqdn()
 
         if self.is_registered() and self.options.force:
             # First let's try to un-register previous consumer; if this fails


### PR DESCRIPTION
I tried to use the subscription-manager on SUSE SLES11 and SLES12 and recognized, that socket.gethostname() on these systems will just return the "hostname" without the FQDN. I guess, usually you want to register the system with the FQDN on candlepin. 

On RHEL, socket.gethostname() will return the FQDN => means, gethostname() and getfqdn() is the same. Therefore, use socket.getfqdn() to get subscription-manager to work on SLES, too.