### PR TITLE
D-Bus service for removing pools (all/ID/serial num.)

### DIFF
--- a/src/rhsmlib/dbus/objects/attach.py
+++ b/src/rhsmlib/dbus/objects/attach.py
@@ -68,8 +68,9 @@ class AttachDBusObject(base_object.BaseObject):
     @util.dbus_handle_exceptions
     def PoolAttach(self, pools, quantity, proxy_options, sender=None):
         self.ensure_registered()
-        pools = dbus_utils.dbus_to_python(pools, list)
-        quantity = dbus_utils.dbus_to_python(quantity, int)
+        pools = dbus_utils.dbus_to_python(pools, expected_type=list)
+        quantity = dbus_utils.dbus_to_python(quantity, expected_type=int)
+        proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
 
         if quantity < 1:
             raise dbus.DBusException("Quantity must be a positive number.")

--- a/src/rhsmlib/dbus/objects/entitlement.py
+++ b/src/rhsmlib/dbus/objects/entitlement.py
@@ -30,6 +30,10 @@ log = logging.getLogger(__name__)
 
 
 class EntitlementDBusObject(base_object.BaseObject):
+    """
+    A D-Bus object interacting with subscription-manager to list, get status
+    and remove pools.
+    """
     default_dbus_path = constants.ENTITLEMENT_DBUS_PATH
     interface_name = constants.ENTITLEMENT_INTERFACE
 
@@ -43,6 +47,12 @@ class EntitlementDBusObject(base_object.BaseObject):
     )
     @util.dbus_handle_exceptions
     def GetStatus(self, on_date, sender=None):
+        """
+        Get status of entitlements
+        :param on_date: Date
+        :param sender: Not used argument
+        :return: String with JSON dump
+        """
         try:
             on_date = dbus_utils.dbus_to_python(on_date)
             if on_date == "":
@@ -65,6 +75,13 @@ class EntitlementDBusObject(base_object.BaseObject):
     )
     @util.dbus_handle_exceptions
     def GetPools(self, options, proxy_options, sender=None):
+        """
+        Try to get pools installed/available/consumed at this system
+        :param options: D-Bus object storing options of query
+        :param proxy_options: D-Bus object with proxy configuration
+        :param sender: Not used argument
+        :return: String with JSON dump
+        """
         options = dbus_utils.dbus_to_python(options, expected_type=dict)
         proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
 
@@ -81,3 +98,68 @@ class EntitlementDBusObject(base_object.BaseObject):
         on_date = datetime.strptime(on_date, '%Y-%m-%d')
         if on_date.date() < datetime.now().date():
             raise dbus.DBusException("Past dates are not allowed")
+
+    @util.dbus_service_method(
+        constants.ENTITLEMENT_INTERFACE,
+        in_signature='a{sv}',
+        out_signature='s'
+    )
+    @util.dbus_handle_exceptions
+    def RemoveAllEntitlements(self, proxy_options, sender=None):
+        """
+        Try to remove all entitlements (subscriptions) from the system
+        :param proxy_options: Settings of proxy
+        :param sender: Not used argument
+        :return: Json string containing response
+        """
+        proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
+        cp = self.build_uep(proxy_options, proxy_only=True)
+        entitlement_service = EntitlementService(cp)
+        result = entitlement_service.remove_all_entitlements()
+        return json.dumps(result)
+
+    @util.dbus_service_method(
+        constants.ENTITLEMENT_INTERFACE,
+        in_signature='asa{sv}',
+        out_signature='s'
+    )
+    @util.dbus_handle_exceptions
+    def RemoveEntitlementsByPoolIds(self, pool_ids, proxy_options, sender=None):
+        """
+        Try to remove entitlements (subscriptions) by pool_ids
+        :param pool_ids: List of pool IDs
+        :param proxy_options: Settings of proxy
+        :param sender: Not used argument
+        :return: Json string representing list of serial numbers
+        """
+        pool_ids = dbus_utils.dbus_to_python(pool_ids, expected_type=list)
+        proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
+
+        cp = self.build_uep(proxy_options, proxy_only=True)
+        entitlement_service = EntitlementService(cp)
+        removed_pools, unremoved_pools, removed_serials = entitlement_service.remove_entilements_by_pool_ids(pool_ids)
+
+        return json.dumps(removed_serials)
+
+    @util.dbus_service_method(
+        constants.ENTITLEMENT_INTERFACE,
+        in_signature='asa{sv}',
+        out_signature='s'
+    )
+    @util.dbus_handle_exceptions
+    def RemoveEntitlementsBySerials(self, serials, proxy_options, sender=None):
+        """
+        Try to remove entitlements (subscriptions) by serials
+        :param serials: List of serial numbers of subscriptions
+        :param proxy_options: Settings of proxy
+        :param sender: Not used argument
+        :return: Json string representing list of serial numbers
+        """
+        serials = dbus_utils.dbus_to_python(serials, expected_type=list)
+        proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
+
+        cp = self.build_uep(proxy_options, proxy_only=True)
+        entitlement_service = EntitlementService(cp)
+        removed_serials, unremoved_serials = entitlement_service.remove_entitlements_by_serials(serials)
+
+        return json.dumps(removed_serials)

