### PR TITLE
include the rhsm package egg-info directory to not break python level…

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -806,6 +806,7 @@ install -m 644 %{_builddir}/%{buildsubdir}/etc-conf/ca/redhat-uep.pem %{buildroo
 %defattr(-,root,root,-)
 %dir %{python_sitearch}/rhsm
 %{python_sitearch}/rhsm/*
+%{python_sitearch}/rhsm-*.egg-info
 
 %files -n subscription-manager-rhsm-certificates
 %attr(755,root,root) %dir %{_sysconfdir}/rhsm


### PR DESCRIPTION
… dependency

Without this file, whilst the code will exist, if you add in a
requirement of rhsm into a setup.py it will complain that rhsm
distribution is not found.

This line was removed where it used to exist within the python-rhsm package.
See here
https://github.com/candlepin/python-rhsm/blob/9cdc40131597d76d0464bb72e0b5f1033b2e369b/python-rhsm.spec#L96

This unnecessarily breaks code with a python level dependency on this library.