### PR TITLE
1448501: subman gui can unregister, when network is up again

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -60,6 +60,7 @@ from subscription_manager.gui.mysubstab import MySubscriptionsTab
 from subscription_manager.gui.preferences import PreferencesDialog
 from subscription_manager.gui.utils import handle_gui_exception, linkify
 from subscription_manager.gui.reposgui import RepositoriesDialog
+from subscription_manager.gui.networkConfig import reset_resolver
 from subscription_manager.overrides import Overrides
 from subscription_manager.cli import system_exit
 
@@ -472,6 +473,7 @@ class MainWindow(widgets.SubmanBaseWidget):
 
     def _perform_unregister(self):
         try:
+            reset_resolver()
             managerlib.unregister(self.backend.cp_provider.get_consumer_auth_cp(), self.identity.uuid)
         except Exception as e:
             log.error("Error unregistering system with entitlement platform.")

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -52,6 +52,7 @@ from subscription_manager.gui.autobind import DryRunResult, \
         ServiceLevelNotSupportedException, AllProductsCoveredException, \
         NoProductsException
 from subscription_manager.jsonwrapper import PoolWrapper
+from subscription_manager.gui.networkConfig import reset_resolver
 
 _ = lambda x: gettext.ldgettext("rhsm", x)
 
@@ -97,33 +98,6 @@ class RemoteUnregisterException(Exception):
     This exception is to be used when we are unable to unregister from the server.
     """
     pass
-
-
-# from old smolt code.. Force glibc to call res_init()
-# to rest the resolv configuration, including reloading
-# resolv.conf. This attempt to handle the case where we
-# start up with no networking, fail name resolution calls,
-# and cache them for the life of the process, even after
-# the network starts up, and for dhcp, updates resolv.conf
-def reset_resolver():
-    """Attempt to reset the system hostname resolver.
-    returns 0 on success, or -1 if an error occurs."""
-    try:
-        import ctypes
-        try:
-            resolv = ctypes.CDLL("libc.so.6")
-            r = resolv.__res_init()
-        except (OSError, AttributeError):
-            log.warn("could not find __res_init in libc.so.6")
-            r = -1
-        return r
-    except ImportError:
-        # If ctypes isn't supported (older versions of python for example)
-        # Then just don't do anything
-        pass
-    except Exception as e:
-        log.warning("reset_resolver failed: %s", e)
-        pass
 
 
 def server_info_from_config(config):


### PR DESCRIPTION
* When subman gui is started without working network, then
  file /etc/resolv.conf does not include any record for
  DNS server. When network is up again, then glibc does not
  reread this file automaticaly and function getaddrinfo()
  fails. It is necessary to reread this file explicitly
  using reset_resolver()
* I tried to triger reset_resolver() using D-Bus signals
  from NetworkManager, but it didn't work in subman-gui
  for some reason. Simple example of this approach is in
  this gist:

https://gist.github.com/jirihnidek/4759643a12abcd5d39f41d9d206512d5

* More information about reseting resolv.conf:

https://stackoverflow.com/questions/30360029/if-getaddrinfo-fails-once-it-fails-forever-even-after-network-is-ready