--- a/src/rhsmlib/dbus/objects/products.py
+++ b/src/rhsmlib/dbus/objects/products.py
@@ -52,7 +52,8 @@ class ProductsDBusObject(base_object.BaseObject):
         init_dep_injection()
 
         self.ensure_registered()
-        filter_string = dbus_utils.dbus_to_python(filter_string, str)
+        filter_string = dbus_utils.dbus_to_python(filter_string, expected_type=str)
+        proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
 
         cp = self.build_uep(proxy_options, proxy_only=True)
 

--- a/src/rhsmlib/dbus/objects/unregister.py
+++ b/src/rhsmlib/dbus/objects/unregister.py
@@ -23,7 +23,7 @@ system from Candlepin server.
 import dbus
 import logging
 
-from rhsmlib.dbus import constants, base_object, util
+from rhsmlib.dbus import constants, base_object, util, dbus_utils
 from rhsmlib.services.unregister import UnregisterService
 
 from subscription_manager.injectioninit import init_dep_injection
@@ -56,6 +56,7 @@ class UnregisterDBusObject(base_object.BaseObject):
         :param proxy_options: Definition of proxy settings
         :param sender: Not used argument
         """
+        proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
 
         self.ensure_registered()
 

--- a/src/rhsmlib/services/entitlement.py
+++ b/src/rhsmlib/services/entitlement.py
@@ -12,6 +12,7 @@ from __future__ import print_function, division, absolute_import
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
+
 import collections
 import datetime
 import logging
@@ -20,9 +21,11 @@ import six
 from subscription_manager import injection as inj
 from subscription_manager.i18n import ugettext as _
 from subscription_manager import managerlib, utils
+from subscription_manager.entcertlib import EntCertActionInvoker
 
 from rhsm import certificate
 from rhsmlib.services import exceptions, products
+import rhsm.connection as connection
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +36,7 @@ class EntitlementService(object):
         self.identity = inj.require(inj.IDENTITY)
         self.product_dir = inj.require(inj.PROD_DIR)
         self.entitlement_dir = inj.require(inj.ENT_DIR)
+        self.entcertlib = EntCertActionInvoker()
 
     def get_status(self, on_date=None):
         sorter = inj.require(inj.CERT_SORTER, on_date)
@@ -45,7 +49,7 @@ class EntitlementService(object):
             return {'status': 'Unknown', 'reasons': {}, 'valid': False}
 
     def get_pools(self, pool_subsets=None, matches=None, pool_only=None, match_installed=None,
-            no_overlap=None, service_level=None, show_all=None, on_date=None, **kwargs):
+                  no_overlap=None, service_level=None, show_all=None, on_date=None, **kwargs):
         # We accept a **kwargs argument so that the DBus object can pass whatever dictionary it receives
         # via keyword expansion.
         if kwargs:
@@ -107,6 +111,10 @@ class EntitlementService(object):
         pooltype_cache = inj.require(inj.POOLTYPE_CACHE)
 
         consumed_statuses = []
+        # FIXME: the cache of CertificateDirectory should be smart enough and refreshing
+        # should not be necessary. When new certificate is installed/deleted and rhsm-service
+        # is running, then list of certificate is not automatically refreshed ATM.
+        self.entitlement_dir.refresh()
         certs = self.entitlement_dir.list()
         cert_filter = utils.EntitlementCertificateFilter(filter_string=matches, service_level=service_level)
 
@@ -197,7 +205,7 @@ class EntitlementService(object):
         return consumed_statuses
 
     def get_available_pools(self, show_all=None, on_date=None, no_overlap=None,
-            match_installed=None, matches=None, service_level=None, **kwargs):
+                            match_installed=None, matches=None, service_level=None, **kwargs):
         available_pools = managerlib.get_available_entitlements(
             get_all=show_all,
             active_on=on_date,
@@ -219,24 +227,101 @@ class EntitlementService(object):
 
     def validate_options(self, options):
         if not set(['installed', 'consumed', 'available']).issuperset(options['pool_subsets']):
-            raise exceptions.ValidationError(_('Error: invalid listing type provided.  Only "installed", '
-                '"consumed", or "available" are allowed'))
+            raise exceptions.ValidationError(
+                _('Error: invalid listing type provided.  Only "installed", '
+                  '"consumed", or "available" are allowed')
+            )
         if options['show_all'] and 'available' not in options['pool_subsets']:
-            raise exceptions.ValidationError(_("Error: --all is only applicable with --available"))
+            raise exceptions.ValidationError(
+                _("Error: --all is only applicable with --available")
+            )
         elif options['on_date'] and 'available' not in options['pool_subsets']:
-            raise exceptions.ValidationError(_("Error: --ondate is only applicable with --available"))
+            raise exceptions.ValidationError(
+                _("Error: --ondate is only applicable with --available")
+            )
         elif options['service_level'] is not None \
                 and not set(['consumed', 'available']).intersection(options['pool_subsets']):
-            raise exceptions.ValidationError(_("Error: --servicelevel is only applicable with --available "
-                "or --consumed"))
+            raise exceptions.ValidationError(
+                _("Error: --servicelevel is only applicable with --available or --consumed")
+            )
         elif options['match_installed'] and 'available' not in options['pool_subsets']:
-            raise exceptions.ValidationError(_("Error: --match-installed is only applicable with "
-                "--available"))
+            raise exceptions.ValidationError(
+                _("Error: --match-installed is only applicable with --available")
+            )
         elif options['no_overlap'] and 'available' not in options['pool_subsets']:
-            raise exceptions.ValidationError(_("Error: --no-overlap is only applicable with --available"))
+            raise exceptions.ValidationError(
+                _("Error: --no-overlap is only applicable with --available")
+            )
         elif options['pool_only'] \
                 and not set(['consumed', 'available']).intersection(options['pool_subsets']):
-            raise exceptions.ValidationError(_("Error: --pool-only is only applicable with --available "
-                "and/or --consumed"))
+            raise exceptions.ValidationError(
+                _("Error: --pool-only is only applicable with --available and/or --consumed")
+            )
         elif not self.identity.is_valid() and 'available' in options['pool_subsets']:
             raise exceptions.ValidationError(_("Error: this system is not registered"))
+
+    def _unbind_ids(self, unbind_method, consumer_uuid, ids):
+        """
+        Method for unbinding entitlements
+        :param unbind_method: unbindByPoolId or unbindBySerial
+        :param consumer_uuid: UUID of consumer
+        :param ids: List of serials or pool_ids
+        :return: Tuple of two lists containing unbinded and not-unbinded subscriptions
+        """
+        success = []
+        failure = []
+        for id_ in ids:
+            try:
+                unbind_method(consumer_uuid, id_)
+                success.append(id_)
+            except connection.RestlibException as re:
+                if re.code == 410:
+                    raise
+                failure.append(id_)
+                log.error(re)
+        return success, failure
+
+    def remove_all_entitlements(self):
+        """
+        Try to remove all entilements
+        :return: Result of REST API call
+        """
+
+        response = self.cp.unbindAll(self.identity.uuid)
+        self.entcertlib.update()
+
+        return response
+
+    def remove_entilements_by_pool_ids(self, pool_ids):
+        """
+        Try to remove entitlements by pool IDs
+        :param pool_ids: List of pool IDs
+        :return: List of serial numbers of removed subscriptions
+        """
+
+        removed_serials = []
+        _pool_ids = utils.unique_list_items(pool_ids)  # Don't allow duplicates
+        # FIXME: the cache of CertificateDirectory should be smart enough and refreshing
+        # should not be necessary. I vote for i-notify to be used there somehow.
+        self.entitlement_dir.refresh()
+        pool_id_to_serials = self.entitlement_dir.list_serials_for_pool_ids(_pool_ids)
+        removed_pools, unremoved_pools = self._unbind_ids(self.cp.unbindByPoolId, self.identity.uuid, _pool_ids)
+        if removed_pools:
+            for pool_id in removed_pools:
+                removed_serials.extend(pool_id_to_serials[pool_id])
+        self.entcertlib.update()
+
+        return removed_pools, unremoved_pools, removed_serials
+
+    def remove_entitlements_by_serials(self, serials):
+        """
+        Try to remove pools by Serial numbers
+        :param serials: List of serial numbers
+        :return: List of serial numbers of already removed subscriptions
+        """
+
+        _serials = utils.unique_list_items(serials)  # Don't allow duplicates
+        removed_serials, unremoved_serials = self._unbind_ids(self.cp.unbindBySerial, self.identity.uuid, _serials)
+        self.entcertlib.update()
+
+        return removed_serials, unremoved_serials

--- a/src/subscription_manager/async.py
+++ b/src/subscription_manager/async.py
@@ -28,7 +28,7 @@ from subscription_manager.managerlib import fetch_certificates
 from subscription_manager.injection import IDENTITY, \
         PLUGIN_MANAGER, CP_PROVIDER, require
 
-from rhsmlib.services import attach
+from rhsmlib.services import attach, entitlement
 
 
 class AsyncPool(object):
@@ -93,7 +93,8 @@ class AsyncBind(object):
         can be removed, because it doesn't really give us any more information
         """
         try:
