### PR TITLE
1451003: identity reports right info in name field

### DIFF
--- a/src/subscription_manager/identity.py
+++ b/src/subscription_manager/identity.py
@@ -84,7 +84,7 @@ class ConsumerIdentity:
     def getConsumerName(self):
         altName = self.x509.alt_name
         # must account for old format and new
-        return altName.replace("DirName:/CN=", "").replace("URI:CN=", "")
+        return altName.replace("DirName:/CN=", "").replace("URI:CN=", "").split(", ")[-1]
 
     def getSerialNumber(self):
         return self.x509.serial


### PR DESCRIPTION
* Bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1451003
* AltName can contain two values with begining: DirName:/CN= in
  product certificate. Only second value contains valid name.
  The first value contains UUID. As you can see command:

      rct cc /etc/pki/consumer/cert.pem | grep "Alt Name:"

  can return something like this:

      DirName:/CN=c3e72e3f-bb86-4f87-ac67-9c0e6eed7658, \
      DirName:/CN=localhost.localdomain

  or this:

      Alt Name: URI:CN=rhel01.localdomain

  The second case is old type of format and it has to be supported
  too.