### PR TITLE
restructure RepoFile hierarchy

### DIFF
--- a/src/subscription_manager/api/repos.py
+++ b/src/subscription_manager/api/repos.py
@@ -17,7 +17,7 @@ import fnmatch
 import subscription_manager.injection as inj
 
 from subscription_manager.api import request_injection
-from subscription_manager.repolib import RepoActionInvoker, RepoFile
+from subscription_manager.repolib import RepoActionInvoker, YumRepoFile
 
 
 @request_injection
@@ -54,7 +54,7 @@ def _set_enable_for_yum_repositories(setting, *repo_ids):
         for repo in repos_to_change:
             repo['enabled'] = setting
 
-        repo_file = RepoFile()
+        repo_file = YumRepoFile()
         repo_file.read()
         for repo in repos_to_change:
             repo_file.update(repo)

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -53,7 +53,7 @@ from subscription_manager.jsonwrapper import PoolWrapper
 from subscription_manager import managerlib
 from subscription_manager.managerlib import valid_quantity
 from subscription_manager.release import ReleaseBackend, MultipleReleaseProductsError
-from subscription_manager.repolib import RepoActionInvoker, RepoFile, YumPluginManager, manage_repos_enabled
+from subscription_manager.repolib import RepoActionInvoker, YumRepoFile, YumPluginManager, manage_repos_enabled
 from subscription_manager.utils import parse_server_info, \
         parse_baseurl_info, format_baseurl, is_valid_server_info, \
         MissingCaCertException, get_client_versions, get_server_versions, \
@@ -2120,7 +2120,7 @@ class ReposCommand(CliCommand):
                 for repo in changed_repos:
                     repo['enabled'] = status
                 if changed_repos:
-                    repo_file = RepoFile()
+                    repo_file = YumRepoFile()
                     repo_file.read()
                     for repo in changed_repos:
                         repo_file.update(repo)

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -776,7 +776,7 @@ class MigrationEngine(object):
         repolib.RepoActionInvoker().update()
 
         # read in the redhat.repo file
-        repofile = repolib.RepoFile()
+        repofile = repolib.YumRepoFile()
         repofile.read()
 
         # enable any extra channels we are using and write out redhat.repo

--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -334,7 +334,7 @@ class ProductManager(object):
 
         # Read the redhat.repo file so we can check if any of our
         # repos have been disabled by --disablerepo or another plugin.
-        repo_file = repolib.RepoFile()
+        repo_file = repolib.YumRepoFile()
         repo_file.read()
 
         enabled_in_redhat_repo = []

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -168,7 +168,7 @@ class SubManFixture(unittest.TestCase):
         self.mock_calc.calculate.return_value = None
 
         # Avoid trying to read real /etc/yum.repos.d/redhat.repo
-        self.mock_repofile_path_exists_patcher = patch('subscription_manager.repolib.RepoFile.path_exists')
+        self.mock_repofile_path_exists_patcher = patch('subscription_manager.repolib.YumRepoFile.path_exists')
         mock_repofile_path_exists = self.mock_repofile_path_exists_patcher.start()
         mock_repofile_path_exists.return_value = True
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -34,7 +34,7 @@ class RepoApiTest(SubManFixture):
         self.invoker = invoker_patcher.start()
         self.addCleanup(invoker_patcher.stop)
 
-        repo_file_patcher = patch("subscription_manager.api.repos.RepoFile", autospec=True)
+        repo_file_patcher = patch("subscription_manager.api.repos.YumRepoFile", autospec=True)
         self.repo_file = repo_file_patcher.start()
         self.addCleanup(repo_file_patcher.stop)
 

--- a/test/test_certdirectory.py
+++ b/test/test_certdirectory.py
@@ -29,7 +29,7 @@ from .stubs import StubProduct, StubEntitlementCertificate, \
     StubProductCertificate
 from subscription_manager.certdirectory import Path, EntitlementDirectory, \
     ProductDirectory, ProductCertificateDirectory, Directory
-from subscription_manager.repolib import RepoFile
+from subscription_manager.repolib import YumRepoFile
 from subscription_manager.productid import ProductDatabase
 
 
@@ -72,7 +72,7 @@ class PathTests(unittest.TestCase):
         # Fake that the redhat.repo exists:
 
         Path.ROOT = '/mnt/sysimage'
-        rf = RepoFile()
+        rf = YumRepoFile()
         self.assertEqual("/mnt/sysimage/etc/yum.repos.d/redhat.repo", rf.path)
 
     def test_product_database(self):

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -889,7 +889,7 @@ class TestReposCommand(TestCliCommand):
                 match_dict_list)
         self.assertTrue(repolib_instance.update.called)
 
-    @patch("subscription_manager.managercli.RepoFile")
+    @patch("subscription_manager.managercli.YumRepoFile")
     def test_set_repo_status_when_disconnected(self, mock_repofile):
         self._inject_mock_invalid_consumer()
         mock_repofile_inst = mock_repofile.return_value

--- a/test/test_migration.py
+++ b/test/test_migration.py
@@ -1212,7 +1212,7 @@ class TestMigration(SubManFixture):
         self.assertEqual(service_level, "Premium")
 
     @patch("subscription_manager.repolib.RepoActionInvoker")
