### PR TITLE
1537473: Subman rpm requires python-setuptools

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -132,6 +132,7 @@ Requires:  virt-what
 Requires:  %{rhsm_package_name} = %{version}
 Requires:  %{py_package_prefix}-six
 Requires:  %{py_package_prefix}-dateutil
+Requires:  %{py_package_prefix}-setuptools
 
 %if %{with python3}
 Requires: python3-dbus


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1537473