### PR TITLE
Don't run gui tests by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ can be used:
 
 See `cockpit/README.md` for more detailed information on cockpit development.
 
+Testing
+-------
+We run tests using nose (see candlepinproject.org for details).  Some tests
+are not run by default. For example, since we are not maintaining the GTK GUI
+for all platforms, they are not run by default. They can be included via
+`-a gui` option for the nose command. It is recommended if you run the GUI
+tests to also use `--with-xvfb` in order to use Xvfb instead of spawning
+GTK windows in your desktop session (ex. `nosetests -a gui --with-xvfb`).
+
 Troubleshooting
 ---------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 
 [nosetests]
-with-xvfb=True
 with-randomly=True
 cover-html=True
 # exclude tests with names that match regex .*ga_impls.*
@@ -8,4 +7,4 @@ cover-html=True
 # to load modules that would have that name, and seems to ignore 'ignore-files'
 # Workaround for nose/ga/pygobject issues introduced with pygobject3-3.14
 exclude=.*ga_impls.*
-attr=!zypper,!functional
+attr=!zypper,!functional,!gui

--- a/test/gui/test_about.py
+++ b/test/gui/test_about.py
@@ -24,9 +24,11 @@ import mock
 
 from subscription_manager.ga import Gtk as ga_Gtk
 from subscription_manager.gui import about
-from .fixture import OPEN_FUNCTION
+from test.fixture import OPEN_FUNCTION
+from nose.plugins.attrib import attr
 
 
+@attr('gui')
 class TestAboutDialog(unittest.TestCase):
     @mock.patch('subscription_manager.gui.about.get_server_versions')
     @mock.patch('subscription_manager.gui.about.get_client_versions')

--- a/test/gui/test_contract_selection_gui.py
+++ b/test/gui/test_contract_selection_gui.py
@@ -9,6 +9,7 @@ import datetime
 from dateutil.tz import tzutc
 
 from subscription_manager.gui import contract_selection
+from nose.plugins.attrib import attr
 
 
 def stubSelectedCallback(self, pool):
@@ -19,6 +20,7 @@ def stubCancelCallback(self):
     pass
 
 
