### PR TITLE
1540204: Raise RateLimitExceededException with headers

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -669,7 +669,8 @@ class BaseRestLib(object):
                                              request_type=request_type,
                                              handler=handler)
                 elif str(response['status']) in ['429']:
-                    raise RateLimitExceededException(response['status'])
+                    raise RateLimitExceededException(response['status'],
+                                                     headers=response.get('headers'))
 
                 elif str(response['status']) == str(httplib.PROXY_AUTHENTICATION_REQUIRED):
                     raise ProxyException


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1540204
* virt-who wasn't able to get "Retry-After:" header in some cases