### PR TITLE
1444453: Have gettext return unicode instead of bytes.

### DIFF
--- a/bin/rct
+++ b/bin/rct
@@ -28,14 +28,11 @@ import sys
 reload(sys)
 sys.setdefaultencoding('utf-8')
 
-from subscription_manager.i18n import configure_i18n
+from subscription_manager.i18n import configure_i18n, ugettext as _
 configure_i18n()
 
 from subscription_manager import logutil
 logutil.init_logger()
-
-import gettext
-_ = gettext.gettext
 
 from rct.cli import RctCLI
 

--- a/bin/rhsm-debug
+++ b/bin/rhsm-debug
@@ -29,7 +29,7 @@ reload(sys)
 sys.setdefaultencoding('utf-8')
 import os
 
-from subscription_manager.i18n import configure_i18n
+from subscription_manager.i18n import configure_i18n, ugettext as _
 configure_i18n()
 
 from subscription_manager import logutil
@@ -37,9 +37,6 @@ logutil.init_logger()
 
 from rhsm_debug.cli import RhsmDebugCLI
 from subscription_manager.cli import system_exit
-
-import gettext
-_ = gettext.gettext
 
 
 try:

--- a/bin/subscription-manager-gui
+++ b/bin/subscription-manager-gui
@@ -48,10 +48,9 @@ import dbus.service
 import dbus.glib
 import dbus.exceptions
 import logging
-import gettext
 import signal
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
@@ -135,7 +134,7 @@ except RuntimeError, e:
 try:
     # this has to be done first thing due to module level translated vars.
     from subscription_manager.i18n import configure_i18n
-    configure_i18n(with_glade=True)
+    configure_i18n()
 
     from subscription_manager import logutil
     logutil.init_logger()

--- a/python-rhsm/src/rhsm/utils.py
+++ b/python-rhsm/src/rhsm/utils.py
@@ -15,15 +15,12 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 #
 
-import gettext
 import os
 import re
 
 import six.moves.urllib.parse
 
 from rhsm.config import DEFAULT_PROXY_PORT
-
-_ = lambda x: gettext.ldgettext("rhsm", x)
 
 
 def remove_scheme(uri):

--- a/src/daemons/rhsmcertd-worker.py
+++ b/src/daemons/rhsmcertd-worker.py
@@ -40,8 +40,7 @@ from subscription_manager.i18n_optparse import OptionParser, \
     WrappedIndentedHelpFormatter, USAGE
 from subscription_manager.utils import generate_correlation_id
 
-import gettext
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 
 def exit_on_signal(_signumber, _stackframe):

--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
@@ -36,6 +36,7 @@ ga_loader.init_ga(gtk_version="3")
 from subscription_manager.ga import GObject as ga_GObject
 from subscription_manager.ga import Gtk as ga_Gtk
 from subscription_manager.gui import managergui
+from subscription_manager.i18n import configure_gettext
 from subscription_manager.injectioninit import init_dep_injection
 from subscription_manager.gui import registergui
 from subscription_manager import utils
@@ -44,6 +45,8 @@ from subscription_manager.gui import utils as gui_utils
 ga_GObject.threads_init()
 
 __all__ = ["RHSMSpoke"]
+
+configure_gettext()
 
 
 class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):

--- a/src/rct/cert_commands.py
+++ b/src/rct/cert_commands.py
@@ -15,7 +15,6 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 #
 import base64
-import gettext
 import os
 
 from rhsm import certificate, _certificate
@@ -26,7 +25,7 @@ from rct.printing import printc, type_to_string
 
 from subscription_manager.cli import InvalidCLIOptionError
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 
 class RCTCertCommand(RCTCliCommand):

--- a/src/rct/commands.py
+++ b/src/rct/commands.py
@@ -17,9 +17,7 @@ from __future__ import print_function, division, absolute_import
 
 import sys
 
-import gettext
 from subscription_manager.cli import AbstractCLICommand
-_ = gettext.gettext
 
 
 class RCTCliCommand(AbstractCLICommand):

--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -15,7 +15,6 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 #
 import errno
-import gettext
 import os
 import sys
 
@@ -29,7 +28,7 @@ from rct.printing import xstr
 from subscription_manager.cli import InvalidCLIOptionError
 from rhsm import ourjson as json
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 
 def get_value(json_dict, path):

--- a/src/rct/printing.py
+++ b/src/rct/printing.py
@@ -14,7 +14,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import gettext
 import signal
 
 from rhsm.certificate2 import EntitlementCertificate, ProductCertificate, IdentityCertificate
@@ -22,7 +21,7 @@ from rhsm.certificate2 import EntitlementCertificate, ProductCertificate, Identi
 # BZ 973938 python doesn't correctly handle SIGPIPE
 signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 
 # TODO: to be extra paranoid, we could ask to print

--- a/src/rhsm_debug/debug_commands.py
+++ b/src/rhsm_debug/debug_commands.py
@@ -15,7 +15,6 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 #
 import errno
-import gettext
 import optparse
 import os
 import sys
@@ -33,11 +32,11 @@ from rhsm import ourjson as json
 from rhsm.config import initConfig
 from rhsmlib.services import config
 
-_ = gettext.gettext
-
-conf = config.Config(initConfig())
+from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger('rhsm-app.' + __name__)
+
+conf = config.Config(initConfig())
 
 ERR_NOT_REGISTERED_MSG = _("This system is not yet registered. Try 'subscription-manager register --help' for more information.")
 ERR_NOT_REGISTERED_CODE = 1

--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -13,7 +13,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import gettext
 import socket
 import json
 import logging