+@attr('gui')
 class ContractSelection(unittest.TestCase):
     pool = {'productName': 'SomeProduct',
             'consumed': 3,

--- a/test/gui/test_facts_gui.py
+++ b/test/gui/test_facts_gui.py
@@ -1,13 +1,15 @@
 from __future__ import print_function, division, absolute_import
 
-from .fixture import SubManFixture
+from test.fixture import SubManFixture
 
 from subscription_manager.injection import provide, IDENTITY
-from .stubs import StubUEP, StubFacts
+from test.stubs import StubUEP, StubFacts
 from subscription_manager.gui import factsgui
 from mock import NonCallableMock, patch
+from nose.plugins.attrib import attr
 
 
+@attr('gui')
 class FactDialogTests(SubManFixture):
 
     def setUp(self):

--- a/test/gui/test_gui_utils.py
+++ b/test/gui/test_gui_utils.py
@@ -9,6 +9,7 @@ from rhsm.connection import RestlibException
 from subscription_manager.ga import Gtk as ga_Gtk
 from subscription_manager.gui import utils
 from subscription_manager.gui import storage
+from nose.plugins.attrib import attr
 
 # we need gtk 2.18+ to do the right markup in likify
 MIN_GTK_MAJOR = 2
@@ -16,6 +17,7 @@ MIN_GTK_MINOR = 18
 MIN_GTK_MICRO = 0
 
 
+@attr('gui')
 class TestLinkify(unittest.TestCase):
     no_url = "this does not have a url"
     https_url = "https://www.redhat.com"
@@ -72,6 +74,7 @@ class TestLinkify(unittest.TestCase):
         self.assertEqual(ret, self.expected_example_2)
 
 
+@attr('gui')
 class TestGatherGroup(unittest.TestCase):
     def test_gather_group(self):
         """
@@ -99,6 +102,7 @@ class TestGatherGroup(unittest.TestCase):
         self.assertEqual(names, set(['root', 'child-1', 'child-2', 'grandchild-1']))
 
 
+@attr('gui')
 class TestGuiExceptionMapper(unittest.TestCase):
     def test_restlib_exception_with_markup(self):
         exception_mapper = utils.GuiExceptionMapper()

--- a/test/gui/test_handle_gui_exception.py
+++ b/test/gui/test_handle_gui_exception.py
@@ -10,9 +10,10 @@ import socket
 from rhsm.https import ssl
 
 from subscription_manager.gui import utils
-from .fixture import FakeException, FakeLogger
+from test.fixture import FakeException, FakeLogger
 
 import rhsm.connection as connection
+from nose.plugins.attrib import attr
 
 
 class FakeErrorWindow(object):
@@ -20,6 +21,7 @@ class FakeErrorWindow(object):
         self.msg = msg
 
 
+@attr('gui')
 @patch('subscription_manager.gui.utils.log', FakeLogger())
 @patch('subscription_manager.gui.utils.show_error_window', FakeErrorWindow)
 class HandleGuiExceptionTests(unittest.TestCase):

--- a/test/gui/test_managergui.py
+++ b/test/gui/test_managergui.py
@@ -1,14 +1,16 @@
 from __future__ import print_function, division, absolute_import
 
-from .fixture import SubManFixture
+from test.fixture import SubManFixture
 import mock
 
-from . import stubs
+from test import stubs
 from subscription_manager.gui import managergui, registergui
 from subscription_manager.injection import provide, \
         PRODUCT_DATE_RANGE_CALCULATOR, PROD_DIR
+from nose.plugins.attrib import attr
 
 
+@attr('gui')
 class TestManagerGuiMainWindow(SubManFixture):
     def test_main_window(self):
 
@@ -20,6 +22,7 @@ class TestManagerGuiMainWindow(SubManFixture):
                               prod_dir=stubs.StubProductDirectory([]))
 
 
+@attr('gui')
 class TestRegisterScreen(SubManFixture):
     def test_register_screen(self):
         registergui.RegisterDialog(stubs.StubBackend())

--- a/test/gui/test_network_config_gui.py
+++ b/test/gui/test_network_config_gui.py
@@ -1,15 +1,17 @@
 from __future__ import print_function, division, absolute_import
 
-from .fixture import SubManFixture
+from test.fixture import SubManFixture
 from subscription_manager.gui import networkConfig
 import mock
 import rhsm.connection as connection
 import rhsm.config
 import rhsm.utils
 import socket
-from . import stubs
+from test import stubs
+from nose.plugins.attrib import attr
 
 
+@attr('gui')
 class TestNetworkConfigDialog(SubManFixture):
 
     def setUp(self):

--- a/test/gui/test_preferences.py
+++ b/test/gui/test_preferences.py
@@ -18,14 +18,15 @@ from __future__ import print_function, division, absolute_import
 import mock
 
 
-from . import stubs
+from test import stubs
 
-from .fixture import SubManFixture
+from test.fixture import SubManFixture
 from subscription_manager.ga import Gdk as ga_Gdk
 
 from subscription_manager.injection import require, IDENTITY
 
 from subscription_manager.gui import preferences
+from nose.plugins.attrib import attr
 
 CONSUMER_DATA = {'autoheal': True,
                  'releaseVer': {'id': 1, 'releaseVer': '123123'},
@@ -41,6 +42,7 @@ def get_releases():
     return ["123123", "1", "2", "4", "blippy"]
 
 
+@attr('gui')
 class TestPreferencesDialog(SubManFixture):
     _getConsumerData = None
 

--- a/test/gui/test_progress_gui.py
+++ b/test/gui/test_progress_gui.py
@@ -6,8 +6,10 @@ except ImportError:
     import unittest
 
 from subscription_manager.gui import progress
+from nose.plugins.attrib import attr
 
 
+@attr('gui')
 class TestProgress(unittest.TestCase):
     def setUp(self):
         self.pw = progress.Progress("test title", "this is a test label")

--- a/test/gui/test_registrationgui.py
+++ b/test/gui/test_registrationgui.py
@@ -2,9 +2,9 @@ from __future__ import print_function, division, absolute_import
 
 from mock import Mock, patch
 
-from .fixture import SubManFixture
+from test.fixture import SubManFixture
 
-from .stubs import StubBackend, StubFacts
+from test.stubs import StubBackend, StubFacts
 from subscription_manager.gui.registergui import RegisterWidget, RegisterInfo,  \
     CredentialsScreen, ActivationKeyScreen, ChooseServerScreen, AsyncBackend, \
     CREDENTIALS_PAGE, CHOOSE_SERVER_PAGE
@@ -15,8 +15,10 @@ from subscription_manager.ga import Gtk as ga_Gtk
 
 import sys
 import six
+from nose.plugins.attrib import attr
 
 
+@attr('gui')
 class RegisterWidgetTests(SubManFixture):
     def setUp(self):
         super(RegisterWidgetTests, self).setUp()
@@ -145,6 +147,7 @@ class StubReg(object):
         self.facts = StubFacts(fact_dict=self.expected_facts)
 
 
+@attr('gui')
 class CredentialsScreenTests(SubManFixture):
 
     def setUp(self):
@@ -170,6 +173,7 @@ class CredentialsScreenTests(SubManFixture):
                           self.screen.consumer_name.get_text())
 
 
+@attr('gui')
 class ActivationKeyScreenTests(SubManFixture):
     def setUp(self):
         super(ActivationKeyScreenTests, self).setUp()
@@ -185,6 +189,7 @@ class ActivationKeyScreenTests(SubManFixture):
         self.assertEqual(expected, result)
 
 
+@attr('gui')
 class ChooseServerScreenTests(SubManFixture):
     def setUp(self):
         super(ChooseServerScreenTests, self).setUp()
@@ -224,6 +229,7 @@ class ChooseServerScreenTests(SubManFixture):
         self.assertEqual(expected, result)
 
 
+@attr('gui')
 class AsyncBackendTests(SubManFixture):
     def setUp(self):
         super(AsyncBackendTests, self).setUp()

--- a/test/gui/test_repogui.py
+++ b/test/gui/test_repogui.py
@@ -15,14 +15,16 @@ from __future__ import print_function, division, absolute_import
 #
 
 from mock import Mock
-from .fixture import SubManFixture
+from test.fixture import SubManFixture
 from subscription_manager.async import AsyncRepoOverridesUpdate
 from subscription_manager.gui.reposgui import RepositoriesDialog
 from subscription_manager.repolib import Repo
 from subscription_manager.overrides import Override
-from .stubs import StubEntitlementCertificate, StubProduct
+from test.stubs import StubEntitlementCertificate, StubProduct
+from nose.plugins.attrib import attr
 
 
+@attr('gui')
 class TestReposGui(SubManFixture):
 
     def setUp(self):
@@ -166,6 +168,7 @@ class TestReposGui(SubManFixture):
         return combo_box.get_model()[column][1]
 
 
+@attr('gui')
 class TestingOverridesAsync(AsyncRepoOverridesUpdate):
 
     def _process_callback(self, callback, *args):


### PR DESCRIPTION
Since we're planning on not supporting the GUI w/ Python 3, and they
were causing issues on F27 (segfaults!) that were non-trivial to
determine the root cause of, we'll just stop running them by default.

Ran into these issues while developing #1761, so it may be necessary to
pull these changes in to test that PR against Python 3...

C-I should still be running them by using a different config file for
nose.