-            self.cp_provider.get_consumer_auth_cp().unbindBySerial(self.identity.uuid, serial)
+            ent_service = entitlement.EntitlementService(self.cp_provider.get_consumer_auth_cp())
+            ent_service.remove_entitlements_by_serials([serial])
             try:
                 self.certlib.update()
             except Disconnected:

--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -156,11 +156,11 @@ class CertificateDirectory(Directory):
                 if p.id == p_hash:
                     certs.add(c)
                     # Keep track of stacks that provide our product
-                    if (c.order and c.order.stacking_id):
+                    if c.order and c.order.stacking_id:
                         providing_stack_ids.add(c.order.stacking_id)
 
             # Keep track of stack ids in case we need them later.  avoids another loop
-            if (c.order and c.order.stacking_id):
+            if c.order and c.order.stacking_id:
                 if c.order.stacking_id not in stack_id_map:
                     stack_id_map[c.order.stacking_id] = set()
                 stack_id_map[c.order.stacking_id].add(c)
@@ -178,7 +178,7 @@ class CertificateDirectory(Directory):
                     return c
         return None
 
-    #Set up an alias for backwards compatibility
+    # Set up an alias for backwards compatibility
     findByProduct = find_by_product
 
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1706,20 +1706,6 @@ class RemoveCommand(CliCommand):
         elif not self.options.all and not self.options.pool_ids:
             system_exit(os.EX_USAGE, _("Error: This command requires that you specify one of --serial, --pool or --all."))
 
