### PR TITLE
1507030: RestlibExceptions should show they originate server-side

### DIFF
--- a/build_ext/i18n.py
+++ b/build_ext/i18n.py
@@ -173,7 +173,7 @@ class Gettext(BaseCommand):
         for desktop_file in Utils.find_files_of_type('etc-conf', '*.desktop.in'):
             spawn(cmd + [desktop_file])
 
-        cmd = ['xgettext', '--from-code=utf-8', '--sort-by-file', '-o', tmp_key_file]
+        cmd = ['xgettext', '--from-code=utf-8', '--add-comments=TRANSLATORS:', '--sort-by-file', '-o', tmp_key_file]
 
         # These tuples contain a template for the file name that will contain a list of
         # all source files of a given type to translate, a function that finds all the

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -135,7 +135,8 @@ class RestlibException(ConnectionException):
         self.headers = headers or {}
 
     def __str__(self):
-        return self.msg
+        error_title = httplib.responses.get(self.code, "Unknown")
+        return "HTTP error (%s - %s): %s" % (self.code, error_title, self.msg)
 
 
 class GoneException(RestlibException):
@@ -167,7 +168,8 @@ class NetworkException(ConnectionException):
         self.code = code
 
     def __str__(self):
-        return "Network error code: %s" % self.code
+        error_title = httplib.responses.get(self.code, "Unknown")
+        return "HTTP error (%s - %s)" % (self.code, error_title)
 
 
 class RemoteServerException(ConnectionException):

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -87,7 +87,7 @@ class TestExceptionMapper(unittest.TestCase):
         mapper = ExceptionMapper()
 
         err = RestlibException(404, expected_message)
-        self.assertEqual(expected_message, mapper.get_message(err))
+        self.assertEqual("HTTP error code 404: %s" % expected_message, mapper.get_message(err))
 
     def test_returns_none_when_no_mapped_exception_present(self):
         mapper = ExceptionMapper()


### PR DESCRIPTION
The message printed to the console doesn't include the official error title (Page Not Found, Internal Service Error, etc.) because we don't have translations for them and I feel that the sense of the message -- that there was an error server-side -- is conveyed well enough with the phrase "HTTP error code".

I am a little concerned about error messages coming back in UTF8.  I used our "convert this to unicode if you can" utility method, but it feels like kind of a hack and none of the other error messages need to bother with it.

Testing this can be annoying.  Here is how I do it.

1. Set up a local Candlepin and register to it.
2. Go into the `rhsm.conf` file and change the port to 3131
3. Drop the following in a file named `500.response`
   ```
   HTTP/1.1 500 Internal Server Error
   Server: Apache-Coyote/1.1
   x-candlepin-request-uuid: 9e62bc70-811f-4047-bf16-b7aeff20f593
   X-Version: 2.0.43-1
   X-Version: 2.0.43-1
   Content-Type: application/json
   Content-Length: 127

   {"displayMessage": "Something in Candlepin broke обновлении","request-uuid": "9e62bc70-811f-4047-bf16-b7aeff20f593"}  
   ```
4. Generate a server certificate
   ```
   openssl req -new -x509 -newkey rsa:2048 -nodes -days 3650 -subj "/CN=Poor Man HTTP Server CA" -out poor-man.crt -keyout poor-man.key
   ```
5. Run an ersatz HTTP server with the command
   ```
   ncat --listen --keep-open -vv --ssl-cert ./poor-man.crt --ssl-key ./poor-man.key -p 3131 --exec '/bin/cat 500.response'
   ```
6. Run a subscription-manager command.  The ncat server listening on 3131 will always return the response in the `500.response` file.  Subscription-manager will interpret this as a 500 error and you'll get directed into the error handling code.

Final note: I added an argument to our `xgettext` invocation that will pull comments marked with the tag "TRANSLATORS:" and put those comments in the `keys.pot` file above the msgid to provide context.