### PR TITLE
1489877: minor typo in /etc/rhsm/rhsm.conf comment

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -64,7 +64,7 @@ pluginDir = /usr/share/rhsm-plugins
 # The directory to search for plugin configuration files
 pluginConfDir = /etc/rhsm/pluginconf.d
 
-# Manage automatic enabling of yum plugins (product-id, subsription-manager)
+# Manage automatic enabling of yum plugins (product-id, subscription-manager)
 auto_enable_yum_plugins = 1
 
 [rhsmcertd]

--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -298,7 +298,7 @@ class MainWindow(widgets.SubmanBaseWidget):
             messageWindow.InfoDialog(
                 YumPluginManager.warning_message(enabled_yum_plugins),
                 self._get_window(),
-                _("Warning - subscribtion-manager plugins were automatically enabled")
+                _("Warning - subscription-manager plugins were automatically enabled")
             )
 
     def registered(self):


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1489877
* Fixed typo in rhsm.conf comment and in sub-man gui