### PR TITLE
1489917: More robust reading of yum plugin file

### DIFF
--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -19,7 +19,6 @@ from __future__ import print_function, division, absolute_import
 #
 
 from iniparse import RawConfigParser as ConfigParser
-import iniparse
 import logging
 import os
 import string

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -168,7 +168,7 @@ class YumPluginManager(object):
                             yum_plugin_file_name
                         )
 
-            if is_plugin_enabled == cls.YUM_PLUGIN_ENABLED or is_plugin_enabled is True:
+            if is_plugin_enabled == cls.YUM_PLUGIN_ENABLED:
                 log.debug('Yum plugin: "%s" already enabled. Nothing to do.' % yum_plugin_file_name)
             else:
                 log.warn('Enabling yum plugin: "%s".' % yum_plugin_file_name)


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1489917
* Configuration file of yum plugin can contain values of
  `enabled` option:
```
enabled = true
enabled = false
enabled = 1
enabled = 0
```
* Code can handle other unusual situations:
  - Option `enabled` does not have valid value, e.g.: 1.0, 4, etc.
  - Option `enabled` is missing or uncommented
  - Section `main` is missing or uncommented
* Added more unit tests
* Note: When iniparse module is not able to parse config file,
  then this config file is skipped. Only in this situation yum
  plugin is not enabled, because yum plugin will not be able
  to read too.