### PR TITLE
1551465: Fix unicode decode issue on py 2.6

### DIFF
--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -77,7 +77,7 @@ class Package(object):
     @staticmethod
     def _normalize_string(value):
         if type(value) is six.binary_type:
-            return value.decode('utf-8', errors='replace')
+            return value.decode('utf-8', 'replace')
         return value
 
 


### PR DESCRIPTION
In python 2.6 on Centos 6 (and equivalent versions of RHEL), the decode method of strings does not accept the errors argument as a keyword argument.

This was causing very strange behaviour during firstboot (subscription-manager would attempt to auto-attach when it should not, as well as much more).

