### PR TITLE
1447211: Don't try to read non-existing json cache file.

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -111,11 +111,9 @@ class CacheManager(object):
             f.close()
             if debug:
                 log.debug("Wrote cache: %s" % self.CACHE_FILE)
-        except IOError, e:
-            if debug:
-                log.error("Unable to write cache: %s" %
-                        self.CACHE_FILE)
-                log.exception(e)
+        except IOError as err:
+            log.error("Unable to write cache: %s" % self.CACHE_FILE)
+            log.exception(err)
 
     def _read_cache(self):
         """
@@ -127,12 +125,24 @@ class CacheManager(object):
             data = self._load_data(f)
             f.close()
             return data
-        except IOError:
+        except IOError as err:
             log.error("Unable to read cache: %s" % self.CACHE_FILE)
+            log.exception(err)
         except ValueError:
             # ignore json file parse errors, we are going to generate
             # a new as if it didn't exist
             pass
+
+    def read_cache_only(self):
+        """
+        Try to read only cached data. When cache does not exist,
+        then None is returned.
+        """
+        if self._cache_exists():
+            return self._read_cache()
+        else:
+            log.debug("Cache file %s does not exist" % self.CACHE_FILE)
+            return None
 
     def update_check(self, uep, consumer_uuid, force=False):
         """
@@ -620,11 +630,11 @@ class ContentAccessCache(object):
 
 
 class RhsmIconCache(CacheManager):
-    '''
+    """
     Cache to keep track of last status returned by the StatusCache.
     This cache is specifically used to ensure RHSM icon pops up only
     when the status changes.
-    '''
+    """
 
     CACHE_FILE = "/var/lib/rhsm/cache/rhsm_icon.json"
 
@@ -638,8 +648,9 @@ class RhsmIconCache(CacheManager):
         try:
             self.data = json.loads(open_file.read()) or {}
             return self.data
-        except IOError:
+        except IOError as err:
             log.error("Unable to read cache: %s" % self.CACHE_FILE)
+            log.exception(err)
         except ValueError:
             # ignore json file parse errors, we are going to generate
             # a new as if it didn't exist
@@ -647,11 +658,11 @@ class RhsmIconCache(CacheManager):
 
 
 class WrittenOverrideCache(CacheManager):
-    '''
+    """
     Cache to keep track of the overrides used last time the a redhat.repo
     was written.  Doesn't track server status, we've got another cache for
     that.
-    '''
+    """
 
     CACHE_FILE = "/var/lib/rhsm/cache/written_overrides.json"
 
@@ -665,8 +676,9 @@ class WrittenOverrideCache(CacheManager):
         try:
             self.overrides = json.loads(open_file.read()) or {}
             return self.overrides
-        except IOError:
+        except IOError as err:
             log.error("Unable to read cache: %s" % self.CACHE_FILE)
+            log.exception(err)
         except ValueError:
             # ignore json file parse errors, we are going to generate
             # a new as if it didn't exist

--- a/src/subscription_manager/facts.py
+++ b/src/subscription_manager/facts.py
@@ -64,7 +64,7 @@ class Facts(CacheManager):
             log.debug("Cache %s does not exit" % self.CACHE_FILE)
             return True
 
-        cached_facts = self._read_cache() or {}
+        cached_facts = self.read_cache_only() or {}
         # In order to accurately check for changes, we must refresh local data
         self.facts = self.get_facts(True)
 
@@ -74,7 +74,7 @@ class Facts(CacheManager):
         return False
 
     def get_facts(self, refresh=False):
-        if ((len(self.facts) == 0) or refresh):
+        if len(self.facts) == 0 or refresh:
             collector = AllFactsCollector()
             facts = collector.get_all()
             self.plugin_manager.run('post_facts_collection', facts=facts)

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -260,7 +260,7 @@ class RepoUpdateActionCommand(object):
         # Only attempt to update the overrides if they are supported
         # by the server.
         if self.override_supported:
-            self.written_overrides._read_cache()
+            self.written_overrides.read_cache_only()
 
             try:
                 override_cache = inj.require(inj.OVERRIDE_STATUS_CACHE)
@@ -268,7 +268,7 @@ class RepoUpdateActionCommand(object):
                 override_cache = OverrideStatusCache()
 
             if cache_only:
-                status = override_cache._read_cache()
+                status = override_cache.read_cache_only()
             else:
                 status = override_cache.load_status(self.uep, self.identity.uuid)
 


### PR DESCRIPTION
* Fixes bug: https://bugzilla.redhat.com/show_bug.cgi?id=1447211
* Added more debug print, when it is not possible to read any
  cache json file.
* Refactored code a little bit to not use protected method.