### PR TITLE
Add BuildRequires for gcc

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -175,6 +175,7 @@ Requires(post): %{?suse_version:aaa_base} %{!?suse_version:chkconfig}
 Requires(preun): %{?suse_version:aaa_base} %{!?suse_version:chkconfig, initscripts}
 %endif
 
+BuildRequires: gcc
 BuildRequires: %{py_package_prefix}-devel
 BuildRequires: %{py_package_prefix}-setuptools
 BuildRequires: gettext


### PR DESCRIPTION
See https://fedoraproject.org/wiki/Packaging:C_and_C%2B%2B#Packaging

I got an [announcement email](https://lists.fedoraproject.org/archives/list/devel-announce@lists.fedoraproject.org/thread/IJFYI5Q2BYZKIGDFS2WLOBDUSEGWHIKV/) from Igor Gnatenko at Fedora Project stating that this is a new requirement.