### PR TITLE
1446469: Use sys.setdefaultencoding('utf-8') in better way.

### DIFF
--- a/bin/rct
+++ b/bin/rct
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/python
 
 #
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
@@ -19,6 +19,7 @@ if __name__ != '__main__':
     raise ImportError("This module can not be imported.")
 
 import sys
+reload(sys)
 sys.setdefaultencoding('utf-8')
 
 from subscription_manager.i18n import configure_i18n

--- a/bin/rhn-migrate-classic-to-rhsm
+++ b/bin/rhn-migrate-classic-to-rhsm
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/python
 #
 # Copyright (c) 2013 Red Hat, Inc.
 #
@@ -18,8 +18,8 @@ if __name__ != '__main__':
     raise ImportError("module cannot be imported")
 
 import sys
+reload(sys)
 sys.setdefaultencoding('utf-8')
-import site
 import os
 
 

--- a/bin/rhsm-debug
+++ b/bin/rhsm-debug
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/python
 
 #
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
@@ -19,8 +19,8 @@ if __name__ != '__main__':
     raise ImportError("This module can not be imported.")
 
 import sys
+reload(sys)
 sys.setdefaultencoding('utf-8')
-import site
 import os
 
 from subscription_manager.i18n import configure_i18n

--- a/bin/sat5to6
+++ b/bin/sat5to6
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/python
 #
 # Copyright (c) 2013 Red Hat, Inc.
 #
@@ -18,8 +18,8 @@ if __name__ != '__main__':
     raise ImportError("module cannot be imported")
 
 import sys
+reload(sys)
 sys.setdefaultencoding('utf-8')
-import site  # NOQA - Ignore this flake8 violation
 import os
 
 

--- a/bin/subscription-manager
+++ b/bin/subscription-manager
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/python
 #
 # wrapper for subscription Manager commandline tool.
 #
@@ -22,8 +22,8 @@ if __name__ != '__main__':
     raise ImportError("module cannot be imported")
 
 import sys
+reload(sys)
 sys.setdefaultencoding('utf-8')
-import site
 import os
 
 # work around for https://bugzilla.redhat.com/show_bug.cgi?id=1402009


### PR DESCRIPTION
* Method `setdefaultencoding()` is available in `sys` module at
  Python start-up. Thus reloading of sys module. More informatin:
  http://stackoverflow.com/questions/3828723/why-should-we-not-use-sys-setdefaultencodingutf-8-in-a-py-script
* This also make remote debugging in PyCharm more seamless.
* Finally it fixes this bug:
  https://bugzilla.redhat.com/show_bug.cgi?id=1446469
  It was caused by removing of: `import site` in this commit:
  dc665c1dab8b45cbbc7337b28e3bd2a550e29067