### PR TITLE
Cockpit: use translations from root dir

### DIFF
--- a/build_ext/i18n.py
+++ b/build_ext/i18n.py
@@ -142,6 +142,11 @@ class Gettext(BaseCommand):
         files.extend(list(Utils.find_files_of_type('src', '*.ui', '*.glade')))
         return files
 
+    def find_js(self):
+        files = []
+        files.extend(list(Utils.find_files_of_type('cockpit/src', '*.js', '*.jsx')))
+        return files
+
     def find_desktop(self):
         files = []
         files.extend(list(Utils.find_files_of_type('etc-conf', '*.desktop.in')))
@@ -182,6 +187,7 @@ class Gettext(BaseCommand):
             ('%s.c_files', self.find_c, 'C', ['-k_', '-kN_']),
             ('%s.py_files', self.find_py, 'Python', []),
             ('%s.glade_files', self.find_glade, 'Glade', []),
+            ('%s.js_files', self.find_js, 'JavaScript', []),
         ]
 
         for manifest_template, search_func, language, other_options in trans_types:

--- a/cockpit/package.json
+++ b/cockpit/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "webpack",
     "jasmine": "jasmine",
+    "po2json": "po2json",
     "vagrant-watch": "webpack --watch & vagrant rsync-auto",
     "watch": "webpack --watch"
   },
@@ -24,12 +25,14 @@
     "eslint-loader": "~1.6.1",
     "eslint-plugin-react": "~6.9.0",
     "extract-text-webpack-plugin": "2.1.2",
+    "glob": "^7.1.2",
     "jasmine": "^2.7.0",
     "jquery": "^3.2.1",
     "jshint": "~2.9.1",
     "jshint-loader": "~0.8.3",
     "patternfly": "^3.27.4",
     "patternfly-react": "https://github.com/candlepin/patternfly-react",
+    "po2json": "^0.4.5",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "style-loader": "^0.18.2",

--- a/cockpit/src/index.html
+++ b/cockpit/src/index.html
@@ -31,7 +31,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 <body>
     <div id="app"></div>
     <script type="text/javascript" src="../base1/cockpit.js"></script>
-    <script type="text/javascript" src="../*/po.js"></script>
+    <script type="text/javascript" src="po.js"></script>
     <script type="text/javascript" src="index.js"></script>
 </body>
 </html>