@@ -31,7 +30,8 @@ from subscription_manager.injectioninit import init_dep_injection
 
 init_dep_injection()
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
+
 log = logging.getLogger(__name__)
 
 from rhsmlib.services import config

--- a/src/rhsmlib/facts/dmiinfo.py
+++ b/src/rhsmlib/facts/dmiinfo.py
@@ -18,15 +18,14 @@ from __future__ import print_function, division, absolute_import
 Note: This module will fail to import if dmidecode fails to import.
       firmware_info.py expects that and handles it, and any other
       module that imports it should handle an import error as well."""
-import gettext
 import logging
 import os
+
+from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 
 from rhsmlib.facts import collector
-
-_ = gettext.gettext
 
 FIRMWARE_DUMP_FILENAME = "dmi.dump"
 

--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -18,7 +18,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import gettext
 import logging
 import os
 import platform
@@ -28,8 +27,6 @@ import sys
 
 from rhsmlib.facts import cpuinfo
 from rhsmlib.facts import collector
-
-_ = gettext.gettext
 
 log = logging.getLogger(__name__)
 

--- a/src/rhsmlib/facts/virt.py
+++ b/src/rhsmlib/facts/virt.py
@@ -16,8 +16,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 import logging
 import string
 
@@ -27,8 +25,6 @@ from rhsmlib.facts import collector
 from rhsmlib.compat import check_output as compat_check_output
 
 log = logging.getLogger(__name__)
-
-_ = gettext.gettext
 
 
 class VirtWhatCollector(collector.FactsCollector):

--- a/src/subscription_manager/action_client.py
+++ b/src/subscription_manager/action_client.py
@@ -18,7 +18,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import gettext
 import logging
 
 from subscription_manager import base_action_client
@@ -33,8 +32,6 @@ from subscription_manager.content_action_client import ContentActionClient
 
 
 log = logging.getLogger(__name__)
-
-_ = gettext.gettext
 
 
 class ActionClient(base_action_client.BaseActionClient):

--- a/src/subscription_manager/async.py
+++ b/src/subscription_manager/async.py
@@ -18,7 +18,6 @@ from __future__ import print_function, division, absolute_import
 #
 
 import threading
-import gettext
 import sys
 
 from six.moves import queue
@@ -28,8 +27,6 @@ from subscription_manager.entcertlib import Disconnected
 from subscription_manager.managerlib import fetch_certificates
 from subscription_manager.injection import IDENTITY, \
         PLUGIN_MANAGER, CP_PROVIDER, require
-
-_ = gettext.gettext
 
 
 class AsyncPool(object):

--- a/src/subscription_manager/branding/__init__.py
+++ b/src/subscription_manager/branding/__init__.py
@@ -24,12 +24,11 @@ directory. The module should contains a Branding class, whose instances have
 attributes matching the names of those on DefaultBranding for any values you
 want to override.
 """
-import gettext
 import glob
 import os
 import sys
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 __all__ = ["get_branding"]
 

