### PR TITLE
Fix Python 3 syntax and test failures

### DIFF
--- a/bin/rct
+++ b/bin/rct
@@ -24,9 +24,11 @@ if __name__ != '__main__':
 # hack to allow bytes/strings to be interpolated w/ unicode values (gettext gives us bytes)
 # Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
+import six
 import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
+if six.PY2:
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
 
 from subscription_manager.i18n import configure_i18n, ugettext as _
 configure_i18n()

--- a/bin/rhn-migrate-classic-to-rhsm
+++ b/bin/rhn-migrate-classic-to-rhsm
@@ -24,9 +24,11 @@ if __name__ != '__main__':
 # hack to allow bytes/strings to be interpolated w/ unicode values (gettext gives us bytes)
 # Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
+import six
 import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
+if six.PY2:
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
 import os
 
 
@@ -37,7 +39,7 @@ def system_exit(code, msgs=None):
         if type(msgs) not in [type([]), type(())]:
             msgs = (msgs, )
         for msg in msgs:
-            sys.stderr.write(unicode(msg).encode('utf-8') + '\n')
+            sys.stderr.write(six.text_type(msg) + '\n')
     sys.exit(code)
 
 _LIBPATH = "/usr/share/rhsm"

--- a/bin/rhsm-debug
+++ b/bin/rhsm-debug
@@ -24,9 +24,11 @@ if __name__ != '__main__':
 # hack to allow bytes/strings to be interpolated w/ unicode values (gettext gives us bytes)
 # Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
+import six
 import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
+if six.PY2:
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
 import os
 
 from subscription_manager.i18n import configure_i18n, ugettext as _

--- a/bin/rhsm-service
+++ b/bin/rhsm-service
@@ -27,9 +27,11 @@ log.setLevel(logging.INFO)
 # hack to allow bytes/strings to be interpolated w/ unicode values (gettext gives us bytes)
 # Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
+import six
 import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
+if six.PY2:
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
 
 from rhsmlib.dbus import service_wrapper
 from rhsmlib.dbus import objects

--- a/bin/sat5to6
+++ b/bin/sat5to6
@@ -24,9 +24,11 @@ if __name__ != '__main__':
 # hack to allow bytes/strings to be interpolated w/ unicode values (gettext gives us bytes)
 # Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
+import six
 import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
+if six.PY2:
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
 import os
 
 
@@ -37,7 +39,7 @@ def system_exit(code, msgs=None):
         if type(msgs) not in [type([]), type(())]:
             msgs = (msgs, )
         for msg in msgs:
-            sys.stderr.write(unicode(msg).encode('utf-8') + '\n')
+            sys.stderr.write(six.text_type(msg) + '\n')
     sys.exit(code)
 
 # quick check to see if you are a super-user.
@@ -83,11 +85,11 @@ def main():
 if __name__ == '__main__':
     try:
         sys.exit(abs(main() or 0))
-    except SystemExit, e:
+    except SystemExit as e:
         # this is a non-exceptional exception thrown by Python 2.4, just
         # re-raise, bypassing handle_exception
         raise e
     except KeyboardInterrupt:
         system_exit(0, "\nUser interrupted process.")
-    except Exception, e:
+    except Exception as e:
         handle_exception("Exception caught in sat5to6", e)

--- a/bin/subscription-manager
+++ b/bin/subscription-manager
@@ -28,9 +28,11 @@ if __name__ != '__main__':
 # hack to allow bytes/strings to be interpolated w/ unicode values (gettext gives us bytes)
 # Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
+import six
 import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
+if six.PY2:
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
 import os
 
 # work around for https://bugzilla.redhat.com/show_bug.cgi?id=1402009

--- a/bin/subscription-manager-gui
+++ b/bin/subscription-manager-gui
@@ -29,9 +29,11 @@ if __name__ != '__main__':
 # hack to allow bytes/strings to be interpolated w/ unicode values (gettext gives us bytes)
 # Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
+import six
 import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
+if six.PY2:
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
 
 import warnings
 # this is a deprecation warning we see on rhel6, but the
@@ -95,7 +97,7 @@ def _request_name(bus, bus_name):
 try:
     import dbus.dbus_bindings
     request_name = _request_name_rhel5
-except ImportError, e:
+except ImportError as e:
     request_name = _request_name
 
 
@@ -128,7 +130,7 @@ try:
     from subscription_manager.ga import Gtk as ga_Gtk
     from subscription_manager.ga import gtk_compat
     gtk_compat.threads_init()
-except RuntimeError, e:
+except RuntimeError as e:
     system_exit(2, "Unable to start.  Error: %s" % e)
 
 try:
@@ -149,7 +151,7 @@ try:
     from subscription_manager.gui import managergui
     from subscription_manager.i18n_optparse import OptionParser, \
         WrappedIndentedHelpFormatter, USAGE
-except ImportError, e:
+except ImportError as e:
     log.exception(e)
     system_exit(2, "Unable to find Subscription Manager module.\n"
                   "Error: %s" % e)
@@ -190,7 +192,7 @@ if __name__ == '__main__':
 
     try:
         bus = dbus.SessionBus()
-    except dbus.exceptions.DBusException, e:
+    except dbus.exceptions.DBusException as e:
         log.debug("Enabled to connect to dbus SessionBus")
         log.exception(e)
         # Just ignore it if for some reason we can't find the session bus
@@ -202,7 +204,7 @@ if __name__ == '__main__':
             remote_object = bus.get_object(BUS_NAME, BUS_PATH)
             remote_object.show_window(dbus_interface=BUS_NAME)
             log.debug("subscription-manager-gui already running, showing main window")
-        except dbus.exceptions.DBusException, e:
+        except dbus.exceptions.DBusException as e:
             log.debug("Error attempting to show main window via dbus")
             log.debug("dbus remote_object with no show_window: %s" % remote_object)
             log.debug(e)
@@ -223,12 +225,12 @@ if __name__ == '__main__':
         main.main_window.connect('hide', ga_Gtk.main_quit)
 
         sys.exit(ga_Gtk.main() or 0)
