### PR TITLE
Improve the cockpit plugin dev experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,30 +9,30 @@ from the  Candlepin.
  - https://fedorahosted.org/subscription-manager/
  - https://github.com/candlepin/subscription-Manager
 
-Cockpit
--------
-Cockpit development requires [yarn](https://yarnpkg.com/) to be installed.
-The easiest way to set this up on Fedora is:
-
-```bash
-sudo dnf install -y npm
-sudo npm install -g yarn
-```
-
-See `cockpit/README.md` for more information.
-
 Vagrant
 -------
 
 `vagrant up` can be used to spin up various VMs set up for development work.
 These VMs are all configured using the included ansible role "subman-devel".
-The `PYTHONPATH` and `PATH` inside these environments is modified so that
+The python paths and `PATH` inside these environments are modified so that
 running `subscription-manager` or `subscription-manager-gui` will use
 scripts and modules from the source code.
 
+Cockpit can be accessed at port 9090 on the VM, for example:
+https://centos7.subman.example.com:9090/
+
+**NOTE**: Use of hostnames per above requires the vagrant hostmanager plugin.
+Cockpit credentials are the same as user credientials;
+i.e. User name: `vagrant` password: `vagrant`
+
+There are two links added in the cockpit interface: one for the
+subscription-manager cockpit plugin itself, and then one which runs integration
+tests for the D-Bus interface.
+
 Currently, the source is set up as a vagrant shared folder using rsync. This
 means that it is necessary to use `vagrant rsync` to sync changes with the
-host if desired.
+host if desired. `vagrant rsync-auto` can be used to monitor the directory for
+changes and then sync when appropriate.
 
 The ansible role that provisions the VMs tries to find the IP address of
 candlepin.example.com, so if the candlepin vagrant image is started first,
@@ -72,6 +72,27 @@ export SUBMAN_RHSM_PASSWORD=password
 Note, however, since the registration is necessary to download RPMs to set up
 the VM for development, registering against a local candlepin might not be
 particularly useful (at least not for initial provisioning).
+
+D-Bus Development
+-----------------
+In a vagrant VM, the `com.redhat.RHSM1` service along with related files 
+(scripts, policy files, etc.) are linked to those from the source. However, it
+is necessary to restart the D-Bus service if edits are made while it is running
+with, for example, `sudo systemctl restart rhsm`.
+
+Cockpit
+-------
+
+The easiest way to get started with cockpit plugin development is Vagrant.
+Inside the VM, from the directory `/vagrant/cockpit`, the following commands
+can be used:
+
+ - `yarn install` - fetch dependencies, and update the lockfile if necessary.
+ - `npm run build` - do a build of the JavaScript source.
+ - `npm run watch` - monitor the source for changes and rebuild the cockpit
+  plugin when necessary.
+
+See `cockpit/README.md` for more detailed information on cockpit development.
 
 Troubleshooting
 ---------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,13 +38,11 @@ Vagrant.configure("2") do |config|
   # setup shared folder
   config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: [
     "build",
-    "build_ext",
     "python-rhsm/build",
-    "python-rhsm/build_ext",
     "python-rhsm/src/rhsm/_certificate.so",
     "subscription-manager.egg-info",
+    "cockpit/node_modules",
   ]
-  config.vm.synced_folder "cockpit/dist", "/usr/local/share/cockpit/subscription-manager", create: true
 
   # Set up the hostmanager plugin to automatically configure host & guest hostnames
   if Vagrant.has_plugin?("vagrant-hostmanager")

--- a/cockpit/README.md
+++ b/cockpit/README.md
@@ -1,24 +1,42 @@
 # Subscription-manager
 **A Cockpit plugin to administer candlepin subscriptions**
 
-See [docs/build-notes.md](docs/build-notes.md) for more information on how to build and install this package.
-
 Development Quickstart
 ----------------------
-To install necessary libraries & get a development VM provisioned:
-
-```bash
-sudo dnf install -y npm
-sudo npm install -g yarn
-yarn install
-vagrant up
-```
+Run `vagrant up`. subscription-manager cockpit plugin code lands in
+`/vagrant/cockpit`.
 
 Once the VM is up, cockpit is accessible via https://centos7.subman.example.com:9090 (must have vagrant hostmanager plugin installed). The fedora VM works similarly.
 
-Afterwards:
-```bash
-npm run watch  # shortcut to webpack --watch & vagrant rsync-auto
-```
+NPM scripts (documented below) should be used to rebuild plugin artifacts when
+code is edited.
 
-Then any changes to `src/*` will be picked up by webpack and built, and subsequently synced to the VM.
+Development Outside of Vagrant
+------------------------------
+ - `nvm` is recommended but not required (https://github.com/creationix/nvm).
+ - `yarn` needs to be installed globally (`npm install -g yarn`).
+ - `yarn install` needs to be run from the `cockpit` subdirectory.
+
+With these steps, the cockpit plugin code can be built from the host.
+
+Yarn
+----
+Yarn is used to install, remove, and update NPM packages for the plugin.
+
+The most common commands are:
+ - `yarn add <package> --dev`: Add a JavaScript dependency.
+ - `yarn install`: Install JavaScript dependencies and update the lockfile if
+   necessary.
+
+(See https://yarnpkg.com for more details on using yarn).
+
+NPM Scripts
+-----------
+There are several commands configured in `package.json`, these should be run
+from the `cockpit` subdirectory:
+ - `npm run build` - do a build of the JavaScript source with results in `dist`
+ - `npm run watch` - monitor the source for changes and rebuild the cockpit
+   plugin when necessary.
+ - `npm run vagrant-watch`: same as `npm run watch`, and also invokes
+   `vagrant rsync-auto`. Useful if you want to develop on the host and see the
+   effects in a VM.

--- a/cockpit/webpack.config.js
+++ b/cockpit/webpack.config.js
@@ -11,7 +11,7 @@ var externals = {
 /* These can be overridden, typically from the Makefile.am */
 const srcdir = (process.env.SRCDIR || __dirname) + path.sep + "src";
 const builddir = (process.env.SRCDIR || __dirname);
-const distdir = process.env.NODE_ENV === 'vagrant' ? '/usr/local/share/cockpit/subscription-manager' : (builddir + path.sep + "dist");
+const distdir = builddir + path.sep + "dist";
 const section = process.env.ONLYDIR || null;
 const nodedir = path.resolve((process.env.SRCDIR || __dirname), "node_modules");
 

--- a/vagrant/roles/subman-devel/defaults/main.yml
+++ b/vagrant/roles/subman-devel/defaults/main.yml
@@ -2,6 +2,7 @@
 subman_checkout_dir: .
 subman_setup_hacking_environment: false
 subman_add_vagrant_candlepin_to_hosts: false
+subman_nodejs_version: v6.11.3
 distro_package_command: yum
 distro_specific_deps:
     - koji
@@ -9,7 +10,6 @@ distro_specific_deps:
     - git
     - gcc
     - make
-    - npm
     - python-pip
     - m2crypto
     - python-ethtool
@@ -20,3 +20,4 @@ distro_specific_deps:
     - libselinux-python
     - xorg-x11-server-Xvfb
     - yum-utils
+libexec_path: /usr/libexec

--- a/vagrant/roles/subman-devel/files/com.redhat.RHSM1.conf
+++ b/vagrant/roles/subman-devel/files/com.redhat.RHSM1.conf
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?> <!-- -*- XML -*- -->
+
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+    <include>/vagrant/etc-conf/dbus/system.d/com.redhat.RHSM1.conf</include>
+</busconfig>

--- a/vagrant/roles/subman-devel/files/sitecustomize.py
+++ b/vagrant/roles/subman-devel/files/sitecustomize.py
@@ -1,0 +1,4 @@
+import sys
+
+sys.path.insert(0, '/vagrant/python-rhsm/src')
+sys.path.insert(0, '/vagrant/src')

--- a/vagrant/roles/subman-devel/tasks/cockpit.yml
+++ b/vagrant/roles/subman-devel/tasks/cockpit.yml
@@ -11,9 +11,3 @@
     enabled: yes
     state: started
   become: yes
-
-- name: alter node_env
-  lineinfile:
-    name: /etc/environment
-    line: "NODE_ENV=vagrant"
-  become: yes

--- a/vagrant/roles/subman-devel/tasks/main.yml
+++ b/vagrant/roles/subman-devel/tasks/main.yml
@@ -123,11 +123,25 @@
   with_items: "{{ distro_specific_python_rhsm_build_deps }}"
   when: distro_specific_python_rhsm_build_deps is defined
 
+- name: install nvm
+  shell: 'curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.4/install.sh | bash'
+  args:
+    creates: /home/vagrant/.nvm
+    warn: no
+
+- name: use nvm to install nodejs
+  shell: >
+    /bin/bash -c
+    ". ~/.nvm/nvm.sh &&
+    nvm install {{ subman_nodejs_version }} &&
+    nvm alias default {{ subman_nodejs_version }}"
+  args:
+    creates: /home/vagrant/.nvm/versions/node/{{ subman_nodejs_version }}
+
 - name: install yarn (for cockpit package build)
   npm:
     name: yarn
     global: yes
-  become: yes
 
 - include: cockpit.yml
   when: ansible_distribution == 'Fedora' or (ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7')
@@ -179,9 +193,9 @@
   become: yes
 
 - name: alter PYTHONPATH
-  lineinfile:
-    name: /etc/environment
-    line: "PYTHONPATH={{ subman_checkout_dir }}/src:{{ subman_checkout_dir }}/python-rhsm/src"
+  copy:
+    src: sitecustomize.py
+    dest: /usr/lib/python{{ ansible_python_version[:-2] }}/site-packages/sitecustomize.py
   become: yes
 
 - name: set GTK version
@@ -196,6 +210,56 @@
     line: "Defaults    secure_path = {{ subman_checkout_dir }}/bin:/sbin:/bin:/usr/sbin:/usr/bin"
     regexp: '^Defaults\s+secure_path.*'
   become: yes
+
+- name: replace rhsm-service with symlink
+  file:
+    src: /vagrant/bin/rhsm-service
+    dest: "{{ libexec_path }}/rhsm-service"
+    state: link
+    force: yes
+  become: yes
+  when: subman_setup_hacking_environment
+
+# needed for dbus to read /vagrant/etc-conf/dbus/system.d
+- name: disable selinux
+  selinux:
+    state: permissive
+    policy: targeted
+  become: yes
+
+# the shim includes /vagrant/etc-conf/dbus/system.d/com.redhat.RHSM1.conf
+- name: replace RHSM1 dbus policy file with shim
+  copy:
+    src: com.redhat.RHSM1.conf
+    dest: /etc/dbus-1/system.d/com.redhat.RHSM1.conf
+  become: yes
+  when: subman_setup_hacking_environment
+
+- name: add cockpit local plugin dir
+  file:
+    path: /usr/local/share/cockpit
+    state: directory
+  become: yes
+  when: subman_setup_hacking_environment
+
+- name: yarn install (for convenience)
+  command: yarn install
+  args:
+    chdir: /vagrant/cockpit
+
+- name: webpack build (for convenience)
+  command: npm run build
+  args:
+    chdir: /vagrant/cockpit
+
+- name: add symlink to dist for cockpit plugin
+  file:
+    src: /vagrant/cockpit/dist
+    dest: /usr/local/share/cockpit/subscription-manager
+    state: link
+    force: yes
+  become: yes
+  when: subman_setup_hacking_environment
 
 - name: add candlepin.example.com to hosts (using this host as reference)
   lineinfile:

--- a/vagrant/roles/subman-devel/vars/openSUSE Leap.yml
+++ b/vagrant/roles/subman-devel/vars/openSUSE Leap.yml
@@ -42,3 +42,5 @@ distro_specific_python_rhsm_build_deps:
  - python-setuptools
  - openssl-devel
  - python-six
+
+libexec_path: /usr/lib


### PR DESCRIPTION
Changes:
 - `/vagrant/src` and `/vagrant/python-rhsm/src` are now in the python path for all processes, by using `sitecustomize.py`
 - `/usr/libexec/rhsm-service` is a now symlink to `/vagrant/bin/rhsm-service`
 - webpack is now configured the same in the VM
 - `/usr/local/share/cockpit/subscription-manager` is now a symlink to `/vagrant/cockpit/dist`
 - Excludes are now adjusted to avoid problems when rsyncing
 - The dbus config file for RHSM1 is replaced with a shim that includes `/vagrant/etc-conf/dbus/system.d/com.redhat.RHSM1.conf`
 - selinux is set to permissive to allow the aforementioned shim to work.
 - `nvm` is used to install npm, instead of relying on the version in EPEL

With these changes, a developer should be able to simply checkout the code, `vagrant up`, and see the results in the cockpit interface at ex. https://centos7.subman.example.com:9090/ . Note that you may need to use `vagrant destroy` and `vagrant up` to recreate the VM in order to realize all the effects of the changes in this commit.

Also, the symlinks/shim allow a more interactive D-Bus development, where only rsync and then stopping the stale process is necessary.