### PR TITLE
Fix polymorphy for RHSMLogHandler

### DIFF
--- a/src/subscription_manager/logutil.py
+++ b/src/subscription_manager/logutil.py
@@ -63,18 +63,15 @@ class SubmanDebugLoggingFilter(object):
         return self.on
 
 
-# NOTE: python 2.6 and earlier versions of the logging module
-#       defined the log handlers as old style classes. In order
-#       to use super(), we also inherit from 'object'
-class RHSMLogHandler(logging.handlers.RotatingFileHandler, object):
-    """Logging Handler for /var/log/rhsm/rhsm.log"""
-    def __init__(self, *args, **kwargs):
-        try:
-            super(RHSMLogHandler, self).__init__(*args, **kwargs)
-        # fallback to stdout if we can't open our logger
-        except Exception:
-            logging.StreamHandler.__init__(self)
-        self.addFilter(ContextLoggingFilter(name=""))
+def RHSMLogHandler(*args, **kwargs):
+    """Factory for Logging Handler for /var/log/rhsm/rhsm.log"""
+    try:
+        result = logging.handlers.RotatingFileHandler(*args, **kwargs)
+    # fallback to stdout if we can't open our logger
+    except Exception:
+        result = logging.StreamHandler()
+    result.addFilter(ContextLoggingFilter(name=""))
+    return result
 
 
 class SubmanDebugHandler(logging.StreamHandler, object):


### PR DESCRIPTION
polymorphy can only be properly handled on the reference level, not at the object level.

Especially calling "__init__" of a different class than direct ancestors is most definitive going to blow up.
In this case, the maxBytes variable is missing after initializing with the wrong initializer.
