### PR TITLE
1500106: subscription-manager status --ondate do not ignore date

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -316,12 +316,7 @@ class EntitlementStatusCache(StatusCache):
     """
     CACHE_FILE = "/var/lib/rhsm/cache/entitlement_status.json"
 
-    def _sync_with_server(self, uep, uuid, *args, **kwargs):
-        on_date = None
-        if len(args) > 0:
-            on_date = args[0]
-        elif 'on_date' in kwargs:
-            on_date = kwargs['on_date']
+    def _sync_with_server(self, uep, uuid, on_date=None, *args, **kwargs):
         self.server_status = uep.getCompliance(uuid, on_date)
 
 

--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -146,7 +146,7 @@ class ComplianceManager(object):
 
         if 'status' in status and len(status['status']):
             self.system_status = status['status']
-        #Some old candlepin versions do not return 'status' with information
+        # Some old candlepin versions do not return 'status' with information
         elif status['nonCompliantProducts']:
             self.system_status = 'invalid'
         elif self.partially_valid_products or self.partial_stacks or \
@@ -176,7 +176,7 @@ class ComplianceManager(object):
                     self.partially_valid_products and pid not in \
                     unentitled_pids:
                 log.warn("Installed product %s not present in response from "
-                        "server." % pid)
+                         "server." % pid)
                 unentitled_pids.append(pid)
 
         for unentitled_pid in unentitled_pids:
@@ -184,7 +184,7 @@ class ComplianceManager(object):
             # Ignore anything server thinks we have but we don't.
             if prod_cert is None:
                 log.warn("Server reported installed product not on system: %s" %
-                        unentitled_pid)
+                         unentitled_pid)
                 continue
             self.unentitled_products[unentitled_pid] = prod_cert
 
@@ -340,7 +340,11 @@ class CertSorter(ComplianceManager):
 
     def get_compliance_status(self):
         status_cache = inj.require(inj.ENTITLEMENT_STATUS_CACHE)
-        return status_cache.load_status(self.cp_provider.get_consumer_auth_cp(), self.identity.uuid)
+        return status_cache.load_status(
+            self.cp_provider.get_consumer_auth_cp(),
+            self.identity.uuid,
+            self.on_date
+        )
 
     def update_product_manager(self):
         if self.is_registered():

--- a/src/subscription_manager/injection.py
+++ b/src/subscription_manager/injection.py
@@ -77,8 +77,7 @@ class FeatureBroker(object):
             raise KeyError("Unknown feature: %r" % feature)
 
         if isinstance(provider, (type, six.class_types)):
-            # Args should never be used with singletons, they are ignored
-            self.providers[feature] = provider()
+            self.providers[feature] = provider(*args, **kwargs)
         elif six.callable(provider):
             return provider(*args, **kwargs)
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -413,6 +413,26 @@ class TestEntitlementStatusCache(SubManFixture):
         self.assertEqual(dummy_status, self.status_cache.server_status)
         self.assertEqual(1, self.status_cache.write_cache.call_count)
 
+    def test_load_from_server_on_date_args(self):
+        uep = Mock()
+        dummy_status = {"a": "1"}
+        uep.getCompliance = Mock(return_value=dummy_status)
+
+        self.status_cache.load_status(uep, "SOMEUUID", "2199-12-25")
+
+        self.assertEqual(dummy_status, self.status_cache.server_status)
+        self.assertEqual(1, self.status_cache.write_cache.call_count)
+
+    def test_load_from_server_on_date_kwargs(self):
+        uep = Mock()
+        dummy_status = {"a": "1"}
+        uep.getCompliance = Mock(return_value=dummy_status)
+
+        self.status_cache.load_status(uep, "SOMEUUID", on_date="2199-12-25")
+
+        self.assertEqual(dummy_status, self.status_cache.server_status)
+        self.assertEqual(1, self.status_cache.write_cache.call_count)
+
     def test_server_no_compliance_call(self):
         uep = Mock()
         uep.getCompliance = Mock(side_effect=RestlibException("boom"))


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1500106
* Argument on_date is not lost between calling sub-man CLI command
  line option and calling REST API
* TODO: add unit tests covering this case