### PR TITLE
1510024: Handle rhel-alt product tags properly

### DIFF
--- a/src/subscription_manager/rhelproduct.py
+++ b/src/subscription_manager/rhelproduct.py
@@ -34,9 +34,11 @@ class RHELProductMatcher(object):
     """
     def __init__(self, product=None):
         self.product = product
-        # Match "rhel-6" or "rhel-11"
+        # Match "rhel-6" or "rhel-11" or "rhel-alt-7" (bz1510024)
         # but not "rhel-6-server" or "rhel-6-server-highavailabilty"
-        self.pattern = "rhel-\d+$|rhel-5-workstation$"
+        # NOTE: we considered rhel(-[\w\d]+)?-\d+$ but decided against it
+        # due to possibility of unintentional matches
+        self.pattern = "rhel(-alt)?-\d+$|rhel-5-workstation$"
 
     def is_rhel(self):
         """return true if this is a rhel product cert"""

--- a/test/test_rhelproduct.py
+++ b/test/test_rhelproduct.py
@@ -17,26 +17,29 @@ from .fixture import SubManFixture
 #  rhel-6-resilientstorage
 class TestRHELProductMatcher(SubManFixture):
 
-    matches = ["rhel-6,rhel-6-client",
-               "rhel-6,rhel-6-client",
-               "rhel-6,rhel-6-computenode",
-               "rhel-6,rhel-6-server",
-               "rhel-6,rhel-6-ibm-power",
-               "rhel-6,rhel-6-ibm-system-z",
-               "rhel-6,rhel-6-server",
-               "rhel-6,rhel-6-workstation",
-               "rhel-6,rhel-6-workstation",
-               "rhel-11",
-               "rhel-6,rhel-6-someotherthing",
-               "rhel-11,rhel-11-something",
-               # See bz1108257 rhel-5-workstation is a RHEL variant, but doesn't have
-               # a rhel-5 product tag.
-               "rhel-5-client-workstation,rhel-5-workstation",
-               "rhel-5-workstation",
-               # RHEL5 Client variant, 68.pem, aka Desktop
-               # "rhel-5-client" should never appear as the only tag, it's a
-               # rhel-5 variant
-               "rhel-5,rhel-5-client"]
+    matches = [
+        "rhel-alt-7,rhel-alt-7-power9",
+        "rhel-6,rhel-6-client",
+        "rhel-6,rhel-6-client",
+        "rhel-6,rhel-6-computenode",
+        "rhel-6,rhel-6-server",
+        "rhel-6,rhel-6-ibm-power",
+        "rhel-6,rhel-6-ibm-system-z",
+        "rhel-6,rhel-6-server",
+        "rhel-6,rhel-6-workstation",
+        "rhel-6,rhel-6-workstation",
+        "rhel-11",
+        "rhel-6,rhel-6-someotherthing",
+        "rhel-11,rhel-11-something",
+        # See bz1108257 rhel-5-workstation is a RHEL variant, but doesn't have
+        # a rhel-5 product tag.
+        "rhel-5-client-workstation,rhel-5-workstation",
+        "rhel-5-workstation",
+        # RHEL5 Client variant, 68.pem, aka Desktop
+        # "rhel-5-client" should never appear as the only tag, it's a
+        # rhel-5 variant
+        "rhel-5,rhel-5-client",
+    ]
 
     not_matches = ["rhel-5-server-scalablefilesystem,rhel-5-scalablefilesystem",
                    "rhel-5-server-clusterstorage,rhel-5-clusterstorage",


### PR DESCRIPTION
For now we'll support just rhel-alt additionally, though it wouldn't be
hard to change to a more general matcher in the future if needed.
Comment left in the code to that effect.