### PR TITLE
1450818: Bug fix of com.redhat.Subscriptionmanager D-Bus policy

### DIFF
--- a/etc-conf/dbus/system.d/com.redhat.SubscriptionManager.conf
+++ b/etc-conf/dbus/system.d/com.redhat.SubscriptionManager.conf
@@ -8,12 +8,31 @@
   <policy user="root">
     <allow own="com.redhat.SubscriptionManager"/>
     <allow own="com.redhat.SubscriptionManager.PluginEvent"/>
+
+    <!-- Only root can trigger methods in these services -->
+    <allow send_destination="com.redhat.SubscriptionManager"/>
+    <allow send_destination="com.redhat.SubscriptionManager.PluginEvent"/>
+
+    <!-- Basic D-Bus API stuff -->
+    <allow send_destination="com.redhat.SubscriptionManager"
+        send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="com.redhat.SubscriptionManager"
+        send_interface="org.freedesktop.DBus.ObjectManager"/>
   </policy>
 
   <policy context="default">
-    <allow send_destination="com.redhat.SubscriptionManager"/>
-    <allow send_destination="com.redhat.SubscriptionManager.EntitlementStatus"/>
+    <!-- Common user can only check status of entitlement -->
+    <allow send_destination="com.redhat.SubscriptionManager"
+        send_path="/EntitlementStatus"
+        send_member="check_status"/>
+
+    <!-- Basic D-Bus API stuff -->
+    <allow send_destination="com.redhat.SubscriptionManager"
+        send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="com.redhat.SubscriptionManager"
+        send_interface="org.freedesktop.DBus.ObjectManager"/>
   </policy>
+
 
 </busconfig>
 


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1450818
* Any user was able to popup on an user logged in graphic mode.
  The popup will contain warnings about subscription/entitlements
  status, but it does not allow any modifications.
* Thus local user was able to do abuse & prank to an user logged
  in graphical mode.
* Only root user should be able to trigger method update_status
  now. e.g. using this command:
```bash
busctl call com.redhat.SubscriptionManager /EntitlementStatus \
com.redhat.SubscriptionManager.EntitlementStatus update_status i 5
```
* Common user should be able to trigger only check_status method
  now e.g. using this command:
```bash
busctl call com.redhat.SubscriptionManager /EntitlementStatus \
com.redhat.SubscriptionManager.EntitlementStatus check_status
```
  It does not trigger REST API call to candlepin server.
* I didn't test com.redhat.SubscriptionManager.PluginEvent, but
  only root should be able to trigger methods from this service.