### PR TITLE
Support the configuration of a repo metadata signing key

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -35,7 +35,10 @@ no_proxy =
 
 [rhsm]
 # Content base URL:
-baseurl= https://cdn.redhat.com
+baseurl = https://cdn.redhat.com
+
+# Repository metadata GPG key URL:
+repomd_gpg_url =
 
 # Server CA certificate location:
 ca_cert_dir = /etc/rhsm/ca/

--- a/man/asciidoc/rhsm.conf.5.asciidoc
+++ b/man/asciidoc/rhsm.conf.5.asciidoc
@@ -82,6 +82,11 @@ baseurl::
   the full *baseurl* would be for example:
   *https://sat6.example.com/pulp/repos* .
 
+repomd_gpg_url::
+  The URL of the GPG key that was used to sign this repository's metadata.
+  The specified GPG key will be used in addition to any GPG keys defined
+  by the entitlement.
+
 ca_cert_dir::
   The location for the certificates which are used to communicate with the
   server and to pulldown content.

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -122,6 +122,11 @@ would be for example:
 \&.
 .RE
 .PP
+repomd_gpg_url
+.RS 4
+The URL of the GPG key that was used to sign this repository's metadata\&. The specified GPG key will be used in addition to any GPG keys defined by the entitlement\&.
+.RE
+.PP
 ca_cert_dir
 .RS 4
 The location for the certificates which are used to communicate with the server and to pull down content\&.

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -61,6 +61,7 @@ SERVER_DEFAULTS = {
         }
 RHSM_DEFAULTS = {
         'baseurl': 'https://' + DEFAULT_CDN_HOSTNAME,
+        'repomd_gpg_url': '',
         'ca_cert_dir': DEFAULT_CA_CERT_DIR,
         'repo_ca_cert': '%(ca_cert_dir)sredhat-uep.pem',
         'productcertdir': '/etc/pki/product',

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -775,11 +775,20 @@ class Repo(dict):
 
         # If no GPG key URL is specified, turn gpgcheck off:
         gpg_url = content.gpg
+        if gpg_url:
+            gpg_url = utils.url_base_join(baseurl, gpg_url)
+        repomd_gpg_url = conf['rhsm']['repomd_gpg_url']
+        if repomd_gpg_url:
+            repomd_gpg_url = utils.url_base_join(baseurl, repomd_gpg_url)
+            if not gpg_url or gpg_url in ['https://', 'http://']:
+                gpg_url = repomd_gpg_url
+            elif repomd_gpg_url not in gpg_url:
+                gpg_url += ',' + repomd_gpg_url
         if not gpg_url:
             repo['gpgkey'] = ""
             repo['gpgcheck'] = '0'
         else:
-            repo['gpgkey'] = utils.url_base_join(baseurl, gpg_url)
+            repo['gpgkey'] = gpg_url
             # Leave gpgcheck as the default of 1
 
         repo['sslclientkey'] = content.cert.key_path()

--- a/test/rhsm/unit/config-tests.py
+++ b/test/rhsm/unit/config-tests.py
@@ -39,7 +39,8 @@ proxy_password =
 
 [rhsm]
 ca_cert_dir = /etc/rhsm/ca-test/
-baseurl= https://content.example.com
+baseurl = https://content.example.com
+repomd_gpg_url = https://content.example.com/gpg
 repo_ca_cert = %(ca_cert_dir)sredhat-uep-non-default.pem
 productCertDir = /etc/pki/product
 entitlementCertDir = /etc/pki/entitlement
@@ -100,7 +101,8 @@ proxy_user =
 proxy_password =
 
 [rhsm]
-baseurl= https://content.example.com
+baseurl = https://content.example.com
+repomd_gpg_url = https://content.example.com/gpg
 repo_ca_cert = %(ca_cert_dir)sredhat-uep.pem
 productCertDir = /etc/pki/product
 entitlementCertDir = /etc/pki/entitlement
@@ -130,7 +132,8 @@ proxy_user =
 proxy_password =
 
 [rhsm]
-baseurl= https://content.example.com
+baseurl = https://content.example.com
+repomd_gpg_url = https://content.example.com/gpg
 repo_ca_cert = %(s %%(ca_cert_dir)sredhat-uep.pem
 productCertDir = /etc/pki/product
 entitlementCertDir = /etc/pki/entitlement
@@ -264,6 +267,10 @@ class ConfigTests(BaseConfigTests):
     def test_get_empty(self):
         value = self.cfgParser.get("foo", "bar")
         self.assertEqual("", value)
+
+    def test_get_repomd_gpg_url(self):
+        value = self.cfgParser.get("rhsm", "repomd_gpg_url")
+        self.assertEqual("https://content.example.com/gpg", value)
 
     def test_get_repo_ca_cert(self):
         value = self.cfgParser.get("rhsm", "repo_ca_cert")

--- a/test/rhsmlib_test/test_config.py
+++ b/test/rhsmlib_test/test_config.py
@@ -47,7 +47,8 @@ proxy_password =
 
 [rhsm]
 ca_cert_dir = /etc/rhsm/ca-test/
-baseurl= https://content.example.com
+baseurl = https://content.example.com
+repomd_gpg_url =
 repo_ca_cert = %(ca_cert_dir)sredhat-uep-non-default.pem
 productCertDir = /etc/pki/product
 entitlementCertDir = /etc/pki/entitlement

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -60,7 +60,8 @@ proxy_password = proxy_password
 no_proxy =
 
 [rhsm]
-baseurl= https://content.example.com
+baseurl = https://content.example.com
+repomd_gpg_url =
 repo_ca_cert = %(ca_cert_dir)sredhat-uep.pem
 productCertDir = /etc/pki/product
 entitlementCertDir = /etc/pki/entitlement


### PR DESCRIPTION
This repo metadata signing key will be used in addition to any RPM signing keys that are configured for each repository.

This is necessary to support the use of repo_gpgcheck=1 with Satellite, since Satellite must sign the metadata using a local GPG key, while the RPMs in each repository will be signed using the upstream repository's GPG key as specified in the entitlement certs.

See https://bugzilla.redhat.com/show_bug.cgi?id=1410638