### PR TITLE
1466453: [RFE] rhn-migrate-classic-to-rhsm auto-enable yum plugins

### DIFF
--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -993,6 +993,12 @@ def main(args=None, five_to_six_script=False):
     set_defaults(options, five_to_six_script)
     validate_options(options)
     MigrationEngine(options).main()
+
+    # Try to enable yum plugins: subscription-manager and product-id
+    enabled_yum_plugins = repolib.YumPluginManager.enable_yum_plugins()
+    if len(enabled_yum_plugins) > 0:
+        print(_('WARNING') + '\n\n' + repolib.YumPluginManager.warning_message(enabled_yum_plugins))
+
     try:
         sys.stdout.flush()
         sys.stderr.flush()


### PR DESCRIPTION
* Bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1466453
* It reuses code from sub-man. See also BZ:
  https://bugzilla.redhat.com/show_bug.cgi?id=1319927
* It enables yum plugins: subscription-manager and product-id
* This automatic enablement can be disabled in rhsm.conf