### PR TITLE
1443159: Added default value for splay configuration

### DIFF
--- a/python-rhsm/src/rhsm/config.py
+++ b/python-rhsm/src/rhsm/config.py
@@ -73,7 +73,8 @@ RHSM_DEFAULTS = {
 
 RHSMCERTD_DEFAULTS = {
         'certcheckinterval': '240',
-        'autoattachinterval': '1440'
+        'autoattachinterval': '1440',
+        'splay': '1'
         }
 
 LOGGING_DEFAULTS = {


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1443159
* Added default value to rhsmcertd.splay. It is important,
  when you run following command:

      subscription-manager config --list,

  then default values are displayed inside [] brackets.
  Example of output (autoattachinterval has changed value):

      [rhsmcertd]
         autoattachinterval = 100
         certcheckinterval = [240]
         splay = [1]