### PR TITLE
1477958: Use inotify for checking changes of consumer certs

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -67,6 +67,14 @@ pluginConfDir = /etc/rhsm/pluginconf.d
 # Manage automatic enabling of yum plugins (product-id, subscription-manager)
 auto_enable_yum_plugins = 1
 
+# Inotify is used for monitoring changes in directories with certificates.
+# Currently only the /etc/pki/consumer directory is monitored by the
+# rhsm.service. When this directory is mounted using a network file system
+# without inotify notification support (e.g. NFS), then disabling inotify
+# is strongly recommended. When inotify is disabled, periodical directory
+# polling is used instead.
+inotify = 1
+
 [rhsmcertd]
 # Interval to run cert check (in minutes):
 certCheckInterval = 240

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -186,6 +186,11 @@ auto_enable_yum_plugins
 .RS 4
 When this option is enabled, then yum plugins subscription-manager and plugin-id are enabled every-time subscription-manager or subscription-manager-gui is executed.
 .RE
+.PP
+inotify
+.RS 4
+Inotify is used for monitoring changes in directories with certificates. Currently only the /etc/pki/consumer directory is monitored by the rhsm.service. When this directory is mounted using a network file system without inotify notification support (e.g. NFS), then disabling inotify is strongly recommended. When inotify is disabled, periodical directory polling is used instead.
+.RE
 .SH "[RHSMCERTD] OPTIONS"
 .PP
 certCheckInterval

