### PR TITLE
Do not use private network addresses for vagrant hostmanager

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,6 +51,7 @@ Vagrant.configure("2") do |config|
     config.hostmanager.manage_host = true
     config.hostmanager.manage_guest = true
     config.hostmanager.include_offline = true
+    config.hostmanager.ignore_private_ip = true
   end
 
   vm_boxes.each do |name, box|


### PR DESCRIPTION
Noticed this while reviewing #1797 .

As we now define a private network for use with the PXE server / client, the vagrant hostmanager plugin seems to pick the static ip for all of the boxes defined in our vagrantfile.
Adding this configuration option effectively stops this from happening.

To repro the original issue run `vagrant up` on the master branch from a clean checkout. After this, check your /etc/hosts file and notice that all the addresses listed are '192.168.111.5'.

See the [hostmanager plugin](https://github.com/devopsgroup-io/vagrant-hostmanager) for more details.