### PR TITLE
rct cat-manifest: show Web and API urls from consumer.json

### DIFF
--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -213,6 +213,8 @@ class CatManifestCommand(RCTManifestCommand):
             contentAccessMode = 'org_environment'
         to_print.append((_("Content Access Mode"), contentAccessMode))
         to_print.append((_("Type"), get_value(data, "type.label")))
+        to_print.append((_("API URL"), get_value(data, "urlApi")))
+        to_print.append((_("Web URL"), get_value(data, "urlWeb")))
         self._print_section(_("Consumer:"), to_print)
 
     def _get_product_attribute(self, name, data):

--- a/test/manifestdata.py
+++ b/test/manifestdata.py
@@ -16,6 +16,8 @@ Consumer:
 \tUUID: ba5ac769-207e-421c-bfd2-a23c767114af
 \tContent Access Mode: entitlement
 \tType: sam
+\tAPI URL: https://subscription.rhn.stage.redhat.com/subscription/consumers/
+\tWeb URL: access.stage.redhat.com/management/distributors/
 
 Subscription:
 \tName: RHN Monitoring (Up to 1 guest)
@@ -48,7 +50,9 @@ consumer_json = """
         "label": "sam",
         "manifest": true
     },
-    "uuid": "ba5ac769-207e-421c-bfd2-a23c767114af"
+    "uuid": "ba5ac769-207e-421c-bfd2-a23c767114af",
+    "urlApi": "https://subscription.rhn.stage.redhat.com/subscription/consumers/",
+    "urlWeb": "access.stage.redhat.com/management/distributors/"
 }"""
 
 meta_json = """


### PR DESCRIPTION
this is useful for debugging why a satellite cannot access the distributor :)