### PR TITLE
Add parameter to D-Bus API to pass locale for localization of errors

### DIFF
--- a/src/rhsmlib/dbus/objects/attach.py
+++ b/src/rhsmlib/dbus/objects/attach.py
@@ -17,6 +17,7 @@ import json
 import logging
 
 from subscription_manager import entcertlib
+from subscription_manager.i18n import Locale
 
 from rhsmlib.dbus import constants, base_object, util, dbus_utils
 from rhsmlib.services.attach import AttachService
@@ -29,10 +30,12 @@ log = logging.getLogger(__name__)
 
 
 class AttachDBusObject(base_object.BaseObject):
-    """A DBus object that interacts with subscription-manager to attach various
+    """
+    A DBus object that interacts with subscription-manager to attach various
     subscriptions.  Results are either a JSON string or a list of JSON strings.
     We don't return the JSON in an actual dictionary because deeply nested structures
-    are a nightmare in DBus land.  See https://stackoverflow.com/questions/31658423/"""
+    are a nightmare in DBus land.  See https://stackoverflow.com/questions/31658423/
+    """
     default_dbus_path = constants.ATTACH_DBUS_PATH
     interface_name = constants.ATTACH_INTERFACE
 
@@ -41,12 +44,15 @@ class AttachDBusObject(base_object.BaseObject):
 
     @util.dbus_service_method(
         constants.ATTACH_INTERFACE,
-        in_signature='sa{sv}',
+        in_signature='sa{sv}s',
         out_signature='s')
     @util.dbus_handle_exceptions
-    def AutoAttach(self, service_level, proxy_options, sender=None):
+    def AutoAttach(self, service_level, proxy_options, locale, sender=None):
         self.ensure_registered()
-        service_level = dbus_utils.dbus_to_python(service_level, str)
+        service_level = dbus_utils.dbus_to_python(service_level, expected_type=str)
+        proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
+        locale = dbus_utils.dbus_to_python(locale, expected_type=str)
+        Locale.set(locale)
 
         cp = self.build_uep(proxy_options, proxy_only=True)
         attach_service = AttachService(cp)
@@ -63,14 +69,17 @@ class AttachDBusObject(base_object.BaseObject):
 
     @util.dbus_service_method(
         constants.ATTACH_INTERFACE,
-        in_signature='asia{sv}',
+        in_signature='asia{sv}s',
         out_signature='as')
     @util.dbus_handle_exceptions
-    def PoolAttach(self, pools, quantity, proxy_options, sender=None):
+    def PoolAttach(self, pools, quantity, proxy_options, locale, sender=None):
         self.ensure_registered()
         pools = dbus_utils.dbus_to_python(pools, expected_type=list)
         quantity = dbus_utils.dbus_to_python(quantity, expected_type=int)
         proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
+
+        locale = dbus_utils.dbus_to_python(locale, expected_type=str)
+        Locale.set(locale)
 
         if quantity < 1:
             raise dbus.DBusException("Quantity must be a positive number.")

--- a/src/rhsmlib/dbus/objects/config.py
+++ b/src/rhsmlib/dbus/objects/config.py
@@ -17,6 +17,8 @@ import dbus
 import logging
 import six
 
+from subscription_manager.i18n import Locale
+
 from rhsmlib.dbus import constants, base_object, util, dbus_utils
 from rhsmlib.services.config import Config
 
@@ -34,11 +36,14 @@ class ConfigDBusObject(base_object.BaseObject):
 
     @util.dbus_service_method(
         constants.CONFIG_INTERFACE,
-        in_signature='sv')
+        in_signature='svs')
     @util.dbus_handle_exceptions
-    def Set(self, property_name, new_value, sender=None):
-        property_name = dbus_utils.dbus_to_python(property_name, str)
-        new_value = dbus_utils.dbus_to_python(new_value, str)
+    def Set(self, property_name, new_value, locale, sender=None):
+        property_name = dbus_utils.dbus_to_python(property_name, expected_type=str)
+        new_value = dbus_utils.dbus_to_python(new_value, expected_type=str)
+        locale = dbus_utils.dbus_to_python(locale, expected_type=str)
+        Locale.set(locale)
+
         section, _dot, property_name = property_name.partition('.')
 
         if not property_name:
@@ -49,10 +54,13 @@ class ConfigDBusObject(base_object.BaseObject):
 
     @util.dbus_service_method(
         constants.CONFIG_INTERFACE,
-        in_signature='',
+        in_signature='s',
         out_signature='a{sv}')
     @util.dbus_handle_exceptions
-    def GetAll(self, sender=None):
+    def GetAll(self, locale, sender=None):
+        locale = dbus_utils.dbus_to_python(locale, expected_type=str)
+        Locale.set(locale)
+
         d = dbus.Dictionary({}, signature='sv')
         for k, v in six.iteritems(self.config):
             d[k] = dbus.Dictionary({}, signature='ss')
@@ -63,10 +71,13 @@ class ConfigDBusObject(base_object.BaseObject):
 
     @util.dbus_service_method(
         constants.CONFIG_INTERFACE,
-        in_signature='s',
+        in_signature='ss',
         out_signature='v')
     @util.dbus_handle_exceptions
-    def Get(self, property_name, sender=None):
+    def Get(self, property_name, locale, sender=None):
+        locale = dbus_utils.dbus_to_python(locale, expected_type=str)
+        Locale.set(locale)
+
         section, _dot, property_name = property_name.partition('.')
 
         if property_name:

--- a/src/rhsmlib/dbus/objects/products.py
+++ b/src/rhsmlib/dbus/objects/products.py
@@ -20,6 +20,7 @@ from rhsmlib.dbus import constants, base_object, util, dbus_utils
 from rhsmlib.services.products import InstalledProducts
 
 from subscription_manager.injectioninit import init_dep_injection
+from subscription_manager.i18n import Locale
 
 init_dep_injection()
 
@@ -39,10 +40,10 @@ class ProductsDBusObject(base_object.BaseObject):
 
     @util.dbus_service_method(
         constants.PRODUCTS_INTERFACE,
-        in_signature='sa{sv}',
+        in_signature='sa{sv}s',
         out_signature='s')
     @util.dbus_handle_exceptions
-    def ListInstalledProducts(self, filter_string, proxy_options, sender=None):
+    def ListInstalledProducts(self, filter_string, proxy_options, locale, sender=None):
 
         # We reinitialize dependency injection here for following reason. When new product
         # certificate is installed (or existing is removed), then this change is not propagated to
@@ -53,6 +54,9 @@ class ProductsDBusObject(base_object.BaseObject):
 
         filter_string = dbus_utils.dbus_to_python(filter_string, expected_type=str)
         proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
+        locale = dbus_utils.dbus_to_python(locale, expected_type=str)
+
+        Locale.set(locale)
 
         cp = self.build_uep(proxy_options, proxy_only=True)
 

--- a/src/rhsmlib/dbus/objects/unregister.py
+++ b/src/rhsmlib/dbus/objects/unregister.py
@@ -28,6 +28,7 @@ from rhsmlib.services.unregister import UnregisterService
 
 from subscription_manager.injectioninit import init_dep_injection
 from subscription_manager.utils import restart_virt_who
+from subscription_manager.i18n import Locale
 
 init_dep_injection()
 
@@ -47,16 +48,20 @@ class UnregisterDBusObject(base_object.BaseObject):
 
     @util.dbus_service_method(
         constants.UNREGISTER_INTERFACE,
-        in_signature='a{sv}',
+        in_signature='a{sv}s',
         out_signature='')
     @util.dbus_handle_exceptions
-    def Unregister(self, proxy_options, sender=None):
+    def Unregister(self, proxy_options, locale, sender=None):
         """
         Definition and implementation of D-Bus method
         :param proxy_options: Definition of proxy settings
