### PR TITLE
1463765: Fix wrong Indic-language translations

### DIFF
--- a/po/as.po
+++ b/po/as.po
@@ -3966,8 +3966,7 @@ msgstr ""
 #: src/subscription_manager/managercli.py:524
 #, python-format
 msgid "Unable to reach the server at %s:%s%s"
-msgstr "%s ত চাৰ্ভাৰ প্ৰাপ্ত কৰিব নোৱাৰি:%s%s"
-
+msgstr "%s:%s%s ত চাৰ্ভাৰ প্ৰাপ্ত কৰিব নোৱাৰি"
 #: src/subscription_manager/gui/registergui.py:1910
 msgid "Validating connection"
 msgstr ""

--- a/po/gu.po
+++ b/po/gu.po
@@ -3952,7 +3952,7 @@ msgstr ""
 #: src/subscription_manager/managercli.py:524
 #, python-format
 msgid "Unable to reach the server at %s:%s%s"
-msgstr "%s પર સર્વર સુધી પહોંચવાનુ અસમર્થ:%s%s"
+msgstr "%s:%s%s પર સર્વર સુધી પહોંચવાનુ અસમર્થ"
 
 #: src/subscription_manager/gui/registergui.py:1910
 msgid "Validating connection"

--- a/po/hi.po
+++ b/po/hi.po
@@ -3961,7 +3961,7 @@ msgstr ""
 #: src/subscription_manager/managercli.py:524
 #, python-format
 msgid "Unable to reach the server at %s:%s%s"
-msgstr "%s पर सर्वर पर पहुँचने में त्रुटि:%s%s"
+msgstr "%s:%s%s पर सर्वर पर पहुँचने में त्रुटि"
 
 #: src/subscription_manager/gui/registergui.py:1910
 msgid "Validating connection"

--- a/po/kn.po
+++ b/po/kn.po
@@ -4108,7 +4108,7 @@ msgstr ""
 #: src/subscription_manager/managercli.py:524
 #, python-format
 msgid "Unable to reach the server at %s:%s%s"
-msgstr "%s ಎಂಬಲ್ಲಿರುವ ಪೂರೈಕೆಗಣಕವನ್ನು ತಲುಪಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ:%s%s"
+msgstr "%s:%s%s ಎಂಬಲ್ಲಿರುವ ಪೂರೈಕೆಗಣಕವನ್ನು ತಲುಪಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
 
 #: src/subscription_manager/gui/registergui.py:1910
 msgid "Validating connection"

--- a/po/pa.po
+++ b/po/pa.po
@@ -4052,7 +4052,7 @@ msgstr ""
 #: src/subscription_manager/managercli.py:524
 #, python-format
 msgid "Unable to reach the server at %s:%s%s"
-msgstr "%s ਤੇ ਸਰਵਰ ਤੱਕ ਨਹੀਂ ਪਹੁੰਚ ਸਕਿਆ:%s%s"
+msgstr "%s:%s%s ਤੇ ਸਰਵਰ ਤੱਕ ਨਹੀਂ ਪਹੁੰਚ ਸਕਿਆ"
 
 #: src/subscription_manager/gui/registergui.py:1910
 msgid "Validating connection"

--- a/po/ta_IN.po
+++ b/po/ta_IN.po
@@ -4097,7 +4097,7 @@ msgstr ""
 #: src/subscription_manager/managercli.py:524
 #, python-format
 msgid "Unable to reach the server at %s:%s%s"
-msgstr "%s இல் சேவையகத்தை அடைய முடியவில்லை:%s%s"
+msgstr "%s:%s%s இல் சேவையகத்தை அடைய முடியவில்லை"
 
 #: src/subscription_manager/gui/registergui.py:1910
 msgid "Validating connection"

--- a/po/te.po
+++ b/po/te.po
@@ -4065,7 +4065,7 @@ msgstr ""
 #: src/subscription_manager/managercli.py:524
 #, python-format
 msgid "Unable to reach the server at %s:%s%s"
-msgstr "%s వద్దని సర్వర్‌ను చేరలేకపోతోంది:%s%s"
+msgstr "%s:%s%s వద్దని సర్వర్‌ను చేరలేకపోతోంది"
 
 #: src/subscription_manager/gui/registergui.py:1910
 msgid "Validating connection"


### PR DESCRIPTION
Indic languages that had incorrect translations where server:port/prefix
wrong. I chose to do these manually, rather than through zanata to limit
the scope of the change.

NOTE: this change already landed in subscription-manager-1.19.21-1,
unintentionally did not land in master yet.