-    def _unbind_ids(self, unbind_method, consumer_uuid, ids):
-        success = []
-        failure = []
-        for id_ in ids:
-            try:
-                unbind_method(consumer_uuid, id_)
-                success.append(id_)
-            except connection.RestlibException as re:
-                if re.code == 410:
-                    system_exit(os.EX_SOFTWARE, re.msg)
-                failure.append(id_)
-                log.error(re)
-        return (success, failure)
-
     def _print_unbind_ids_result(self, success, failure, id_name):
         if success:
             if id_name == "pools":
@@ -1747,10 +1733,10 @@ class RemoveCommand(CliCommand):
         self._validate_options()
         return_code = 0
         if self.is_registered():
-            identity = inj.require(inj.IDENTITY)
+            ent_service = entitlement.EntitlementService(self.cp)
             try:
                 if self.options.all:
-                    total = self.cp.unbindAll(identity.uuid)
+                    total = ent_service.remove_all_entitlements()
                     # total will be None on older Candlepins that don't
                     # support returning the number of subscriptions unsubscribed from
                     if total is None:
@@ -1761,31 +1747,29 @@ class RemoveCommand(CliCommand):
                                         "%s subscriptions removed at the server.",
                                         count) % count)
                 else:
-                    removed_serials = []
+                    # Try to remove subscriptions defined by pool IDs first (remove --pool=...)
                     if self.options.pool_ids:
-                        pool_ids = unique_list_items(self.options.pool_ids)  # Don't allow duplicates
-                        pool_id_to_serials = self.entitlement_dir.list_serials_for_pool_ids(pool_ids)
-                        success, failure = self._unbind_ids(self.cp.unbindByPoolId, identity.uuid, pool_ids)
-                        self._print_unbind_ids_result(success, failure, "pools")
-                        if not success:
+                        removed_pools, unremoved_pools, removed_serials = ent_service.remove_entilements_by_pool_ids(self.options.pool_ids)
+                        if not removed_pools:
                             return_code = 1
