### PR TITLE
1365472: Add mnemonic for subscription-manager spoke

### DIFF
--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
@@ -51,7 +51,7 @@ class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
     helpFile = "SubscriptionManagerSpoke.xml"
     category = SystemCategory
     icon = "subscription-manager"
-    title = "Subscription Manager"
+    title = "_Subscription Manager"
 
     def __init__(self, data, storage, payload, instclass):
         NormalSpoke.__init__(self, data, storage, payload, instclass)


### PR DESCRIPTION
This allows you to press Alt+S in initial-setup to go directly into
subscription-manager registergui.