+        :param locale: String with locale (e.g. de_DE.UTF-8)
         :param sender: Not used argument
         """
         proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
+        locale = dbus_utils.dbus_to_python(locale, expected_type=str)
+
+        Locale.set(locale)
 
         self.ensure_registered()
 

--- a/src/rhsmlib/dbus/util.py
+++ b/src/rhsmlib/dbus/util.py
@@ -17,6 +17,7 @@ import sys
 import six
 import decorator
 import dbus.service
+import json
 
 from rhsmlib.dbus import exceptions
 
@@ -37,10 +38,17 @@ def dbus_handle_exceptions(func, *args, **kwargs):
     except dbus.DBusException as e:
         log.exception(e)
         raise
-    except Exception as e:
-        log.exception(e)
+    except Exception as err:
+        log.exception(err)
         trace = sys.exc_info()[2]
-        six.reraise(exceptions.RHSM1DBusException, "%s: %s" % (type(e).__name__, str(e)), trace)
+        # Raise exception string as JSON string. Thus it can be parsed and printed properly.
+        error_msg = json.dumps(
+            {
+                "exception": type(err).__name__,
+                "message": str(err)
+            }
+        )
+        six.reraise(exceptions.RHSM1DBusException, error_msg, trace)
 
 
 def dbus_service_method(*args, **kwargs):

--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -15,6 +15,8 @@ from __future__ import print_function, division, absolute_import
 #
 import gettext
 import locale
+import logging
+from threading import local
 
 import six
 
@@ -22,6 +24,15 @@ import six
 APP = 'rhsm'
 # Directory where translations are deployed:
 DIR = '/usr/share/locale/'
+
+TRANSLATION = gettext.translation(APP, fallback=True)
+
+# Save current language using thread safe approach
+LOCALE = local()
+LOCALE.language = None
+LOCALE.lang = None
+
+log = logging.getLogger(__name__)
 
 
 def configure_i18n():
@@ -51,10 +62,94 @@ def configure_gettext():
     gettext.bind_textdomain_codeset(APP, 'UTF-8')
     locale.bind_textdomain_codeset(APP, 'UTF-8')
 
-translation = gettext.translation(APP, fallback=True)
-if six.PY3:  # gettext returns unicode in Python 3
-    ugettext = translation.gettext
-    ungettext = translation.ngettext
-else:
-    ugettext = translation.ugettext
-    ungettext = translation.ungettext
+
+def ugettext(*args, **kwargs):
+    if six.PY2:
+        if hasattr(LOCALE, 'lang') and LOCALE.lang is not None:
+            return LOCALE.lang.ugettext(*args, **kwargs)
+        else:
+            return TRANSLATION.ugettext(*args, **kwargs)
+    else:
+        if hasattr(LOCALE, 'lang') and LOCALE.lang is not None:
+            return LOCALE.lang.gettext(*args, **kwargs)
+        else:
+            return TRANSLATION.gettext(*args, **kwargs)
+
+
+def ungettext(*args, **kwargs):
+    if six.PY2:
+        if hasattr(LOCALE, 'lang') and LOCALE.lang is not None:
+            return LOCALE.lang.ungettext(*args, **kwargs)
+        else:
+            return TRANSLATION.ungettext(*args, **kwargs)
+    else:
+        if hasattr(LOCALE, 'lang') and LOCALE.lang is not None:
+            return LOCALE.lang.ngettext(*args, **kwargs)
+        else:
+            return TRANSLATION.ngettext(*args, **kwargs)
+
+
+class Locale(object):
+    """
+    Class used for changing languages on the fly
+    """
+
+    translations = {}
+
+    @classmethod
+    def _find_lang_alternative(cls, language):
+        """
+        Try to find alternative for given language
+        :param language: string with code of language e.g. de_LU
+        :return: Instance of gettext.translation and code of new_language
+        """
+        lang = None
+        new_language = None
+        # For similar case: 'de'
+        if '_' not in language:
+            new_language = language + '_' + language.upper()
+        # For similar cases: 'de_AT' (Austria), 'de_LU' (Luxembourg)
+        elif language[0:2] != language[3:5]:
+            new_language = language[0:2] + '_' + language[0:2].upper() + language[5:]
+        if new_language is not None:
+            try:
+                lang = gettext.translation(APP, DIR, languages=[new_language])
+            except IOError as err:
+                log.info('Could not import locale either for %s: %s' % (new_language, err))
+                new_language = None
+            else:
+                log.debug('Using new locale for language: %s' % new_language)
+                cls.translations[language] = lang
+        return lang, new_language
+
+    @classmethod
+    def set(cls, language):
+        """
+        Set language used by gettext and ungettext method. This method is
+        intended for changing language on the fly, because rhsm service can
+        be used by many users with different language preferences at the
+        same time.
+        :param language: String representing locale
+                (e.g. de, de_DE, de_DE.utf-8, de_DE.UTF-8)
+        """
+        lang = None
+
+        if language != '':
+            if language in cls.translations.keys():
+                log.debug('Reusing locale for language: %s' % language)
+                lang = cls.translations[language]
+            else:
+                # Try to find given language
+                try:
+                    lang = gettext.translation(APP, DIR, languages=[language])
+                except IOError as err:
+                    log.info('Could not import locale for %s: %s' % (language, err))
+                    # When original language was not found, then we will try another
+                    # alternatives.
+                    lang, language = cls._find_lang_alternative(language)
+                else:
+                    log.debug('Using new locale for language: %s' % language)
+                    cls.translations[language] = lang
+
+        LOCALE.language = language
+        LOCALE.lang = lang

--- a/test/rhsmlib_test/test_attach.py
+++ b/test/rhsmlib_test/test_attach.py
@@ -202,18 +202,83 @@ class TestAttachDBusObject(DBusObjectTest, InjectionMockingTest):
 
         self.mock_attach.attach_pool.return_value = CONTENT_JSON
 
-        dbus_method_args = [['x', 'y'], 1, {}]
+        dbus_method_args = [['x', 'y'], 1, {}, '']
+        self.dbus_request(assertions, self.interface.PoolAttach, dbus_method_args)
+
+    def test_pool_attach_using_proxy(self):
+        def assertions(*args):
+            expected_content = [json.dumps(CONTENT_JSON), json.dumps(CONTENT_JSON)]
+            result = args[0]
+            self.assertEqual(result, expected_content)
+
+        self.mock_attach.attach_pool.return_value = CONTENT_JSON
+
+        dbus_method_args = [
+            ['x', 'y'],
+            1,
+            {
+                'proxy_hostname': 'proxy.company.com',
+                'proxy_port': '3128',
+                'proxy_user': 'user',
+                'proxy_password': 'secret'
+            },
+            ''
+        ]
+        self.dbus_request(assertions, self.interface.PoolAttach, dbus_method_args)
+
+    def test_pool_germany_attach(self):
+        def assertions(*args):
+            expected_content = [json.dumps(CONTENT_JSON), json.dumps(CONTENT_JSON)]
+            result = args[0]
+            self.assertEqual(result, expected_content)
+
+        self.mock_attach.attach_pool.return_value = CONTENT_JSON
+
+        dbus_method_args = [['x', 'y'], 1, {}, 'de']
+        self.dbus_request(assertions, self.interface.PoolAttach, dbus_method_args)
+
+    def test_pool_germany_GERMANY__attach(self):
+        def assertions(*args):
+            expected_content = [json.dumps(CONTENT_JSON), json.dumps(CONTENT_JSON)]
+            result = args[0]
+            self.assertEqual(result, expected_content)
+
+        self.mock_attach.attach_pool.return_value = CONTENT_JSON
+
+        dbus_method_args = [['x', 'y'], 1, {}, 'de_DE']
+        self.dbus_request(assertions, self.interface.PoolAttach, dbus_method_args)
+
+    def test_pool_germany_utf8_attach(self):
+        def assertions(*args):
+            expected_content = [json.dumps(CONTENT_JSON), json.dumps(CONTENT_JSON)]
+            result = args[0]
+            self.assertEqual(result, expected_content)
+
+        self.mock_attach.attach_pool.return_value = CONTENT_JSON
+
+        dbus_method_args = [['x', 'y'], 1, {}, 'de_DE.utf-8']
+        self.dbus_request(assertions, self.interface.PoolAttach, dbus_method_args)
+
+    def test_pool_germany_UTF8_attach(self):
+        def assertions(*args):
+            expected_content = [json.dumps(CONTENT_JSON), json.dumps(CONTENT_JSON)]
+            result = args[0]
+            self.assertEqual(result, expected_content)
+
+        self.mock_attach.attach_pool.return_value = CONTENT_JSON
+
+        dbus_method_args = [['x', 'y'], 1, {}, 'de_DE.UTF-8']
         self.dbus_request(assertions, self.interface.PoolAttach, dbus_method_args)
 
     def test_must_be_registered_pool(self):
         self.mock_identity.is_valid.return_value = False
-        pool_method_args = [['x', 'y'], 1, {}]
+        pool_method_args = [['x', 'y'], 1, {}, '']
         with six.assertRaisesRegex(self, dbus.DBusException, r'requires the consumer to be registered.*'):
             self.dbus_request(None, self.interface.PoolAttach, pool_method_args)
 
     def test_must_be_registered_auto(self):
         self.mock_identity.is_valid.return_value = False
-        auto_method_args = ['service_level', {}]
+        auto_method_args = ['service_level', {}, '']
         with six.assertRaisesRegex(self, dbus.DBusException, r'requires the consumer to be registered.*'):
             self.dbus_request(None, self.interface.AutoAttach, auto_method_args)
 
@@ -224,5 +289,5 @@ class TestAttachDBusObject(DBusObjectTest, InjectionMockingTest):
 
         self.mock_attach.attach_auto.return_value = CONTENT_JSON
 
-        dbus_method_args = ['service_level', {}]
+        dbus_method_args = ['service_level', {}, '']
         self.dbus_request(assertions, self.interface.AutoAttach, dbus_method_args)

--- a/test/rhsmlib_test/test_config.py
+++ b/test/rhsmlib_test/test_config.py
@@ -200,7 +200,7 @@ class TestConfigDBusObject(DBusObjectTest, TestUtilsMixin):
             result = args[0]
             self.assertIn("server", result)
 
-        dbus_method_args = []
+        dbus_method_args = ['']
         self.dbus_request(assertions, self.interface.GetAll, dbus_method_args)
 
     def test_get_property(self):
@@ -208,7 +208,7 @@ class TestConfigDBusObject(DBusObjectTest, TestUtilsMixin):
             result = args[0]
             self.assertIn('server.example.com', result)
 
-        dbus_method_args = ['server.hostname']
+        dbus_method_args = ['server.hostname', '']
         self.dbus_request(assertions, self.interface.Get, dbus_method_args)
 
     def test_get_section(self):
@@ -216,18 +216,18 @@ class TestConfigDBusObject(DBusObjectTest, TestUtilsMixin):
             result = args[0]
             self.assertIn('hostname', result)
 
-        dbus_method_args = ['server']
+        dbus_method_args = ['server', '']
         self.dbus_request(assertions, self.interface.Get, dbus_method_args)
 
     def test_set(self):
         def assertions(*args):
             self.assertEqual('new', self.parser.get('server', 'hostname'))
 
-        dbus_method_args = ['server.hostname', 'new']
+        dbus_method_args = ['server.hostname', 'new', '']
         self.dbus_request(assertions, self.interface.Set, dbus_method_args)
 
     def test_set_section_fails(self):
-        dbus_method_args = ['server', 'new']
+        dbus_method_args = ['server', 'new', '']
 
         with six.assertRaisesRegex(self, dbus.DBusException, r'Setting an entire section is not.*'):
             self.dbus_request(None, self.interface.Set, dbus_method_args)

--- a/test/rhsmlib_test/test_entitlement.py
+++ b/test/rhsmlib_test/test_entitlement.py
@@ -432,7 +432,8 @@ class TestEntitlementDBusObject(DBusObjectTest, InjectionMockingTest):
             self.assertEqual(expected_return, result)
 
         self.mock_entitlement.get_status.return_value = expected_status
-        self.dbus_request(assertions, self.interface.GetStatus, [""])
+        dbus_method_args = ["", ""]
+        self.dbus_request(assertions, self.interface.GetStatus, dbus_method_args)
 
     def test_remove_entitlement_by_serial(self):
         """
