### PR TITLE
New Vagrant file for creating PXEBOOT server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ dist
 .settings
 *.retry
 .vagrant
+vagrant/vagrant_data/*.iso

--- a/vagrant/roles/pxe-server/defaults/main.yml
+++ b/vagrant/roles/pxe-server/defaults/main.yml
@@ -1,0 +1,49 @@
+---
+required_rpms:
+  - dhcp
+  - tftp
+  - tftp-server
+  - syslinux
+  - wget
+  - vsftpd
+
+##### CentOS 7 #####
+
+# distro_name: "centos"
+# distro_version: "7"
+# # Newer version is available e.g. here: http://ftp.cvut.cz/centos/7/isos/x86_64/
+# iso_img_server: "http://ftp.cvut.cz/centos/7/isos/x86_64"
+# iso_img_file: "CentOS-7-x86_64-Minimal-1708.iso"
+# # Fresh sha256 checksums of CentOS images can be found e.g. here:
+# # http://ftp.cvut.cz/centos/7/isos/x86_64/sha256sum.txt
+# iso_img_checksum: "sha256:bba314624956961a2ea31dd460cd860a77911c1e0a56e4820a12b9c5dad363f5"
+
+##### Fedora 27 #####
+
+distro_name: "fedora"
+distro_version: "27"
+# Newer version is available e.g. here: https://download.fedoraproject.org/pub/fedora/linux/releases/
+iso_img_server: "https://download.fedoraproject.org/pub/fedora/linux/releases/27/Server/x86_64/iso"
+iso_img_file: "Fedora-Server-dvd-x86_64-27-1.6.iso"
+# Fresh sha256 checksums of Fedora images can be found here:
+# https://download.fedoraproject.org/pub/fedora/linux/releases/27/Server/x86_64/iso/Fedora-Server-27-1.6-x86_64-CHECKSUM
+iso_img_checksum: "sha256:e383dd414bb57231b20cbed11c4953cac71785f7d4f5990b0df5ad534a0ba95c"
+
+iso_img_url: "{{iso_img_server}}/{{iso_img_file}}"
+iso_img_mount_path: "/mnt/iso_img"
+
+# This is only default value and it is overwritten in Vagrantfile
+# by ansible.extra_vars, because IP address of PXE server has to
+# be known during definition of private network used by PXE server.
+pxe_server_ip_addr: "192.168.111.5/24"
+
+syslinux_files:
+  - pxelinux.0
+  - menu.c32
+  - memdisk
+  - mboot.c32
+  - chain.c32
+
+kernel_files:
+  - vmlinuz
+  - initrd.img

--- a/vagrant/roles/pxe-server/tasks/main.yml
+++ b/vagrant/roles/pxe-server/tasks/main.yml
@@ -1,0 +1,129 @@
+---
+- name: install required RPMs
+  package:
+    name: "{{item}}"
+    state: present
+  become: yes
+  with_items: "{{required_rpms}}"
+
+- name: create configuration file for eth1
+  template:
+    src: ifcfg-eth1.j2
+    dest: /etc/sysconfig/network-scripts/ifcfg-eth1
+  become: yes
+
+- name: restart network
+  service:
+    name: network
+    state: restarted
+  become: true
+
+- name: modify configuration file of dhcp server
+  template:
+    src: dhcpd.conf.j2
+    dest: /etc/dhcp/dhcpd.conf
+  become: yes
+
+- name: start and enable dhcpd service
+  service:
+    name: dhcpd
+    enabled: yes
+    state: started
+  become: true
+
+- name: start and enable tftp socket
+  service:
+    name: tftp.socket
+    enabled: yes
+    state: started
+  become: true
+
+- name: start and enable vsftpd service
+  service:
+    name: vsftpd
+    enabled: yes
+    state: started
+  become: true
+
+- name: download minimal installation iso image to localhost
+  get_url:
+    url: "{{iso_img_url}}"
+    dest: "vagrant_data/{{iso_img_file}}"
+    checksum: "{{iso_img_checksum}}"
+  delegate_to: localhost
+
+- name: create directory /vagrant_data
+  file:
+    path: /vagrant_data
+    state: directory
+    owner: vagrant
+    group: vagrant
+    mode: 0755
+  become: true
+
+- name: copy iso image to pxe server
+  copy:
+    src: "vagrant_data/{{iso_img_file}}"
+    dest: "/vagrant_data/{{iso_img_file}}"
+  become: true
+
+- name: mount iso image
+  mount:
+    src: "/vagrant_data/{{iso_img_file}}"
+    path: "{{iso_img_mount_path}}"
+    fstype: "iso9660"
+    opts: ro
+    state: mounted
+  become: true
+
+- name: rsync content of iso image with /var/ftp/pub
+  shell: "rsync -a {{iso_img_mount_path}}/ /var/ftp/pub"
+  become: true
+
+- name: unmount iso image
+  mount:
+    path: "{{iso_img_mount_path}}"
+    state: unmounted
+  become: true
+
+- name: create directory /var/lib/tftpboot/pxelinux.cfg
+  file:
+    path: /var/lib/tftpboot/pxelinux.cfg
+    state: directory
+    mode: 0755
+  become: true
+
+- name: create directory /var/lib/tftpboot/netboot
+  file:
+    path: /var/lib/tftpboot/netboot
+    state: directory
+    mode: 0755
+  become: true
+
+- name: copy syslinux files to /var/lib/tftpboot
+  copy:
+    src: "/usr/share/syslinux/{{item}}"
+    remote_src: yes
+    dest: /var/lib/tftpboot
+  with_items: "{{syslinux_files}}"
+  become: true
+
+- name: copy pxeboot kernel files to /var/lib/tftpboot/netboot
+  copy:
+    src: "/var/ftp/pub/images/pxeboot/{{item}}"
+    remote_src: yes
+    dest: /var/lib/tftpboot/netboot
+  with_items: "{{kernel_files}}"
+  become: true
+
+- name: create default file containing boot menu
+  template:
+    src: default.j2
+    dest: /var/lib/tftpboot/pxelinux.cfg/default
+  become: true
+
+- name: create kickstart file
+  template:
+    src: "ks_{{distro_name}}{{distro_version}}.cfg.j2"
+    dest: /var/ftp/pub/ks.cfg
+  become: true

--- a/vagrant/roles/pxe-server/templates/default.j2
+++ b/vagrant/roles/pxe-server/templates/default.j2
@@ -1,0 +1,9 @@
+default menu.c32
+prompt 0
+timeout 30
+MENU TITLE *** PXE Menu ***
+
+LABEL {{distro_name}}{{distro_version}}_x64
+MENU LABEL {{distro_name}} {{distro_version}} x86_64
+KERNEL /netboot/vmlinuz
+APPEND initrd=/netboot/initrd.img inst.repo=ftp://{{pxe_server_ip_addr | ipaddr('address')}}/pub ks=ftp://{{pxe_server_ip_addr | ipaddr('address')}}/pub/ks.cfg inst.sshd

--- a/vagrant/roles/pxe-server/templates/dhcpd.conf.j2
+++ b/vagrant/roles/pxe-server/templates/dhcpd.conf.j2
@@ -1,0 +1,23 @@
+# DHCP Server Configuration file.
+#   see /usr/share/doc/dhcp*/dhcpd.conf.example
+#   see dhcpd.conf(5) man page
+#
+# option definitions common to all supported networks...
+ddns-update-style interim;
+ignore client-updates;
+authoritative;
+allow booting;
+allow bootp;
+allow unknown-clients;
+subnet {{pxe_server_ip_addr | ipaddr('network')}} netmask {{pxe_server_ip_addr | ipaddr('netmask')}} {
+  range {{pxe_server_ip_addr | ipaddr('network') | regex_replace('.0$', '.50')}} {{pxe_server_ip_addr | ipaddr('network') | regex_replace('.0$', '.253')}};
+  option domain-name-servers {{pxe_server_ip_addr | ipaddr('address')}};
+  option domain-name "server1.example.com";
+  option routers {{pxe_server_ip_addr | ipaddr('address')}};
+  option broadcast-address {{pxe_server_ip_addr | ipaddr('broadcast')}};
+  default-lease-time 600;
+  max-lease-time 7200;
+
+  next-server {{pxe_server_ip_addr | ipaddr('address')}};
+  filename "pxelinux.0";
+}

