### PR TITLE
1329349: Add subscription-manager plugin to yum-config-manager

### DIFF
--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -18,7 +18,7 @@ from __future__ import print_function, division, absolute_import
 #
 
 import os
-from yum.plugins import TYPE_CORE, TYPE_INTERACTIVE
+from yum.plugins import TYPE_CORE
 
 from subscription_manager import injection as inj
 from subscription_manager.repolib import RepoActionInvoker
@@ -31,7 +31,7 @@ from rhsm import connection
 from rhsm import config
 
 requires_api_version = '2.5'
-plugin_type = (TYPE_CORE, TYPE_INTERACTIVE)
+plugin_type = (TYPE_CORE,)
 
 # TODO: translate strings
 


### PR DESCRIPTION
`yum-config-manager` does not load plugins of type `TYPE_INTERACTIVE`.
According to http://yum.baseurl.org/wiki/WritingYumPlugins, `TYPE_INTERACTIVE`
indicates that a plugin may terminate yum early or output extra information.

We don't terminate yum... while we do provide some extra information, we do
similarly in the `product-id` plugin.

This change improves the user experience, by being able to use
`yum-config-manager` without first running a yum command to populate
redhat.repo.