### PR TITLE
Fix issue where tests run in a certain order caused encoding errors.

### DIFF
--- a/src/subscription_manager/api/__init__.py
+++ b/src/subscription_manager/api/__init__.py
@@ -19,6 +19,7 @@ external applications.
 All reasonable efforts will be made to maintain compatibility.
 """
 from functools import wraps
+from subscription_manager import logutil
 
 injected = False
 
@@ -31,7 +32,6 @@ def request_injection(func):
     def func_wrapper(*args, **kwargs):
         global injected
         if not injected:
-            from subscription_manager import logutil
             logutil.init_logger()
 
             from subscription_manager.injectioninit import init_dep_injection

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -42,6 +42,10 @@ class RepoApiTest(SubManFixture):
         self.stub_uep = uep_patcher.start()
         self.addCleanup(uep_patcher.stop)
 
+        logging_patcher = patch("subscription_manager.api.logutil")
+        logging_patcher.start()
+        self.addCleanup(logging_patcher.stop)
+
     def test_disable_repo(self):
         repo_settings = {
             'enabled': '1',


### PR DESCRIPTION
The issue can be replicated in master with

```
nosetests  --randomly-seed=1506092144 test.test_api:RepoApiTest.test_enable_repo test.test_managercli:HandleExceptionTests.test_he_unicode
```

The failure is dependent on the RepoApiTest running before HandleExceptionTests.