-                        else:
-                            for pool_id in success:
-                                removed_serials.extend(pool_id_to_serials[pool_id])
-                    success = []
-                    failure = []  # Clear this list to make sure we don't display the pool ids as serial
+                        self._print_unbind_ids_result(removed_pools, unremoved_pools, "pools")
+                    else:
+                        removed_serials = []
+                    # Then try to remove subscriptions defined by serials (remove --serial=...)
+                    unremoved_serials = []
                     if self.options.serials:
                         serials = unique_list_items(self.options.serials)
-                        serials_to_remove = [serial for serial in serials if serial not in removed_serials]  # Don't remove serials already removed by a pool
-                        success, failure = self._unbind_ids(self.cp.unbindBySerial, identity.uuid, serials_to_remove)
-                        removed_serials.extend(success)
-                        if not success:
+                        # Don't remove serials already removed by a pool
+                        serials_to_remove = [serial for serial in serials if serial not in removed_serials]
+                        _removed_serials, unremoved_serials = ent_service.remove_entitlements_by_serials(serials_to_remove)
+                        removed_serials.extend(_removed_serials)
+                        if not _removed_serials:
                             return_code = 1
-                    self._print_unbind_ids_result(removed_serials, failure, "serial numbers")
-                self.entcertlib.update()
-            except connection.RestlibException as re:
-                log.error(re)
-                system_exit(os.EX_SOFTWARE, re.msg)
+                    # Print final result of removing pools
+                    self._print_unbind_ids_result(removed_serials, unremoved_serials, "serial numbers")
+            except connection.RestlibException as err:
+                log.error(err)
+                system_exit(os.EX_SOFTWARE, err.msg)
             except Exception as e:
                 handle_exception(_("Unable to perform remove due to the following exception: %s") % e, e)
         else:

--- a/test/rhsmlib_test/test_entitlement.py
+++ b/test/rhsmlib_test/test_entitlement.py
@@ -23,6 +23,8 @@ from subscription_manager import injection as inj
 from subscription_manager.identity import Identity
 from subscription_manager.cert_sorter import CertSorter
 from subscription_manager.reasons import Reasons
+from subscription_manager.certdirectory import EntitlementDirectory
+from subscription_manager.cp_provider import CPProvider
 
 from rhsm import connection
 
@@ -39,6 +41,7 @@ class TestEntitlementService(InjectionMockingTest):
         self.mock_identity = mock.Mock(spec=Identity, name="Identity").return_value
         self.mock_cp = mock.Mock(spec=connection.UEPConnection, name="UEPConnection").return_value
         self.mock_sorter_class = mock.Mock(spec=CertSorter, name="CertSorter")
+        self.mock_ent_dir = mock.Mock(spec=EntitlementDirectory, name="EntitlementDirectory").return_value
 
     def injection_definitions(self, *args, **kwargs):
         if args[0] == inj.IDENTITY:
@@ -49,6 +52,8 @@ class TestEntitlementService(InjectionMockingTest):
             instance = self.mock_sorter_class(*args[1:])
             self.mock_sorter_class.return_value = instance
             return instance
+        elif args[0] == inj.ENT_DIR:
+            return self.mock_ent_dir
         else:
             return None
 
@@ -208,6 +213,180 @@ class TestEntitlementService(InjectionMockingTest):
         filtered = service.get_available_pools(service_level="NotFound")
         self.assertEqual(0, len(filtered))
 
