### PR TITLE
1448855: golden ticket entitlement was not removed.

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -583,8 +583,8 @@ class ContentAccessCache(object):
         uep = self.cp_provider.get_consumer_auth_cp()
         try:
             response = uep.getAccessibleContent(self.identity.uuid, if_modified_since=if_modified_since)
-        except connection.RestlibException as e:
-            log.warning("Unable to query for content access updates", exc_info=e)
+        except connection.RestlibException as err:
+            log.warning("Unable to query for content access updates: %s", err)
             return None
         if response is None or "contentListing" not in response:
             return None


### PR DESCRIPTION
* Bug fix of: https://bugzilla.redhat.com/show_bug.cgi?id=1448855
* Golden ticket entitlement was not removed when you set
  contentAccessMode to " " back from "org_environment".
* When candlepin returned modified/empty list of ent. certificates,
  then rogue ent. certificates were removed from
  /etc/pki/entitlemens, but golden ticket certs were not removed.
* Small refactoring and code style tweaks.