### PR TITLE
ENT-166: Adds tool to make updates.img file for use with anaconda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ dist
 .settings
 *.retry
 .vagrant
+updates.img

--- a/scripts/build_updates_img.sh
+++ b/scripts/build_updates_img.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# A script that wraps make install to create an updates.img suitable for anaconda.
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+UPDATE_DIR=$(mktemp -d)
+pushd $PROJECT_ROOT
+
+rm ./updates.img 2>/dev/null
+
+# Install files to the temporary build dir
+export DESTDIR=$UPDATE_DIR
+make -e install
+
+# Build img file (See https://fedoraproject.org/wiki/Anaconda/Updates)
+find $UPDATE_DIR | cpio -o -c | gzip > ./updates.img
+
+# Clean up after ourselves
+rm -rf $UPDATE_DIR
+popd
+unset DESTDIR
+
+


### PR DESCRIPTION
* Adds a script that takes the result of make install and
  compresses it using cpio and gzip to a format suitable for
  use with anaconda installer.