+    def test_remove_all_pools(self):
+        """
+        Test of removing all pools
+        """
+        ent_service = EntitlementService(self.mock_cp)
+        ent_service.entcertlib = mock.Mock().return_value
+        ent_service.entcertlib.update = mock.Mock()
+        ent_service.cp.unbindAll = mock.Mock(return_value='[]')
+
+        response = ent_service.remove_all_entitlements()
+        self.assertEqual(response, '[]')
+
+    def test_remove_all_pools_by_id(self):
+        """
+        Test of removing all pools by IDs of pool
+        """
+        ent_service = EntitlementService(self.mock_cp)
+        ent_service.cp.unbindByPoolId = mock.Mock()
+        ent_service.entitlement_dir.list_serials_for_pool_ids = mock.Mock(return_value={
+            '4028fa7a5dea087d015dea0b025003f6': ['6219625278114868779'],
+            '4028fa7a5dea087d015dea0adf560152': ['3573249574655121394']
+        })
+        ent_service.entcertlib = mock.Mock().return_value
+        ent_service.entcertlib.update = mock.Mock()
+
+        removed_pools, unremoved_pools, removed_serials = ent_service.remove_entilements_by_pool_ids(
+            ['4028fa7a5dea087d015dea0b025003f6',
+             '4028fa7a5dea087d015dea0adf560152']
+        )
+
+        expected_removed_serials = [
+            '6219625278114868779',
+            '3573249574655121394'
+        ]
+        expected_removed_pools = [
+            '4028fa7a5dea087d015dea0b025003f6',
+            '4028fa7a5dea087d015dea0adf560152'
+        ]
+
+        self.assertEqual(expected_removed_serials, removed_serials)
+        self.assertEqual(expected_removed_pools, removed_pools)
+        self.assertEqual([], unremoved_pools)
+
+    def test_remove_dupli_pools_by_id(self):
+        """
+        Test of removing pools specified with duplicities
+        (one pool id is set twice)
+        """
+        ent_service = EntitlementService(self.mock_cp)
+        ent_service.cp.unbindByPoolId = mock.Mock()
+        ent_service.entitlement_dir.list_serials_for_pool_ids = mock.Mock(return_value={
+            '4028fa7a5dea087d015dea0b025003f6': ['6219625278114868779'],
+            '4028fa7a5dea087d015dea0adf560152': ['3573249574655121394']
+        })
+        ent_service.entcertlib = mock.Mock().return_value
+        ent_service.entcertlib.update = mock.Mock()
+
+        removed_pools, unremoved_pools, removed_serials = ent_service.remove_entilements_by_pool_ids(
+            ['4028fa7a5dea087d015dea0b025003f6',
+             '4028fa7a5dea087d015dea0b025003f6',
+             '4028fa7a5dea087d015dea0adf560152']
+        )
+
+        expected_removed_serials = [
+            '6219625278114868779',
+            '3573249574655121394'
+        ]
+        expected_removed_pools = [
+            '4028fa7a5dea087d015dea0b025003f6',
+            '4028fa7a5dea087d015dea0adf560152'
+        ]
+
+        self.assertEqual(expected_removed_serials, removed_serials)
+        self.assertEqual(expected_removed_pools, removed_pools)
+        self.assertEqual([], unremoved_pools)
+
+    def test_remove_some_pools_by_id(self):
+        """
+        Test of removing only some pools, because one pool ID is not valid
+        """
+        ent_service = EntitlementService(self.mock_cp)
+
+        def stub_unbind(uuid, pool_id):
+            if pool_id == 'does_not_exist_d015dea0adf560152':
+                raise connection.RestlibException(400, 'Error')
+
+        ent_service.cp.unbindByPoolId = mock.Mock(side_effect=stub_unbind)
+        ent_service.entitlement_dir.list_serials_for_pool_ids = mock.Mock(return_value={
+            '4028fa7a5dea087d015dea0b025003f6': ['6219625278114868779'],
+            '4028fa7a5dea087d015dea0adf560152': ['3573249574655121394']
+        })
+        ent_service.entcertlib = mock.Mock().return_value
+        ent_service.entcertlib.update = mock.Mock()
+
+        removed_pools, unremoved_pools, removed_serials = ent_service.remove_entilements_by_pool_ids(
+            ['4028fa7a5dea087d015dea0b025003f6', 'does_not_exist_d015dea0adf560152']
+        )
+
+        expected_removed_serials = ['6219625278114868779']
+        expected_removed_pools = ['4028fa7a5dea087d015dea0b025003f6']
+        expected_unremoved_pools = ['does_not_exist_d015dea0adf560152']
+
+        self.assertEqual(expected_removed_serials, removed_serials)
+        self.assertEqual(expected_removed_pools, removed_pools)
+        self.assertEqual(expected_unremoved_pools, unremoved_pools)
+
+    def test_remove_all_pools_by_serial(self):
+        """
+        Test of removing all pools by serial numbers
+        """
+        ent_service = EntitlementService(self.mock_cp)
+        ent_service.cp.unbindBySerial = mock.Mock()
+
+        ent_service.entcertlib = mock.Mock().return_value
+        ent_service.entcertlib.update = mock.Mock()
+
+        removed_serial, unremoved_serials = ent_service.remove_entitlements_by_serials(
+            ['6219625278114868779', '3573249574655121394']
+        )
+
+        expected_removed_serials = ['6219625278114868779', '3573249574655121394']
+
+        self.assertEqual(expected_removed_serials, removed_serial)
+        self.assertEqual([], unremoved_serials)
+
+    def test_remove_dupli_pools_by_serial(self):
+        """
+        Test of removing pools specified with duplicities
+        (one serial number is set twice)
+        """
+        ent_service = EntitlementService(self.mock_cp)
+        ent_service.cp.unbindBySerial = mock.Mock()
+
+        ent_service.entcertlib = mock.Mock().return_value
+        ent_service.entcertlib.update = mock.Mock()
+
+        removed_serial, unremoved_serials = ent_service.remove_entitlements_by_serials(
+            ['6219625278114868779',
+             '6219625278114868779',
+             '3573249574655121394']
+        )
+
+        expected_removed_serials = ['6219625278114868779', '3573249574655121394']
+
+        self.assertEqual(expected_removed_serials, removed_serial)
+        self.assertEqual([], unremoved_serials)
+
+    def test_remove_some_pools_by_serial(self):
+        """
+        Test of removing some of pools by serial numbers, because one serial
+        number is not valid.
+        """
+        ent_service = EntitlementService(self.mock_cp)
+
+        def stub_unbind(uuid, serial):
+            if serial == 'does_not_exist_1394':
+                raise connection.RestlibException(400, 'Error')
+
+        ent_service.cp.unbindBySerial = mock.Mock(side_effect=stub_unbind)
+
+        ent_service.entcertlib = mock.Mock().return_value
+        ent_service.entcertlib.update = mock.Mock()
+
+        removed_serial, unremoved_serials = ent_service.remove_entitlements_by_serials(
+            ['6219625278114868779',
+             'does_not_exist_1394']
+        )
+
+        expected_removed_serials = ['6219625278114868779']
+        expected_unremoved_serials = ['does_not_exist_1394']
+
+        self.assertEqual(expected_removed_serials, removed_serial)
+        self.assertEqual(expected_unremoved_serials, unremoved_serials)
+
 
 class TestEntitlementDBusObject(DBusObjectTest, InjectionMockingTest):
     def setUp(self):
