### PR TITLE
1441397: added --noproxy for rhsm-debug auto-completion

### DIFF
--- a/etc-conf/rhsm-debug.completion.sh
+++ b/etc-conf/rhsm-debug.completion.sh
@@ -3,7 +3,7 @@
 # vim:ts=2:sw=2:et:
 
 # common options
-_rhsm_debug_common_opts="-h --help --proxy --proxyuser --proxypassword"
+_rhsm_debug_common_opts="-h --help --proxy --proxyuser --proxypassword --noproxy"
 
 # main complete function
 _rhsm_debug()


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1441397
* Forgot to add --noproxy bash completion for rhsm-debug in this PR: #1638