### PR TITLE
Implement bootstrap-select component

### DIFF
--- a/cockpit/package.json
+++ b/cockpit/package.json
@@ -24,13 +24,15 @@
     "eslint-loader": "~1.6.1",
     "eslint-plugin-react": "~6.9.0",
     "jasmine": "^2.7.0",
+    "jquery": "^3.2.1",
     "jshint": "~2.9.1",
     "jshint-loader": "~0.8.3",
+    "patternfly": "^3.27.4",
     "patternfly-react": "https://github.com/candlepin/patternfly-react",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
     "style-loader": "^0.18.2",
     "webpack": "^2.6.1"
   },
-  "dependencies": {
-    "react-lite": "0.15.30"
-  }
+  "dependencies": {}
 }

--- a/cockpit/src/Select/Select.jsx
+++ b/cockpit/src/Select/Select.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import $ from 'jquery';
+import 'bootstrap';
+import 'bootstrap-select';
+
+const PropTypes = React.PropTypes;
+
+/* React pattern component for a dropdown/select control */
+class Select extends React.Component {
+    componentDidMount() {
+        this.$el = $(this.el);
+        this.$el.selectpicker().change(this.props.onChange);
+    }
+
+    componentWillUnmount() {
+        this.$el.selectpicker('destroy');
+    }
+
+    render() {
+        return (
+            <div>
+                <select id={this.props.id} className="selectpicker" ref={el => this.el = el}>
+                    {this.props.children}
+                </select>
+            </div>
+        );
+    }
+}
+
+Select.propTypes = {
+    onChange: PropTypes.func,
+    id: PropTypes.string,
+    children: PropTypes.arrayOf(PropTypes.element),
+};
+
+export default Select;

--- a/cockpit/src/index.html
+++ b/cockpit/src/index.html
@@ -26,13 +26,12 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
     <link rel="stylesheet" href="../base1/patternfly.css">
     <link href="subscriptions.css" rel="stylesheet">
-
-    <script type="text/javascript" src="../base1/cockpit.js"></script>
-    <script type="text/javascript" src="../*/po.js"></script>
-    <script type="text/javascript" src="index.js"></script>
 </head>
 
 <body>
     <div id="app"></div>
+    <script type="text/javascript" src="../base1/cockpit.js"></script>
+    <script type="text/javascript" src="../*/po.js"></script>
+    <script type="text/javascript" src="index.js"></script>
 </body>
 </html>

--- a/cockpit/src/index.js
+++ b/cockpit/src/index.js
@@ -19,6 +19,7 @@
 
 var cockpit = require("cockpit");
 var React = require("react");
+var ReactDOM = require("react-dom");
 var subscriptionsClient = require("./subscriptions-client");
 var subscriptionsRegister = require("./subscriptions-register.jsx");
 var subscriptionsView = require("./subscriptions-view.jsx");
