### PR TITLE
1422196: Update container certs after plugin install

### DIFF
--- a/src/content_plugins/container_content.py
+++ b/src/content_plugins/container_content.py
@@ -25,14 +25,14 @@ requires_api_version = "1.1"
 from subscription_manager.plugin.container import \
     ContainerContentUpdateActionCommand
 
-# Default location where we'll manage hostname specific directories of
-# certificates.
-HOSTNAME_CERT_DIR = "/etc/docker/certs.d/"
-
 
 class ContainerContentPlugin(base_plugin.SubManPlugin):
     """Plugin for adding docker content action to subscription-manager"""
     name = "container_content"
+
+    # Default location where we'll manage hostname specific directories of
+    # certificates.
+    HOSTNAME_CERT_DIR = "/etc/docker/certs.d/"
 
     def update_content_hook(self, conduit):
         """
@@ -47,6 +47,27 @@ class ContainerContentPlugin(base_plugin.SubManPlugin):
         cmd = ContainerContentUpdateActionCommand(
             ent_source=conduit.ent_source,
             registry_hostnames=registry_hostnames.split(','),
-            host_cert_dir=HOSTNAME_CERT_DIR)
+            host_cert_dir=self.HOSTNAME_CERT_DIR)
         report = cmd.perform()
         conduit.reports.add(report)
+
+
+def main():
+    from subscription_manager.plugins import PluginManager
+    from subscription_manager import injectioninit
+    from subscription_manager.plugins import UpdateContentConduit
+    from subscription_manager.model.ent_cert import EntitlementDirEntitlementSource
+    from subscription_manager.content_action_client import ContentPluginActionReport
+
+    plugin_manager = PluginManager()
+    plugin_class = plugin_manager.get_plugins()['container_content.ContainerContentPlugin']
+    plugin = plugin_class()
+    injectioninit.init_dep_injection()
+    ent_source = EntitlementDirEntitlementSource()
+    reports = ContentPluginActionReport()
+    conduit = UpdateContentConduit(plugin_class, reports=reports, ent_source=ent_source)
+    plugin.update_content_hook(conduit)
+
+
+if __name__ == "__main__":
+    main()

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -693,6 +693,9 @@ touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
 scrollkeeper-update -q -o %{_datadir}/omf/%{name} || :
 %endif
 
+%post -n subscription-manager-plugin-container
+%{__python} %{rhsm_plugins_dir}/container_content.py || :
+
 %preun
 if [ $1 -eq 0 ] ; then
     %if %use_systemd


### PR DESCRIPTION
In order to accomplish this, I added an invocation of `python
content_plugins/container_content.py` to the post-install scriptlet of
`subscription-manager-plugin-container`.

I added the main method to `container_content.py`, as this kept the
logic of invoking the hook close to the hook itself, and avoided
complexities with adjusting the `PYTHONPATH`.

By invoking the hook (rather than say, calling rhsmcertd-worker), we
avoid going to the network, and instead simply reference entitlements
already present to update the client certs for registry access
(currently at /etc/docker/certs.d).

Testing requires an entitlement with a product with matching tags and
content of type "containerimage".