--- a/vagrant/roles/pxe-server/templates/ifcfg-eth1.j2
+++ b/vagrant/roles/pxe-server/templates/ifcfg-eth1.j2
@@ -1,0 +1,6 @@
+DEVICE="eth1"
+BOOTPROTO="static"
+ONBOOT="yes"
+TYPE="Ethernet"
+IPADDR={{pxe_server_ip_addr | ipaddr('address')}}
+NETMASK={{pxe_server_ip_addr | ipaddr('netmask')}}

--- a/vagrant/roles/pxe-server/templates/ks_centos7.cfg.j2
+++ b/vagrant/roles/pxe-server/templates/ks_centos7.cfg.j2
@@ -1,0 +1,50 @@
+#version=DEVEL
+# System authorization information
+auth --enableshadow --passalgo=sha512
+# Use network installation
+url --url="ftp://{{pxe_server_ip_addr | ipaddr('address')}}/pub"
+# Use graphical install
+graphical
+# Run the Setup Agent on first boot
+firstboot --enable
+ignoredisk --only-use=vda
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+
+# Network information
+network  --bootproto=dhcp --device=eth0 --ipv6=auto --activate
+network  --hostname=localhost.localdomain
+
+# Root password
+rootpw --plaintext redhat
+# System services
+services --disabled="chronyd"
+# System timezone
+timezone Europe/Prague --isUtc --nontp
+# System bootloader configuration
+bootloader --location=mbr --boot-drive=vda
+# Partition clearing information
+clearpart --all --initlabel --drives=vda
+# Disk partitioning information
+autopart --type=lvm
+
+# Shut down and power off the system after the installation has successfully completed
+poweroff
+
+%packages
+@^minimal
+@core
+
+%end
+
+%addon com_redhat_kdump --disable --reserve-mb='auto'
+
+%end
+
+%anaconda
+pwpolicy root --minlen=6 --minquality=1 --notstrict --nochanges --notempty
+pwpolicy user --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
+pwpolicy luks --minlen=6 --minquality=1 --notstrict --nochanges --notempty
+%end

