### PR TITLE
1506970: Fixed default custom URL in cockpit plugin

### DIFF
--- a/cockpit/src/subscriptions-register.jsx
+++ b/cockpit/src/subscriptions-register.jsx
@@ -26,7 +26,7 @@ import Select from "./Select/Select.jsx";
 function defaultRegisterDialogSettings() {
     return {
         url: 'default',
-        serverUrl: 'subscription.rhn.redhat.com',
+        serverUrl: 'subscription.rhsm.redhat.com',
         proxy: false,
         proxyServer: '',
         proxyUser: '',


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1506970
* Chnaged string from: subscription.rhn.redhat.com (wrong value)
  to: subscription.rhsm.redhat.com