### PR TITLE
Do not enable gpgcheck if the only a metadata gpg key is configured

### DIFF
--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -775,8 +775,12 @@ class Repo(dict):
 
         # If no GPG key URL is specified, turn gpgcheck off:
         gpg_url = content.gpg
-        if gpg_url:
+        if not gpg_url:
+            gpg_url = ''
+            repo['gpgcheck'] = '0'
+        else:
             gpg_url = utils.url_base_join(baseurl, gpg_url)
+            # Leave gpgcheck as the default of 1
         repomd_gpg_url = conf['rhsm']['repomd_gpg_url']
         if repomd_gpg_url:
             repomd_gpg_url = utils.url_base_join(baseurl, repomd_gpg_url)
@@ -784,12 +788,7 @@ class Repo(dict):
                 gpg_url = repomd_gpg_url
             elif repomd_gpg_url not in gpg_url:
                 gpg_url += ',' + repomd_gpg_url
-        if not gpg_url:
-            repo['gpgkey'] = ""
-            repo['gpgcheck'] = '0'
-        else:
-            repo['gpgkey'] = gpg_url
-            # Leave gpgcheck as the default of 1
+        repo['gpgkey'] = gpg_url
 
         repo['sslclientkey'] = content.cert.key_path()
         repo['sslclientcert'] = content.cert.path


### PR DESCRIPTION
Per https://github.com/candlepin/subscription-manager/pull/1749#discussion_r159297538 I adjusted the logic in that PR such that gpgcheck would be enabled if a repo metadata gpg key is configured.

Unfortunately, I had forgotten why I originally implemented it to disable gpgcheck if only a repo metadata gpg key is configured ... After further testing of the merged commit, I've re-discovered that this causes problems for repositories that contain unsigned RPMs and therefore do not have a non-metadata gpg key configured.  If the only configured gpg key on a repository is the metadata gpg key, then only the global repo_gpgcheck yum configuration option should be enabled, and the per-repository gpgcheck configuration option should be disabled.
  