@@ -218,9 +397,28 @@ class TestEntitlementDBusObject(DBusObjectTest, InjectionMockingTest):
         entitlement_patcher = mock.patch('rhsmlib.dbus.objects.entitlement.EntitlementService', autospec=True)
         self.mock_entitlement = entitlement_patcher.start().return_value
         self.addCleanup(entitlement_patcher.stop)
+        self.mock_identity = mock.Mock(spec=Identity, name="Identity").return_value
+        self.mock_cp = mock.Mock(spec=connection.UEPConnection, name="UEPConnection").return_value
+        self.mock_sorter_class = mock.Mock(spec=CertSorter, name="CertSorter")
+        self.mock_ent_dir = mock.Mock(spec=EntitlementDirectory, name="EntitlementDirectory").return_value
 
     def injection_definitions(self, *args, **kwargs):
-        return None
+        if args[0] == inj.IDENTITY:
+            return self.mock_identity
+        elif args[0] == inj.CERT_SORTER:
+            # This sleight of hand is needed because we want to check the arguments given
+            # when the cert sorter is instantiated.
+            instance = self.mock_sorter_class(*args[1:])
+            self.mock_sorter_class.return_value = instance
+            return instance
+        elif args[0] == inj.ENT_DIR:
+            return self.mock_ent_dir
+        elif args[0] == inj.CP_PROVIDER:
+            provider = mock.Mock(spec=CPProvider, name="CPProvider")
+            provider.get_consumer_auth_cp.return_value = mock.Mock(name="MockCP")
+            return provider
+        else:
+            return None
 
     def dbus_objects(self):
         return [EntitlementDBusObject]
@@ -235,3 +433,80 @@ class TestEntitlementDBusObject(DBusObjectTest, InjectionMockingTest):
 
         self.mock_entitlement.get_status.return_value = expected_status
         self.dbus_request(assertions, self.interface.GetStatus, [""])