@@ -446,7 +447,7 @@ class TestEntitlementDBusObject(DBusObjectTest, InjectionMockingTest):
             result = args[0]
             self.assertEqual(expected_return, result)
 
-        dbus_method_args = [["6219625278114868779"], {}]
+        dbus_method_args = [["6219625278114868779"], {}, ""]
         self.dbus_request(assertation, self.interface.RemoveEntitlementsBySerials, dbus_method_args)
 
     def test_remove_more_entitlement_by_serials(self):
@@ -461,7 +462,7 @@ class TestEntitlementDBusObject(DBusObjectTest, InjectionMockingTest):
             result = args[0]
             self.assertEqual(expected_return, result)
 
-        dbus_method_args = [["6219625278114868779", "3573249574655121394"], {}]
+        dbus_method_args = [["6219625278114868779", "3573249574655121394"], {}, ""]
         self.dbus_request(assertation, self.interface.RemoveEntitlementsBySerials, dbus_method_args)
 
     def test_remove_entitlement_by_serial_with_wrong_serial(self):
@@ -477,7 +478,7 @@ class TestEntitlementDBusObject(DBusObjectTest, InjectionMockingTest):
             result = args[0]
             self.assertEqual(expected_return, result)
 
-        dbus_method_args = [["6219625278114868779", "3573249574655121394"], {}]
+        dbus_method_args = [["6219625278114868779", "3573249574655121394"], {}, ""]
         self.dbus_request(assertation, self.interface.RemoveEntitlementsBySerials, dbus_method_args)
 
     def test_remove_entitlement_by_pool_id(self):