--- a/cockpit/src/index.js
+++ b/cockpit/src/index.js
@@ -67,7 +67,7 @@ function openRegisterDialog() {
         registerDialogDetails.onChange = updatedData;
 
         var dialogProps = {
-              'title': _("Register system"),
+              'title': _("Register System"),
               'body': React.createElement(subscriptionsRegister.dialogBody, registerDialogDetails),
           };
 

--- a/cockpit/src/subscriptions-register.jsx
+++ b/cockpit/src/subscriptions-register.jsx
@@ -60,7 +60,7 @@ var PatternDialogBody = React.createClass({
                         <tr>
                             <td>
                                 <label className="control-label" htmlFor="subscription-proxy-server">
-                                    {_("Server")}
+                                    {_("Proxy Location")}
                                 </label>
                             </td>
                             <td><input className="form-control" id="subscription-proxy-server" type="text"
@@ -72,7 +72,7 @@ var PatternDialogBody = React.createClass({
                         <tr>
                             <td>
                                 <label className="control-label" htmlFor="subscription-proxy-user">
-                                    {_("User")}
+                                    {_("Proxy Username")}
                                 </label>
                             </td>
                             <td><input className="form-control" id="subscription-proxy-user" type="text"
@@ -84,7 +84,7 @@ var PatternDialogBody = React.createClass({
                         <tr>
                             <td>
                                 <label className="control-label" htmlFor="subscription-proxy-password">
-                                    {_("Password")}
+                                    {_("Proxy Password")}
                                 </label>
                             </td>
                             <td><input className="form-control" id="subscription-proxy-password" type="password"
@@ -129,7 +129,7 @@ var PatternDialogBody = React.createClass({
                                 <label>
                                     <input id="subscription-proxy-use" type="checkbox" checked={this.props.proxy}
                                            onChange={value => this.props.onChange('proxy', value)}/>
-                                    {_("Use proxy server")}
+                                    {_("I would like to connect via an HTTP proxy.")}
                                 </label>
                                 {proxy}
                             </td>

--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -56,10 +56,10 @@ var SubscriptionProductDetails = React.createClass({
     render: function() {
         return (
             <div key={this.props.productId}>
-                <tr><td className="form-tr-ct-title">{_("Product name")}</td><td><span>{this.props.productName}</span></td></tr>
+                <tr><td className="form-tr-ct-title">{_("Product Name")}</td><td><span>{this.props.productName}</span></td></tr>
                 <tr><td className="form-tr-ct-title">{_("Product ID")}</td><td><span>{this.props.productId}</span></td></tr>
                 <tr><td className="form-tr-ct-title">{_("Version")}</td><td><span>{this.props.version}</span></td></tr>
-                <tr><td className="form-tr-ct-title">{_("Architecture")}</td><td><span>{this.props.arch}</span></td></tr>
+                <tr><td className="form-tr-ct-title">{_("Arch")}</td><td><span>{this.props.arch}</span></td></tr>
                 <tr><td className="form-tr-ct-title">{_("Status")}</td><td><span>{this.props.status}</span></td></tr>
                 <tr><td className="form-tr-ct-title">{_("Starts")}</td><td><span>{this.props.starts}</span></td></tr>
                 <tr><td className="form-tr-ct-title">{_("Ends")}</td><td><span>{this.props.ends}</span></td></tr>
@@ -165,7 +165,7 @@ var SubscriptionStatus = React.createClass({
         var note;
         var isUnregistering = (this.props.status == "unregistering");
         if (this.props.status == 'Unknown') {
-            label = <label>{ _("Status: System isn't registered") }</label>;
+            label = <label>{ cockpit.format(_("Status: $0"), _("This system is currently not registered.")) }</label>;
             action = (<button className="btn btn-primary"
                               onClick={this.handleRegisterSystem}>{_("Register")}</button>
             );
@@ -178,7 +178,7 @@ var SubscriptionStatus = React.createClass({
                 note = (
                     <div className="dialog-wait-ct">
                         <div className="spinner spinner-sm"></div>
-                        <span>{ _("Unregistering system...") }</span>
+                        <span>{ _("Unregistering") }</span>
                     </div>
                 );
             }
@@ -233,7 +233,7 @@ var SubscriptionsPage = React.createClass({
         var entries = this.props.products.map(function(itm) {
             var tabRenderers = [
                 {
-                    name: _("Details"),
+                    name: _("Product's Subscription Details"),
                     renderer: SubscriptionProductDetails,
                     data: itm,
                 },
@@ -247,7 +247,7 @@ var SubscriptionsPage = React.createClass({
             <SubscriptionStatus {...this.props }/>
             <Listing
                     title={ _("Installed products") }
-                    emptyCaption={ _("No installed products on the system.") }
+                    emptyCaption={ _("No installed products detected.") }
                     >
                 {entries}
             </Listing>

--- a/cockpit/yarn.lock
+++ b/cockpit/yarn.lock
@@ -88,6 +88,10 @@ ansi-styles@^3.1.0:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
+
 anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
@@ -946,6 +950,14 @@ chalk@^2.1.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chalk@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  dependencies:
+    ansi-styles "~1.0.0"
+    has-color "~0.1.0"
+    strip-ansi "~0.1.0"
 
 chokidar@^1.4.3:
   version "1.7.0"
@@ -1974,6 +1986,12 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+gettext-parser@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/gettext-parser/-/gettext-parser-1.1.0.tgz#2c5a6638d893934b9b55037d0ad82cb7004b2679"
+  dependencies:
+    encoding "^0.1.11"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -1997,7 +2015,7 @@ glob@^6.0.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -2047,6 +2065,10 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+has-color@~0.1.0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
 
 has-flag@^1.0.0:
   version "1.0.0"
@@ -2804,6 +2826,13 @@ node-pre-gyp@^0.6.36:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
+nomnom@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
+  dependencies:
+    chalk "~0.4.0"
+    underscore "~1.6.0"
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -3066,6 +3095,13 @@ pkg-dir@^1.0.0:
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+
+po2json@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/po2json/-/po2json-0.4.5.tgz#47bb2952da32d58a1be2f256a598eebc0b745118"
+  dependencies:
+    gettext-parser "1.1.0"
+    nomnom "1.8.1"
 
 postcss-calc@^5.2.0:
   version "5.3.1"
@@ -3933,6 +3969,10 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-ansi@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -4112,6 +4152,10 @@ uncontrollable@^4.0.1:
   resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.1.0.tgz#e0358291252e1865222d90939b19f2f49f81c1a9"
   dependencies:
     invariant "^2.1.0"
+
+underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
 uniq@^1.0.1:
   version "1.0.1"

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -801,6 +801,8 @@ rm -rf %{buildroot}
 %{_datadir}/cockpit/subscription-manager/index.min.js.gz
 %{_datadir}/cockpit/subscription-manager/subscriptions.css
 %{_datadir}/cockpit/subscription-manager/manifest.json
+%{_datadir}/cockpit/subscription-manager/po.*.js
+%{_datadir}/cockpit/subscription-manager/po.js
 %{_datadir}/metainfo/org.cockpit-project.subscription-manager.metainfo.xml
 %endif
 


### PR DESCRIPTION
This means:
 - build the translations from those po files use po2json
 - import the resulting files into cockpit via `cockpit.locale`
 - hook js/jsx files into our xgettext usage via setup.py

In index.html, we now reference `po.js`.
Cockpit will automatically serve `po.${language}.js` instead when present.