### PR TITLE
1392709: Display better error msg., when wrong proxy is set up

### DIFF
--- a/python-rhsm/src/rhsm/connection.py
+++ b/python-rhsm/src/rhsm/connection.py
@@ -529,9 +529,14 @@ class BaseRestLib(object):
                 if not id_cert.is_valid():
                     raise ExpiredIdentityCertException()
             raise
-        except socket.error as e:
-            if str(e)[-3:] == str(httplib.PROXY_AUTHENTICATION_REQUIRED):
-                raise ProxyException(e)
+        except socket.gaierror as err:
+            if self.proxy_hostname and self.proxy_port:
+                raise ProxyException("Unable to connect to: %s:%s %s "
+                                     % (self.proxy_hostname, self.proxy_port, err))
+            raise
+        except socket.error as err:
+            if str(err)[-3:] == str(httplib.PROXY_AUTHENTICATION_REQUIRED):
+                raise ProxyException(err)
             raise
         response = conn.getresponse()
         result = {

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -29,6 +29,7 @@ _ = gettext.gettext
 
 SOCKET_MESSAGE = _('Network error, unable to connect to server. Please see /var/log/rhsm/rhsm.log for more information.')
 NETWORK_MESSAGE = _('Network error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information.')
+PROXY_MESSAGE = _("Proxy error, unable to connect to proxy server.")
 UNAUTHORIZED_MESSAGE = _("Unauthorized: Invalid credentials for request.")
 FORBIDDEN_MESSAGE = _("Forbidden: Invalid credentials for request.")
 REMOTE_SERVER_MESSAGE = _("Remote server error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information.")
@@ -50,6 +51,7 @@ class ExceptionMapper(object):
         self.message_map = {
             socket_error: (SOCKET_MESSAGE, self.format_default),
             Disconnected: (SOCKET_MESSAGE, self.format_default),
+            connection.ProxyException: (PROXY_MESSAGE, self.format_default),
             connection.NetworkException: (NETWORK_MESSAGE, self.format_default),
             connection.UnauthorizedException: (UNAUTHORIZED_MESSAGE, self.format_default),
             connection.ForbiddenException: (FORBIDDEN_MESSAGE, self.format_default),


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1392709
* When connection to candlepin server is ended with socket.gaierror
  and proxy is configured, then raise ProxyException
* Added special message for ProxyExeption
* Small refactoring.