--- a/src/subscription_manager/branding/redhat_branding.py
+++ b/src/subscription_manager/branding/redhat_branding.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
-import gettext
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 
 class Branding(object):

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -20,7 +20,6 @@ Classes here track various information last sent to the server, compare
 this with the current state, and perform an update on the server if
 necessary.
 """
-import gettext
 import logging
 import os
 import socket
@@ -37,7 +36,8 @@ from subscription_manager.isodate import parse_date
 
 from rhsmlib.services import config
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
+
 log = logging.getLogger(__name__)
 
 PACKAGES_RESOURCE = "packages"

--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -15,7 +15,6 @@ from __future__ import print_function, division, absolute_import
 #
 from copy import copy
 from datetime import datetime
-import gettext
 import logging
 
 from rhsm.certificate import GMT
@@ -26,7 +25,7 @@ from subscription_manager.reasons import Reasons
 from subscription_manager import file_monitor
 from subscription_manager import utils
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 

--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -16,8 +16,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 import logging
 import os
 
@@ -29,7 +27,6 @@ from rhsmlib.services import config
 from rhsm.certificate2 import CONTENT_ACCESS_CERT_TYPE
 
 log = logging.getLogger(__name__)
-_ = gettext.gettext
 
 conf = config.Config(initConfig())
 

--- a/src/subscription_manager/cli.py
+++ b/src/subscription_manager/cli.py
@@ -14,7 +14,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import gettext
 import os
 import sys
 
@@ -22,7 +21,7 @@ from subscription_manager.printing_utils import columnize, echo_columnize_callba
 from subscription_manager.i18n_optparse import OptionParser, WrappedIndentedHelpFormatter
 from subscription_manager.utils import print_error
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 
 class InvalidCLIOptionError(Exception):

--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -14,7 +14,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import gettext
 import logging
 import socket
 
@@ -29,8 +28,9 @@ from subscription_manager.injection import IDENTITY, require
 from subscription_manager import rhelentbranding
 import subscription_manager.injection as inj
 
+from subscription_manager.i18n import ungettext, ugettext as _
+
 log = logging.getLogger(__name__)
-_ = gettext.gettext
 
 CONTENT_ACCESS_CERT_CAPABILITY = "org_level_content_access"
 
@@ -306,9 +306,9 @@ class EntCertUpdateAction(object):
         # entitlement directory before we go to delete expired certs.
         rogue_count = len(self.report.rogue)
         if rogue_count > 0:
-            print(gettext.ngettext("%s local certificate has been deleted.",
-                                   "%s local certificates have been deleted.",
-                                   rogue_count) % rogue_count)
+            print(ungettext("%s local certificate has been deleted.",
+                            "%s local certificates have been deleted.",
+                            rogue_count) % rogue_count)
             self.ent_dir.refresh()
 
 

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -15,17 +15,15 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
 import inspect
 from socket import error as socket_error
 from rhsm.https import ssl, httplib
-import gettext
 
 from rhsm import connection, utils
 
 from subscription_manager.entcertlib import Disconnected
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 SOCKET_MESSAGE = _('Network error, unable to connect to server. Please see /var/log/rhsm/rhsm.log for more information.')
 NETWORK_MESSAGE = _('Network error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information.')

--- a/src/subscription_manager/factlib.py
+++ b/src/subscription_manager/factlib.py
@@ -16,14 +16,10 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 import logging
 
 from .certlib import Locker, ActionReport
 from subscription_manager import injection as inj
-
-_ = gettext.gettext
 
 log = logging.getLogger(__name__)
 

--- a/src/subscription_manager/facts.py
+++ b/src/subscription_manager/facts.py
@@ -12,9 +12,7 @@ from __future__ import print_function, division, absolute_import
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
-
 from datetime import datetime
-import gettext
 import logging
 import os
 
@@ -24,7 +22,6 @@ from rhsm import ourjson as json
 
 from rhsmlib.facts.all import AllFactsCollector
 
-_ = gettext.gettext
 log = logging.getLogger(__name__)
 
 

--- a/src/subscription_manager/gui/about.py
+++ b/src/subscription_manager/gui/about.py
@@ -14,9 +14,7 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
 import datetime
-import gettext
 import os
 import subprocess
 
@@ -25,7 +23,7 @@ from subscription_manager.ga import Gtk as ga_Gtk
 from subscription_manager.gui.utils import get_running_as_firstboot
 from subscription_manager.utils import get_client_versions, get_server_versions
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 LICENSE = _("\nThis software is licensed to you under the GNU General Public License, "
             "version 2 (GPLv2). There is NO WARRANTY for this software, express or "

--- a/src/subscription_manager/gui/allsubs.py
+++ b/src/subscription_manager/gui/allsubs.py
@@ -14,9 +14,7 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
 import datetime
-import gettext
 import logging
 
 from subscription_manager.ga import Gtk as ga_Gtk
@@ -34,7 +32,7 @@ from subscription_manager.jsonwrapper import PoolWrapper
 from subscription_manager import managerlib
 from subscription_manager.managerlib import allows_multi_entitlement, valid_quantity
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 

--- a/src/subscription_manager/gui/autobind.py
+++ b/src/subscription_manager/gui/autobind.py
@@ -16,11 +16,7 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
 import logging
-
-import gettext
-_ = gettext.gettext
 
 log = logging.getLogger(__name__)
 

--- a/src/subscription_manager/gui/contract_selection.py
+++ b/src/subscription_manager/gui/contract_selection.py
@@ -14,9 +14,7 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
 import datetime
-import gettext
 import time
 
 from subscription_manager.ga import Gtk as ga_Gtk
@@ -28,7 +26,7 @@ from subscription_manager import isodate
 from subscription_manager.jsonwrapper import PoolWrapper
 from subscription_manager.managerlib import allows_multi_entitlement
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 
 class ContractSelectionWindow(widgets.SubmanBaseWidget):

--- a/src/subscription_manager/gui/factsgui.py
+++ b/src/subscription_manager/gui/factsgui.py
@@ -14,8 +14,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 import logging
 
 from subscription_manager.ga import Gtk as ga_Gtk
@@ -25,7 +23,7 @@ from subscription_manager.gui.utils import handle_gui_exception, linkify
 from subscription_manager import injection as inj
 from rhsm.connection import GoneException
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 

--- a/src/subscription_manager/gui/filter.py
+++ b/src/subscription_manager/gui/filter.py
@@ -14,14 +14,10 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 import logging
 
 from subscription_manager.ga import Gtk as ga_Gtk
 from subscription_manager.gui import widgets
-
-_ = gettext.gettext
 
 log = logging.getLogger(__name__)
 

--- a/src/subscription_manager/gui/firstboot/rhsm_login.py
+++ b/src/subscription_manager/gui/firstboot/rhsm_login.py
@@ -1,11 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
-import gettext
 import sys
 import logging
 import dbus.mainloop.glib
-
-_ = lambda x: gettext.ldgettext("rhsm", x)
 
 from subscription_manager import ga_loader
 ga_loader.init_ga()
@@ -36,12 +33,12 @@ from rhsmlib.facts.hwprobe import HardwareCollector
 from subscription_manager.gui import managergui
 from subscription_manager.gui import registergui
 from subscription_manager.gui.utils import format_exception
-from subscription_manager.i18n import configure_i18n
 
 from firstboot import module
 from firstboot import constants
 
-configure_i18n(with_glade=True)
+from subscription_manager.i18n import configure_i18n, ugettext as _
+configure_i18n()
 
 from rhsm.utils import remove_scheme
 

--- a/src/subscription_manager/gui/importsub.py
+++ b/src/subscription_manager/gui/importsub.py
@@ -14,8 +14,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 import logging
 import os
 
@@ -25,9 +23,9 @@ from subscription_manager.gui import messageWindow
 from subscription_manager.gui.utils import show_error_window
 from subscription_manager.managerlib import ImportFileExtractor
 
-log = logging.getLogger(__name__)
+from subscription_manager.i18n import ugettext as _
 
-_ = gettext.gettext
+log = logging.getLogger(__name__)
 
 
 class ImportSubDialog(object):

--- a/src/subscription_manager/gui/installedtab.py
+++ b/src/subscription_manager/gui/installedtab.py
@@ -24,15 +24,14 @@ from rhsmlib.facts.hwprobe import ClassicCheck
 from subscription_manager.utils import friendly_join
 
 import logging
-import gettext
 from subscription_manager.ga import GObject as ga_GObject
 from subscription_manager.ga import Gtk as ga_Gtk
 from subscription_manager.ga import GdkPixbuf as ga_GdkPixbuf
 import os
 
-log = logging.getLogger(__name__)
+from subscription_manager.i18n import ungettext, ugettext as _
 
-_ = gettext.gettext
+log = logging.getLogger(__name__)
 
 prefix = os.path.dirname(__file__)
 VALID_IMG = os.path.join(prefix, "data/icons/valid.svg")
@@ -212,9 +211,9 @@ class InstalledProductsTab(widgets.SubscriptionManagerTab):
                         entry['image'] = self._render_icon('green')
                         entry['status'] = _('Subscribed')
                         entry['validity_note'] = \
-                            gettext.ngettext("Covered by contract %s through %s",
-                                             'Covered by contracts %s through %s',
-                                             num_of_contracts) % \
+                            ungettext("Covered by contract %s through %s",
+                                      'Covered by contracts %s through %s',
+                                      num_of_contracts) % \
                             (contract,
                              managerlib.format_date(entry['expiration_date']))
                 else:

--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -18,11 +18,9 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
 from subscription_manager.injection import require, IDENTITY, CERT_SORTER, CP_PROVIDER
 import subscription_manager.injection as inj
 
-import gettext
 import locale
 import logging
 import webbrowser
@@ -63,13 +61,7 @@ from subscription_manager.gui.reposgui import RepositoriesDialog
 from subscription_manager.overrides import Overrides
 from subscription_manager.cli import system_exit
 
-
-_ = gettext.gettext
-
-gettext.textdomain("rhsm")
-
-#Gtk.glade.bindtextdomain("rhsm")
-#Gtk.Window.set_default_icon_name("subscription-manager")
+from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 

--- a/src/subscription_manager/gui/messageWindow.py
+++ b/src/subscription_manager/gui/messageWindow.py
@@ -14,13 +14,8 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import gettext
-
 from subscription_manager.ga import GObject as ga_GObject
 from subscription_manager.ga import Gtk as ga_Gtk
-
-
-_ = gettext.gettext
 
 
 # wrap a long line...

--- a/src/subscription_manager/gui/mysubstab.py
+++ b/src/subscription_manager/gui/mysubstab.py
@@ -14,7 +14,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import gettext
 import os
 from datetime import datetime
 
@@ -35,8 +34,8 @@ from subscription_manager.gui import widgets
 from subscription_manager.gui.utils import handle_gui_exception
 from subscription_manager.utils import is_true_value
 
+from subscription_manager.i18n import ugettext as _
 
-_ = gettext.gettext
 
 prefix = os.path.dirname(__file__)
 WARNING_IMG = os.path.join(prefix, "data/icons/partial.svg")

--- a/src/subscription_manager/gui/networkConfig.py
+++ b/src/subscription_manager/gui/networkConfig.py
@@ -14,8 +14,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 import logging
 import os
 import threading
@@ -35,11 +33,11 @@ import subscription_manager.injection as inj
 from subscription_manager.gui import progress
 from subscription_manager.gui import widgets
 
-_ = gettext.gettext
-
-DIR = os.path.dirname(__file__)
+from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
+
+DIR = os.path.dirname(__file__)
 
 
 class NetworkConfigDialog(widgets.SubmanBaseWidget):

--- a/src/subscription_manager/gui/preferences.py
+++ b/src/subscription_manager/gui/preferences.py
@@ -14,8 +14,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 import logging
 
 from subscription_manager.ga import Gtk as ga_Gtk
@@ -24,7 +22,7 @@ from subscription_manager.gui import utils
 from subscription_manager import injection as inj
 from subscription_manager import release
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 

--- a/src/subscription_manager/gui/redeem.py
+++ b/src/subscription_manager/gui/redeem.py
@@ -14,15 +14,13 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 import logging
 
 from subscription_manager.gui.utils import handle_gui_exception
 from subscription_manager.gui import widgets
 from subscription_manager.injection import IDENTITY, require
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -16,8 +16,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 import logging
 import re
 import socket
@@ -53,9 +51,8 @@ from subscription_manager.gui.autobind import DryRunResult, \
         NoProductsException
 from subscription_manager.jsonwrapper import PoolWrapper
 
-_ = lambda x: gettext.ldgettext("rhsm", x)
+from subscription_manager.i18n import ugettext as _
 
-gettext.textdomain("rhsm")
 log = logging.getLogger(__name__)
 
 from rhsmlib.services import config
@@ -262,11 +259,14 @@ class RegisterWidget(widgets.SubmanBaseWidget):
     initial_screen = CHOOSE_SERVER_PAGE
 
     screen_ready = ga_GObject.property(type=bool, default=True)
-    register_button_label = ga_GObject.property(type=str, default=_('Register'))
+    register_button_label = ga_GObject.property(type=str)
     # TODO: a prop equivalent to initial-setups 'completed' and 'status' props
 
     def __init__(self, backend, reg_info=None, parent_window=None):
         super(RegisterWidget, self).__init__()
+
+        self.set_property('register-button-label',
+                          _('Register'))
 
         self.backend = backend
 

--- a/src/subscription_manager/gui/reposgui.py
+++ b/src/subscription_manager/gui/reposgui.py
@@ -14,8 +14,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 import logging
 
 from subscription_manager.ga import Gtk as ga_Gtk
@@ -36,7 +34,7 @@ from subscription_manager.gui.widgets import TextTreeViewColumn, CheckBoxColumn,
 from subscription_manager.gui.messageWindow import YesNoDialog
 from subscription_manager.overrides import Override
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 

--- a/src/subscription_manager/gui/utils.py
+++ b/src/subscription_manager/gui/utils.py
@@ -16,7 +16,6 @@ from __future__ import print_function, division, absolute_import
 #
 
 import datetime
-import gettext
 import logging
 import re
 import threading
@@ -43,8 +42,6 @@ EVEN_ROW_COLOR = '#eeeeee'
 
 # set if we are in firstboot, to disable linkify, see bz#814378
 FIRSTBOOT = False
-
-_ = lambda x: gettext.ldgettext("rhsm", x)
 
 cfg = config.initConfig()
 

--- a/src/subscription_manager/gui/widgets.py
+++ b/src/subscription_manager/gui/widgets.py
@@ -14,9 +14,7 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
 import datetime
-import gettext
 import logging
 import os
 import time
@@ -39,18 +37,18 @@ from subscription_manager.gui import storage
 from subscription_manager.gui import utils
 from subscription_manager import managerlib
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
+
+log = logging.getLogger(__name__)
 
 GLADE_DIR = os.path.join(os.path.dirname(__file__), "data/glade")
 UI_DIR = os.path.join(os.path.dirname(__file__), "data/ui")
 UI_SUFFIX = "ui"
 GLADE_SUFFIX = "glade"
 
-
 WARNING_COLOR = '#FFFB82'
 EXPIRED_COLOR = '#FFAF99'
 
-log = logging.getLogger(__name__)
 # Some versions of gtk has incorrect translations for the calendar widget
 # and gtk itself complains about this with errors like:
 #

--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -13,6 +13,10 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+import gettext
+import locale
+
+import six
 
 # Localization domain:
 APP = 'rhsm'
@@ -20,21 +24,37 @@ APP = 'rhsm'
 DIR = '/usr/share/locale/'
 
 
-def configure_i18n(with_glade=False):
+def configure_i18n():
     """
     Configure internationalization for the application. Should only be
     called once per invocation. (once for CLI, once for GUI)
     """
-    import gettext
     import locale
     try:
         locale.setlocale(locale.LC_ALL, '')
     except locale.Error:
         locale.setlocale(locale.LC_ALL, 'C')
+    configure_gettext()
+
+
+def configure_gettext():
+    """Configure gettext for all RHSM-related code.
+
+    Since Glade internally uses gettext, we need to use the C-level bindings in locale to adjust the encoding.
+
+    See https://docs.python.org/2/library/locale.html#access-to-message-catalogs
+
+    Exposed as its own function so that it can be called safely in the initial-setup case.
+    """
     gettext.bindtextdomain(APP, DIR)
     gettext.textdomain(APP)
+    gettext.bind_textdomain_codeset(APP, 'UTF-8')
+    locale.bind_textdomain_codeset(APP, 'UTF-8')
 
-#    if (with_glade):
-#        import gtk.glade
-#        gtk.glade.bindtextdomain(APP, DIR)
-#        gtk.glade.textdomain(APP)
+translation = gettext.translation(APP, fallback=True)
+if six.PY3:  # gettext returns unicode in Python 3
+    ugettext = translation.gettext
+    ungettext = translation.ngettext
+else:
+    ugettext = translation.ugettext
+    ungettext = translation.ungettext

--- a/src/subscription_manager/i18n_optparse.py
+++ b/src/subscription_manager/i18n_optparse.py
@@ -25,16 +25,16 @@ Just use this instead of optparse, the interface should be the same.
 For some backgorund, see:
 http://bugs.python.org/issue4319
 """
