### PR TITLE
1457197: Env. variable no_proxy=* is not ignored

### DIFF
--- a/python-rhsm/src/rhsm/connection.py
+++ b/python-rhsm/src/rhsm/connection.py
@@ -241,11 +241,14 @@ def _fix_no_proxy():
 
     no_proxy = os.environ.get('no_proxy') or os.environ.get('NO_PROXY')
     if no_proxy is not None:
-        # Remove all leading white spaces and asterisks from items of no_proxy
-        no_proxy = ','.join([item.lstrip(' *') for item in no_proxy.split(',')])
-        # Save no_proxy back to 'no_proxy', because proxy_bypass_environment()
-        # tries to read 'no_proxy' first
-        os.environ['no_proxy'] = no_proxy
+        if no_proxy != '*':
+            # Remove all leading white spaces and asterisks from items of no_proxy
+            # except item containing only "*" (urllib supports alone asterisk).
+            no_proxy = ','.join([item.lstrip(' *') for item in no_proxy.split(',')])
+            # Save no_proxy back to 'no_proxy' and 'NO_PROXY'
+            os.environ['no_proxy'] = no_proxy
+            os.environ['NO_PROXY'] = no_proxy
+        log.debug('Environment variable NO_PROXY=%s will be used' % no_proxy)
 
 
 # FIXME: this is terrible, we need to refactor

--- a/python-rhsm/test/unit/connection-tests.py
+++ b/python-rhsm/test/unit/connection-tests.py
@@ -118,7 +118,8 @@ class ConnectionTests(unittest.TestCase):
 
     def test_order(self):
         # should follow the order: HTTPS, https, HTTP, http
-        with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host:4444', 'http_proxy': 'http://notme:orme@host:2222'}):
+        with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host:4444',
+                                       'http_proxy': 'http://notme:orme@host:2222'}):
             uep = UEPConnection(username="dummy", password="dummy",
                  handler="/Test/", insecure=True)
             self.assertEqual("u", uep.proxy_user)
@@ -165,8 +166,29 @@ class ConnectionTests(unittest.TestCase):
                                     handler='/test', insecure=True, no_proxy=host)
                 self.assertEqual(None, uep.proxy_hostname)
 
+    def test_no_proxy_with_one_asterisk_via_api(self):
+        """Test that API trumps env var with one asterisk and config."""
+        host = self.cp.host
+        port = self.cp.ssl_port
+
+        def mock_config(section, name):
+            if (section, name) == ('server', 'no_proxy'):
+                return 'foo.example.com'
+            if (section, name) == ('server', 'hostname'):
+                return host
+            if (section, name) == ('server', 'port'):
+                return port
+            return None
+
+        with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host',
+                                       'NO_PROXY': '*'}):
+            with patch.object(connection.config, 'get', mock_config):
+                uep = UEPConnection(username='dummy', password='dummy',
+                                    handler='/test', insecure=True, no_proxy=host)
+                self.assertEqual(None, uep.proxy_hostname)
+
     def test_no_proxy_with_asterisk_via_api(self):
-        """Test that API trumps env var and config."""
+        """Test that API trumps env var with asterisk and config."""
         host = self.cp.host
         port = self.cp.ssl_port
 
@@ -194,11 +216,36 @@ class ConnectionTests(unittest.TestCase):
                                 handler='/test', insecure=True)
             self.assertEqual(None, uep.proxy_hostname)
 
-    def test_no_proxy_with_asterisk_via_environment_variable(self):
-        """Test that env var no_proxy works."""
+    def test_NO_PROXY_with_one_asterisk_via_environment_variable(self):
+        """Test that env var NO_PROXY with only one asterisk works."""
+        with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host',
+                                       'NO_PROXY': '*'}):
+            uep = UEPConnection(username='dummy', password='dummy',
+                                handler='/test', insecure=True)
+            self.assertEqual(None, uep.proxy_hostname)
+
+    def test_no_proxy_with_one_asterisk_via_environment_variable(self):
+        """Test that env var no_proxy with only one asterisk works."""
+        with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host',
+                                       'no_proxy': '*'}):
+            uep = UEPConnection(username='dummy', password='dummy',
+                                handler='/test', insecure=True)
+            self.assertEqual(None, uep.proxy_hostname)
+
+    def test_NO_PROXY_with_asterisk_via_environment_variable(self):
+        """Test that env var NO_PROXY with asterisk works."""
         host = '*' + self.cp.host
         with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host',
                                        'NO_PROXY': host}):
+            uep = UEPConnection(username='dummy', password='dummy',
+                                handler='/test', insecure=True)
+            self.assertEqual(None, uep.proxy_hostname)
+
+    def test_no_proxy_with_asterisk_via_environment_variable(self):
+        """Test that env var no_proxy with asterisk works."""
+        host = '*' + self.cp.host
+        with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host',
+                                       'no_proxy': host}):
             uep = UEPConnection(username='dummy', password='dummy',
                                 handler='/test', insecure=True)
             self.assertEqual(None, uep.proxy_hostname)

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -273,7 +273,7 @@ def get_server_versions(cp, exception_on_timeout=False):
                 log.info("Server Versions: Error: consumer has been deleted, unable to check server version")
             else:
                 # a more useful error would be handy here
-                log.error(("Error while checking server version: %s") % e)
+                log.error("Error while checking server version: %s" % e)
 
             log.exception(e)
             cp_version = _("Unknown")


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1457197
* Command line argumnet --noproxy=* is not ignored too
* Added log.debug print with new content of NO_PROXY
* Added more unit tests covering no_proxy=* and some other
  cases: no_proxy/NO_PROXY
* Small refactoring