### PR TITLE
1457348: Use https for the redhat.com/forgot_password label.

### DIFF
--- a/src/subscription_manager/branding/redhat_branding.py
+++ b/src/subscription_manager/branding/redhat_branding.py
@@ -29,4 +29,4 @@ class Branding(object):
                 _("To learn more about RHN registration and technologies please consult this Knowledge Base Article: https://access.redhat.com/kb/docs/DOC-45563")
         self.REGISTERED_TO_BOTH_SUMMARY = _("RHN Classic and Red Hat Subscription Management")
         self.GUI_FORGOT_LOGIN_TIP = \
-                _("Tip: Forgot your login or password? Look it up at http://redhat.com/forgot_password")
+                _("Tip: Forgot your login or password? Look it up at https://redhat.com/forgot_password")

--- a/src/subscription_manager/gui/data/ui/credentials.ui
+++ b/src/subscription_manager/gui/data/ui/credentials.ui
@@ -163,7 +163,7 @@
                 <property name="hexpand">True</property>
                 <property name="xpad">1</property>
                 <property name="ypad">2</property>
-                <property name="label" translatable="yes">&lt;small&gt;Tip: Forgot your login or password? Look it up at http://redhat.com/forgot_password&lt;/small&gt;</property>
+                <property name="label" translatable="yes">&lt;small&gt;Tip: Forgot your login or password? Look it up at https://redhat.com/forgot_password&lt;/small&gt;</property>
                 <property name="use_markup">True</property>
                 <property name="wrap">True</property>
                 <property name="selectable">True</property>


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1457348