-import gettext
 import optparse
 from optparse import IndentedHelpFormatter as _IndentedHelpFormatter
 from optparse import OptionParser as _OptionParser
 import sys
 import textwrap
 
+from subscription_manager.i18n import ugettext as _
 
-_ = gettext.gettext
-optparse._ = gettext.gettext
+
+optparse._ = _
 
 # note default is lower caps
 USAGE = _("%prog [OPTIONS]")

--- a/src/subscription_manager/jsonwrapper.py
+++ b/src/subscription_manager/jsonwrapper.py
@@ -15,11 +15,7 @@ from __future__ import print_function, division, absolute_import
 #
 
 # This module contains wrappers for JSON returned from the CP server.
-
-import gettext
 from subscription_manager.utils import is_true_value
-
-_ = gettext.gettext
 
 
 class PoolWrapper(object):

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -21,7 +21,6 @@ import datetime
 import fileinput
 import fnmatch
 import getpass
-import gettext
 import logging
 from optparse import OptionValueError
 import os
@@ -66,7 +65,7 @@ from subscription_manager.printing_utils import columnize, format_name, \
         none_wrap_columnize_callback, echo_columnize_callback, highlight_by_filter_string_columnize_callback
 from subscription_manager.utils import generate_correlation_id
 
-_ = gettext.gettext
+from subscription_manager.i18n import ungettext, ugettext as _
 
 log = logging.getLogger(__name__)
 