--- a/python-rhsm/src/rhsm/config.py
+++ b/python-rhsm/src/rhsm/config.py
@@ -72,6 +72,7 @@ RHSM_DEFAULTS = {
         'plugindir': '/usr/share/rhsm-plugins',
         'pluginconfdir': '/etc/rhsm/pluginconf.d',
         'auto_enable_yum_plugins': '1',
+        'inotify': '1'
         }
 
 RHSMCERTD_DEFAULTS = {

--- a/src/rhsmlib/dbus/inotify.py
+++ b/src/rhsmlib/dbus/inotify.py
@@ -1,0 +1,94 @@
+from __future__ import print_function, division, absolute_import
+
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+"""
+This module includes notifier using inotify. The notifier checks
+for changes in /etc/pki/consumers for newly created or deleted
+certificates.
+"""
+
+import logging
+import pyinotify
+
+from subscription_manager import injection as inj
+
+log = logging.getLogger(__name__)
+
+
+class EventHandler(pyinotify.ProcessEvent):
+    """
+    Class used for reloading consumer certificate
+    """
+    def __init__(self, *args, **kwargs):
+        super(EventHandler, self).__init__(*args, **kwargs)
+        self.identity = inj.require(inj.IDENTITY)
+
+    def process_IN_CREATE(self, event):
+        """
+        This method is executed every time new file is created
+        in directory with certificates of consumer
+        :param event: Inotify event
+        :return: None
+        """
+        if event.pathname == self.identity.cert_dir_path + '/cert.pem':
+            log.debug("New consumer certificate %s was created", event.pathname)
+        if event.pathname == self.identity.cert_dir_path + '/key.pem':
+            log.debug("New consumer key %s was created", event.pathname)
+        self.identity.reload()
+
+    def process_IN_DELETE(self, event):
+        """
+        This method is executed every time any file is deleted
+        in directory with certificates of consumer
+        :param event: Inotify event
+        :return: None
+        """
+        if event.pathname == self.identity.cert_dir_path + '/cert.pem':
+            log.debug("Existing consumer certificate %s was removed", event.pathname)
+        if event.pathname == self.identity.cert_dir_path + '/key.pem':
+            log.debug("Existing consumer key %s was removed", event.pathname)
+        self.identity.reload()
+
+
+def inotify_cb(notifier):
+    """
+    This method check if notifier should be terminated or not
+    :param notifier: Notifier object
+    :return: True, when notifier should be terminated.
+    """
+    return notifier.server.terminate_loop
+
+
+def inotify_worker(server):
+    """
+    Thread worker using inotify for checking changes in directory
+    with consumer certificates
+    :param server: Reference to instance of Server
+    :return None
+    """
+    watch_manager = pyinotify.WatchManager()
+    # Create custom event handler
+    handler = EventHandler()
+    # Create notifier with timeout (one second).
+    notifier = pyinotify.Notifier(watch_manager, handler, timeout=1000)
+    # Add reference at server into notifier
+    notifier.server = server
+    # We are interested only newly created files (system was registered)
+    # and deleted files (system was unregistered)
+    mask = pyinotify.IN_DELETE | pyinotify.IN_CREATE
+    # Start to watch for events in directory with certificates of consumer
+    watch_manager.add_watch(handler.identity.cert_dir_path, mask, rec=False)
+    # Start loop. The loop can be stop in callback every second (timeout)
+    notifier.loop(callback=inotify_cb)

--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -12,27 +12,79 @@ from __future__ import print_function, division, absolute_import
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-#
+
 import logging
 import dbus.service
 import dbus.server
 import dbus.mainloop.glib
 import threading
+import sys
+import time
+
+from rhsm.config import initConfig
 
 from rhsmlib.dbus import constants
+from rhsmlib.services import config
 
 from subscription_manager import ga_loader
 ga_loader.init_ga()
 from subscription_manager.ga import GLib
+from subscription_manager import cert_sorter
 
+from six.moves import configparser
 from functools import partial
 
 log = logging.getLogger(__name__)
 
+try:
+    import pyinotify
+except ImportError:
+    log.info('Module pyinotify cannot be imported. Fallback mode: periodical directory polling will be used.')
+else:
+    from rhsmlib.dbus import inotify
+
+conf = config.Config(initConfig())
+
+
+def polling_worker(server):
+    """
+    Thread worker using periodical polling of directories with certificates.
+    This is used only in fallback mode, when it is not possible to use pyinotify
+    or using of inotify was disabled in rhsm.conf.
+    :param server: Reference to instance of Server
+    :return: None
+    """
+    cs = cert_sorter.CertSorter()
+    while server.terminate_loop is False:
+        cs.force_cert_check()
+        time.sleep(2.0)
+
+
+def inotify_enabled():
+    """
+    Check if inotify is enabled or disabled in rhsm.conf.
+    It is enabled by default.
+    :return: It returns True, when inotify is enabled. Otherwise it returns False.
+    """
+    try:
+        use_inotify = conf['rhsm'].get_int('inotify')
+    except ValueError as e:
+        log.exception(e)
+        return True
+    except configparser.Error as e:
+        log.exception(e)
+        return True
+    else:
+        if use_inotify is None:
+            return True
+
+    return bool(use_inotify)
+
 
 class Server(object):
     def __init__(self, bus_class=None, bus_name=None, object_classes=None, bus_kwargs=None):
-        """Create a connection to a bus defined by bus_class and bus_kwargs; instantiate objects in
+        """
+        Create a connection to a bus defined by bus_class and bus_kwargs; instantiate objects in
         object_classes; expose them under bus_name and enter a GLib mainloop.  bus_kwargs are generally
         only necessary if you're using dbus.bus.BusConnection
 
@@ -56,6 +108,15 @@ class Server(object):
             log.exception("Could not create bus class")
             raise
 
+        self.terminate_loop = False
+        #
+        if 'pyinotify' in sys.modules and inotify_enabled():
+            log.debug('Using pyinotify %s' % pyinotify.__version__)
+            self._thread = threading.Thread(target=inotify.inotify_worker, args=(self,))
+        else:
+            self._thread = threading.Thread(target=polling_worker, args=(self,))
+        self._thread.start()
+
         self.connection_name = dbus.service.BusName(self.bus_name, self.bus)
         self.mainloop = GLib.MainLoop()
 
@@ -71,8 +132,10 @@ class Server(object):
             )
 
     def run(self, started_event=None, stopped_event=None):
-        """The two arguments, started_event and stopped_event, should be instances of threading.Event that
-        will be set when the mainloop has finished starting and stopping."""
+        """
+        The two arguments, started_event and stopped_event, should be instances of threading.
+        Event that will be set when the mainloop has finished starting and stopping.
+        """
         try:
             GLib.idle_add(self.notify_started, started_event)
             self.mainloop.run()
@@ -83,12 +146,16 @@ class Server(object):
         except Exception as e:
             log.exception(e)
         finally:
+            # Terminate loop of notifier
+            self.terminate_loop = True
             if stopped_event:
                 stopped_event.set()
 
     def notify_started(self, started_event):