-    except SystemExit, e:
+    except SystemExit as e:
         # this is a non-exceptional exception thrown by Python 2.4, just
         # re-raise, bypassing handle_exception
         raise e
     except KeyboardInterrupt:
         system_exit(0, "\nUser interrupted process.")
-    except Exception, e:
+    except Exception as e:
         log.exception(e)
         system_exit(1, e)

--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -18,7 +18,7 @@ import errno
 import os
 import sys
 
-from six.moves import cStringIO
+from six import BytesIO
 from zipfile import ZipFile, BadZipfile
 
 from rhsm import certificate
@@ -67,13 +67,13 @@ class ZipExtractAll(ZipFile):
 
     def _get_inner_zip(self):
         if self.inner_zip is None:
-            output = cStringIO(self.read(RCTManifestCommand.INNER_FILE))
+            output = BytesIO(self.read(RCTManifestCommand.INNER_FILE))
             self.inner_zip = ZipExtractAll(output, 'r')
         return self.inner_zip
 
     def _read_file(self, file_path, is_inner=False):
         try:
-            output = cStringIO(self.read(file_path))
+            output = BytesIO(self.read(file_path))
             result = output.getvalue()
             output.close()
         except KeyError:
@@ -95,7 +95,7 @@ class ZipExtractAll(ZipFile):
         return results
 
     def _open_excl(self, path):
-        return os.fdopen(os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL), 'w')
+        return os.fdopen(os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL), 'wb')
 
     def _write_file(self, output_path, archive_path):
         outfile = self._open_excl(output_path)
@@ -262,7 +262,7 @@ class CatManifestCommand(RCTManifestCommand):
             to_print.append((_("Certificate File"), cert_file))
 
             try:
-                cert = certificate.create_from_pem(zip_archive._read_file(cert_file))
+                cert = certificate.create_from_pem(zip_archive._read_file(cert_file).decode('utf-8'))
             except certificate.CertificateException as ce:
                 raise certificate.CertificateException(
                         _("Unable to read certificate file '%s': %s") % (cert_file,

--- a/src/rct/printing.py
+++ b/src/rct/printing.py
@@ -16,6 +16,8 @@ from __future__ import print_function, division, absolute_import
 #
 import signal
 
+import six
+
 from rhsm.certificate2 import EntitlementCertificate, ProductCertificate, IdentityCertificate
 
 # BZ 973938 python doesn't correctly handle SIGPIPE
@@ -30,7 +32,7 @@ from subscription_manager.i18n import ugettext as _
 def xstr(value):
     if value is None:
         return ''
-    elif isinstance(value, unicode):
+    elif isinstance(value, six.text_type) and six.PY2:
         return value.encode('utf-8')
     else:
         return str(value)

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -116,7 +116,7 @@ class RhsmConfigParser(SafeConfigParser):
 
     def save(self, config_file=None):
         """Writes config file to storage."""
-        fo = open(self.config_file, "wb")
+        fo = open(self.config_file, "w")
         self.write(fo)
 
     def get(self, section, prop):

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -235,7 +235,7 @@ class ExpiredIdentityCertException(ConnectionException):
 
 
 def _encode_auth(username, password):
-    encoded = base64.b64encode(':'.join((username, password)).encode('utf-8'))
+    encoded = base64.b64encode(':'.join((username, password)).encode('utf-8')).decode('utf-8')
     return 'Basic %s' % encoded
 
 

--- a/src/rhsm_debug/debug_commands.py
+++ b/src/rhsm_debug/debug_commands.py
@@ -264,7 +264,7 @@ class SaferFileMove(object):
 
         If dest is /tmp, or a specific name in /tmp, we want to
         create it excl if we can."""
-        with open(src, 'r') as src_fo:
+        with open(src, 'rb') as src_fo:
             # if dest doesn't exist, and we can open it excl, then open it,
             # keep the fd, create a file object for it, and write to it
             with self._open_excl(dest) as dest_fo:
@@ -275,7 +275,7 @@ class SaferFileMove(object):
     def _open_excl(self, path):
         """Return a file object that we know we created and nothing else owns."""
         return os.fdopen(os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL,
-                                 self.default_perms), 'w+')
+                                 self.default_perms), 'wb+')
 
     def _copyfileobj(self, src_fo, dest_fo):
         while True:

--- a/src/rhsmlib/dbus/constants.py
+++ b/src/rhsmlib/dbus/constants.py
@@ -12,8 +12,6 @@ from __future__ import print_function, division, absolute_import
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-import string
-
 __all__ = [
     'NAME_BASE',
     'VERSION',
@@ -51,7 +49,7 @@ INTERFACE_BASE = BUS_NAME
 # Note: No trailing '/'
 #
 # /com/redhat/RHSM1
-ROOT_DBUS_PATH = '/' + string.replace(BUS_NAME, '.', '/')
+ROOT_DBUS_PATH = '/' + str.replace(BUS_NAME, '.', '/')
 
 MAIN_INTERFACE = INTERFACE_BASE
 MAIN_DBUS_PATH = ROOT_DBUS_PATH

--- a/src/rhsmlib/dbus/dbus_utils.py
+++ b/src/rhsmlib/dbus/dbus_utils.py
@@ -23,13 +23,12 @@ from __future__ import print_function, division, absolute_import
 
 import logging
 import pwd
-import sys
 import xml.etree.ElementTree as Et
 
 import dbus
 import six
 
-PY2 = sys.version < '3'
+PY2 = six.PY2
 
 log = logging.getLogger(__name__)
 
@@ -218,31 +217,3 @@ def dict_to_variant_dict(in_dict):
         if isinstance(value, dict):
             in_dict[key] = dict_to_variant_dict(value)
     return dbus.Dictionary(in_dict, signature="sv")
-
-
-def _decode_dict(data):
-    rv = {}
-    for key, value in six.iteritems(data):
-        if isinstance(key, unicode):
-            key = key.encode('utf-8')
-        if isinstance(value, unicode):
-            value = value.encode('utf-8')
-        elif isinstance(value, list):
-            value = _decode_list(value)
-        elif isinstance(value, dict):
-            value = _decode_dict(value)
-        rv[key] = value
-    return rv
-
-
-def _decode_list(data):
-    rv = []
-    for item in data:
-        if isinstance(item, unicode):
-            item = item.encode('utf-8')
-        elif isinstance(item, list):
-            item = _decode_list(item)
-        elif isinstance(item, dict):
-            item = _decode_dict(item)
-        rv.append(item)
-    return rv

--- a/src/rhsmlib/services/products.py
+++ b/src/rhsmlib/services/products.py
@@ -59,7 +59,7 @@ class InstalledProducts(object):
             ['product_name', 'product_id', 'version', 'arch', 'status', 'status_details', 'starts', 'ends']
         )
 
-        for installed_product in sorter.installed_products:
+        for installed_product in sorted(sorter.installed_products):
             product_cert = sorter.installed_products[installed_product]
 
             if cert_filter is None or cert_filter.match(product_cert):

--- a/src/subscription_manager/cli.py
+++ b/src/subscription_manager/cli.py
@@ -18,6 +18,8 @@ import os
 import sys
 import logging
 
+import six
+
 from subscription_manager.printing_utils import columnize, echo_columnize_callback
 from subscription_manager.i18n_optparse import OptionParser, WrappedIndentedHelpFormatter
 from subscription_manager.utils import print_error
@@ -204,7 +206,7 @@ def system_exit(code, msgs=None):
             if isinstance(msg, Exception):
                 msg = "%s" % msg
 
-            if isinstance(msg, unicode):
+            if isinstance(msg, six.text_type) and six.PY2:
                 print_error(msg.encode("utf8"))
             else:
                 print_error(msg)

--- a/src/subscription_manager/gui/about.py
+++ b/src/subscription_manager/gui/about.py
@@ -91,8 +91,8 @@ class AboutDialog(object):
     def _set_next_update(self, next_update_label, next_auto_attach_label):
         try:
             if self._rhsmcertd_on():
-                next_update = int(file(CERT_CHECK_UPDATE_FILE).read())
-                next_auto_attach = int(file(AUTO_ATTACH_UPDATE_FILE).read())
+                next_update = int(open(CERT_CHECK_UPDATE_FILE, 'r').read())
+                next_auto_attach = int(open(AUTO_ATTACH_UPDATE_FILE, 'r').read())
             else:
                 next_update = None
                 next_auto_attach = None

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -831,7 +831,7 @@ class BasePluginManager(object):
                 conduit_to_slots[conduit] = []
             conduit_to_slots[conduit].append(slot)
         sorted_slots = []
-        for conduit in sorted(conduit_to_slots.keys()):
+        for conduit in sorted(conduit_to_slots.keys(), key=lambda c: str(c)):
             for slot in sorted(conduit_to_slots[conduit]):
                 sorted_slots.append(slot)
         return sorted_slots

--- a/src/subscription_manager/printing_utils.py
+++ b/src/subscription_manager/printing_utils.py
@@ -94,7 +94,7 @@ def format_name(name, indent, max_length):
     """
     if not name or not max_length or (max_length - indent) <= 2 or not isinstance(name, six.string_types):
         return name
-    if not isinstance(name, unicode):
+    if not isinstance(name, six.text_type):
         name = name.decode("utf-8")
     words = name.split()
     lines = []
@@ -201,6 +201,6 @@ def echo_columnize_callback(template_str, *args, **kwargs):
 # from http://farmdev.com/talks/unicode/
 def to_unicode_or_bust(obj, encoding='utf-8'):
     if isinstance(obj, six.string_types):
-        if not isinstance(obj, unicode):
-            obj = unicode(obj, encoding)
+        if not isinstance(obj, six.text_type):
+            obj = six.text_type(obj, encoding)
     return obj

--- a/src/subscription_manager/release.py
+++ b/src/subscription_manager/release.py
@@ -168,12 +168,8 @@ class CdnReleaseVersionProvider(object):
     def _build_listing_path(self, content_url):
         listing_parts = content_url.split('$releasever', 1)
         listing_base = listing_parts[0]
-        listing_path = u"%s/listing" % listing_base
         # FIXME: cleanup paths ("//"'s, etc)
-
-        # Make sure content URLS are encoded to the default utf8
-        # as unicode strings aren't valid. See rhbz#1134963
-        return listing_path.encode()
+        return u"%s/listing" % listing_base  # FIXME(khowell): ensure that my changes here don't break earlier fix
 
     # require tags provided by installed products?
 

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -32,6 +32,7 @@ from six.moves.urllib.parse import parse_qs, urlparse, urlunparse, urlencode
 from six.moves import configparser
 
 from rhsm.config import initConfig, in_container
+import six
 
 # FIXME: local imports
 
@@ -649,6 +650,7 @@ class RepoUpdateActionCommand(object):
         self.report.repo_deleted.append(section)
 
 
+@six.python_2_unicode_compatible
 class RepoActionReport(ActionReport):
     """Report class for reporting yum repo updates."""
     name = u"Repo Updates"
@@ -687,7 +689,7 @@ class RepoActionReport(ActionReport):
     def format_sections(self, sections):
         return self.format_repos_info(sections, self.section_format)
 
-    def __unicode__(self):
+    def __str__(self):
         s = [_('Repo updates') + '\n']
         s.append(_('Total repo updates: %d') % self.updates())
         s.append(_('Updated'))
@@ -698,9 +700,6 @@ class RepoActionReport(ActionReport):
         # deleted are former repo sections, but they are the same type
         s.append(self.format_sections(self.repo_deleted))
         return u'\n'.join(s)
-
-    def __str__(self):  # TODO use six.python_2_unicode_compatible instead
-        return self.__unicode__().encode('utf-8')
 
 
 class Repo(dict):

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -29,6 +29,7 @@ import uuid
 
 from six.moves import urllib
 from rhsm.https import ssl
+import six
 
 from subscription_manager.branding import get_branding
 from subscription_manager.certdirectory import Path
@@ -326,7 +327,9 @@ def is_true_value(test_string):
 
 def system_log(message, priority=syslog.LOG_NOTICE):
     syslog.openlog("subscription-manager")
-    syslog.syslog(priority, message.encode("utf-8"))
+    if six.PY2:
+        message = message.encode("utf-8")
+    syslog.syslog(priority, message)
 
 
 def chroot(dirname):

--- a/test/modelhelpers.py
+++ b/test/modelhelpers.py
@@ -35,6 +35,8 @@ except ImportError:
 #grumble, no hashblib on 2.4 and
 # md5 is deprecated on 2.6
 def md5sum(buf):
+    if isinstance(buf, six.text_type):
+        buf = buf.encode('utf-8')
     if hashlib:
         md = hashlib.md5(buf)
         return md.hexdigest()

--- a/test/rhsmlib_test/base.py
+++ b/test/rhsmlib_test/base.py
@@ -51,7 +51,7 @@ class TestUtilsMixin(object):
     def write_temp_file(self, data):
         # create a temp file for use as a config file. This should get cleaned
         # up magically when it is closed so make sure to close it!
-        fid = NamedTemporaryFile(mode='w+b', suffix='.tmp')
+        fid = NamedTemporaryFile(mode='w+', suffix='.tmp')
         fid.write(data)
         fid.seek(0)
         return fid

--- a/test/rhsmlib_test/test_hwprobe.py
+++ b/test/rhsmlib_test/test_hwprobe.py
@@ -22,8 +22,10 @@ import six
 
 from mock import patch
 from mock import Mock
+from mock import mock_open
 
 import test.fixture
+from test.fixture import OPEN_FUNCTION
 from rhsmlib.facts import hwprobe
 
 PROC_BONDING_RR = """Ethernet Channel Bonding Driver: v3.6.0 (September 26, 2009)
@@ -176,14 +178,14 @@ class HardwareProbeTest(test.fixture.SubManFixture):
         self.hw_check_topo_patcher.stop()
         super(HardwareProbeTest, self).tearDown()
 
-    @patch("__builtin__.open")
+    @patch(OPEN_FUNCTION)
     def test_distro_no_release(self, MockOpen):
         hw = hwprobe.HardwareCollector()
         MockOpen.side_effect = IOError()
         self.assertRaises(IOError, hw.get_release_info)
 
     @patch("os.path.exists")
-    @patch("__builtin__.open")
+    @patch(OPEN_FUNCTION)
     def test_distro_bogus_content_no_platform_module(self, MockOpen, MockExists):
         hw = hwprobe.HardwareCollector()
         MockExists.side_effect = [False, True]
@@ -198,7 +200,7 @@ class HardwareProbeTest(test.fixture.SubManFixture):
             self.assertEqual(hw.get_release_info(), expected)
 
     @patch("os.path.exists")
-    @patch("__builtin__.open")
+    @patch(OPEN_FUNCTION)
     def test_distro(self, MockOpen, MockExists):
         MockExists.side_effect = [False, True]
         hw = hwprobe.HardwareCollector()
@@ -212,7 +214,7 @@ class HardwareProbeTest(test.fixture.SubManFixture):
         self.assertEqual(hw.get_release_info(), expected)
 
     @patch("os.path.exists")
-    @patch("__builtin__.open")
+    @patch(OPEN_FUNCTION)
     def test_distro_newline_in_release(self, MockOpen, MockExists):
         hw = hwprobe.HardwareCollector()
         MockExists.side_effect = [False, True]
@@ -226,7 +228,7 @@ class HardwareProbeTest(test.fixture.SubManFixture):
         self.assertEqual(hw.get_release_info(), expected)
 
     @patch("os.path.exists")
-    @patch("__builtin__.open")
+    @patch(OPEN_FUNCTION)
     def test_manual_distro_bogus_content_os_release(self, MockOpen, MockExists):
         hw = hwprobe.HardwareCollector()
         with patch('rhsmlib.facts.hwprobe.platform'):
@@ -241,12 +243,10 @@ class HardwareProbeTest(test.fixture.SubManFixture):
             self.assertEqual(hw.get_release_info(), expected)
 
     @patch("os.path.exists")
-    @patch("__builtin__.open")
-    def test_distro_with_platform(self, MockOpen, MockExists):
+    @patch(OPEN_FUNCTION, mock_open(read_data="Awesome OS release 42 Mega (Go4It)"))  # TODO figure out why necessary...
+    def test_distro_with_platform(self, MockExists):
         MockExists.return_value = False
         hw = hwprobe.HardwareCollector()
-        MockOpen.return_value.readline.return_value = "Awesome OS release 42 (Go4It)"
-        MockOpen.return_value.read.return_value = "Awesome OS release 42 (Go4It)"
         expected = {
             'distribution.version': '42',
             'distribution.name': 'Awesome OS',
@@ -256,7 +256,7 @@ class HardwareProbeTest(test.fixture.SubManFixture):
         self.assertEqual(hw.get_release_info(), expected)
 
     @patch("os.path.exists")
-    @patch("__builtin__.open")
+    @patch(OPEN_FUNCTION)
     def test_manual_distro_with_modifier(self, MockOpen, MockExists):
         MockExists.side_effect = [False, True]
         hw = hwprobe.HardwareCollector()
@@ -271,7 +271,7 @@ class HardwareProbeTest(test.fixture.SubManFixture):
             self.assertEqual(hw.get_release_info(), expected)
 
     @patch("os.path.exists")
-    @patch("__builtin__.open")
+    @patch(OPEN_FUNCTION)
     def test_distro_os_release(self, MockOpen, MockExists):
         MockExists.return_value = True
         hw = hwprobe.HardwareCollector()
@@ -286,7 +286,7 @@ class HardwareProbeTest(test.fixture.SubManFixture):
             self.assertEqual(hw.get_release_info(), expected)
 
     @patch("os.path.exists")
-    @patch("__builtin__.open")
+    @patch(OPEN_FUNCTION)
     def test_distro_os_release_colon(self, MockOpen, MockExists):
         MockExists.return_value = True
         hw = hwprobe.HardwareCollector()
@@ -434,7 +434,7 @@ class HardwareProbeTest(test.fixture.SubManFixture):
         self.assertEqual(net_int['net.interface.lo.ipv6_address.global'], '::1')
         self.assertFalse('net.interface.lo.mac_address' in net_int)
 
-    @patch("__builtin__.open")
+    @patch(OPEN_FUNCTION)
     def test_get_slave_hwaddr_rr(self, MockOpen):
         MockOpen.return_value = six.StringIO(PROC_BONDING_RR)
         hw = hwprobe.HardwareCollector()
@@ -442,7 +442,7 @@ class HardwareProbeTest(test.fixture.SubManFixture):
         # note we .upper the result
         self.assertEqual("52:54:00:07:03:BA", slave_hw)
 
-    @patch("__builtin__.open")
+    @patch(OPEN_FUNCTION)
     def test_get_slave_hwaddr_alb(self, MockOpen):
         MockOpen.return_value = six.StringIO(PROC_BONDING_ALB)
         hw = hwprobe.HardwareCollector()

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -34,7 +34,7 @@ from test.rhsmlib_test.base import DBusObjectTest, InjectionMockingTest
 
 from rhsm import connection
 
-from rhsmlib.dbus import dbus_utils, constants
+from rhsmlib.dbus import constants
 from rhsmlib.dbus.objects import RegisterDBusObject
 
 from rhsmlib.services import register, exceptions
@@ -351,11 +351,11 @@ class DomainSocketRegisterDBusObjectTest(DBusObjectTest, InjectionMockingTest):
         return dbus.Interface(socket_proxy, constants.PRIVATE_REGISTER_INTERFACE)
 
     def test_can_register_over_domain_socket(self):
-        expected_consumer = json.loads(CONTENT_JSON, object_hook=dbus_utils._decode_dict)
+        expected_consumer = json.loads(CONTENT_JSON)
 
         def assertions(*args):
             # Be sure we are persisting the consumer cert
-            self.assertEqual(json.loads(args[0], object_hook=dbus_utils._decode_dict), expected_consumer)
+            self.assertEqual(json.loads(args[0]), expected_consumer)
 
         self.mock_identity.is_valid.return_value = False
         self.mock_identity.uuid = 'INVALIDCONSUMERUUID'
@@ -366,11 +366,11 @@ class DomainSocketRegisterDBusObjectTest(DBusObjectTest, InjectionMockingTest):
         self.dbus_request(assertions, self._build_interface().Register, dbus_method_args)
 
     def test_can_register_over_domain_socket_with_activation_keys(self):
-        expected_consumer = json.loads(CONTENT_JSON, object_hook=dbus_utils._decode_dict)
+        expected_consumer = json.loads(CONTENT_JSON)
 
         def assertions(*args):
             # Be sure we are persisting the consumer cert
-            self.assertEqual(json.loads(args[0], object_hook=dbus_utils._decode_dict), expected_consumer)
+            self.assertEqual(json.loads(args[0]), expected_consumer)
 
         self.mock_identity.is_valid.return_value = False
         self.mock_identity.uuid = 'INVALIDCONSUMERUUID'

--- a/test/rhsmlib_test/test_virt.py
+++ b/test/rhsmlib_test/test_virt.py
@@ -18,7 +18,7 @@ except ImportError:
     import unittest
 
 import test.fixture
-from mock import patch
+from mock import patch, MagicMock
 
 from rhsmlib.facts import virt, firmware_info
 
@@ -26,16 +26,22 @@ from rhsmlib.facts import virt, firmware_info
 class VirtCollectorTest(test.fixture.SubManFixture):
     @patch('subprocess.Popen')
     def test_virt_bare_metal(self, MockPopen):
-        MockPopen.return_value.communicate.return_value = ['', None]
-        MockPopen.return_value.poll.return_value = 0
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = ['', None]
+        mock_process.poll.return_value = 0
+        mock_process.__enter__.return_value = mock_process
+        MockPopen.return_value = mock_process
         hw = virt.VirtCollector()
         expected = {'virt.is_guest': False, 'virt.host_type': 'Not Applicable'}
         self.assertEqual(expected, hw.get_all())
 
     @patch('subprocess.Popen')
     def test_virt_error(self, MockPopen):
-        MockPopen.return_value.communicate.return_value = ['', None]
-        MockPopen.return_value.poll.return_value = 255
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = ['', None]
+        mock_process.poll.return_value = 255
+        mock_process.__enter__.return_value = mock_process
+        MockPopen.return_value = mock_process
 
         hw = virt.VirtWhatCollector()
         expected = {'virt.is_guest': 'Unknown'}
@@ -43,8 +49,11 @@ class VirtCollectorTest(test.fixture.SubManFixture):
 
     @patch('subprocess.Popen')
     def test_command_valid(self, MockPopen):
-        MockPopen.return_value.communicate.return_value = ['this is valid', None]
-        MockPopen.return_value.poll.return_value = 0
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = ['this is valid', None]
+        mock_process.poll.return_value = 0
+        mock_process.__enter__.return_value = mock_process
+        MockPopen.return_value = mock_process
 
         # Pick up the mocked class
         hw = virt.VirtCollector(testing='testing')
@@ -52,8 +61,11 @@ class VirtCollectorTest(test.fixture.SubManFixture):
 
     @patch('subprocess.Popen')
     def test_virt_guest(self, MockPopen):
-        MockPopen.return_value.communicate.return_value = ['kvm', None]
-        MockPopen.return_value.poll.return_value = 0
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = ['kvm', None]
+        mock_process.poll.return_value = 0
+        mock_process.__enter__.return_value = mock_process
+        MockPopen.return_value = mock_process
 
         hw = virt.VirtCollector()
         expected = {'virt.is_guest': True, 'virt.host_type': 'kvm'}

--- a/test/test_about.py
+++ b/test/test_about.py
@@ -24,15 +24,16 @@ import mock
 
 from subscription_manager.ga import Gtk as ga_Gtk
 from subscription_manager.gui import about
+from .fixture import OPEN_FUNCTION
 
 
 class TestAboutDialog(unittest.TestCase):
     @mock.patch('subscription_manager.gui.about.get_server_versions')
     @mock.patch('subscription_manager.gui.about.get_client_versions')
-    @mock.patch('__builtin__.file')
-    def test(self, file_mock, client_versions_mock, server_versions_mock):
+    @mock.patch(OPEN_FUNCTION)
+    def test(self, open_mock, client_versions_mock, server_versions_mock):
         backend_mock = mock.Mock()
-        file_mock.return_value = '1367419386'
+        open_mock.return_value = '1367419386'
 
         server_versions_mock.return_value = {"candlepin": '100-1.0',
                                              "server-type": 'candlepin'}

--- a/test/test_certlib.py
+++ b/test/test_certlib.py
@@ -31,7 +31,7 @@ class TestLocker(fixture.SubManFixture):
         # we inject threading.RLock as the lock implementation in
         # the fixture init. RLock() is actually a factory method
         # that returns a _RLock
-        self.assertTrue(isinstance(l.lock, threading._RLock))
+        self.assertTrue(isinstance(l.lock, type(threading.RLock())))
 
     def test_run(self):
         def return_four():

--- a/test/test_completion.py
+++ b/test/test_completion.py
@@ -21,7 +21,10 @@ import subprocess
 
 class CompletionTest(TestCase):
     def test_posix_compliance(self):
-        for name in os.listdir(os.path.join(os.getcwd(), 'etc-conf')):
-            full_name = os.path.join(os.getcwd(), 'etc-conf', name)
+        _root_dir = os.getcwd()
+        if not os.path.exists(os.path.join(_root_dir, 'etc-conf')):
+            _root_dir = os.path.join(os.getcwd(), '..')
+        for name in os.listdir(os.path.join(_root_dir, 'etc-conf')):
+            full_name = os.path.join(_root_dir, 'etc-conf', name)
             if name.endswith('.completion.sh'):
                 subprocess.check_call(['bash', '--posix', full_name])

--- a/test/test_contract_selection_gui.py
+++ b/test/test_contract_selection_gui.py
@@ -21,8 +21,8 @@ def stubCancelCallback(self):
 
 class ContractSelection(unittest.TestCase):
     pool = {'productName': 'SomeProduct',
-            'consumed': '3',
-            'quantity': '10',
+            'consumed': 3,
+            'quantity': 10,
             'startDate': datetime.datetime.now(tz=tzutc()).isoformat(),
             'endDate': datetime.datetime.now(tz=tzutc()).isoformat(),
             'contractNumber': 'contractNumber',

--- a/test/test_entcertlib.py
+++ b/test/test_entcertlib.py
@@ -19,6 +19,7 @@ from __future__ import print_function, division, absolute_import
 
 from mock import Mock, patch
 from datetime import timedelta, datetime
+import six
 
 from .stubs import StubEntitlementCertificate, StubProduct, StubEntitlementDirectory
 
@@ -52,11 +53,11 @@ class TestEntCertUpdateReport(fixture.SubManFixture):
         r.rogue.append(self._stub_cert())
 
         # an UnicodeError will fail the tests
-        report_str = unicode(r)
+        report_str = six.text_type(r)
         '%s' % report_str
 
         with fixture.locale_context('de_DE.utf8'):
-            report_str = unicode(r)
+            report_str = six.text_type(r)
             '%s' % r
 
     def _stub_cert(self):

--- a/test/test_i18n_optparse.py
+++ b/test/test_i18n_optparse.py
@@ -6,7 +6,6 @@ try:
 except ImportError:
     import unittest
 
-import optparse
 import six
 
 from subscription_manager import i18n_optparse
@@ -31,23 +30,3 @@ class TestWrappedIndentedHelpFormatter(unittest.TestCase):
         # own for consistency
         fu = self.hf.format_usage("%%prog [OPTIONS]")
         self.assertEqual(fu[:6], "Usage:")
-
-    # just to verify the old broken way continues
-    # to be broken and the way we detect that still works
-    def test_old(self):
-        old_formatter = optparse.IndentedHelpFormatter(width=50)
-        parser = i18n_optparse.OptionParser(description="test",
-                                            formatter=old_formatter)
-        parser.add_option("-t", "--test", dest="test",
-                          default=None,
-                          help="このシステム用に権利があるレポジトリのがあるレポジトリの一覧表示")
-        # This case, width this formatter, this string, and this width,
-        # the old formatter would split in a multibyte char, creating
-        # a string that doesn't decode to utf8. So verify this still
-        # happens with the old string
-        try:
-            fh = parser.format_option_help()
-            fh.decode("utf8")
-            self.fail("Should raise an exception")
-        except UnicodeDecodeError:
-            pass

--- a/test/test_lock.py
+++ b/test/test_lock.py
@@ -45,7 +45,7 @@ class TestLock(unittest.TestCase):
         acquire_timeout = acquire_timeout or 5.0
 
         sys_path = os.path.join(os.path.dirname(__file__), "../src")
-        self.other_process = subprocess.Popen(["/usr/bin/python", __file__, lockfile_path],
+        self.other_process = subprocess.Popen([sys.executable, __file__, lockfile_path],
                                               close_fds=True,
                                               stdin=subprocess.PIPE,
                                                env={'PYTHONPATH': sys_path})
@@ -73,7 +73,7 @@ class TestLock(unittest.TestCase):
 
     def close_lock_holder(self):
         try:
-            self.other_process.communicate("whatever")
+            self.other_process.communicate("whatever".encode('utf-8'))
         except Exception as e:
             print(e)
             # whatever, we closed it in the other thread
@@ -125,7 +125,7 @@ class TestLock(unittest.TestCase):
         b = lock.Lock(lock_path)
         res = b.acquire(blocking=False)
         self.assertFalse(b.acquired())
-        self.other_process.communicate("whatever")
+        self.other_process.communicate("whatever".encode('utf-8'))
         self.assertFalse(res)
 
     def test_lock(self):

--- a/test/test_logutil.py
+++ b/test/test_logutil.py
@@ -94,7 +94,7 @@ class TestLogutil(fixture.SubManFixture):
         for logger_name, log_level in logging_conf:
             real_log_level = logging.getLogger(logger_name).getEffectiveLevel()
             self.assertTrue(
-                logging._levelNames[log_level] == real_log_level or
+                logging.getLevelName(log_level) == real_log_level or
                 log_level == real_log_level)
 
     def test_set_invalid_logger_level(self):

--- a/test/test_managerlib.py
+++ b/test/test_managerlib.py
@@ -925,7 +925,7 @@ class TestMergedPoolsStackingGroupSorter(unittest.TestCase):
         self.assertEqual(1, len(sorter.groups))
         group = sorter.groups[0]
 
-        self.assertEqual("Test Prod 2", group.name)
+        self.assertIn(group.name, ["Test Prod 1", "Test Prod 2"])
         self.assertEqual(2, len(group.entitlements))
 
         self.assertEqual(pools[0], group.entitlements[0])
@@ -965,11 +965,10 @@ class TestMergedPoolsStackingGroupSorter(unittest.TestCase):
         group1 = sorter.groups[0]
         group2 = sorter.groups[1]
 
-        self.assertEqual("Test Prod 2", group1.name)
+        self.assertEqual(set([group1.name, group2.name]), set(["", "Test Prod 2"]))
         self.assertEqual(1, len(group1.entitlements))
         self.assertEqual(pools[0], group1.entitlements[0])
 
-        self.assertEqual("", group2.name)
         self.assertEqual(1, len(group2.entitlements))
         self.assertEqual(pools[1], group2.entitlements[0])
 
@@ -1032,7 +1031,7 @@ class MergedPoolsTests(unittest.TestCase):
         self.assertFalse('virt_only' in merged_pools.pools[3]['attributes'])
 
 
-class PoolStashTest(unittest.TestCase):
+class PoolStashTest(SubManFixture):
 
     def test_empty_stash_zero_length(self):
         my_stash = PoolStash()

--- a/test/test_migration.py
+++ b/test/test_migration.py
@@ -25,7 +25,7 @@ from . import stubs
 
 from mock import patch, NonCallableMock, MagicMock, Mock, call
 from rhsm.https import ssl
-from .fixture import Capture, SubManFixture, temp_file
+from .fixture import Capture, SubManFixture, temp_file, OPEN_FUNCTION
 from optparse import OptionParser
 from textwrap import dedent
 
@@ -886,13 +886,13 @@ class TestMigration(SubManFixture):
             ]
         self.engine.check_for_conflicting_channels(channels)
 
-    @patch("__builtin__.open", autospec=True)
+    @patch(OPEN_FUNCTION, autospec=True)
     def test_get_release(self, mock_open):
         mock_open.return_value = six.StringIO("Red Hat Enterprise Linux Server release 6.3 (Santiago)")
         release = self.engine.get_release()
         self.assertEqual(release, "RHEL-6")
 
-    @patch("__builtin__.open", autospec=True)
+    @patch(OPEN_FUNCTION, autospec=True)
     def test_read_channel_cert_mapping(self, mock_open):
         mock_open.return_value.readlines.return_value = [
             "xyz: abc\n",
@@ -1048,7 +1048,7 @@ class TestMigration(SubManFixture):
         self.engine.legacy_purge(sc, None)
         mock_shutil.assert_called_with(self.system_id_file, "%s.save" % self.system_id_file)
 
-    @patch("__builtin__.open", autospec=True)
+    @patch(OPEN_FUNCTION, autospec=True)
     def test_disable_yum_rhn_plugin(self, mock_open):
         mo = mock_open.return_value
         mo.readlines.return_value = [
@@ -1264,12 +1264,12 @@ class TestMigration(SubManFixture):
         (opts, args) = parser.parse_args(["--remove-rhn-packages"])
         self.assertTrue(opts.remove_legacy_packages)
 
-    @patch("__builtin__.open", autospec=True)
+    @patch(OPEN_FUNCTION, autospec=True)
     def test_is_using_systemd_false_on_rhel6(self, mock_open):
         mock_open.return_value = six.StringIO("Red Hat Enterprise Linux Server release 6.3 (Santiago)")
         self.assertFalse(self.engine.is_using_systemd())
 
-    @patch("__builtin__.open", autospec=True)
+    @patch(OPEN_FUNCTION, autospec=True)
     def test_is_using_systemd_true_on_rhel7(self, mock_open):
         mock_open.return_value = six.StringIO("Red Hat Enterprise Linux Server release 7.2 (Maipo)")
         self.assertTrue(self.engine.is_using_systemd())

--- a/test/test_po_files.py
+++ b/test/test_po_files.py
@@ -6,6 +6,7 @@ except ImportError:
     import unittest
 
 from . import fixture
+import six
 
 from subscription_manager import managercli
 from subscription_manager.printing_utils import to_unicode_or_bust
@@ -60,7 +61,7 @@ class TestUnicodeGettext(TestLocale):
     def test_ja_not_serial(self):
         with fixture.locale_context('ja_JP.UTF-8'):
             msg = _("'%s' is not a valid serial number") % "123123"
-            unicode(to_unicode_or_bust(msg)).encode("UTF-8") + '\n'
+            six.text_type(to_unicode_or_bust(msg)) + u'\n'
 
     def test_system_exit(self):
         with fixture.locale_context('ja_JP.UTF-8'):

--- a/test/test_rct_manifest_command.py
+++ b/test/test_rct_manifest_command.py
@@ -41,10 +41,10 @@ from .fixture import Capture, SubManFixture
 
 
 def _build_valid_manifest():
-    manifest_zip = six.StringIO()
+    manifest_zip = six.BytesIO()
     manifest_object = ZipFile(manifest_zip, "w", compression=zipfile.ZIP_STORED)
     manifest_object.writestr("signature", "dummy")
-    consumer_export_zip = six.StringIO()
+    consumer_export_zip = six.BytesIO()
     consumer_export_object = ZipFile(consumer_export_zip, "w", compression=zipfile.ZIP_STORED)
     consumer_export_object.writestr("export/consumer.json", manifestdata.consumer_json)
     consumer_export_object.writestr("export/meta.json", manifestdata.meta_json)
@@ -177,7 +177,7 @@ class RCTManifestCommandTests(SubManFixture):
 class RCTManifestExtractTests(unittest.TestCase):
 
     def test_extractall_outside_base(self):
-        zip_file_object = six.StringIO()
+        zip_file_object = six.BytesIO()
         archive = ZipExtractAll(zip_file_object, "w", compression=zipfile.ZIP_STORED)
         archive.writestr("../../../../wat", "this is weird")
 
@@ -187,7 +187,7 @@ class RCTManifestExtractTests(unittest.TestCase):
         shutil.rmtree(tmp_dir)
 
     def test_extractall_net_path(self):
-        zip_file_object = six.StringIO()
+        zip_file_object = six.BytesIO()
         archive = ZipExtractAll(zip_file_object, "w", compression=zipfile.ZIP_STORED)
         archive.writestr(r"\\nethost\share\whatever", "this is weird")
 
@@ -203,7 +203,7 @@ class RCTManifestExtractTests(unittest.TestCase):
         shutil.rmtree(tmp_dir)
 
     def test_extractall_local(self):
-        zip_file_object = six.StringIO()
+        zip_file_object = six.BytesIO()
         archive = ZipExtractAll(zip_file_object, "w", compression=zipfile.ZIP_STORED)
         archive.writestr("./some/path", "this is okay I think, though odd")
 
@@ -218,6 +218,6 @@ class RCTManifestExtractTests(unittest.TestCase):
 
     @mock.patch("sys.exit")
     def test_extractall_nonzip(self, mock_exit):
-        not_zip_file_object = six.StringIO()
+        not_zip_file_object = six.BytesIO()
         ZipExtractAll(not_zip_file_object, "r")
         mock_exit.assert_called_with(1)

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -16,7 +16,6 @@ from __future__ import print_function, division, absolute_import
 #
 import os
 
-from contextlib import nested
 from mock import Mock, NonCallableMock, patch, MagicMock
 
 from .stubs import StubUEP
@@ -86,9 +85,10 @@ class CliRegistrationTests(SubManFixture):
         self._inject_ipm()
         self.mock_register.register.side_effect = exceptions.ServiceError()
 
-        with nested(Capture(silent=True), self.assertRaises(SystemExit)) as e:
-            cmd.main(['register', '--consumerid=TaylorSwift', '--username=testuser1', '--password=password', '--org=test_org'])
-            self.assertEqual(e.code, os.EX_USAGE)
+        with Capture(silent=True):
+            with self.assertRaises(SystemExit) as e:
+                cmd.main(['register', '--consumerid=TaylorSwift', '--username=testuser1', '--password=password', '--org=test_org'])
+                self.assertEqual(e.code, os.EX_USAGE)
 
     def test_strip_username_and_password(self):
         username, password = RegisterCommand._get_username_and_password(" ", " ")
@@ -167,8 +167,9 @@ class CliRegistrationTests(SubManFixture):
             rc.options.activation_keys = None
             rc._prompt_for_environment = Mock(return_value="not_an_env")
 
-            with nested(Capture(silent=True), self.assertRaises(SystemExit)):
-                rc._get_environment_id(mock_uep, 'owner', None)
+            with Capture(silent=True):
+                with self.assertRaises(SystemExit):
+                    rc._get_environment_id(mock_uep, 'owner', None)
 
     def test_deprecate_consumer_type(self):
         with patch('rhsm.connection.UEPConnection', new_callable=StubUEP) as mock_uep:
@@ -177,6 +178,7 @@ class CliRegistrationTests(SubManFixture):
             cmd = RegisterCommand()
             self._inject_mock_invalid_consumer()
 
-            with nested(Capture(silent=True), self.assertRaises(SystemExit)) as e:
-                cmd.main(['register', '--type=candlepin'])
-                self.assertEqual(e.code, os.EX_USAGE)
+            with Capture(silent=True):
+                with self.assertRaises(SystemExit) as e:
+                    cmd.main(['register', '--type=candlepin'])
+                    self.assertEqual(e.code, os.EX_USAGE)

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -294,10 +294,10 @@ class TestReleaseIsCorrectRhel(fixture.SubManFixture):
         content_url = \
                 "/content/dist/rhel/server/6/$releasever/$basearch/os/"
         listing_path = self.cdn_rv_provider._build_listing_path(content_url)
-        self.assertEqual(listing_path, "/content/dist/rhel/server/6//listing")
+        self.assertEqual(listing_path, u"/content/dist/rhel/server/6//listing")
 
         # /content/beta/rhel/server/6/$releasever/$basearch/optional/os
         content_url = \
                 "/content/beta/rhel/server/6/$releasever/$basearch/optional/os"
         listing_path = self.cdn_rv_provider._build_listing_path(content_url)
-        self.assertEqual(listing_path, "/content/beta/rhel/server/6//listing")
+        self.assertEqual(listing_path, u"/content/beta/rhel/server/6//listing")

--- a/test/test_rhsm_debug_command.py
+++ b/test/test_rhsm_debug_command.py
@@ -23,6 +23,7 @@ from datetime import datetime
 
 from . import fixture
 from .test_managercli import TestCliCommand
+import six
 
 from rhsm_debug import debug_commands
 from rhsm_debug import cli
@@ -227,7 +228,7 @@ class TestCompileCommand(TestCliCommand):
             self.cc.main(["--destination", self.path])
             self.cc._validate_options()
         except InvalidCLIOptionError as e:
-            self.assertEqual(e.message, "The destination directory for the archive must already exist.")
+            self.assertEqual(six.text_type(e), "The destination directory for the archive must already exist.")
         else:
             self.fail("No Exception Raised")
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -536,7 +536,6 @@ class TestFriendlyJoin(fixture.SubManFixture):
         self.assertEqual("One", friendly_join(["One"]))
         self.assertEqual("One and Two", friendly_join(["One", "Two"]))
         self.assertEqual("One, Two, and Three", friendly_join(["One", "Two", "Three"]))
-        self.assertEqual("Three, Two, and One", friendly_join(set(["One", "Two", "Three"])))
         self.assertEqual("", friendly_join([]))
         self.assertEqual("", friendly_join(None))
         self.assertEqual("", friendly_join(set()))


### PR DESCRIPTION
After this lands, we will be able to run tests via Fedora with
nosetests-3. Additionally the bin scripts should also work with Python
3. For example, `python3 bin/subscription-manager` should work (with the
proper `PYTHONPATH`).