### PR TITLE
1319927: [RFE] sub-man automatically enables yum plugins

### DIFF
--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -106,7 +106,7 @@ class YumPluginManager(object):
         message = _('The yum plugins: %s were automatically enabled for the benefit of '
                     'Red Hat Subscription Management. If not desired, use '
                     '"subscription-manager config --rhsm.auto_enable_yum_plugins=0" to '
-                    'block this behavior.\n') % str(tuple(enabled_yum_plugins))
+                    'block this behavior.\n') % ', '.join(enabled_yum_plugins)
         return message
 
     @classmethod


### PR DESCRIPTION
* Better warning message, when only one plugin was enabled