### PR TITLE
1459194: open Online Documentation, when env. var. LANG is unset

### DIFF
--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -569,7 +569,10 @@ class MainWindow(widgets.SubmanBaseWidget):
 
     def _get_online_doc_url(self):
         lang, encoding = locale.getdefaultlocale()
-        url = ONLINE_DOC_URL_TEMPLATE % (lang.replace("_", "-"))
+        if lang is not None:
+            url = ONLINE_DOC_URL_TEMPLATE % (lang.replace("_", "-"))
+        else:
+            url = ONLINE_DOC_FALLBACK_URL
         try:
             urllib.request.urlopen(url)
         except urllib.error.URLError:


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1459194
* When no LANG env. variable is set, then try to open default URL.