### PR TITLE
Define python version when calling make command.

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -179,8 +179,9 @@ Requires(post): %{?suse_version:aaa_base} %{!?suse_version:chkconfig}
 Requires(preun): %{?suse_version:aaa_base} %{!?suse_version:chkconfig, initscripts}
 %endif
 
+BuildRequires: %{?suse_version:python-devel >= 2.6} %{!?suse_version:%{py_package_prefix}-devel}
+BuildRequires: openssl-devel
 BuildRequires: gcc
-BuildRequires: %{py_package_prefix}-devel
 BuildRequires: %{py_package_prefix}-setuptools
 BuildRequires: gettext
 BuildRequires: intltool
@@ -208,10 +209,6 @@ BuildRequires: systemd-rpm-macros
 BuildRequires: systemd
 %endif
 
-# The %{?something:foo} expands to foo only when something is **defined**.  Likewise the
-# %{!?something:foo} expands only when something is **not defined**.
-BuildRequires: %{?suse_version:python-devel >= 2.6} %{!?suse_version:%{py_package_prefix}-devel}
-BuildRequires: openssl-devel
 
 %description
 The Subscription Manager package provides programs and libraries to allow users
@@ -406,7 +403,7 @@ Subscription Manager Cockpit UI
 
 %build
 make -f Makefile VERSION=%{version}-%{release} CFLAGS="%{optflags}" \
-    LDFLAGS="%{__global_ldflags}" OS_DIST="%{dist}" %{?gtk_version}
+    LDFLAGS="%{__global_ldflags}" OS_DIST="%{dist}" PYTHON="%{__python}" %{?gtk_version}
 
 %install
 rm -rf %{buildroot}


### PR DESCRIPTION
Subscription manager wasn't building in Fedora 27.  When running 'make'
to build '_certificate.so', 'make' was invoking 'setup.py' with 'python'
instead of 'python3'.  The result was that '/usr/include/python2.7' was
added to the 'gcc' command.  That was fine in Fedora 26 as that
directory and header files were already in the buildroot for whatever
reason.  In Fedora 27, something changed and our buildroot only had
'/usr/include/python3.6m' so we need to run 'setup.py' under 'python3'
so that 'gcc' will receive the correct include path.

This commit also removes duplicate BuildRequires for %{py_package_prefix}-devel.