### PR TITLE
Adds a new vagrant box "opensuse42.2"

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,17 @@ export SUBMAN_RHSM_PASSWORD=password
 Note, however, since the registration is necessary to download RPMs to set up
 the VM for development, registering against a local candlepin might not be
 particularly useful (at least not for initial provisioning).
+
+Troubleshooting
+---------------
+
+If you are working inside one of the vagrant boxes and you find subscription-manager and/or
+subscription-manager-gui will not work with output that looks like the following:
+"Unable to find Subscription Manager module.
+Error: libssl.so.10: cannot open shared object file: No such file or directory"
+
+You should be able to run `vagrant provision [vm-name]` from the host machine to fix the issue.
+
+This issue can happen if the python-rhsm/build or python-rhsm/build_ext directories are copied to
+the virtual machine and the virtual machine provides different libraries than those available on
+the build host.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ Vagrant.configure("2") do |config|
     "centos7" => "centos/7",
     "centos6" => "centos/6",
     "fedora25" => "fedora/25-cloud-base",
+    "opensuse42.2" => "opensuse/openSUSE-42.2-x86_64",
   }
 
   extra_boxes_loaded = false
@@ -34,7 +35,8 @@ Vagrant.configure("2") do |config|
   config.ssh.forward_x11 = true
 
   # setup shared folder
-  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude:
+    "subscription-manager.egg-info, build, build_ext, python-rhsm/{build{,_ext}}"
 
   # Set up the hostmanager plugin to automatically configure host & guest hostnames
   if Vagrant.has_plugin?("vagrant-hostmanager")
@@ -52,6 +54,7 @@ Vagrant.configure("2") do |config|
       host.vm.provider :libvirt do |domain|
         domain.graphics_type = "spice"
         domain.video_type = "qxl"
+        domain.memory = 1024
       end
     end
   end

--- a/vagrant/roles/subman-devel/defaults/main.yml
+++ b/vagrant/roles/subman-devel/defaults/main.yml
@@ -2,3 +2,19 @@
 subman_checkout_dir: .
 subman_setup_hacking_environment: false
 subman_add_vagrant_candlepin_to_hosts: false
+distro_package_command: yum
+distro_specific_deps:
+    - tito
+    - git
+    - gcc
+    - make
+    - python-pip
+    - m2crypto
+    - python-ethtool
+    - librsvg2
+    - libxslt-devel
+    - dbus-x11
+    - python-dmidecode
+    - libselinux-python
+    - xorg-x11-server-Xvfb
+    - yum-utils

--- a/vagrant/roles/subman-devel/tasks/main.yml
+++ b/vagrant/roles/subman-devel/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: load distribution-specific vars
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution }}.yml"
+      paths: vars
+      skip: yes
+
 # workaround for https://github.com/ansible/ansible/pull/24179
 # FIXME remove when possible
 - name: configure rhsm hostname (rhel only)
@@ -44,26 +52,39 @@
   become: yes
   when: ansible_distribution == 'RedHat'
 
+- name: install spacewalk repo (openSUSE Leap)
+  get_url:
+    url: http://download.opensuse.org/repositories/systemsmanagement:/spacewalk/openSUSE_Leap_42.2/systemsmanagement:spacewalk.repo
+    dest: /etc/zypp/repos.d/
+  become: yes
+  when: ansible_distribution == 'openSUSE Leap'
+
+- name: Update vagrant env_keep to include DISPLAY (openSUSE Leap)
+  lineinfile:
+    dest: /etc/sudoers.d/vagrant
+    line: 'Defaults:vagrant  env_keep += "DISPLAY"'
+    state: present
+  become: yes
+  when: ansible_distribution == 'openSUSE Leap'
+
 - name: install non-pip/spec deps
   package:
     name: "{{ item }}"
     state: present
   become: yes
