### PR TITLE
1444512: Display deleted uuid in facts dialog correctly.

### DIFF
--- a/src/subscription_manager/gui/data/glade/factsdialog.glade
+++ b/src/subscription_manager/gui/data/glade/factsdialog.glade
@@ -4,7 +4,7 @@
   <!--
  interface-naming-policy project-wide -->
   <object class="GtkWindow" id="system_facts_dialog">
-    <property name="width_request">500</property>
+    <property name="width_request">550</property>
     <property name="height_request">400</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Subscription Manager - Facts</property>
@@ -45,6 +45,8 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap_mode">char</property>
                     <property name="selectable">True</property>
                     <accessibility/>
                     <child internal-child="accessible">
@@ -77,6 +79,8 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap_mode">char</property>
                     <property name="selectable">True</property>
                     <accessibility/>
                     <child internal-child="accessible">
@@ -111,6 +115,8 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap_mode">char</property>
                     <property name="selectable">True</property>
                     <accessibility/>
                     <child internal-child="accessible">

--- a/src/subscription_manager/gui/data/ui/factsdialog.ui
+++ b/src/subscription_manager/gui/data/ui/factsdialog.ui
@@ -3,7 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="system_facts_dialog">
-    <property name="width_request">500</property>
+    <property name="width_request">550</property>
     <property name="height_request">400</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Subscription Manager - Facts</property>
@@ -49,6 +49,8 @@
                     <property name="can_focus">False</property>
                     <property name="hexpand">True</property>
                     <property name="selectable">True</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap_mode">char</property>
                     <property name="xalign">0</property>
                     <child internal-child="accessible">
                       <object class="AtkObject" id="system_id_label-atkobject">
@@ -83,6 +85,8 @@
                     <property name="can_focus">False</property>
                     <property name="hexpand">True</property>
                     <property name="selectable">True</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap_mode">char</property>
                     <property name="ellipsize">end</property>
                     <property name="xalign">0</property>
                     <child internal-child="accessible">
@@ -118,6 +122,8 @@
                     <property name="can_focus">False</property>
                     <property name="hexpand">True</property>
                     <property name="selectable">True</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap_mode">char</property>
                     <property name="xalign">0</property>
                     <child internal-child="accessible">
                       <object class="AtkObject" id="environment_label-atkobject">

--- a/src/subscription_manager/gui/factsgui.py
+++ b/src/subscription_manager/gui/factsgui.py
@@ -21,6 +21,7 @@ from subscription_manager.ga import Gtk as ga_Gtk
 from subscription_manager.gui import widgets
 from subscription_manager.gui.utils import handle_gui_exception, linkify
 from subscription_manager import injection as inj
+from rhsm.connection import GoneException
 
 _ = gettext.gettext
 
@@ -135,6 +136,11 @@ class SystemFactsDialog(widgets.SubmanBaseWidget):
         # very broad exception
         except Exception, e:
             log.error("Could not get owner name: %s" % e)
+            if isinstance(e, GoneException) and identity.uuid:
+                if e.deleted_id == identity.uuid:
+                    self.system_id_label.set_text(_('Error: Deleted uuid: %s') % identity.uuid)
+                else:
+                    self.system_id_label.set_text(_('Error: Wrong uuid: %s') % identity.uuid)
             self.owner_label.hide()
             self.owner_title.hide()
 


### PR DESCRIPTION
* BZ bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1444512
* I made facts dialog little bit wider to display message about
  deleted/wrong uuid.
* I'm not sure about displaying such error message in label, but
  it is better than nothing.