### PR TITLE
Replace cockpit-subscriptions

### DIFF
--- a/cockpit/src/manifest.json
+++ b/cockpit/src/manifest.json
@@ -1,12 +1,13 @@
 {
     "version": "0.1",
+    "name": "subscriptions",
     "requires": {
         "cockpit": "137"
     },
-
+    "priority": 2,
     "tools": {
         "index": {
-            "label": "subscription-manager"
+            "label": "Subscriptions"
         }
     }
 }


### PR DESCRIPTION
Both RPMs can be installed, but when subscription-manager-cockpit is
installed, it will take priority over cockpit-subscriptions.

This is accomplished by name and priority changes in manifest.json.