### PR TITLE
1461003: Deprecate --type option on register command

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -156,7 +156,7 @@ _subscription_manager_register()
 {
   local opts="--activationkey --auto-attach --autosubscribe --baseurl --consumerid
               --environment --force --name --org --password --release
-              --servicelevel --type --username
+              --servicelevel --username
               ${_subscription_manager_common_url_opts}
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -255,21 +255,6 @@ Registers the system to an environment within an organization.
 .B --release=VERSION
 Shortcut for "release --set=VERSION"
 
-.TP
-.B --type=CONSUMERTYPE
-Sets the type of unit to register. Most units in the inventory will use the default value of
-.B system.
-For development or test units, this can be
-.B person
-, which indicates a personal (rather than organizational) unit. Another type of unit can be
-.B candlepin
-for a local content service or
-.B domain
-for an IP domain.
-.B hypervisor
-indicates a host which will provide subscriptions to guest virtual machines.
-
-
 .SS UNREGISTER OPTIONS
 The
 .B unregister
@@ -878,17 +863,6 @@ provided with the registration request, registration fails with a remote server 
 .B rhsm.log,
 there will be errors about being unable to load the owners interface.
 
-
-.PP
-Some information is assigned automatically. Subscription Manager automatically generates a unique ID for the system which is used by the subscription management service and it assigns a unit type, which indicates what kinds of software are available for the system. The name for the entry can be manually assigned (for use within an on-premise subscription service, for instance). A handful of subscriptions (such as specialized servers for content or identity management) have their own specific unit type. For example:
-
-.RS
-.nf
-subscription-manager register --username=admin
---password=secret --type=system --name=server1
---org="IT Dept"
-.fi
-.RE
 
 .PP
 If a system is registered and then somehow its subscription information is lost -- a drive crashes or the certificates are deleted or corrupted -- the system can be re-registered, with all of its subscriptions restored, by registering with the existing ID.

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -22,7 +22,7 @@ import fileinput
 import fnmatch
 import getpass
 import logging
-from optparse import OptionValueError
+from optparse import OptionValueError, SUPPRESS_HELP
 import os
 import re
 import readline
@@ -1025,7 +1025,7 @@ class RegisterCommand(UserPassCommand):
         self.parser.add_option("--baseurl", dest="base_url",
                               default=None, help=_("base URL for content in form of https://hostname:port/prefix"))
         self.parser.add_option("--type", dest="consumertype", default="system", metavar="UNITTYPE",
-                               help=_("the type of unit to register, defaults to system"))
+                               help=SUPPRESS_HELP)
         self.parser.add_option("--name", dest="consumername", metavar="SYSTEMNAME",
                                help=_("name of the system to register, defaults to the hostname"))
         self.parser.add_option("--consumerid", dest="consumerid", metavar="SYSTEMID",
@@ -1070,6 +1070,8 @@ class RegisterCommand(UserPassCommand):
             system_exit(os.EX_USAGE, _("Error: Must provide --org with activation keys."))
         elif (self.options.force and self.options.consumerid):
             system_exit(os.EX_USAGE, _("Error: Can not force registration while attempting to recover registration with consumerid. Please use --force without --consumerid to re-register or use the clean command and try again without --force."))
+        elif (self.options.consumertype and not (self.options.consumertype == 'rhui' or self.options.consumertype == 'system')):
+            system_exit(os.EX_USAGE, _("Error: The --type option has been deprecated and may not be used."))
 
     def persist_server_options(self):
         """

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -196,3 +196,15 @@ class CliRegistrationTests(SubManFixture):
 
             with nested(Capture(silent=True), self.assertRaises(SystemExit)):
                 rc._get_environment_id(mock_uep, 'owner', None)
+
+    def test_deprecate_consumer_type(self):
+        with patch('rhsm.connection.UEPConnection', new_callable=StubUEP) as mock_uep:
+            self.stub_cp_provider.basic_auth_cp = mock_uep
+
+            cmd = RegisterCommand()
+            self._inject_mock_invalid_consumer()
+            cmd._persist_identity_cert = self.stub_persist
+
+            with nested(Capture(silent=True), self.assertRaises(SystemExit)) as e:
+                cmd.main(['register', '--type=candlepin'])
+                self.assertEqual(e.code, os.EX_USAGE)


### PR DESCRIPTION
still allows the default of 'system' and the option 'rhui'.
does not show in help.