@@ -1809,9 +1808,9 @@ class RemoveCommand(CliCommand):
                         print(_("All subscriptions have been removed at the server."))
                     else:
                         count = total['deletedRecords']
-                        print(gettext.ngettext("%s subscription removed at the server.",
-                                               "%s subscriptions removed at the server.",
-                                                count) % count)
+                        print(ungettext("%s subscription removed at the server.",
+                                        "%s subscriptions removed at the server.",
+                                        count) % count)
                 else:
                     removed_serials = []
                     if self.options.pool_ids:

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -16,7 +16,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import gettext
 import glob
 import logging
 import os
@@ -28,7 +27,6 @@ import syslog
 from rhsm import connection
 from rhsm.config import initConfig
 from rhsm.certificate import Key, CertificateException, create_from_pem
-
 
 import subscription_manager.cache as cache
 from subscription_manager.cert_sorter import StackingGroupSorter, ComplianceManager
@@ -46,9 +44,9 @@ from subscription_manager import utils
 from subscription_manager.identity import ConsumerIdentity
 from dateutil.tz import tzlocal
 
-log = logging.getLogger(__name__)
+from subscription_manager.i18n import ugettext as _
 
-_ = gettext.gettext
+log = logging.getLogger(__name__)
 
 cfg = initConfig()
 ENT_CONFIG_DIR = cfg.get('rhsm', 'entitlementCertDir')

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -16,7 +16,6 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 #
 import getpass
