### PR TITLE
1464571: Improve multiple product certs errors

### DIFF
--- a/src/subscription_manager/gui/preferences.py
+++ b/src/subscription_manager/gui/preferences.py
@@ -17,6 +17,7 @@ from __future__ import print_function, division, absolute_import
 import logging
 
 from subscription_manager.ga import Gtk as ga_Gtk
+from subscription_manager.gui import messageWindow
 from subscription_manager.gui import widgets
 from subscription_manager.gui import utils
 from subscription_manager import injection as inj
@@ -141,7 +142,12 @@ class PreferencesDialog(widgets.SubmanBaseWidget):
         if consumer_json['releaseVer']:
             current_release = consumer_json['releaseVer']['releaseVer']
 
-        available_releases = self.release_backend.get_releases()
+        try:
+            available_releases = self.release_backend.get_releases()
+        except release.MultipleReleaseProductsError as err:
+            log.error("Getting releases failed: %s" % err)
+            messageWindow.ErrorDialog(err.translated_message())
+            available_releases = []
         # current release might not be in the release listing
         if current_release and current_release not in available_releases:
             available_releases.insert(0, current_release)

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1388,10 +1388,6 @@ class ReleaseCommand(CliCommand):
             print(_("Release not set"))
 
     def _do_command(self):
-        more_product_cert_err_msg = _(
-            "Error: More than one release product certificate installed."
-        )
-
         cdn_url = conf['rhsm']['baseurl']
         # note: parse_baseurl_info will populate with defaults if not found
         (cdn_hostname, cdn_port, _cdn_prefix) = parse_baseurl_info(cdn_url)
@@ -1416,7 +1412,7 @@ class ReleaseCommand(CliCommand):
                 releases = self.release_backend.get_releases()
             except MultipleReleaseProductsError as err:
                 log.error("Getting releases failed: %s" % err)
-                system_exit(os.EX_CONFIG, more_product_cert_err_msg)
+                system_exit(os.EX_CONFIG, err.translated_message())
 
             if self.options.release in releases:
                 self.cp.updateConsumer(
@@ -1435,7 +1431,7 @@ class ReleaseCommand(CliCommand):
                 releases = self.release_backend.get_releases()
             except MultipleReleaseProductsError as err:
                 log.error("Getting releases failed: %s" % err)
-                system_exit(os.EX_CONFIG, more_product_cert_err_msg)
+                system_exit(os.EX_CONFIG, err.translated_message())
 
             if len(releases) == 0:
                 system_exit(os.EX_CONFIG, _(

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -209,10 +209,12 @@ class StubProductCertificate(ProductCertificate):
         if not end_date:
             end_date = datetime.now() + timedelta(days=365)
 
+        path = "/path/to/fake_product.pem"
+
         super(StubProductCertificate, self).__init__(products=products,
                                                      serial=random.randint(1, 10000000),
                                                      start=start_date, end=end_date,
-                                                     version=version)
+                                                     version=version, path=path)
 
     def __str__(self):
         s = []


### PR DESCRIPTION
Made the error message and the translated message consistent. Also moved
the translation to a method on the exception, and added error handling
to the preferences GUI. (See
https://bugzilla.redhat.com/show_bug.cgi?id=1464571 comments 6-8 for
source of these requests)