### PR TITLE
add tasks to setup hacking environment in debian

### DIFF
--- a/vagrant/roles/subman-devel/tasks/main.yml
+++ b/vagrant/roles/subman-devel/tasks/main.yml
@@ -176,6 +176,43 @@
     line: "PYTHONPATH={{ subman_checkout_dir }}/src:{{ subman_checkout_dir }}/python-rhsm/src"
   become: yes
 
+- name: compile c artifacts
+  make:
+    chdir: "{{ subman_checkout_dir }}"
+  when: subman_setup_hacking_environment and ansible_distribution == 'Debian'
+
+- name: install c artifacts
+  make:
+    chdir: "{{ subman_checkout_dir }}"
+    target: install
+  become: yes
+  when: subman_setup_hacking_environment and ansible_distribution == 'Debian'
+
+- name: configure python sys.path
+  blockinfile:
+    path: /etc/python2.7/sitecustomize.py
+    block: |
+      # append rhsm to python path
+      import sys
+      sys.path.append('{{ subman_checkout_dir }}/src')
+      sys.path.append('{{ subman_checkout_dir }}/python-rhsm/src')
+  become: yes
+  when: subman_setup_hacking_environment and ansible_distribution == 'Debian'
+
+- name: install python-rshm
+  pip:
+    name: "{{ subman_checkout_dir }}/python-rhsm"
+    extra_args: "-e"
+  become: yes
+  when: subman_setup_hacking_environment and ansible_distribution == 'Debian'
+
+- name: install subscription-manager
+  pip:
+    name: "{{ subman_checkout_dir }}"
+    extra_args: "-e"
+  become: yes
+  when: subman_setup_hacking_environment and ansible_distribution == 'Debian'
+
 - name: set GTK version
   lineinfile:
     name: /etc/environment

--- a/vagrant/roles/subman-devel/tasks/main.yml
+++ b/vagrant/roles/subman-devel/tasks/main.yml
@@ -176,19 +176,19 @@
     line: "PYTHONPATH={{ subman_checkout_dir }}/src:{{ subman_checkout_dir }}/python-rhsm/src"
   become: yes
 
-- name: compile c artifacts
+- name: compile c artifacts (Debian only)
   make:
     chdir: "{{ subman_checkout_dir }}"
   when: subman_setup_hacking_environment and ansible_distribution == 'Debian'
 
-- name: install c artifacts
+- name: install c artifacts (Debian only)
   make:
     chdir: "{{ subman_checkout_dir }}"
     target: install
   become: yes
   when: subman_setup_hacking_environment and ansible_distribution == 'Debian'
 
-- name: configure python sys.path
+- name: configure python sys.path (Debian only)
   blockinfile:
     path: /etc/python2.7/sitecustomize.py
     block: |
@@ -199,14 +199,14 @@
   become: yes
   when: subman_setup_hacking_environment and ansible_distribution == 'Debian'
 
-- name: install python-rshm
+- name: install python-rshm (Debian only)
   pip:
     name: "{{ subman_checkout_dir }}/python-rhsm"
     extra_args: "-e"
   become: yes
   when: subman_setup_hacking_environment and ansible_distribution == 'Debian'
 
-- name: install subscription-manager
+- name: install subscription-manager (Debian only)
   pip:
     name: "{{ subman_checkout_dir }}"
     extra_args: "-e"


### PR DESCRIPTION
I do not know if these instructions do any harm, but they enable me to subscribe the debian vagrant box to a forklifteded katello dev instance.
Comments are welcome.