### PR TITLE
1501889: Enable yum plugins after sub-man subcommand is executed

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2620,10 +2620,11 @@ class ManagerCLI(CLI):
 
     def main(self):
         managerlib.check_identity_cert_perms()
+        ret = CLI.main(self)
+        # Try to enable all yum plugins (subscription-manager and plugin-id)
         enabled_yum_plugins = YumPluginManager.enable_yum_plugins()
         if len(enabled_yum_plugins) > 0:
-            print(_('WARNING') + '\n\n' + YumPluginManager.warning_message(enabled_yum_plugins))
-        ret = CLI.main(self)
+            print('\n' + _('WARNING') + '\n\n' + YumPluginManager.warning_message(enabled_yum_plugins))
         # Try to flush all outputs, see BZ: 1350402
         try:
             sys.stdout.flush()


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1501889
* Warning message is printed after output of sub-command.