### PR TITLE
1446638: Remove dbus-x11 dependency

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -78,7 +78,6 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:  python-ethtool
 Requires:  python-iniparse
 Requires:  python-decorator
-Requires:  dbus-x11
 Requires:  virt-what
 Requires:  python-rhsm >= 1.19.5
 Requires:  python-decorator
@@ -183,7 +182,6 @@ Requires: pygtk2 pygtk2-libglade
 Requires: dejavu-sans-fonts
 %endif
 Requires: usermode-gtk
-Requires: dbus-x11
 Requires: gnome-icon-theme
 Requires(post): scrollkeeper
 Requires(postun): scrollkeeper


### PR DESCRIPTION
It's not necessary, even for subscription-manager-gui. It looks like
subscription-manager-gui will just ignore any failures in acquiring the
session bus: see 90ca1d4cb582a5576051eece5b1522fd86471ce0

Also we did some smoke tests w/ removing it on EL7, with no issues.