### PR TITLE
1452075: print only readable SSL error to console

### DIFF
--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -74,7 +74,7 @@ class ExceptionMapper(object):
         return message_template % bad_ca_cert_error.cert_path
 
     def format_ssl_error(self, ssl_error, message_template):
-        return message_template % str(ssl_error)
+        return message_template % ssl_error
 
     def format_restlib_exception(self, restlib_exception, message_template):
         return restlib_exception.msg

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -163,7 +163,7 @@ CONSUMED_LIST = [
 ]
 
 
-def handle_exception(msg, ex, map_message=True):
+def handle_exception(msg, ex):
 
     # On Python 2.4 and earlier, sys.exit triggers a SystemExit exception,
     # which can land us into this block of code. We do not want to handle
@@ -180,11 +180,9 @@ def handle_exception(msg, ex, map_message=True):
     log.exception(ex)
 
     exception_mapper = ExceptionMapper()
-    mapped_message = None
-    if map_message:
-        mapped_message = exception_mapper.get_message(ex)
-    else:
-        mapped_message = msg % ex
+
+    mapped_message = exception_mapper.get_message(ex)
+
     if mapped_message:
         system_exit(os.EX_SOFTWARE, mapped_message)
     else:
@@ -1140,9 +1138,8 @@ class RegisterCommand(UserPassCommand):
             except ssl.SSLError as e:
                 # since the user can override serverurl for register, a common use case is to try to switch servers
                 # using register --force... However, this normally cannot successfully unregister since the servers
-                # are different... So, do not map the message as SSLError is more useful than its mapped message in
-                # debugging this use case (mapped message is misleading in this use case)
-                handle_exception("Unregister failed: %s", e, map_message=False)
+                # are different.
+                handle_exception("Unregister failed: %s", e)
             except Exception as e:
                 handle_exception("Unregister failed", e)
 


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1452075
* Print only readable part of SSL error to console
* When handling exception in register --force command, then do
  map_message to have nice error message.