-  with_items:
-    - tito
-    - git
-    - gcc
-    - make
-    - python-pip
-    - m2crypto
-    - python-ethtool
-    - librsvg2
-    - libxslt-devel
-    - dbus-x11
-    - python-dmidecode
-    - libselinux-python
-    - xorg-x11-server-Xvfb
-    - yum-utils
+  with_items: "{{ distro_specific_deps }}"
+  when: distro_specific_deps is defined
+
+- name: install tito deps (openSUSE Leap)
+  pip:
+    name: blessings
+  become: yes
+  when: ansible_distribution == 'openSUSE Leap'
+
+- name: install tito (openSUSE Leap)
+  pip: name=git+https://github.com/kahowell/tito@suse#egg=tito state=present editable=false
+  become: yes
+  when: ansible_distribution == 'openSUSE Leap'
 
 - name: install deps for subscription-manager-gui (el6 only)
   yum:
@@ -79,16 +100,40 @@
 - name: install subscription-manager build deps
   command: yum-builddep -y {{ subman_checkout_dir }}/subscription-manager.spec
   become: yes
+  when: distro_specific_subman_build_deps is not defined
+
+- name: install distro specific subscription-manager build deps
+  package:
+    name: "{{ item }}"
+    state: present
+  become: yes
+  with_items: "{{ distro_specific_subman_build_deps}}"
+  when: distro_specific_subman_build_deps is defined
 
 - name: install python-rhsm build deps
   command: yum-builddep -y {{ subman_checkout_dir }}/python-rhsm/python-rhsm.spec
   become: yes
+  when: distro_specific_python_rhsm_build_deps is not defined
+
+- name: install distro specific python-rhsm build deps
+  package:
+    name: "{{ item }}"
+    state: present
+  become: yes
+  with_items: "{{ distro_specific_python_rhsm_build_deps }}"
+  when: distro_specific_python_rhsm_build_deps is defined
 
 - name: install python test deps
   pip:
     requirements: test-requirements.txt
     chdir: "{{ subman_checkout_dir }}"
   become: yes
+
+- name: clean python-rhsm build artifacts
+  command: make clean
+  args:
+    chdir: "{{ subman_checkout_dir }}/python-rhsm"
+  when: subman_setup_hacking_environment
 
 - name: build python-rhsm
   command: python setup.py build_ext --inplace
@@ -111,7 +156,7 @@
   when: subman_setup_hacking_environment
 
 - name: install subscription-manager (initial)
-  shell: yum install -y /tmp/tito/*/subscription-manager-[0-9]*
+  shell: "{{ distro_package_command }} install -y /tmp/tito/*/subscription-manager-[0-9]*"
   args:
     chdir: "{{ subman_checkout_dir }}"
     creates: /usr/lib*/python*/site-packages/subscription_manager

--- a/vagrant/roles/subman-devel/vars/openSUSE Leap.yml
+++ b/vagrant/roles/subman-devel/vars/openSUSE Leap.yml
@@ -1,0 +1,44 @@
+---
+distro_package_command: zypper
+distro_specific_deps:
+    - git
+    - python-dateutil
+    - python-iniparse
+    - python-bugzilla
+    - python-nose
+    - python-pip
+    - rpm-build
+    - gcc
+    - make
+    - python-m2crypto
+    - python-ethtool
+    - librsvg2
+    - libxslt-devel
+    - python-curses
+    - openssl-devel
+    - python-dmidecode
+    - gdk-pixbuf-loader-rsvg
+
+distro_specific_subman_build_deps:
+  - rpm-python
+  - python-devel
+  - python-setuptools
+  - gettext
+  - intltool
+  - libnotify-devel
+  - desktop-file-utils
+  - python-six
+  - lsb-release
+  - distribution-release
+  - scrollkeeper
+  - gconf2-devel
+  - dbus-1-glib-devel
+  - update-desktop-files
+  - libzypp
+  - gtk3-devel
+
+distro_specific_python_rhsm_build_deps:
+ - python-devel
+ - python-setuptools
+ - openssl-devel
+ - python-six


### PR DESCRIPTION
This adds a vagrant configuration for an openSUSE 42.2 box.

There are a number of differences between the openSUSE box and the others.
In this PR these differences are dealt with using the ansible_distribution var. Some tasks are run only when the ansible_distribution is 'openSUSE Leap'.

A future version of this might include tasks unique to a given distribution in a way much like the variables that are unique to a given distribution (that being in a separate file named for the distribution).

The new box can be created using the command 'vagrant up opensuse42.2'