### PR TITLE
1440319: fixed wrong spelling.

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -151,7 +151,7 @@ Gives the password to use to authenticate to the HTTP proxy.
 
 .TP
 .B --noproxy=NOPROXY
-Specifes a list of domain suffixes which should bypass the HTTP proxy.
+Specifies a list of domain suffixes which should bypass the HTTP proxy.
 
 .SS REGISTER OPTIONS
 The


### PR DESCRIPTION
Just wrong spelling: https://bugzilla.redhat.com/show_bug.cgi?id=1440319