### PR TITLE
1510727: Enable starting of subman GUI, when consumer has been deleted

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -227,8 +227,6 @@ class StatusCache(CacheManager):
             self.last_error = ex
             log.error("Bad identity, unable to connect to server")
             return None
-        except connection.GoneException:
-            raise
         # all of the abover are subclasses of ConnectionException that
         # get handled first
         except (connection.ConnectionException, connection.RateLimitExceededException,


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1510727
* GoneException is child of connection.RestlibException and
  therse is no need to raise this exception.
* Tested many subman CLI commands and it works as expected in
  this situation (consumer has been deleted).
* Note: This bug was caused by this PR #1685. The GoneException
  did not have any effect before this PR was merged, because
  there was 'wrong' order of exceptions. Moving GoneException
  was not good idea.