### PR TITLE
1450210: Make lscpu ignore locale again

### DIFF
--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -528,12 +528,10 @@ class HardwareCollector(collector.FactsCollector):
             return lscpu_info
 
         # copy of parent process environment
-        parent_env = dict(os.environ)
+        lscpu_env = dict(os.environ)
 
-        # let us specify a test dir of /sys info for testing
-        # If the user env sets LC_ALL, it overrides a LANG here, so
-        # use LC_ALL here. See rhbz#1225435
-        lscpu_env = parent_env.update({'LC_ALL': 'en_US.UTF-8'})
+        # # LANGUAGE trumps LC_ALL, LC_CTYPE, LANG. See rhbz#1225435, rhbz#1450210
+        lscpu_env.update({'LANGUAGE': 'en_US.UTF-8'})
         lscpu_cmd = [LSCPU_CMD]
 
         if self.testing:

--- a/test/rhsmlib_test/test_hwprobe.py
+++ b/test/rhsmlib_test/test_hwprobe.py
@@ -674,3 +674,19 @@ class HardwareProbeTest(test.fixture.SubManFixture):
                 'cpu.topology_source': 'kernel /sys cpu sibling lists'
             }
             self.assert_equal_dict(expected, self.hw_check_topo.get_cpu_info())
+
+
+class TestLscpu(unittest.TestCase):
+    @patch('os.environ', {
+        'LANGUAGE': 'ja_JP.eucJP',
+        'LC_ALL': 'ja_JP.eucJP',
+        'LC_CTYPE': 'ja_JP.eucJP',
+        'LANG': 'ja_JP.eucJP',
+    })
+    def test_lscpu_ignores_locale(self):
+        hw_check_topo = hwprobe.HardwareCollector()
+        facts = hw_check_topo.get_ls_cpu_info()
+        # if all values can be decoded as ascii, then lscpu is not using JP locale
+        for key, value in facts.items():
+            key.decode('ascii')
+            value.decode('ascii')


### PR DESCRIPTION
Also, I changed the way we are overriding by using 'LANGUAGE' rather
than 'LC_ALL' since https://docs.python.org/2/library/locale.html#locale.getdefaultlocale
explains that 'LANGUAGE' has the highest precedence.