### PR TITLE
Updates vagrant bits post python-rhsm package rename

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,6 @@ Vagrant.configure("2") do |config|
   # setup shared folder
   config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: [
     "build",
-    "build_ext",
     "src/rhsm/_certificate.so",
     "subscription-manager.egg-info",
     "cockpit/node_modules",

--- a/vagrant/roles/subman-devel/tasks/main.yml
+++ b/vagrant/roles/subman-devel/tasks/main.yml
@@ -160,7 +160,7 @@
   when: subman_setup_hacking_environment and not (ansible_distribution == 'Debian')
 
 - name: install subscription-manager (initial)
-  shell: "{{ distro_package_command }} install -y /tmp/tito/*/subscription-manager-[0-9]*"
+  shell: "{{ distro_package_command }} install -y /tmp/tito/*/subscription-manager-{rhsm-{certificates-,},}[0-9]*"
   args:
     chdir: "{{ subman_checkout_dir }}"
     creates: /usr/lib*/python*/site-packages/subscription_manager


### PR DESCRIPTION
Make sure to install the required subscription-manager-rhsm*
packages along with subscription-manager.

It seems we needed the build_ext module for some of our ./setup.py steps. This no longer excludes that folder for our vagrant setup.

One of the steps of the deploy attempted to install the packages just built by tito. After we renamed python-rhsm to subscription-manager-rhsm* we now have a need to install that first (done by changing the globing).