### PR TITLE
1319927: Remove newline from auto enable message

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2627,7 +2627,7 @@ class ManagerCLI(CLI):
         # Try to enable all yum plugins (subscription-manager and plugin-id)
         enabled_yum_plugins = YumPluginManager.enable_yum_plugins()
         if len(enabled_yum_plugins) > 0:
-            print('\n' + _('WARNING') + '\n\n' + YumPluginManager.warning_message(enabled_yum_plugins))
+            print('\n' + _('WARNING') + '\n\n' + YumPluginManager.warning_message(enabled_yum_plugins) + '\n')
         # Try to flush all outputs, see BZ: 1350402
         try:
             sys.stdout.flush()

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -997,7 +997,7 @@ def main(args=None, five_to_six_script=False):
     # Try to enable yum plugins: subscription-manager and product-id
     enabled_yum_plugins = repolib.YumPluginManager.enable_yum_plugins()
     if len(enabled_yum_plugins) > 0:
-        print(_('WARNING') + '\n\n' + repolib.YumPluginManager.warning_message(enabled_yum_plugins))
+        print(_('WARNING') + '\n\n' + repolib.YumPluginManager.warning_message(enabled_yum_plugins) + '\n')
 
     try:
         sys.stdout.flush()

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -106,7 +106,7 @@ class YumPluginManager(object):
         message = _('The yum plugins: %s were automatically enabled for the benefit of '
                     'Red Hat Subscription Management. If not desired, use '
                     '"subscription-manager config --rhsm.auto_enable_yum_plugins=0" to '
-                    'block this behavior.\n') % ', '.join(enabled_yum_plugins)
+                    'block this behavior.') % ', '.join(enabled_yum_plugins)
         return message
 
     @classmethod


### PR DESCRIPTION
This makes translations inconsistent. (We generally don't have newlines in the translations themselves).