@@ -493,7 +494,7 @@ class TestEntitlementDBusObject(DBusObjectTest, InjectionMockingTest):
             result = args[0]
             self.assertEqual(expected_result, result)
 
-        dbus_method_args = [["4028fa7a5dea087d015dea0b025003f6"], {}]
+        dbus_method_args = [["4028fa7a5dea087d015dea0b025003f6"], {}, ""]
         self.dbus_request(assertation, self.interface.RemoveEntitlementsByPoolIds, dbus_method_args)
 
     def test_remove_all_entitlements(self):
@@ -508,5 +509,5 @@ class TestEntitlementDBusObject(DBusObjectTest, InjectionMockingTest):
             result = args[0]
             self.assertEqual(expected_result, result)
 
-        dbus_method_args = [{}]
+        dbus_method_args = [{}, ""]
         self.dbus_request(assertation, self.interface.RemoveAllEntitlements, dbus_method_args)

--- a/test/rhsmlib_test/test_products.py
+++ b/test/rhsmlib_test/test_products.py
@@ -373,5 +373,5 @@ class TestProductsDBusObject(DBusObjectTest, InjectionMockingTest):
 
         self.mock_products.list.return_value = expected_result
 
-        dbus_method_args = ['', {}]
+        dbus_method_args = ['', {}, '']
         self.dbus_request(assertions, self.interface.ListInstalledProducts, dbus_method_args)