@@ -125,7 +126,7 @@ function initStore(rootElement) {
     subscriptionsClient.init();
 
     dataStore.render = function() {
-        React.render(React.createElement(
+        ReactDOM.render(React.createElement(
             subscriptionsView.page,
             {
                 status: subscriptionsClient.subscriptionStatus.status,

--- a/cockpit/src/subscriptions-register.jsx
+++ b/cockpit/src/subscriptions-register.jsx
@@ -21,22 +21,7 @@ var cockpit = require("cockpit");
 var _ = cockpit.gettext;
 
 var React = require("react");
-
-/* TODO port from cockpit or replace */
-var Select = React.createClass({
-    render: function() {
-        return (
-            <select>{this.props.children}</select>
-        );
-    }
-});
-var SelectEntry = React.createClass({
-    render: function() {
-        return (
-            <option>{this.props.children}</option>
-        );
-    }
-});
+import Select from "./Select/Select.jsx";
 
 function defaultRegisterDialogSettings() {
     return {
@@ -74,7 +59,7 @@ var PatternDialogBody = React.createClass({
                     <tbody>
                         <tr>
                             <td>
-                                <label className="control-label" for="subscription-proxy-server">
+                                <label className="control-label" htmlFor="subscription-proxy-server">
                                     {_("Server")}
                                 </label>
                             </td>
@@ -86,7 +71,7 @@ var PatternDialogBody = React.createClass({
 
                         <tr>
                             <td>
-                                <label className="control-label" for="subscription-proxy-user">
+                                <label className="control-label" htmlFor="subscription-proxy-user">
                                     {_("User")}
                                 </label>
                             </td>
@@ -98,7 +83,7 @@ var PatternDialogBody = React.createClass({
 
                         <tr>
                             <td>
-                                <label className="control-label" for="subscription-proxy-password">
+                                <label className="control-label" htmlFor="subscription-proxy-password">
                                     {_("Password")}
                                 </label>
                             </td>
@@ -118,84 +103,86 @@ var PatternDialogBody = React.createClass({
         return (
             <div className="modal-body">
                 <table className="form-table-ct">
-                    <tr>
-                        <td className="top">
-                            <label className="control-label" for="subscription-register-url">
-                                {_("URL")}
-                            </label>
-                        </td>
-                        <td>
-                            <Select key='urlSource' onChange={ this.props.onChange.bind(this, 'url') }
-                                    id="subscription-register-url" initial="default">
-                                <SelectEntry data='default' key='default'>{ urlEntries['default'] }</SelectEntry>
-                                <SelectEntry data='custom' key='custom'>{ urlEntries['custom'] }</SelectEntry>
-                            </Select>
-                            {customURL}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td className="top">
-                            <label className="control-label">
-                                {_("Proxy")}
-                            </label>
-                        </td>
-                        <td>
-                            <label>
-                                <input id="subscription-proxy-use" type="checkbox" checked={this.props.proxy}
-                                       onChange={ this.props.onChange.bind(this, 'proxy') }/>
-                                {_("Use proxy server")}
-                            </label>
-                            {proxy}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td className="top ">
-                            <label className="control-label" for="subscription-register-username">
-                                {_("Login")}
-                            </label>
-                        </td>
-                        <td>
-                            <input id="subscription-register-username" className="form-control" type="text"
-                                   value={this.props.user}
-                                   onChange={this.props.onChange.bind(this, 'user')}/>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td className="top">
-                            <label className="control-label" for="subscription-register-password">
-                                {_("Password")}
-                            </label>
-                        </td>
-                        <td>
-                            <input id="subscription-register-password" className="form-control" type="password"
-                                   value={this.props.password}
-                                   onChange={this.props.onChange.bind(this, 'password')}/>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td className="top">
-                            <label className="control-label" for="subscription-register-key">
-                                {_("Activation Key")}
-                            </label>
-                        </td>
-                        <td>
-                            <input id="subscription-register-key" className="form-control" type="text"
-                                   placeholder="key_one,key_two" value={this.props.activationKeys}
-                                   onChange={this.props.onChange.bind(this, 'activationKeys')}/>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td className="top">
-                            <label className="control-label" for="subscription-register-org">
-                                {_("Organization")}
-                            </label>
-                        </td>
-                        <td>
-                            <input id="subscription-register-org" className="form-control" type="text"
-                                   value={this.props.org}
-                                   onChange={this.props.onChange.bind(this, 'org')}/>
-                        </td>
-                    </tr>
+                    <tbody>
+                        <tr>
+                            <td className="top">
+                                <label className="control-label" htmlFor="subscription-register-url">
+                                    {_("URL")}
+                                </label>
+                            </td>
+                            <td>
+                                <Select key='urlSource' onChange={ this.props.onChange.bind(this, 'url') }
+                                        id="subscription-register-url">
+                                    <option value="default">{ urlEntries['default'] }</option>
+                                    <option value="custom">{ urlEntries['custom'] }</option>
+                                </Select>
+                                {customURL}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="top">
+                                <label className="control-label">
+                                    {_("Proxy")}
+                                </label>
+                            </td>
+                            <td>
+                                <label>
+                                    <input id="subscription-proxy-use" type="checkbox" checked={this.props.proxy}
+                                           onChange={ this.props.onChange.bind(this, 'proxy') }/>
+                                    {_("Use proxy server")}
+                                </label>
+                                {proxy}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="top ">
+                                <label className="control-label" htmlFor="subscription-register-username">
+                                    {_("Login")}
+                                </label>
+                            </td>
+                            <td>
+                                <input id="subscription-register-username" className="form-control" type="text"
+                                       value={this.props.user}
+                                       onChange={this.props.onChange.bind(this, 'user')}/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="top">
+                                <label className="control-label" htmlFor="subscription-register-password">
+                                    {_("Password")}
+                                </label>
+                            </td>
+                            <td>
+                                <input id="subscription-register-password" className="form-control" type="password"
+                                       value={this.props.password}
+                                       onChange={this.props.onChange.bind(this, 'password')}/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="top">
+                                <label className="control-label" htmlFor="subscription-register-key">
+                                    {_("Activation Key")}
+                                </label>
+                            </td>
+                            <td>
+                                <input id="subscription-register-key" className="form-control" type="text"
+                                       placeholder="key_one,key_two" value={this.props.activationKeys}
+                                       onChange={this.props.onChange.bind(this, 'activationKeys')}/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="top">
+                                <label className="control-label" htmlFor="subscription-register-org">
+                                    {_("Organization")}
+                                </label>
+                            </td>
+                            <td>
+                                <input id="subscription-register-org" className="form-control" type="text"
+                                       value={this.props.org}
+                                       onChange={this.props.onChange.bind(this, 'org')}/>
+                            </td>
+                        </tr>
+                    </tbody>
                 </table>
             </div>
         );

--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -157,7 +157,7 @@ var SubscriptionStatus = React.createClass({
         var errorMessage;
         if (this.props.error) {
             errorMessage = (
-                <DismissableError dismissError={this.props.dismissError}>{this.props.error}</DismissableError>
+                <DismissableError dismissError={this.props.dismissError}>{String(this.props.error)}</DismissableError>
             );
         }
 

--- a/cockpit/webpack.config.js
+++ b/cockpit/webpack.config.js
@@ -89,7 +89,11 @@ var plugins = [
             'NODE_ENV': JSON.stringify(production ? 'production' : 'development')
         }
     }),
-    new copy(info.files)
+    new copy(info.files),
+    new webpack.ProvidePlugin({
+        '$': 'jquery',
+        'jQuery': 'jquery',
+    }),
 ];
 
 if (!production) {
@@ -147,11 +151,6 @@ module.exports = {
     externals: externals,
     output: output,
     devtool: "source-map",
-    resolve: {
-        alias: {
-            "react$": path.resolve(nodedir, "react-lite/dist/react-lite.js")
-        }
-    },
     module: {
         rules: [
             {

--- a/cockpit/yarn.lock
+++ b/cockpit/yarn.lock
@@ -749,6 +749,30 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
+bootstrap-datepicker@~1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/bootstrap-datepicker/-/bootstrap-datepicker-1.6.4.tgz#889ebeced8eaa2ff15ec1f273e4b07531cc43da0"
+  dependencies:
+    jquery ">=1.7.1"
+
+bootstrap-select@^1.12.2:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/bootstrap-select/-/bootstrap-select-1.12.4.tgz#7f15d3c0ce978868d9c09c70f96624f55fa02ee1"
+  dependencies:
+    jquery ">=1.8"
+
+bootstrap-switch@~3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/bootstrap-switch/-/bootstrap-switch-3.3.4.tgz#70e0aeb2a877c0dc766991de108e2170fc29a2ff"
+
+bootstrap-touchspin@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/bootstrap-touchspin/-/bootstrap-touchspin-3.1.1.tgz#9779deac72aaf577e5e762b8512c747c871d9597"
+
+bootstrap@3.3.x, bootstrap@^3.3, bootstrap@~3.3.7:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
+
 brace-expansion@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
@@ -852,6 +876,12 @@ builtin-modules@^1.0.0:
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+
+c3@~0.4.11:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/c3/-/c3-0.4.18.tgz#6f1c4409635263b8a3de607edbab4bdc678c62cb"
+  dependencies:
+    d3 "~3.5.0"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -1136,6 +1166,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-react-class@^15.6.0:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -1236,6 +1274,10 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
+d3@~3.5.0, d3@~3.5.17:
+  version "3.5.17"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-3.5.17.tgz#bc46748004378b21a360c9fc7cf5231790762fb8"
+
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -1247,6 +1289,54 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+datatables.net-bs@>=1.10.9:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/datatables.net-bs/-/datatables.net-bs-2.1.1.tgz#704108972891949d094bf44f53d0654d9fee7bce"
+  dependencies:
+    datatables.net ">=1.10.9"
+    jquery ">=1.7"
+
+datatables.net-colreorder-bs@~1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/datatables.net-colreorder-bs/-/datatables.net-colreorder-bs-1.3.3.tgz#3a9dcb08deebeb5d854079591e06e493ad793a53"
+  dependencies:
+    datatables.net-bs ">=1.10.9"
+    datatables.net-colreorder ">=1.2.0"
+    jquery ">=1.7"
+
+datatables.net-colreorder@>=1.2.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/datatables.net-colreorder/-/datatables.net-colreorder-1.4.1.tgz#389e4b1a274e203979a3718d86c5884d0a0166b6"
+  dependencies:
+    datatables.net "^1.10.15"
+    jquery ">=1.7"
+
+datatables.net-colreorder@~1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/datatables.net-colreorder/-/datatables.net-colreorder-1.3.3.tgz#fc762e350f94224cb2cd45c2b962261a0fffef72"
+  dependencies:
+    datatables.net ">=1.10.9"
+    jquery ">=1.7"
+
+datatables.net-select@~1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/datatables.net-select/-/datatables.net-select-1.2.3.tgz#7c272e81732a41214e101b656f5525d37ec37288"
+  dependencies:
+    datatables.net "^1.10.15"
+    jquery ">=1.7"
+
+datatables.net@>=1.10.9:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-2.1.1.tgz#6f1103ef08054642aecf85e7e25efd592822ee78"
+  dependencies:
+    jquery ">=1.7"
+
+datatables.net@^1.10.15:
+  version "1.10.16"
+  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.10.16.tgz#4b052d1082824261b68eed9d22741b711d3d2469"
+  dependencies:
+    jquery ">=1.7"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -1372,6 +1462,12 @@ domutils@1.5:
     dom-serializer "0"
     domelementtype "1"
 
+drmonty-datatables-colvis@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/drmonty-datatables-colvis/-/drmonty-datatables-colvis-1.1.2.tgz#96ab9edfb48643cc2edda3f87b88933cdee8127c"
+  dependencies:
+    jquery ">=1.7.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -1424,6 +1520,15 @@ entities@1.0:
 entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+eonasdan-bootstrap-datetimepicker@^4.17.47:
+  version "4.17.47"
+  resolved "https://registry.yarnpkg.com/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.47.tgz#7a49970044065276e7965efd16f822735219e735"
+  dependencies:
+    bootstrap "^3.3"
+    jquery "^1.8.3 || ^2.0 || ^3.0"
+    moment "^2.10"
+    moment-timezone "^0.4.0"
 
 errno@^0.1.3:
   version "0.1.4"
@@ -1675,6 +1780,18 @@ fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 fbjs@^0.8.9:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
@@ -1742,6 +1859,10 @@ flat-cache@^1.2.1:
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
+font-awesome@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -1892,6 +2013,10 @@ globby@^5.0.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+google-code-prettify@~1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/google-code-prettify/-/google-code-prettify-1.0.5.tgz#9f477f224dbfa62372e5ef803a7e157410400084"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
@@ -2283,6 +2408,14 @@ jasmine@^2.7.0:
     glob "^7.0.6"
     jasmine-core "~2.8.0"
 
+jquery-match-height@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/jquery-match-height/-/jquery-match-height-0.7.2.tgz#f8d9f3ba5314daab109cf07408674be204be5f0e"
+
+"jquery@>= 2.1.x", jquery@>=1.7, jquery@>=1.7.0, jquery@>=1.7.1, jquery@>=1.8, "jquery@^1.8.3 || ^2.0 || ^3.0", jquery@^3.2.1, jquery@~3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
+
 js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
@@ -2493,7 +2626,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2576,6 +2709,20 @@ minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+moment-timezone@^0.4.0, moment-timezone@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.4.1.tgz#81f598c3ad5e22cdad796b67ecd8d88d0f5baa06"
+  dependencies:
+    moment ">= 2.6.0"
+
+"moment@>= 2.6.0", moment@^2.10:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+
+moment@~2.14.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.14.1.tgz#b35b27c47e57ed2ddc70053d6b07becdb291741c"
 
 ms@2.0.0:
   version "2.0.0"
@@ -2704,7 +2851,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2828,12 +2975,50 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+patternfly-bootstrap-combobox@~1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/patternfly-bootstrap-combobox/-/patternfly-bootstrap-combobox-1.1.7.tgz#6a5e3ccd1170c21b3c4b4aa168a7413e1ddbb6e1"
+
+patternfly-bootstrap-treeview@~2.1.0:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/patternfly-bootstrap-treeview/-/patternfly-bootstrap-treeview-2.1.5.tgz#4c29f2582fb8a2f28f0a928f2f0d324d21d6990d"
+  dependencies:
+    bootstrap "3.3.x"
+    jquery ">= 2.1.x"
+
 "patternfly-react@https://github.com/candlepin/patternfly-react":
   version "0.0.0-semantically-released"
   resolved "https://github.com/candlepin/patternfly-react#b53d94401ca07326c38e567dd75f4963f90c8b49"
   dependencies:
     classnames "^2.2.5"
     react-bootstrap "^0.30.8"
+
+patternfly@^3.27.4:
+  version "3.27.6"
+  resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.27.6.tgz#1d1b4bb1d8c8cbe5f77de4ebc3dc2af21cff6457"
+  dependencies:
+    bootstrap "~3.3.7"
+    font-awesome "^4.7.0"
+    jquery "~3.2.1"
+  optionalDependencies:
+    bootstrap-datepicker "~1.6.4"
+    bootstrap-select "^1.12.2"
+    bootstrap-switch "~3.3.4"
+    bootstrap-touchspin "~3.1.1"
+    c3 "~0.4.11"
+    d3 "~3.5.17"
+    datatables.net "^1.10.15"
+    datatables.net-colreorder "~1.3.2"
+    datatables.net-colreorder-bs "~1.3.2"
+    datatables.net-select "~1.2.0"
+    drmonty-datatables-colvis "~1.1.2"
+    eonasdan-bootstrap-datetimepicker "^4.17.47"
+    google-code-prettify "~1.0.5"
+    jquery-match-height "^0.7.2"
+    moment "~2.14.1"
+    moment-timezone "^0.4.1"
+    patternfly-bootstrap-combobox "~1.1.7"
+    patternfly-bootstrap-treeview "~2.1.0"
 
 pbkdf2@^3.0.3:
   version "3.0.12"
@@ -3153,6 +3338,14 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.10:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prop-types@^15.5.6:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
@@ -3255,9 +3448,14 @@ react-bootstrap@^0.30.8:
     uncontrollable "^4.0.1"
     warning "^3.0.0"
 
-react-lite@0.15.30:
-  version "0.15.30"
-  resolved "https://registry.yarnpkg.com/react-lite/-/react-lite-0.15.30.tgz#7b95b6a85d748a0a5a530aa3bd677f2646350aba"
+react-dom@^15.6.1:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
 
 react-overlays@^0.6.12:
   version "0.6.12"
@@ -3273,6 +3471,16 @@ react-prop-types@^0.4.0:
   resolved "https://registry.yarnpkg.com/react-prop-types/-/react-prop-types-0.4.0.tgz#f99b0bfb4006929c9af2051e7c1414a5c75b93d0"
   dependencies:
     warning "^3.0.0"
+
+react@^15.6.1:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
+  dependencies:
+    create-react-class "^15.6.0"
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I had to switch from react-lite to react because react-lite was not
tolerant of the DOM-tree changes that bootstrap-select uses.

PR Note: right now the base is the branch used for #1693, as this builds on work in that branch. Before merging, let's make sure #1693 is addressed, and then I'll update the base of this PR to `feature/cockpit`.

i.e. at time of writing: review is okay, but merge should wait until #1693.