-import gettext
 import libxml2
 import logging
 import os
@@ -35,7 +34,7 @@ from rhn import rpclib
 from rhsm.connection import RemoteServerException, RestlibException
 from rhsm.utils import ServerUrlParseError
 
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 from subscription_manager import injection as inj
 from subscription_manager.cli import system_exit

--- a/src/subscription_manager/plugin/container.py
+++ b/src/subscription_manager/plugin/container.py
@@ -16,7 +16,6 @@ from __future__ import print_function, division, absolute_import
 #
 
 """ Core code for the container content plugin. """
-import gettext
 import logging
 import os
 import re
@@ -25,9 +24,9 @@ import shutil
 from subscription_manager import certlib
 from subscription_manager.model import find_content
 
-log = logging.getLogger(__name__)
+from subscription_manager.i18n import ugettext as _
 
-_ = gettext.gettext
+log = logging.getLogger(__name__)
 
 CONTAINER_CONTENT_TYPE = "containerimage"
 

--- a/src/subscription_manager/plugin/ostree/action_invoker.py
+++ b/src/subscription_manager/plugin/ostree/action_invoker.py
@@ -14,7 +14,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import gettext
 import logging
 
 # rhsm.conf->iniparse->configParser can raise ConfigParser exceptions
@@ -25,11 +24,9 @@ from subscription_manager.model import find_content
 
 from subscription_manager.plugin.ostree import model
 
-# plugins get
+from subscription_manager.i18n import ugettext as _
+
 log = logging.getLogger(__name__)
-
-_ = gettext.gettext
-
 
 OSTREE_CONTENT_TYPE = "ostree"
 

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -15,7 +15,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import gettext
 import glob
 import imp
 import inspect
@@ -51,8 +50,6 @@ DEFAULT_CONF_PATH = "/etc/rhsm/pluginconf.d/"
 cfg = initConfig()
 
 log = logging.getLogger(__name__)
-
-_ = gettext.gettext
 
 
 class PluginException(Exception):

--- a/src/subscription_manager/printing_utils.py
+++ b/src/subscription_manager/printing_utils.py
@@ -14,8 +14,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 import fnmatch
 import re
 import logging
@@ -24,9 +22,9 @@ import six
 from yum.i18n import utf8_width
 from subscription_manager.utils import get_terminal_width
 
-log = logging.getLogger(__name__)
+from subscription_manager.i18n import ugettext as _
 
-_ = gettext.gettext
+log = logging.getLogger(__name__)
 
 FONT_BOLD = '\033[1m'
 FONT_RED = '\033[31m'

--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -16,8 +16,6 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import gettext
 from gzip import GzipFile
 import logging
 import os
@@ -38,7 +36,6 @@ from subscription_manager import repolib
 import subscription_manager.injection as inj
 from rhsm import ourjson as json
 
-_ = gettext.gettext
 log = logging.getLogger(__name__)
 
 

--- a/src/subscription_manager/reasons.py
+++ b/src/subscription_manager/reasons.py
@@ -14,8 +14,7 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 #
 
-import gettext
-_ = gettext.gettext
+from subscription_manager.i18n import ugettext as _
 
 
 class Reasons(object):

--- a/src/subscription_manager/release.py
+++ b/src/subscription_manager/release.py
@@ -18,7 +18,6 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 #
 
-import gettext
 import logging
 import socket
 import six
@@ -31,8 +30,6 @@ import rhsm.config
 from subscription_manager import injection as inj
 from subscription_manager import listing
 from subscription_manager import rhelproduct
-
-_ = gettext.gettext
 
 log = logging.getLogger(__name__)
 

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -1,3 +1,4 @@
+#
 # -*- coding: utf-8 -*-#
 from __future__ import print_function, division, absolute_import
 
@@ -17,7 +18,6 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 #
 
-import gettext
 from iniparse import RawConfigParser as ConfigParser
 import logging
 import os
@@ -39,6 +39,8 @@ from subscription_manager.certlib import ActionReport, BaseActionInvoker
 from subscription_manager.certdirectory import Path
 from rhsmlib.services import config
 
+from subscription_manager.i18n import ugettext as _
+
 log = logging.getLogger(__name__)
 
 conf = config.Config(initConfig())
@@ -46,8 +48,6 @@ conf = config.Config(initConfig())
 ALLOWED_CONTENT_TYPES = ["yum"]
 
 ZYPPER_REPO_DIR = '/etc/rhsm/zypper.repos.d'
-
-_ = gettext.gettext
 
 
 def manage_repos_enabled():
@@ -539,7 +539,7 @@ class RepoUpdateActionCommand(object):
 
 class RepoActionReport(ActionReport):
     """Report class for reporting yum repo updates."""
