### PR TITLE
1319927: [RFE] sub-man automatically enables yum plugins

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -64,6 +64,9 @@ pluginDir = /usr/share/rhsm-plugins
 # The directory to search for plugin configuration files
 pluginConfDir = /etc/rhsm/pluginconf.d
 
+# Manage automatic enabling of yum plugins (product-id, subsription-manager)
+auto_enable_yum_plugins = 1
+
 [rhsmcertd]
 # Interval to run cert check (in minutes):
 certCheckInterval = 240

--- a/python-rhsm/src/rhsm/config.py
+++ b/python-rhsm/src/rhsm/config.py
@@ -70,7 +70,8 @@ RHSM_DEFAULTS = {
         'full_refresh_on_yum': '0',
         'report_package_profile': '1',
         'plugindir': '/usr/share/rhsm-plugins',
-        'pluginconfdir': '/etc/rhsm/pluginconf.d'
+        'pluginconfdir': '/etc/rhsm/pluginconf.d',
+        'auto_enable_yum_plugins': '1',
         }
 
 RHSMCERTD_DEFAULTS = {

--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -37,6 +37,7 @@ from subscription_manager.ga import GLib as ga_GLib
 
 from subscription_manager.branding import get_branding
 from subscription_manager.entcertlib import EntCertActionInvoker
+from subscription_manager.repolib import YumPluginManager
 from rhsmlib.facts.hwprobe import ClassicCheck
 from rhsmlib.services import unregister
 from subscription_manager.utils import get_client_versions, get_server_versions, parse_baseurl_info, restart_virt_who
@@ -291,6 +292,14 @@ class MainWindow(widgets.SubmanBaseWidget):
 
         if auto_launch_registration and not self.registered():
             self._register_item_clicked(None)
+
+        enabled_yum_plugins = YumPluginManager.enable_yum_plugins()
+        if len(enabled_yum_plugins) > 0:
+            messageWindow.InfoDialog(
+                YumPluginManager.warning_message(enabled_yum_plugins),
+                self._get_window(),
+                _("Warning - subscribtion-manager plugins were automatically enabled")
+            )
 
     def registered(self):
         return self.identity.is_valid()

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -53,7 +53,7 @@ from subscription_manager.jsonwrapper import PoolWrapper
 from subscription_manager import managerlib
 from subscription_manager.managerlib import valid_quantity
 from subscription_manager.release import ReleaseBackend, MultipleReleaseProductsError
-from subscription_manager.repolib import RepoActionInvoker, RepoFile, manage_repos_enabled
+from subscription_manager.repolib import RepoActionInvoker, RepoFile, YumPluginManager, manage_repos_enabled
 from subscription_manager.utils import parse_server_info, \
         parse_baseurl_info, format_baseurl, is_valid_server_info, \
         MissingCaCertException, get_client_versions, get_server_versions, \
@@ -2635,6 +2635,9 @@ class ManagerCLI(CLI):
 
     def main(self):
         managerlib.check_identity_cert_perms()
+        enabled_yum_plugins = YumPluginManager.enable_yum_plugins()
+        if len(enabled_yum_plugins) > 0:
+            print(_('WARNING') + '\n\n' + YumPluginManager.warning_message(enabled_yum_plugins))
         ret = CLI.main(self)
         # Try to flush all outputs, see BZ: 1350402
         try:


### PR DESCRIPTION
* BZ [RFE]: https://bugzilla.redhat.com/show_bug.cgi?id=1319927
* Enable automatic enabling of yum plugins for sub-man CLI
* Automatic enabling of yum plugin is also implemented for sub-man GUI
* It is not implemented for initial-setup, because case desctibed
  in BZ bug report will be covered by sub-man CLI or GUI
* Add some unit tests for this case
* Added template to rhsm.conf file