-        """This callback will be run once the mainloop is up and running.  It's only purpose is to alert
-        other blocked threads that the mainloop is ready."""
+        """
+        This callback will be run once the mainloop is up and running. It's only purpose is to alert
+        other blocked threads that the mainloop is ready.
+        """
         log.debug("Start notification sent")
         if started_event:
             started_event.set()
@@ -96,10 +163,17 @@ class Server(object):
         return False
 
     def shutdown(self):
-        """This method is primarily intended for uses of Server in a thread such as during testing since
+        """
+        This method is primarily intended for uses of Server in a thread such as during testing since
         in a single-threaded program, the execution would be blocked on the mainloop and therefore
-        preclude even calling this method."""
+        preclude even calling this method.
+        """
         self.mainloop.quit()
+
+        # Make sure loop is terminated
+        self.terminate_loop = True
+        # Wait for notification thread to join
+        self._thread.join(2)
 
         # Unregister/remove everything.  Note that if you used dbus.SessionBus or dbus.SystemBus,
         # python-dbus will keep a cache of your old BusName objects even though we are releasing the name

--- a/src/rhsmlib/services/attach.py
+++ b/src/rhsmlib/services/attach.py
@@ -26,6 +26,7 @@ class AttachService(object):
         self.cp = cp
 
     def attach_auto(self, service_level):
+
         if service_level is not None:
             self.cp.updateConsumer(self.identity.uuid, service_level=service_level)
             log.info("Service level set to: %s" % service_level)
@@ -46,6 +47,7 @@ class AttachService(object):
         return resp
 
     def attach_pool(self, pool, quantity):
+
         # If quantity is None, server will assume 1. pre_subscribe will
         # report the same.
         self.plugin_manager.run(

--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -282,7 +282,7 @@ class EntCertUpdateAction(object):
             sn_list = [str(sn) for sn in sn_list]
             # NOTE: use injected IDENTITY, need to validate this
             # handles disconnected errors properly
-            reply = self.uep.getCertificates(self.identity.getConsumerId(),
+            reply = self.uep.getCertificates(self.identity.uuid,
                                               serials=sn_list)
             for cert in reply:
                 result.append(cert)

--- a/src/subscription_manager/healinglib.py
+++ b/src/subscription_manager/healinglib.py
@@ -73,7 +73,7 @@ class HealingUpdateAction(object):
     def perform(self):
         # inject
         identity = inj.require(inj.IDENTITY)
-        uuid = identity.getConsumerId()
+        uuid = identity.uuid
         consumer = self.uep.getConsumer(uuid)
 
         if 'autoheal' not in consumer or not consumer['autoheal']:

--- a/src/subscription_manager/identitycertlib.py
+++ b/src/subscription_manager/identitycertlib.py
@@ -68,7 +68,7 @@ class IdentityUpdateAction(object):
         # FIXME: move persist stuff here
         from subscription_manager import managerlib
 
-        idcert = identity.getConsumerCert()
+        idcert = identity.consumer
 
         consumer = self._get_consumer(identity)
 

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -6,6 +6,7 @@
 %global use_initial_setup 1
 %global use_firstboot 0
 %global use_kitchen 1
+%global use_inotify 1
 %global rhsm_plugins_dir  /usr/share/rhsm-plugins
 
 %if %{use_systemd}
@@ -17,6 +18,7 @@
 %global use_initial_setup 0
 %global use_firstboot 1
 %global use_kitchen 0
+%global use_inotify 0
 %endif
 
 %global use_dnf 0%{?fedora}
@@ -123,6 +125,10 @@ Requires:  %{?gtk3:gobject-introspection, pygobject3-base} %{!?gtk3:pygobject2}
 %ifnarch ppc ppc64 s390 s390x
 Requires:  python-dmidecode
 %endif
+%endif
+
+%if %use_inotify
+Requires:  python-inotify
 %endif
 
 %if %use_systemd


### PR DESCRIPTION
- Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1477958
- I-notify is used for checking of changes in /etc/pki/consumer
  to trigger reloading of `identity`.
- When `pyinotify` module or i-notify at all is not possible to use, then it
  falls back to periodical directory polling. This code is used
  by sub-man gui.
- Small changes in subscription-manager.spec file, because new
  Python module is required at RHEL7 and Fedora.