### PR TITLE
1350402: Try to flush all outputs during exit process

### DIFF
--- a/bin/rct
+++ b/bin/rct
@@ -44,14 +44,15 @@ def main():
 if __name__ == '__main__':
     try:
         sys.exit(abs(main() or 0))
-    except SystemExit, e:
+    except SystemExit as err:
         # This is a non-exceptional exception thrown by Python 2.4, just
         # re-raise, bypassing handle_exception
         try:
             sys.stdout.flush()
+            sys.stderr.flush()
         except IOError:
             pass
-        raise e
+        raise err
     except KeyboardInterrupt:
         sys.stderr.write("\n" + _("User interrupted process."))
         sys.exit(0)

--- a/bin/rhn-migrate-classic-to-rhsm
+++ b/bin/rhn-migrate-classic-to-rhsm
@@ -65,9 +65,9 @@ try:
     from subscription_manager.managercli import handle_exception
 except KeyboardInterrupt:
     system_exit(0, "\nUser interrupted process.")
-except ImportError, e:
+except ImportError as err:
     system_exit(2, "Unable to find Subscription Manager module.\n"
-                  "Error: %s" % e)
+                   "Error: %s" % err)
 
 
 def main():
@@ -83,11 +83,11 @@ def main():
 if __name__ == '__main__':
     try:
         sys.exit(abs(main() or 0))
-    except SystemExit, e:
+    except SystemExit as sys_err:
         # this is a non-exceptional exception thrown by Python 2.4, just
         # re-raise, bypassing handle_exception
-        raise e
+        raise sys_err
     except KeyboardInterrupt:
         system_exit(0, "\nUser interrupted process.")
-    except Exception, e:
-        handle_exception("Exception caught in rhm-migrate-classic-to-rhsm", e)
+    except Exception as err:
+        handle_exception("Exception caught in rhm-migrate-classic-to-rhsm", err)

--- a/bin/rhsm-debug
+++ b/bin/rhsm-debug
@@ -45,9 +45,9 @@ try:
 
 except KeyboardInterrupt:
     system_exit(0, "\nUser interrupted process.")
-except ImportError, e:
+except ImportError as err:
     system_exit(2, "Unable to find Subscription Manager module.\n"
-                  "Error: %s" % e)
+                   "Error: %s" % err)
 
 # quick check to see if you are a super-user.
 if os.getuid() != 0:
@@ -62,20 +62,21 @@ def main():
 if __name__ == '__main__':
     try:
         sys.exit(abs(main() or 0))
-    except SystemExit, e:
-        #this is a non-exceptional exception thrown by Python 2.4, just
-        #re-raise, bypassing handle_exception
+    except SystemExit as sys_err:
+        # This is a non-exceptional exception thrown by Python 2.4, just
+        # re-raise, bypassing handle_exception
         try:
             sys.stdout.flush()
+            sys.stderr.flush()
         except IOError:
             pass
-        raise e
+        raise sys_err
     except KeyboardInterrupt:
         sys.stderr.write("\n" + _("User interrupted process."))
         sys.exit(0)
-    except Exception, e:
+    except Exception as err:
         # rhsm-debug can be invoked from sosreport/libreport/abrt, so
         # letting exceptions all the up to the system excepthook
         # can cause chaos (abrt handler gets called, invokes sosreport, etc)
-        sys.stderr.write("Error collecting rhsm-debug information: %s\n" % e)
+        sys.stderr.write("Error collecting rhsm-debug information: %s\n" % err)
         sys.exit(-1)

--- a/bin/sat5to6
+++ b/bin/sat5to6
@@ -65,9 +65,9 @@ try:
     from subscription_manager.managercli import handle_exception
 except KeyboardInterrupt:
     system_exit(0, "\nUser interrupted process.")
-except ImportError, e:
+except ImportError as err:
     system_exit(2, "Unable to find Subscription Manager module.\n"
-                  "Error: %s" % e)
+                   "Error: %s" % err)
 
 
 def main():

--- a/bin/subscription-manager
+++ b/bin/subscription-manager
@@ -39,7 +39,7 @@ if 'TERM' in os.environ:
 
 
 def system_exit(code, msgs=None):
-    "Exit with a code and optional message(s). Saved a few lines of code."
+    """Exit with a code and optional message(s). Saved a few lines of code."""
 
     if msgs:
         if type(msgs) not in [type([]), type(())]:
@@ -76,9 +76,9 @@ try:
 
 except KeyboardInterrupt:
     system_exit(0, "\nUser interrupted process.")
-except ImportError, e:
+except ImportError as err:
     system_exit(2, "Unable to find Subscription Manager module.\n"
-                  "Error: %s" % e)
+                   "Error: %s" % err)
 
 
 def main():
@@ -94,11 +94,11 @@ def main():
 if __name__ == '__main__':
     try:
         sys.exit(abs(main() or 0))
-    except SystemExit, e:
-        #this is a non-exceptional exception thrown by Python 2.4, just
-        #re-raise, bypassing handle_exception
-        raise e
+    except SystemExit as err:
+        # This is a non-exceptional exception thrown by Python 2.4, just
+        # re-raise, bypassing handle_exception
+        raise err
     except KeyboardInterrupt:
         system_exit(0, "\nUser interrupted process.")
-    except Exception, e:
+    except Exception as e:
         handle_exception("exception caught in subscription-manager", e)

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2824,7 +2824,14 @@ class ManagerCLI(CLI):
 
     def main(self):
         managerlib.check_identity_cert_perms()
-        return CLI.main(self)
+        ret = CLI.main(self)
+        # Try to flush all outputs, see BZ: 1350402
+        try:
+            sys.stdout.flush()
+            sys.stderr.flush()
+        except IOError as io_err:
+            log.error("Error: Unable to print data to stdout/stderr output during exit process: %s" % io_err)
+        return ret
 
 
 if __name__ == "__main__":

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -993,6 +993,11 @@ def main(args=None, five_to_six_script=False):
     set_defaults(options, five_to_six_script)
     validate_options(options)
     MigrationEngine(options).main()
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except IOError as io_err:
+        log.error("Error: Unable to print data to stdout/stderr output during exit process: %s" % io_err)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1350402
* When some output (stdout/stderr) of subscription-manager
  process is blocked (not listening piped process in this case),
  then try to flush it at end. When flushing is not possible,
  then write error message to rhsm.log.
* More details here:

  https://stackoverflow.com/questions/12790328/how-to-silence-sys-excepthook-is-missing-error