### PR TITLE
Add jasmine & placeholder unit/integration tests

### DIFF
--- a/cockpit/package.json
+++ b/cockpit/package.json
@@ -8,6 +8,7 @@
   "license": "LGPL-2.1",
   "scripts": {
     "build": "webpack",
+    "jasmine": "jasmine",
     "vagrant-watch": "webpack --watch & vagrant rsync-auto",
     "watch": "webpack --watch"
   },
@@ -22,6 +23,7 @@
     "eslint": "^3.0.0",
     "eslint-loader": "~1.6.1",
     "eslint-plugin-react": "~6.9.0",
+    "jasmine": "^2.7.0",
     "jshint": "~2.9.1",
     "jshint-loader": "~0.8.3",
     "patternfly-react": "https://github.com/candlepin/patternfly-react",

--- a/cockpit/spec/DummySpec.js
+++ b/cockpit/spec/DummySpec.js
@@ -1,0 +1,5 @@
+describe("FIXME: placeholder test!", function() {
+    it("needs to be replaced with a real test", function() {
+        expect(false).toBe(true);
+    });
+});

--- a/cockpit/spec/dbus/DBusSpecRunner.html
+++ b/cockpit/spec/dbus/DBusSpecRunner.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Jasmine Spec Runner v2.7.0</title>
+
+  <link rel="stylesheet" href="jasmine/jasmine.css">
+
+  <!-- NOTE: These scripts need to be loaded here and not as imports in the spec files.
+       The load order has to be as follows.  If you try to import these, the load order
+       can be messed up.  I suspect that in webpack in the browser, it uses asynchronous
+       loading, but since we don't specify defer or async in the script tag, these files
+       load synchronously -->
+  <script src="jasmine/jasmine.js"></script>
+  <script src="jasmine/jasmine-html.js"></script>
+  <script src="jasmine/boot.js"></script>
+
+  <script src="../base1/cockpit.js"></script>
+</head>
+
+<body>
+  <!-- include bundled spec files here...
+       Note that webpack.config.js now has two entry points.  One for the main app, and
+       another for testing.  -->
+  <script src="dbus-testing.js"></script>
+  Running integration tests
+</body>
+</html>

--- a/cockpit/spec/dbus/dbus.test.js
+++ b/cockpit/spec/dbus/dbus.test.js
@@ -1,0 +1,11 @@
+const cockpit = require("cockpit");
+const service = cockpit.dbus("com.redhat.RHSM1", {"superuser": "require"})
+
+describe("Check that we can Register with subscription-manager", function() {
+
+    it("Should create a unix socket when we register", function() {
+        let proxy = service.proxy("com.redhat.RHSM1.RegisterServer", "/com/redhat/RHSM1/RegisterServer");
+        let start = proxy.Start();
+        start.state();
+    });
+});

--- a/cockpit/spec/dbus/override.json
+++ b/cockpit/spec/dbus/override.json
@@ -1,0 +1,8 @@
+{
+  "tools": {
+    "dbus": {
+      "label": "DBus Testing",
+      "path": "DBusSpecRunner.html"
+    }
+  }
+}

--- a/cockpit/spec/dbus/utils.js
+++ b/cockpit/spec/dbus/utils.js
@@ -1,0 +1,20 @@
+//@flow
+import "../.,/base1/cockpit"
+
+export function startRegister() {
+    const service = cockpit.dbus("com.redhat.RHSM1", {"superuser": "require"});
+
+    let proxy = service.proxy("com.redhat.RHSM1.RegisterServer", "/com/redhat/RHSM1/RegisterServer");
+    let start = proxy.Start();
+    start.state();
+
+    function handler(result) {
+        console.log(result);
+        return result;
+    }
+
+    function err_handler(err) { 
+        console.log(err);
+    }
+    return start.done(handler).fail(err_handler);
+}

--- a/cockpit/spec/support/jasmine.json
+++ b/cockpit/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/cockpit/webpack.config.js
+++ b/cockpit/webpack.config.js
@@ -23,13 +23,19 @@ var info = {
         "index": [
             "./index.js",
             "./subscriptions.css",
-        ]
+        ],
     },
     files: [
         "index.html",
         "manifest.json",
     ],
 };
+
+if (!production) {
+    info.entries["dbus-testing"] = [
+      "spec/dbus/dbus.test.js"
+    ]
+}
 
 var output = {
     path: distdir,
@@ -85,6 +91,36 @@ var plugins = [
     }),
     new copy(info.files)
 ];
+
+if (!production) {
+    /* copy jasmine files over */
+    plugins.unshift(new copy([
+        {
+            from: './spec/dbus/override.json',
+            to: 'override.json'
+        },
+        {
+            from: './spec/dbus/DBusSpecRunner.html',
+            to: 'DBusSpecRunner.html'
+        },
+        {
+            from: './node_modules/jasmine-core/lib/jasmine-core/jasmine.css',
+            to: 'jasmine/jasmine.css'
+        },
+        {
+            from: './node_modules/jasmine-core/lib/jasmine-core/jasmine.js',
+            to: 'jasmine/jasmine.js',
+        },
+        {
+            from: './node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js',
+            to: 'jasmine/jasmine-html.js'
+        },
+        {
+            from: './node_modules/jasmine-core/lib/jasmine-core/boot.js',
+            to: 'jasmine/boot.js'
+        }
+    ]));
+}
 
 /* Only minimize when in production mode */
 if (production) {

--- a/cockpit/yarn.lock
+++ b/cockpit/yarn.lock
@@ -1633,7 +1633,7 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
-exit@0.1.2, exit@0.1.x:
+exit@0.1.2, exit@0.1.x, exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
 
@@ -1867,7 +1867,7 @@ glob@^6.0.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -2270,6 +2270,18 @@ isomorphic-fetch@^2.1.1:
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+
+jasmine-core@~2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.8.0.tgz#bcc979ae1f9fd05701e45e52e65d3a5d63f1a24e"
+
+jasmine@^2.7.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-2.8.0.tgz#6b089c0a11576b1f16df11b80146d91d4e8b8a3e"
+  dependencies:
+    exit "^0.1.2"
+    glob "^7.0.6"
+    jasmine-core "~2.8.0"
 
 js-base64@^2.1.9:
   version "2.1.9"


### PR DESCRIPTION
Run unit tests via `npm run jasmine`

See integration tests via vagrant (see DBus Testing page).

Integration tests have access to a live instance of cockpit.

Original work for D-Bus testing page comes from stoner (@rarebreed).

Unit tests are declared in files that end in [sS]pec.

Integration tests are included in dbus-testing.js via webpack.