### PR TITLE
a new VM 'proxy-server' in a vagrant stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ Note, however, since the registration is necessary to download RPMs to set up
 the VM for development, registering against a local candlepin might not be
 particularly useful (at least not for initial provisioning).
 
+
+> If you want use proxy server to play with subscription you can run it using vagrant:
+>       vagrant up proxy-server
+
+The current info about proxy
+
+url | proxy-server.subman.example.com:3128
+username | proxyuser
+password | password
+
 D-Bus Development
 -----------------
 In a vagrant VM, the `com.redhat.RHSM1` service along with related files 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -155,3 +155,27 @@ Vagrant.configure("2") do |config|
     end
   end
 end
+
+## VM for proxy server
+Vagrant.configure("2") do |config|
+  config.vm.hostname = 'proxy-server.subman.example.com'
+  config.vm.box = 'centos/7'
+  config.vm.define 'proxy-server', autostart: false
+
+  # Set up the hostmanager plugin to automatically configure host & guest hostnames
+  if Vagrant.has_plugin?("vagrant-hostmanager")
+    config.hostmanager.enabled = true
+    config.hostmanager.manage_host = true
+    config.hostmanager.manage_guest = true
+    config.hostmanager.ignore_private_ip = true
+  end
+
+  config.vm.provision "ansible", run: "always" do |ansible|
+    ansible.playbook = "vagrant/vagrant_proxy_server.yml"
+    ansible.groups = {
+      "proxy-servers" => [
+        "proxy-server"
+      ]
+    }
+  end
+end

--- a/vagrant/roles/proxy-server/defaults/main.yml
+++ b/vagrant/roles/proxy-server/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+required_rpms:
+  - squid
+  - python-passlib
+proxy_user_name: "proxyuser"
+proxy_password: "password"

--- a/vagrant/roles/proxy-server/files/squid.conf
+++ b/vagrant/roles/proxy-server/files/squid.conf
@@ -1,0 +1,93 @@
+#
+# Recommended minimum configuration:
+#
+
+#
+# User authentication
+#
+#auth_param basic program /usr/lib64/squid/digest_file_auth /etc/squid/passwd
+auth_param basic program /usr/lib64/squid/basic_ncsa_auth /etc/squid/passwd
+auth_param basic children 5
+auth_param basic realm Squid proxy-caching web server
+auth_param basic credentialsttl 2 hours
+auth_param basic casesensitive off
+acl auth_users proxy_auth REQUIRED
+http_access allow auth_users
+
+# Example rule allowing access from your local networks.
+# Adapt to list your (internal) IP networks from where browsing
+# should be allowed
+acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl localhet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+acl SSL_ports port 8443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 8443	# candlepin test
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
+
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+http_access deny !Safe_ports
+
+# Deny CONNECT to other than secure SSL ports
+http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
+http_access allow localhost manager
+http_access deny manager
+
+# We strongly recommend the following be uncommented to protect innocent
+# web applications running on the proxy server who think the only
+# one who can access services on "localhost" is a local user
+#http_access deny to_localhost
+
+#
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+#
+
+# Example rule allowing access from your local networks.
+# Adapt localnet in the ACL section to list your (internal) IP networks
+# from where browsing should be allowed
+http_access allow localnet
+http_access allow localhost
+
+# And finally deny all other access to this proxy
+http_access deny all
+
+# Squid normally listens to port 3128
+http_port 3128
+
+# Uncomment and adjust the following to add a disk cache directory.
+#cache_dir ufs /var/spool/squid 100 16 256
+
+# Leave coredumps in the first cache dir
+coredump_dir /var/spool/squid
+
+#
+# Add any of your own refresh_pattern entries above these.
+#
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern .		0	20%	4320
+
+host_verify_strict on
+debug_options ALL,3

--- a/vagrant/roles/proxy-server/tasks/main.yml
+++ b/vagrant/roles/proxy-server/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: install required RPMs
+  package:
+    name: "{{item}}"
+    state: present
+  become: yes
+  with_items: "{{required_rpms}}"
+
+- name: create configuration file for squid
+  copy:
+    src: squid.conf
+    dest: /etc/squid/squid.conf
+    follow: yes
+  become: yes
+    
+- name: create passwd file for an authorized user of squid
+  htpasswd:
+    path: /etc/squid/passwd
+    name: "{{ proxy_user_name }}"
+    password: "{{ proxy_password }}"
+    crypt_scheme: apr_md5_crypt
+    mode: 0640
+    owner: root
+    group: squid
+  become: yes
+
+- name: start and enable squid service
+  service:
+    name: squid
+    enabled: yes
+    state: started
+  become: true

--- a/vagrant/vagrant_proxy_server.yml
+++ b/vagrant/vagrant_proxy_server.yml
@@ -1,0 +1,3 @@
+- hosts: proxy-servers
+  roles:
+    - proxy-server


### PR DESCRIPTION
There is an authorization proxy server in Vagrantfile. It can be used for testing purposes mainly.

```shell
cd src/subscription-manager
vagrant up proxy-server
```
See README.md for details.