-    name = "Repo Updates"
+    name = u"Repo Updates"
 
     def __init__(self):
         super(RepoActionReport, self).__init__()
@@ -554,21 +554,20 @@ class RepoActionReport(ActionReport):
     def format_repos_info(self, repos, formatter):
         indent = '    '
         if not repos:
-            return '%s<NONE>' % indent
+            return u'%s<NONE>' % indent
 
         r = []
         for repo in repos:
-            r.append("%s%s" % (indent, formatter(repo)))
-        return '\n'.join(r)
+            r.append(u"%s%s" % (indent, formatter(repo)))
+        return u'\n'.join(r)
 
     def repo_format(self, repo):
-        msg = "[id:%s %s]" % (repo.id,
+        msg = u"[id:%s %s]" % (repo.id,
                                repo['name'])
         return msg.encode('utf8')
 
     def section_format(self, section):
-        msg = "[%s]" % section
-        return msg.encode('utf8')
+        return u"[%s]" % section
 
     def format_repos(self, repos):
         return self.format_repos_info(repos, self.repo_format)
@@ -576,7 +575,7 @@ class RepoActionReport(ActionReport):
     def format_sections(self, sections):
         return self.format_repos_info(sections, self.section_format)
 
-    def __str__(self):
+    def __unicode__(self):
         s = [_('Repo updates') + '\n']
         s.append(_('Total repo updates: %d') % self.updates())
         s.append(_('Updated'))
@@ -586,7 +585,10 @@ class RepoActionReport(ActionReport):
         s.append(_('Deleted'))
         # deleted are former repo sections, but they are the same type
         s.append(self.format_sections(self.repo_deleted))
-        return '\n'.join(s)
+        return u'\n'.join(s)
+
+    def __str__(self):  # TODO use six.python_2_unicode_compatible instead
+        return self.__unicode__().encode('utf-8')
 
 
 class Repo(dict):

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -16,7 +16,6 @@ from __future__ import print_function, division, absolute_import
 #
 
 import collections
-import gettext
 import logging
 import os
 import pprint
@@ -48,11 +47,9 @@ from rhsm.connection import RestlibException, GoneException
 from rhsm.config import DEFAULT_PORT, DEFAULT_PREFIX, DEFAULT_HOSTNAME, \
     DEFAULT_CDN_HOSTNAME, DEFAULT_CDN_PORT, DEFAULT_CDN_PREFIX
 
+from subscription_manager.i18n import ugettext as _
+
 log = logging.getLogger(__name__)
-
-_ = lambda x: gettext.ldgettext("rhsm", x)
-
-gettext.textdomain("rhsm")
 
 
 class DefaultDict(collections.defaultdict):

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -9,8 +9,5 @@ from subscription_manager.i18n import configure_i18n
 
 
 class TestI18N(unittest.TestCase):
-    def test_configure_i18n_without_glade(self):
+    def test_configure_i18n(self):
         configure_i18n()
-
-    def test_configure_i18n_with_glade(self):
-        configure_i18n(with_glade=True)

--- a/test/test_i18n_optparse.py
+++ b/test/test_i18n_optparse.py
@@ -7,6 +7,7 @@ except ImportError:
     import unittest
 
 import optparse
+import six
 
 from subscription_manager import i18n_optparse
 
@@ -14,17 +15,15 @@ from subscription_manager import i18n_optparse
 class TestWrappedIndentedHelpFormatter(unittest.TestCase):
     def setUp(self):
         self.hf = i18n_optparse.WrappedIndentedHelpFormatter(width=50)
-        self.parser = i18n_optparse.OptionParser(description="test",
-                                                 formatter=self.hf)
-        self.parser.add_option("-t", "--test", dest="test",
+        self.parser = i18n_optparse.OptionParser(description=u"test", formatter=self.hf)
+        self.parser.add_option(u"-t", u"--test", dest=u"test",
                                default=None,
-                               help="このシステム用に権利があるレポジトリの一覧表示このシステム用に権利があるレポジトリの一覧表示")
+                               help=u"このシステム用に権利があるレポジトリの一覧表示このシステム用に権利があるレポジトリの一覧表示")
 
     def test_format_option(self):
-        """use the new formatter, check for a result
-        that we can not decode to utf"""
+        # use the new formatter, check for a result that we can decode to utf
         fh = self.parser.format_option_help(self.hf)
-        fh.decode("utf8")
+        self.assertIsInstance(fh, six.text_type)
 
     def test_format_usage(self):
         # optparses default format_usage uses lower cases

--- a/test/test_migration.py
+++ b/test/test_migration.py
@@ -56,7 +56,7 @@ class TestMenu(unittest.TestCase):
     def test_get_item(self):
         self.assertEqual("Hello", self.menu._get_item(1))
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     @patch.object(migrate.Menu, "display_invalid")
     def test_choose(self, mock_display_invalid, mock_input):
         mock_input.side_effect = ["9000", "1"]
@@ -249,7 +249,7 @@ class TestMigration(SubManFixture):
         mock_get.return_value = "subscription.example.com"
         self.assertFalse(migrate.is_hosted())
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     @patch("getpass.getpass", autospec=True)
     def test_authenticate(self, mock_getpass, mock_input):
         mock_input.return_value = "username"
@@ -263,7 +263,7 @@ class TestMigration(SubManFixture):
         self.assertEqual(creds.username, "username")
         self.assertEqual(creds.password, "password")
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     @patch("getpass.getpass", autospec=True)
     def test_get_auth_with_serverurl(self, mock_getpass, mock_input):
         self.engine.options = self.create_options(destination_url='foobar')
@@ -277,7 +277,7 @@ class TestMigration(SubManFixture):
         self.assertEqual(self.engine.destination_creds.username, "destination_username")
         self.assertEqual(self.engine.destination_creds.password, "destination_password")
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     @patch("getpass.getpass", autospec=True)
     def test_get_auth_without_serverurl_and_not_hosted(self, mock_getpass, mock_input):
         self.engine.options = self.create_options()
@@ -292,7 +292,7 @@ class TestMigration(SubManFixture):
         self.assertEqual(self.engine.destination_creds.username, "destination_username")
         self.assertEqual(self.engine.destination_creds.password, "destination_password")
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     @patch("getpass.getpass", autospec=True)
     def test_get_auth_without_serverurl_and_is_hosted(self, mock_getpass, mock_input):
         self.engine.options = self.create_options()
@@ -343,7 +343,7 @@ class TestMigration(SubManFixture):
         self.assertEqual(self.engine.destination_creds.username, "destination_username")
         self.assertEqual(self.engine.destination_creds.password, "destination_password")
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     @patch("getpass.getpass", autospec=True)
     def test_gets_destination_auth_in_keep_state(self, mock_getpass, mock_input):
         self.engine.options = self.create_options(
@@ -620,7 +620,7 @@ class TestMigration(SubManFixture):
         org = self.engine.get_org("some_username")
         self.assertEqual(org, "my_org")
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     def test_enter_org_key(self, mock_input):
         self.engine.options = self.create_options()
         self.engine.cp.getOwnerList = MagicMock()
@@ -632,7 +632,7 @@ class TestMigration(SubManFixture):
         org = self.engine.get_org("some_username")
         self.assertEqual(org, "my_org")
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     def test_enter_org_name(self, mock_input):
         self.engine.options = self.create_options()
         self.engine.cp.getOwnerList = MagicMock()
@@ -644,7 +644,7 @@ class TestMigration(SubManFixture):
         org = self.engine.get_org("some_username")
         self.assertEqual(org, "my_org")
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     def test_enter_bad_org(self, mock_input):
         self.engine.options = self.create_options()
         self.engine.cp.getOwnerList = MagicMock()
@@ -713,7 +713,7 @@ class TestMigration(SubManFixture):
         env = self.engine.get_environment("some_org")
         self.assertEqual(env, "My Environment")
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     def test_enter_environment_name(self, mock_input):
         self.engine.options = self.create_options()
         self.engine.cp.supports_resource = MagicMock()
@@ -729,7 +729,7 @@ class TestMigration(SubManFixture):
         env = self.engine.get_environment("some_org")
         self.assertEqual(env, "My Environment")
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     def test_enter_environment_label(self, mock_input):
         self.engine.options = self.create_options()
         self.engine.cp.supports_resource = MagicMock()
@@ -745,7 +745,7 @@ class TestMigration(SubManFixture):
         env = self.engine.get_environment("some_org")
         self.assertEqual(env, "My Environment")
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     def test_enter_environment_displayName(self, mock_input):
         self.engine.options = self.create_options()
         self.engine.cp.supports_resource = MagicMock()
@@ -761,7 +761,7 @@ class TestMigration(SubManFixture):
         env = self.engine.get_environment("some_org")
         self.assertEqual(env, "My Environment")
 
-    @patch("__builtin__.raw_input", autospec=True)
+    @patch("six.moves.input")
     def test_enter_bad_environment(self, mock_input):
         self.engine.options = self.create_options()
         self.engine.cp.supports_resource = MagicMock()

--- a/test/test_po_files.py
+++ b/test/test_po_files.py
@@ -5,19 +5,14 @@ try:
 except ImportError:
     import unittest
 
-import gettext
 from . import fixture
 
 from subscription_manager import managercli
 from subscription_manager.printing_utils import to_unicode_or_bust
 
-# Localization domain:
-APP = "rhsm"
-DIR = "/usr/share/locale"
-gettext.bindtextdomain(APP, DIR)
-gettext.textdomain(APP)
-
-_ = gettext.gettext
+import gettext
+from subscription_manager import i18n
+_ = gettext.translation(i18n.APP, fallback=True).ugettext
 
 
 class TestLocale(unittest.TestCase):

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -152,7 +152,6 @@ class RepoActionReportTests(fixture.SubManFixture):
         deleted_section_2 = u'一些回購名稱'
         report.repo_deleted = [deleted_section, deleted_section_2]
 
-        # okay as long as no UnicodeErrors
         str(report)
 
         with fixture.locale_context('de_DE.utf8'):


### PR DESCRIPTION
Because we don't control initial-setup, the previous fix did not help
with initial-setup. (We can't change defaultencoding for initial-setup).

The gettext.gettext function returns bytes (i.e. a `str` in Python 2 and
`bytes` in Python 3).  We want unicode instead (i.e. `unicode` in Python
2 and `str` in Python 3) that we will encode for output later.  This
commit also fixes a couple of failing tests that were mixing unicode and
bytes together.
    
See
https://www.wefearchange.org/2012/06/the-right-way-to-internationalize-your.html
    
khowell's notes:
 - cherry-picked from d1cb4f44ea70b46a18c7cea5e19a8fc032864873
 - manually wrote `__str__` in src/subscription_manager/repolib.py to
avoid six dependency (for now)
 - added fixup for registergui - setting the property in __init__.py

I had to change how the register button is set in registergui, because
PyGTK did not like having the default value for a property from unicode,
but was okay with taking unicode later on...

Please verify by installing the changes and invoking `sudo
/usr/libexec/initial-setup/run-initial-setup`. (Might need to install
subscription-manager-initial-setup-addon rpm first, etc).