### PR TITLE
1472715: Python module rhsm should never call exit()

### DIFF
--- a/python-rhsm/src/rhsm/certificate2.py
+++ b/python-rhsm/src/rhsm/certificate2.py
@@ -69,9 +69,8 @@ class _CertFactory(object):
         """
         try:
             pem = open(path, 'r').read()
-        except IOError as e:
-            print(os.strerror(e.errno))
-            exit(1)
+        except IOError as err:
+            raise CertificateException("Error loading certificate: %s" % err)
         return self._read_x509(_certificate.load(path), path, pem)
 
     def create_from_pem(self, pem, path=None):

--- a/python-rhsm/test/unit/certificate-tests.py
+++ b/python-rhsm/test/unit/certificate-tests.py
@@ -17,7 +17,14 @@ from __future__ import print_function, division, absolute_import
 
 import unittest
 
-from rhsm.certificate import Key, Content
+from rhsm.certificate import Key, Content, create_from_file, CertificateException
+
+
+class CertTest(unittest.TestCase):
+
+    def test_non_existent_file(self):
+        with self.assertRaises(CertificateException):
+            create_from_file("/foo/non_existent_cert.pem")
 
 
 class KeyTests(unittest.TestCase):


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1472715
* Noticed this, when I was working at PR for virt-who:
   https://github.com/virt-who/virt-who/pull/83
* The rhsm module has to reaise exception not call exit(),
  otherwise the application is not able to resurect from
  such situation.
* Added unit test for this case.