### PR TITLE
Apply updates.img druing PXE boot

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,11 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# Uncomment following line, when you have problem with reaching
+# https://atlas.hashicorp.com during `vagrant up <machine>`
+# More details here: https://github.com/hashicorp/vagrant/issues/9442
+#Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
+
 require 'yaml'
 
 VAGRANTFILE_DIR = File.dirname(__FILE__)
@@ -118,7 +123,7 @@ Vagrant.configure("2") do |config|
   # PXE server
   config.vm.define 'pxe-server', autostart: false do |host|
     host.vm.hostname = 'pxe-server'
-    host.vm.box = 'centos/7'
+    host.vm.box = 'fedora/27-cloud-base'
 
     host.vm.provision "ansible", run: "always" do |ansible|
       ansible.playbook = "vagrant/vagrant_pxe_server.yml"
@@ -128,7 +133,11 @@ Vagrant.configure("2") do |config|
         ]
       }
       ansible.extra_vars = {
-        "pxe_server_ip_addr" => ip_addr_server + '/' + ip_prefix
+        "pxe_server_ip_addr" => ip_addr_server + '/' + ip_prefix,
+        # There is no python command by default on Fedora 27
+        # and it is necessary to set python interpreter manually
+        # to python3
+        "ansible_python_interpreter" => "/usr/bin/python3"
       }
     end
   end

--- a/vagrant/roles/pxe-server/defaults/main.yml
+++ b/vagrant/roles/pxe-server/defaults/main.yml
@@ -6,6 +6,21 @@ required_rpms:
   - syslinux
   - wget
   - vsftpd
+  - GConf2-devel
+  - git
+  - gcc
+  - make
+  - glib2-devel
+  - dbus-glib-devel
+  - libnotify-devel
+  - gtk3-devel
+  - intltool
+  - python3-devel
+  - openssl-devel
+  - redhat-rpm-config
+  - redhat-lsb-core
+  - m2crypto
+  - librsvg2
 
 ##### CentOS 7 #####
 
@@ -39,10 +54,14 @@ pxe_server_ip_addr: "192.168.111.5/24"
 
 syslinux_files:
   - pxelinux.0
+  - ldlinux.c32
   - menu.c32
   - memdisk
   - mboot.c32
   - chain.c32
+  - vesamenu.c32
+  - libcom32.c32
+  - libutil.c32
 
 kernel_files:
   - vmlinuz

--- a/vagrant/roles/pxe-server/tasks/main.yml
+++ b/vagrant/roles/pxe-server/tasks/main.yml
@@ -116,6 +116,18 @@
   with_items: "{{kernel_files}}"
   become: true
 
+- name: create updates.img file
+  command: "./scripts/build_updates_img.sh --python python3"
+  args:
+    chdir: "/vagrant"
+
+- name: copy updates.img to pxe server
+  copy:
+    src: /vagrant/updates.img
+    remote_src: yes
+    dest: /var/ftp/pub/updates.img
+  become: true
+
 - name: create default file containing boot menu
   template:
     src: default.j2

--- a/vagrant/roles/pxe-server/templates/default.j2
+++ b/vagrant/roles/pxe-server/templates/default.j2
@@ -6,4 +6,4 @@ MENU TITLE *** PXE Menu ***
 LABEL {{distro_name}}{{distro_version}}_x64
 MENU LABEL {{distro_name}} {{distro_version}} x86_64
 KERNEL /netboot/vmlinuz
-APPEND initrd=/netboot/initrd.img inst.repo=ftp://{{pxe_server_ip_addr | ipaddr('address')}}/pub ks=ftp://{{pxe_server_ip_addr | ipaddr('address')}}/pub/ks.cfg inst.sshd
+APPEND initrd=/netboot/initrd.img inst.repo=ftp://{{pxe_server_ip_addr | ipaddr('address')}}/pub ks=ftp://{{pxe_server_ip_addr | ipaddr('address')}}/pub/ks.cfg inst.sshd inst.updates=ftp://{{pxe_server_ip_addr | ipaddr('address')}}/pub/updates.img


### PR DESCRIPTION
* File updates.img is copied to pxe-server as part of:

    vagrant up pxe-server

* File updates.img is downloaded to pxe-client during boot using
  ftp protocol. PXE server is already running vsftp server. Thus
  there is no need to use e.g. HTTP for this purpose.

* Tested with updates.img generated on Fedora 27