--- a/test/rhsmlib_test/test_unregister.py
+++ b/test/rhsmlib_test/test_unregister.py
@@ -88,6 +88,6 @@ class TestUnregisterDBusObject(DBusObjectTest, InjectionMockingTest):
 
     def test_must_be_registered_unregister(self):
         self.mock_identity.is_valid.return_value = False
-        unregister_method_args = [{}]
+        unregister_method_args = [{}, '']
         with six.assertRaisesRegex(self, dbus.DBusException, r'requires the consumer to be registered.*'):
             self.dbus_request(None, self.interface.Unregister, unregister_method_args)


### PR DESCRIPTION
* Implemented changing language on the fly
* Following format of language codes are supported:
   * de
   * de_DE
   * de_DE.UTF-8, de_DE.utf-8
   * de_AT, de_LU, de_AT.utf-8, etc.
* It also set environment variable LC_ALL, because rhsm.connection
  use it to determine requested language. Candlepin returns localized
  error messages according HTTP header: "Accept-Language"
* Added locale parameter to all D-Bus methods
* Error messages from D-Bus methods are returned as JSON string
   e.g.: '{"exception": "EsceptionName", "message": "Error message"}'
   Error message can be easily parsed and displayed in cockpit plugin
* Modified all unit tests to reflect changes in D-Bus API
* Modified subscription-client.js to use benefit of new API