-    @patch("subscription_manager.repolib.RepoFile")
+    @patch("subscription_manager.repolib.YumRepoFile")
     def test_enable_extra_channels(self, mock_repofile, mock_repolib):
         mrf = mock_repofile.return_value
         subscribed_channels = [

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -35,7 +35,7 @@ from .stubs import StubProductCertificate, \
         StubProduct, StubEntitlementCertificate, StubContent, \
         StubProductDirectory, StubConsumerIdentity, StubEntitlementDirectory
 from subscription_manager.repolib import Repo, RepoActionInvoker, \
-        RepoUpdateActionCommand, TidyWriter, RepoFile, YumReleaseverSource, \
+        RepoUpdateActionCommand, TidyWriter, YumRepoFile, YumReleaseverSource, \
         YumPluginManager
 from subscription_manager import injection as inj
 from rhsm.config import RhsmConfigParser
@@ -261,7 +261,7 @@ class RepoUpdateActionTests(fixture.SubManFixture):
         self.assertEqual('blah', old_repo['gpgcheck'])
         self.assertEqual('some_key', old_repo['gpgkey'])
 
-    @patch("subscription_manager.repolib.RepoFile")
+    @patch("subscription_manager.repolib.YumRepoFile")
     def test_update_when_new_repo(self, mock_file):
         mock_file = mock_file.return_value
         mock_file.section.return_value = None
@@ -277,7 +277,7 @@ class RepoUpdateActionTests(fixture.SubManFixture):
         self.assertEqual('some_key', written_repo['gpgkey'])
         self.assertEqual(1, update_report.updates())
 
-    @patch("subscription_manager.repolib.RepoFile")
+    @patch("subscription_manager.repolib.YumRepoFile")
     def test_update_when_repo_not_modified_on_mutable(self, mock_file):
         self._inject_mock_invalid_consumer()
         mock_file = mock_file.return_value
@@ -300,7 +300,7 @@ class RepoUpdateActionTests(fixture.SubManFixture):
         self.assertEqual('new', written_repo['gpgcheck'])
         self.assertEqual(None, written_repo['gpgkey'])
 
-    @patch("subscription_manager.repolib.RepoFile")
+    @patch("subscription_manager.repolib.YumRepoFile")
     def test_update_when_repo_modified_on_mutable(self, mock_file):
         self._inject_mock_invalid_consumer()
         mock_file = mock_file.return_value
@@ -745,22 +745,22 @@ class YumReleaseverSourceIsSetTest(fixture.SubManFixture):
         self.assertTrue(YumReleaseverSource.is_set({'releaseVer': 'None'}))
 
 
-class RepoFileTest(unittest.TestCase):
+class YumRepoFileTest(unittest.TestCase):
 
-    @patch("subscription_manager.repolib.RepoFile.create")
+    @patch("subscription_manager.repolib.YumRepoFile.create")
     @patch("subscription_manager.repolib.TidyWriter")
     def test_configparsers_equal(self, tidy_writer, stub_create):
-        rf = RepoFile()
+        rf = YumRepoFile()
         other = RawConfigParser()
         for parser in [rf, other]:
             parser.add_section('test')
             parser.set('test', 'key', 'val')
         self.assertTrue(rf._configparsers_equal(other))
 
-    @patch("subscription_manager.repolib.RepoFile.create")
+    @patch("subscription_manager.repolib.YumRepoFile.create")
     @patch("subscription_manager.repolib.TidyWriter")
     def test_configparsers_diff_sections(self, tidy_writer, stub_create):
-        rf = RepoFile()
+        rf = YumRepoFile()
         rf.add_section('new_section')
         other = RawConfigParser()
         for parser in [rf, other]:
@@ -768,10 +768,10 @@ class RepoFileTest(unittest.TestCase):
             parser.set('test', 'key', 'val')
         self.assertFalse(rf._configparsers_equal(other))
 
-    @patch("subscription_manager.repolib.RepoFile.create")
+    @patch("subscription_manager.repolib.YumRepoFile.create")
     @patch("subscription_manager.repolib.TidyWriter")
     def test_configparsers_diff_item_val(self, tidy_writer, stub_create):
-        rf = RepoFile()
+        rf = YumRepoFile()
         other = RawConfigParser()
         for parser in [rf, other]:
             parser.add_section('test')
@@ -779,10 +779,10 @@ class RepoFileTest(unittest.TestCase):
         rf.set('test', 'key', 'val2')
         self.assertFalse(rf._configparsers_equal(other))
 
-    @patch("subscription_manager.repolib.RepoFile.create")
+    @patch("subscription_manager.repolib.YumRepoFile.create")
     @patch("subscription_manager.repolib.TidyWriter")
     def test_configparsers_diff_items(self, tidy_writer, stub_create):
-        rf = RepoFile()
+        rf = YumRepoFile()
         other = RawConfigParser()
         for parser in [rf, other]:
             parser.add_section('test')
@@ -790,10 +790,10 @@ class RepoFileTest(unittest.TestCase):
         rf.set('test', 'somekey', 'val')
         self.assertFalse(rf._configparsers_equal(other))
 
-    @patch("subscription_manager.repolib.RepoFile.create")
+    @patch("subscription_manager.repolib.YumRepoFile.create")
     @patch("subscription_manager.repolib.TidyWriter")
     def test_configparsers_equal_int(self, tidy_writer, stub_create):
-        rf = RepoFile()
+        rf = YumRepoFile()
         other = RawConfigParser()
         for parser in [rf, other]:
             parser.add_section('test')


### PR DESCRIPTION
I want to introduce a base class in order to be able to implement repository filetypes that do not follow the configfile layout (e.g. apt sources).

RFC: Should we rename the class RepoFile to YumRepoFile, as subscription-manager is trying to become more generic about packet / archive formats?