### PR TITLE
Output the hostname of the system that was registered along with the UUID

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1210,6 +1210,7 @@ class RegisterCommand(UserPassCommand):
         restart_virt_who()
 
         print((_("The system has been registered with ID: %s ")) % (consumer_info["uuid"]))
+        print(_("The registered system name is: %s") % consumer_info["consumer_name"])
 
         # get a new UEP as the consumer
         self.cp = self.cp_provider.get_consumer_auth_cp()

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -32,6 +32,7 @@ class CliRegistrationTests(SubManFixture):
 
     def stub_persist(self, consumer):
         self.persisted_consumer = consumer
+        self.persisted_consumer['consumer_name'] = 'foobar'
         return self.persisted_consumer
 
     def test_register_persists_consumer_cert(self):


### PR DESCRIPTION
This patch resolves BZ 1463325 which is a request for subscription-manager to output the hostname of the system that was registered along with the uuid.