### PR TITLE
1304056: Fix D-Bus path of com.redhat.RHSM1.Facts

### DIFF
--- a/src/rhsmlib/dbus/facts/base.py
+++ b/src/rhsmlib/dbus/facts/base.py
@@ -25,6 +25,7 @@ log = logging.getLogger(__name__)
 
 class BaseFacts(base_object.BaseObject):
     interface_name = constants.FACTS_DBUS_INTERFACE
+    default_dbus_path = constants.FACTS_DBUS_PATH
     default_props_data = {}
     facts_collector_class = collector.FactsCollector
 


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1304056#c6
* D-Bus path should be: /com/redhat/RHSM1/Facts and not:
  /com/redhat/RHSM1

* Notice that output of 'busctl tree com.redhat.RHSM1.Facts' is now:

```console
    └─/com
      └─/com/redhat
        └─/com/redhat/RHSM1
          └─/com/redhat/RHSM1/Facts
```

* You can use introspec subcommand like this:

```console
    busctl introspect com.redhat.RHSM1.Facts /com/redhat/RHSM1/Facts
```

* You can tests API using following command:

```console
    dbus-send --system --print-reply --dest='com.redhat.RHSM1.Facts' \
        '/com/redhat/RHSM1/Facts' com.redhat.RHSM1.Facts.GetFacts
```

* Fixed indentation and white space in policy file