### PR TITLE
1528625: Prevent dmidecode failure from returning None

### DIFF
--- a/src/rhsmlib/facts/dmiinfo.py
+++ b/src/rhsmlib/facts/dmiinfo.py
@@ -87,7 +87,7 @@ class DmiFirmwareInfoCollector(collector.FactsCollector):
             for tag, func in list(dmi_data.items()):
                 dmiinfo = self._get_dmi_data(func, tag, dmiinfo)
         except Exception as e:
-            log.warn(_("Error reading system DMI information: %s"), e)
+            log.warn(_("Error reading system DMI information: %s"), e, exc_info=True)
         finally:
             self.log_warnings(dmidecode)
         return dmiinfo
@@ -97,7 +97,7 @@ class DmiFirmwareInfoCollector(collector.FactsCollector):
             return func()
         except Exception as e:
             log.warn(_("Error reading system DMI information with %s: %s"), func, e)
-            return None
+            return {}
 
     def _get_dmi_data(self, func, tag, ddict):
         for key, value in list(func.items()):
@@ -126,5 +126,5 @@ class DmiFirmwareInfoCollector(collector.FactsCollector):
     def log_warnings(self, dmidecode):
         dmiwarnings = dmidecode.get_warnings()
         if dmiwarnings:
-            log.warn(_("Error reading system DMI information: %s"), dmiwarnings)
+            log.warn(_("Error reading system DMI information: %s"), dmiwarnings, exc_info=True)
             dmidecode.clear_warnings()


### PR DESCRIPTION
Calls to `dmidecode.connector()` can fail with a "list assignment index
out of range" error (for reasons that are currently unknown).  In this
case, our code should return an empty dictionary instead of None since
the return value is dereferenced later where it is assumed to be a
dictionary.

Additionally, if there are failures during fact gathering, we should
display the stacktrace in the logs for debugging purposes.