+
+    def test_remove_entitlement_by_serial(self):
+        """
+        Test of D-Bus object for removing entitlements by serial number.
+        """
+        removed_unremoved_serials = (["6219625278114868779"], [])
+        self.mock_entitlement.remove_entitlements_by_serials = mock.Mock(return_value=removed_unremoved_serials)
+        expected_return = json.dumps(removed_unremoved_serials[0])
+
+        def assertation(*args):
+            result = args[0]
+            self.assertEqual(expected_return, result)
+
+        dbus_method_args = [["6219625278114868779"], {}]
+        self.dbus_request(assertation, self.interface.RemoveEntitlementsBySerials, dbus_method_args)
+
+    def test_remove_more_entitlement_by_serials(self):
+        """
+        Test of D-Bus object for removing entitlements by more than one serial number.
+        """
+        removed_unremoved_serials = (["6219625278114868779", "3573249574655121394"], [])
+        self.mock_entitlement.remove_entitlements_by_serials = mock.Mock(return_value=removed_unremoved_serials)
+        expected_return = json.dumps(removed_unremoved_serials[0])
+
+        def assertation(*args):
+            result = args[0]
+            self.assertEqual(expected_return, result)
+
+        dbus_method_args = [["6219625278114868779", "3573249574655121394"], {}]
+        self.dbus_request(assertation, self.interface.RemoveEntitlementsBySerials, dbus_method_args)
+
+    def test_remove_entitlement_by_serial_with_wrong_serial(self):
+        """
+        Test of D-Bus object for removing entitlements by serial numbers.
+        List of serial numbers containts also not valid number.
+        """
+        removed_unremoved_serials = (["6219625278114868779"], ["3573249574655121394"])
+        self.mock_entitlement.remove_entitlements_by_serials = mock.Mock(return_value=removed_unremoved_serials)
+        expected_return = json.dumps(removed_unremoved_serials[0])
+
+        def assertation(*args):
+            result = args[0]
+            self.assertEqual(expected_return, result)
+
+        dbus_method_args = [["6219625278114868779", "3573249574655121394"], {}]
+        self.dbus_request(assertation, self.interface.RemoveEntitlementsBySerials, dbus_method_args)
+
+    def test_remove_entitlement_by_pool_id(self):
+        """
+        Test of D-Bus object for removing entitlements by pool IDs
+        """
+        removed_unremoved_pools_serials = (['4028fa7a5dea087d015dea0b025003f6'], [], ['6219625278114868779'])
+        self.mock_entitlement.remove_entilements_by_pool_ids = mock.Mock(return_value=removed_unremoved_pools_serials)
+
+        expected_result = json.dumps(removed_unremoved_pools_serials[2])
+
+        def assertation(*args):
+            result = args[0]
+            self.assertEqual(expected_result, result)
+
+        dbus_method_args = [["4028fa7a5dea087d015dea0b025003f6"], {}]
+        self.dbus_request(assertation, self.interface.RemoveEntitlementsByPoolIds, dbus_method_args)
+
+    def test_remove_all_entitlements(self):
+        """
+        Test of D-Bus object for removing all entitlements
+        """
+        deleted_records = {"deletedRecords": 1}
+        self.mock_entitlement.remove_all_entitlements = mock.Mock(return_value=deleted_records)
+        expected_result = json.dumps(deleted_records)
+
+        def assertation(*args):
+            result = args[0]
+            self.assertEqual(expected_result, result)
+
+        dbus_method_args = [{}]
+        self.dbus_request(assertation, self.interface.RemoveAllEntitlements, dbus_method_args)


### PR DESCRIPTION
* Added three new public methods to entitlement service
* Added three new methods to D-Bus entitlement interface
    (com.redhat.RHSM1.Entitlement)
        RemoveAllPools
        RemovePoolsByIds
        RemovePoolsBySerials
* It is possible to test new API using following commands:

    $ busctl introspect com.redhat.RHSM1 \
      /com/redhat/RHSM1/Entitlement
    $ dbus-send --system --print-reply --dest='com.redhat.RHSM1' \
      '/com/redhat/RHSM1/Entitlement' \
      com.redhat.RHSM1.Entitlement.RemoveAllPools \
      dict:string:string:"",""
    $ dbus-send --system --print-reply --dest='com.redhat.RHSM1' \
      '/com/redhat/RHSM1/Entitlement' \
      com.redhat.RHSM1.Entitlement.RemovePoolsBySerials \
      array:string:'6959731507094690613' dict:string:string:"",""
    $ dbus-send --system --print-reply --dest='com.redhat.RHSM1' \
      '/com/redhat/RHSM1/Entitlement' \
      com.redhat.RHSM1.Entitlement.RemovePoolsByIds \
      array:string:'4028fa7a5dea087d015dea0adf560152' \
      dict:string:string:"",""

* Bug fix: instance of CertificateDirectory has to be refreshed
  in D-Bus service, because content of directory can be changed
  outsite of rhsm-service (typically sub-man and sub-man-gui)
* Added more checks of D-Bus argument type
* New rhsmlib service is used in CLI and GUI
* Added several unit tests for rhsmlib service and D-Bus object