--- a/vagrant/roles/pxe-server/templates/ks_fedora27.cfg.j2
+++ b/vagrant/roles/pxe-server/templates/ks_fedora27.cfg.j2
@@ -1,0 +1,49 @@
+#version=DEVEL
+# System authorization information
+auth --enableshadow --passalgo=sha512
+# Use network installation
+url --url="ftp://{{pxe_server_ip_addr | ipaddr('address')}}/pub"
+# Use graphical install
+graphical
+# Run the Setup Agent on first boot
+firstboot --enable
+ignoredisk --only-use=vda
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+
+# Network information
+network  --bootproto=dhcp --device=ens3 --ipv6=auto --activate
+network  --hostname=pxe-client.localdomain
+
+# Root password
+rootpw --plaintext redhat
+# System services
+services --enabled="chronyd"
+# System timezone
+timezone Europe/Prague --isUtc
+# System bootloader configuration
+bootloader --location=mbr --boot-drive=vda
+# Partition clearing information
+clearpart --all --initlabel --drives=vda
+# Disk partitioning information
+autopart --type=lvm
+
+# Shut down and power off the system after the installation has successfully completed
+poweroff
+
+%packages
+@^server-product-environment
+
+%end
+
+%addon com_redhat_kdump --disable --reserve-mb='128'
+
+%end
+
+%anaconda
+pwpolicy root --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
+pwpolicy user --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
+pwpolicy luks --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
+%end

--- a/vagrant/vagrant.yml
+++ b/vagrant/vagrant.yml
@@ -5,11 +5,11 @@
     - name: install libs so we can use ansible (fedora only)
       raw: sudo yum install -y python python2-dnf
 
-- hosts: all
+- hosts: "subman-devel"
   roles:
     - subman-devel
 
-- hosts: all
+- hosts: "subman-devel"
   gather_facts: no
   become: yes
   tasks:

--- a/vagrant/vagrant_data/README.md
+++ b/vagrant/vagrant_data/README.md
@@ -1,0 +1,3 @@
+This directory is intended for caching of large files downloaded by Ansible
+scripts (e.g. ISO images). If Ansible script will download any new file
+to this directory, then don't forget to update `.gitignore` file.

--- a/vagrant/vagrant_pxe_server.yml
+++ b/vagrant/vagrant_pxe_server.yml
@@ -1,0 +1,3 @@
+- hosts: pxe-servers
+  roles:
+    - pxe-server


### PR DESCRIPTION
* New Vagrant file is in new directory anaconda, because it was
  the simpliest way to not trigger other ansible scripts
* It downloads image of Centos7 minimal image
* I have plan to modify Ansible scripts to support Fedora 27
  in the future
* The IP address of pxe server has to be static, because it is
  necessary to know it before VM with PXE server is created.
  The is used, when private network is created. Otherwise
  client will not boot using PXE.
* The client for testing machine can be created simply in
  virt-manager, but it will requires at least 2GB RAM due to
  some bug in anaconda.