### PR TITLE
1421010: Subman-GUI shows error dialog (wrong proxy settings)

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -135,7 +135,7 @@ class RhsmConfigParser(SafeConfigParser):
         try:
             return SafeConfigParser.get(self, section, prop)
         except InterpolationMissingOptionError:
-            #if there is an interpolation error, resolve it
+            # if there is an interpolation error, resolve it
             raw_val = super(RhsmConfigParser, self).get(section, prop, True)
             interpolations = re.findall("%\((.*?)\)s", raw_val)
             changed = False

--- a/src/subscription_manager/gui/utils.py
+++ b/src/subscription_manager/gui/utils.py
@@ -21,8 +21,6 @@ import re
 import threading
 import socket
 
-import rhsm.config as config
-
 from subscription_manager.ga import GObject as ga_GObject
 from subscription_manager.ga import Gtk as ga_Gtk
 from subscription_manager.ga import gtk_compat as ga_gtk_compat
@@ -43,8 +41,6 @@ EVEN_ROW_COLOR = '#eeeeee'
 # set if we are in firstboot, to disable linkify, see bz#814378
 FIRSTBOOT = False
 
-cfg = config.initConfig()
-
 
 def running_as_firstboot():
     global FIRSTBOOT
@@ -55,7 +51,7 @@ def get_running_as_firstboot():
     return FIRSTBOOT
 
 
-def test_proxy_reachability():
+def test_proxy_reachability(proxy_server, proxy_port):
     """
     Function used for testing reachability of proxy server. Note: this
     function does not test functionality of proxy server.
@@ -63,17 +59,14 @@ def test_proxy_reachability():
     """
 
     result = None
-    if not cfg.get("server", "proxy_hostname"):
-        return True
     try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.settimeout(10)
-        result = s.connect_ex((cfg.get("server", "proxy_hostname"),
-                               int(cfg.get("server", "proxy_port") or config.DEFAULT_PROXY_PORT)))
-    except Exception as e:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(10)
+        result = sock.connect_ex((proxy_server, proxy_port))
+    except socket.error as e:
         log.info("Attempted bad proxy: %s" % e)
     finally:
-        s.close()
+        sock.close()
 
     if result != 0:
         log.error("Proxy connection error: %s" % result)


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1421010
* When proxy requires authentication and no/wrong proxy_user and
  proxy_password is set in rhsm.conf, then error message is
  displayed now too
* Refactored code a little
* There are two variants of error dialog:
  * No `proxy_user` and/or `proxy_password`:
![subman-gui_proxy_auth_required](https://user-images.githubusercontent.com/2057012/32608966-4d4deb44-c55e-11e7-9101-830c32cd2461.png)
  * Wrong `proxy_user` and/or `proxy_password`:
![subman-gui_wrong_user-pass](https://user-images.githubusercontent.com/2057012/32608968-4f7775e8-c55e-11e7-8419-293a9fd53013.png)
