### PR TITLE
1543639 - Properly encode package profile data

### DIFF
--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -45,11 +45,11 @@ class Package(object):
     def to_dict(self):
         """ Returns a dict representation of this packages info. """
         return {
-                'name': self.name,
-                'version': self.version,
-                'release': self.release,
-                'arch': self.arch,
-                'epoch': self.epoch,
+                'name': self._normalize_string(self.name),
+                'version': self._normalize_string(self.version),
+                'release': self._normalize_string(self.release),
+                'arch': self._normalize_string(self.arch),
+                'epoch': self._normalize_string(self.epoch),
                 'vendor': self._normalize_string(self.vendor),  # bz1519512 handle vendors that aren't utf-8
         }
 
@@ -73,6 +73,7 @@ class Package(object):
     def __str__(self):
         return "<Package: %s %s %s>" % (self.name, self.version, self.release)
 
+    # added in support of bz1519512, bz1543639
     @staticmethod
     def _normalize_string(value):
         if type(value) is six.binary_type:

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -173,26 +173,29 @@ class TestProfileManager(unittest.TestCase):
         self.assertEqual(0, res)
 
     def test_package_json_handles_non_unicode(self):
-        package = Package(name="package1", version="1.0.0", release=1, arch="x86_64", vendor=b'\xf6')
+        package = Package(name=b'\xf6', version=b'\xf6', release=b'\xf6', arch=b'\xf6', vendor=b'\xf6')
         data = package.to_dict()
         json_str = json.dumps(data)  # to json
         data = json.loads(json_str)  # and back to an object
-        self.assertEqual(u'\ufffd', data['vendor'])
+        for attr in ['name', 'version', 'release', 'arch', 'vendor']:
+            self.assertEqual(u'\ufffd', data[attr])
 
-    def test_package_json_vendor_as_unicode_type(self):
+    def test_package_json_as_unicode_type(self):
         # note that the data type at time of writing is bytes, so this is just defensive coding
-        package = Package(name="package1", version="1.0.0", release=1, arch="x86_64", vendor=u'Björk')
+        package = Package(name=u'Björk', version=u'Björk', release=u'Björk', arch=u'Björk', vendor=u'Björk')
         data = package.to_dict()
         json_str = json.dumps(data)  # to json
         data = json.loads(json_str)  # and back to an object
-        self.assertEqual(u'Björk', data['vendor'])
+        for attr in ['name', 'version', 'release', 'arch', 'vendor']:
+            self.assertEqual(u'Björk', data[attr])
 
-    def test_package_json_missing_vendor(self):
-        package = Package(name="package1", version="1.0.0", release=1, arch="x86_64", vendor=None)
+    def test_package_json_missing_attributes(self):
+        package = Package(name=None, version=None, release=None, arch=None, vendor=None)
         data = package.to_dict()
         json_str = json.dumps(data)  # to json
         data = json.loads(json_str)  # and back to an object
-        self.assertEqual(None, data['vendor'])
+        for attr in ['name', 'version', 'release', 'arch', 'vendor']:
+            self.assertEqual(None, data[attr])
 
     @staticmethod
     def _mock_pkg_profile(packages):


### PR DESCRIPTION
This fixes the issue I raised in https://bugzilla.redhat.com/show_bug.cgi?id=1543639

```
[root@fedora27 vagrant]# subscription-manager register --username admin --password changeme --force
Unregistering from: centos7-katello-3-5.strangeways.example.com:443/rhsm
The system with UUID 7fba2e9f-7d27-45d6-b096-87a92b45a7fd has been unregistered
All local data removed
Registering to: centos7-katello-3-5.strangeways.example.com:443/rhsm
The system has been registered with ID: bc460d08-76aa-4492-a026-3bfe1d6e5777
The registered system name is: fedora27.strangeways.example.com
[root@fedora27 vagrant]# 
```

If solution is approved I'll write some tests.