### PR TITLE
1427069: Add secondary file to determine external repo file changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ install-files: dbus-install install-conf install-plugins install-post-boot insta
 	install -d $(PREFIX)/var/log/rhsm
 	install -d $(PREFIX)/var/spool/rhsm/debug
 	install -d $(PREFIX)/var/run/rhsm
-	install -d -m 750 $(PREFIX)/var/lib/rhsm/{cache,facts,packages}
+	install -d -m 750 $(PREFIX)/var/lib/rhsm/{cache,facts,packages,repo_server_val}
 
 	# Set up rhsmcertd daemon. If installing on Fedora or RHEL 7+
 	# we prefer systemd over sysv as this is the new trend.

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -93,12 +93,21 @@ class RepoActionInvoker(BaseActionInvoker):
         # Add the current repo data
         repo_file = RepoFile()
         repo_file.read()
+        server_value_repo_file = RepoFile('var/lib/rhsm/repo_server_val/')
+        server_value_repo_file.read()
         for repo in repos:
             existing = repo_file.section(repo.id)
+            server_value_repo = server_value_repo_file.section(repo.id)
+            # we need a repo in the server val file to match any in
+            # the main repo definition file
+            if server_value_repo is None:
+                server_value_repo = Repo(repo.id)
+                server_value_repo['name'] = repo['name']
+                server_value_repo_file.add(server_value_repo)
             if existing is None:
                 current.add(repo)
             else:
-                action.update_repo(existing, repo)
+                action.update_repo(existing, repo, server_value_repo)
                 current.add(existing)
 
         return current
@@ -281,6 +290,7 @@ class RepoUpdateActionCommand(object):
     def perform(self):
         # Load the RepoFile from disk, this contains all our managed yum repo sections:
         repo_file = RepoFile()
+        server_value_repo_file = RepoFile('var/lib/rhsm/repo_server_val/')
         zypper_repo_file = None
         if os.path.exists(ZYPPER_REPO_DIR):
             zypper_repo_file = ZypperRepoFile()
@@ -297,6 +307,7 @@ class RepoUpdateActionCommand(object):
             return 0
 
         repo_file.read()
+        server_value_repo_file.read()
         if zypper_repo_file:
             zypper_repo_file.read()
         valid = set()
@@ -306,13 +317,19 @@ class RepoUpdateActionCommand(object):
         for cont in self.get_unique_content():
             valid.add(cont.id)
             existing = repo_file.section(cont.id)
+            server_value_repo = server_value_repo_file.section(cont.id)
+            if server_value_repo is None:
+                server_value_repo = Repo(cont.id)
+                server_value_repo['name'] = cont['name']
+                server_value_repo_file.add(server_value_repo)
             if existing is None:
                 repo_file.add(cont)
                 self.report_add(cont)
             else:
                 # Updates the existing repo with new content
-                self.update_repo(existing, cont)
+                self.update_repo(existing, cont, server_value_repo)
                 repo_file.update(existing)
+                server_value_repo_file.update(server_value_repo)
                 self.report_update(existing)
 
             if zypper_repo_file:  # no reporting for zypper, already reported for yum
@@ -327,11 +344,13 @@ class RepoUpdateActionCommand(object):
             if section not in valid:
                 self.report_delete(section)
                 repo_file.delete(section)
+                server_value_repo_file.delete(section)
                 if zypper_repo_file:
                     zypper_repo_file.delete(section)
 
         # Write new RepoFile to disk:
         repo_file.write()
+        server_value_repo_file.write()
         if zypper_repo_file:
             zypper_repo_file.write()
         if self.override_supported:
@@ -460,7 +479,7 @@ class RepoUpdateActionCommand(object):
             result[key] = Repo.PROPERTIES.get(key, (1, None))
         return result
 
-    def update_repo(self, old_repo, new_repo):
+    def update_repo(self, old_repo, new_repo, server_value_repo={}):
         """
         Checks an existing repo definition against a potentially updated
         version created from most recent entitlement certificates and
@@ -468,6 +487,8 @@ class RepoUpdateActionCommand(object):
         appropriate and returns the number of changes made. (if any)
         """
         changes_made = 0
+        if server_value_repo is None:
+            server_value_repo = {}
 
         for key, (mutable, _default) in self._build_props(old_repo, new_repo).items():
             new_val = new_repo.get(key)
@@ -478,7 +499,8 @@ class RepoUpdateActionCommand(object):
             # value.
             if mutable and not self._is_overridden(old_repo, key) \
                     and not self._was_overridden(old_repo, key, old_repo.get(key)):
-                if (new_val is not None) and (not old_repo.get(key)):
+                if (new_val is not None) and (not old_repo.get(key) or
+                        old_repo.get(key) == server_value_repo.get(key)):
                     if old_repo.get(key) == new_val:
                         continue
                     old_repo[key] = new_val
@@ -500,6 +522,9 @@ class RepoUpdateActionCommand(object):
 
                 old_repo[key] = new_val
                 changes_made += 1
+
+            if (mutable and new_val is not None):
+                server_value_repo[key] = new_val
 
         return changes_made
 
@@ -791,13 +816,11 @@ class TidyWriter:
 
 class RepoFile(ConfigParser):
 
-    PATH = 'etc/yum.repos.d/'
-
-    def __init__(self, name='redhat.repo'):
+    def __init__(self, path='etc/yum.repos.d/', name='redhat.repo'):
         ConfigParser.__init__(self)
         # note PATH get's expanded with chroot info, etc
-        self.path = Path.join(self.PATH, name)
-        self.repos_dir = Path.abs(self.PATH)
+        self.path = Path.join(path, name)
+        self.repos_dir = Path.abs(path)
         self.manage_repos = manage_repos_enabled()
         # Simulate manage repos turned off if no yum.repos.d directory exists.
         # This indicates yum is not installed so clearly no need for us to

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -420,6 +420,7 @@ rm -rf %{buildroot}
 %if 0%{?suse_version}
 %attr(755,root,root) %dir %{_sysconfdir}/rhsm/zypper.repos.d
 %endif
+
 %attr(644,root,root) %config(noreplace) %{_sysconfdir}/rhsm/rhsm.conf
 %config %attr(644,root,root) %{_sysconfdir}/rhsm/logging.conf
 
@@ -448,6 +449,7 @@ rm -rf %{buildroot}
 %attr(750,root,root) %dir %{_var}/lib/rhsm/facts
 %attr(750,root,root) %dir %{_var}/lib/rhsm/packages
 %attr(750,root,root) %dir %{_var}/lib/rhsm/cache
+%attr(750,root,root) %dir %{_var}/lib/rhsm/repo_server_val
 
 %{_sysconfdir}/bash_completion.d/subscription-manager
 %{_sysconfdir}/bash_completion.d/rct


### PR DESCRIPTION
The tests work to confirm function, but I am not sure if they are the best way. There are 2 mocked files, but only one is available to be probed at the end of the tests.

Suggestions for improvement are welcomed.