### PR TITLE
fix for proxy-server provisioning - resolving of 'candlepin.example.com'

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -169,13 +169,15 @@ Vagrant.configure("2") do |config|
     config.hostmanager.manage_guest = true
     config.hostmanager.ignore_private_ip = true
   end
-
   config.vm.provision "ansible", run: "always" do |ansible|
     ansible.playbook = "vagrant/vagrant_proxy_server.yml"
     ansible.groups = {
       "proxy-servers" => [
         "proxy-server"
       ]
+    }
+    ansible.extra_vars = {
+      "subman_add_vagrant_candlepin_to_hosts" => "true",
     }
   end
 end

--- a/vagrant/roles/proxy-server/tasks/main.yml
+++ b/vagrant/roles/proxy-server/tasks/main.yml
@@ -30,3 +30,18 @@
     enabled: yes
     state: started
   become: true
+
+- name: get IP address for candlepin.example.com
+  local_action: getent
+  args:
+    database: ahostsv4
+    key: candlepin.example.com
+
+- name: add candlepin.example.com to /etc/hosts
+  lineinfile:
+    name: /etc/hosts
+    line: "{{ getent_ahostsv4.keys()[0] }} candlepin.example.com"
+    regexp: 'candlepin.example.com'
+  become: yes
+  ignore_errors: yes
+  when: subman_add_vagrant_candlepin_to_hosts


### PR DESCRIPTION
A proxy server was not able to resolve 'candlepin.example.com'. 
Tried Tested Trusted.