### PR TITLE
Add a new utility for managing system intent

### DIFF
--- a/.tito/lib/rhsmtagger.py
+++ b/.tito/lib/rhsmtagger.py
@@ -1,0 +1,75 @@
+import os
+import six
+from tito.tagger.main import VersionTagger
+from tito.common import info_out, debug, replace_version, run_command
+
+
+class MultiPythonPackageVersionTagger(VersionTagger):
+
+    def __init__(self, config=None, *args, **kwargs):
+        super(MultiPythonPackageVersionTagger, self).__init__(config=config, *args, **kwargs)
+        if not config.has_option('tagconfig', 'python_subpackage_dir'):
+            raise ValueError('Must specify "python_subpackage_dir" property in tito.props\nThis property should be the relative path from the root of the project checkout that contains all additional separately packaged python modules')
+        self.subpackage_dir = config.get('tagconfig', 'python_subpackage_dir')
+
+        if config.has_option('tagconfig', 'python_subpackages'):
+            self.subpackages = config.get('tagconfig', 'python_subpackages').split(',')
+        else:
+            self.subpackages = []
+
+
+    def _update_setup_py_in_dir(self, new_version, package_dir=None):
+        """
+        If this subdir has a setup.py, attempt to update it's version.
+        (This is a very minor tweak to the original _update_setup_py method from VersionTagger
+        """
+
+        if package_dir is not None:
+            full_package_dir = os.path.join(self.full_project_dir, package_dir)
+        else:
+            full_package_dir = self.full_project_dir
+
+        setup_file = os.path.join(full_package_dir, "setup.py")
+        if not os.path.exists(setup_file):
+            return
+
+        debug("Found setup.py in {}, attempting to update version.".format(package_dir))
+
+        # We probably don't want version-release in setup.py as release is
+        # an rpm concept. Hopefully this assumption on
+        py_new_version = new_version.split('-')[0]
+
+        f = open(setup_file, 'r')
+        buf = six.StringIO()
+        for line in f.readlines():
+            buf.write(replace_version(line, py_new_version))
+        f.close()
+
+        # Write out the new setup.py file contents:
+        f = open(setup_file, 'w')
+        f.write(buf.getvalue())
+        f.close()
+        buf.close()
+
+        run_command("git add %s" % setup_file)
+
+    def _update_setup_py(self, new_version):
+        """
+        This overridden method allows us to use one spec file to build multiple
+        python packages, each with it's own setup.py file, but sharing a version.
+        :param new_version: The version to write to the
+        :return:
+        """
+        self._update_version_file(new_version)
+
+        # Update setup.py in root of the project
+        self._update_setup_py_in_dir(new_version)
+
+        # Update setup.py for all subpackages
+        for subpackage_dir in os.listdir(self.subpackage_dir):
+            if not self.subpackages or subpackage_dir in self.subpackages:
+                package_dir = os.path.join(self.subpackage_dir, subpackage_dir)
+                self._update_setup_py_in_dir(new_version, package_dir=package_dir)
+            else:
+                debug("Skipping setup.py version update for subpackage {} due to configuration {}"
+                      .format(subpackage_dir, 'python_subpackages'))

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -2,6 +2,9 @@
 lib_dir = .tito/lib
 builder = rhsmbuild.ScriptBuilder
 script_builder_script = .tito/cockpit-build.sh
-tagger = tito.tagger.VersionTagger
+tagger = rhsmtagger.MultiPythonPackageVersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
+
+[tagconfig]
+python_subpackage_dir=packages

--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ can be used:
 
 See `cockpit/README.md` for more detailed information on cockpit development.
 
+
+intentctl
+---------
+The intentctl utility manages certain user-definable values tracked in
+the /etc/rhsm/intent/intent.json file (in json format).
+
+See ./packages/intentctl/README.md for details on getting started
+
+
 Testing
 -------
 We run tests using nose (see candlepinproject.org for details).  Some tests

--- a/packages/intentctl/Pipfile
+++ b/packages/intentctl/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[dev-packages]
+
+[packages]
+
+[requires]
+python_version = "3.6"

--- a/packages/intentctl/Pipfile.lock
+++ b/packages/intentctl/Pipfile.lock
@@ -1,0 +1,20 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "4e55147db217bb4120f6e68cb8cad7bc37011457441ce0eb9d97308315625834"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {}
+}

--- a/packages/intentctl/README.md
+++ b/packages/intentctl/README.md
@@ -1,0 +1,18 @@
+# Getting started developing the intentctl utility
+
+This subpackage in the rhsm ecosystem uses pipenv to define python requirements and maintain a
+virtual environment for development.
+
+The recommended workflow is as follows:
+
+1) Install pipenv via pip: `sudo pip install pipenv`
+1) From this directory, run `pipenv --three` This creates a new virtual env for just this package
+1) Run the following to install project deps in the virtualenv: `pipenv install`
+1) Run the following to enter the virtual env: `pipenv shell`
+
+
+From inside this virtual env you can freely install the intentctl tool and test it as you like.
+Just run `python ./setup.py install` to install and `python ./setup.py test` to run the tests.
+
+The source for this subpackage is located (from checkout root) at ./src/intentctl
+The tests for this subpackage is located (from checkout root) at ./test/intentctl

--- a/packages/intentctl/setup.cfg
+++ b/packages/intentctl/setup.cfg
@@ -1,0 +1,4 @@
+[nosetests]
+where=../../test/intentctl
+verbose=1
+nocapture=True

--- a/packages/intentctl/setup.py
+++ b/packages/intentctl/setup.py
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+from setuptools import setup, find_packages
+
+test_require = [
+    'mock',
+    'nose'
+]
+
+setup(
+    name="intentctl",
+    version="1.0.0",
+    url="http://www.candlepinproject.org",
+    description="Manage Red Hat System Intent",
+    license="GPLv2",
+    author="Chris Snyder",
+    author_email="chainsaw@redhat.com",
+    packages=find_packages('../../src', include=["intentctl"]),
+    package_dir={
+        "intentctl": "../../src/intentctl"
+    },
+    tests_require=test_require,
+    test_suite='nose.collector',
+    entry_points={
+        "console_scripts": [
+            "intentctl = intentctl.main:main"
+        ]
+    }
+)

--- a/setup.py
+++ b/setup.py
@@ -281,7 +281,7 @@ setup(
     author="Adrian Likins",
     author_email="alikins@redhat.com",
     cmdclass=cmdclass,
-    packages=find_packages('src', exclude=['subscription_manager.gui.firstboot.*', '*.ga_impls', '*.ga_impls.*', '*.plugin.ostree', '*.services.examples']),
+    packages=find_packages('src', exclude=['subscription_manager.gui.firstboot.*', '*.ga_impls', '*.ga_impls.*', '*.plugin.ostree', '*.services.examples', 'intentctl*']),
     package_dir={'': 'src'},
     package_data={
         'subscription_manager.gui': ['data/glade/*.glade', 'data/ui/*.ui', 'data/icons/*.svg'],

--- a/src/intentctl/cli.py
+++ b/src/intentctl/cli.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+import argparse
+from intentctl.intentfiles import IntentStore, USER_INTENT
+import json
+
+
+def add_command(args, intentstore):
+    """
+    Uses the intentstore to add one or more values to a particular property.
+    :param args: The parsed args from argparse, expected attributes are:
+        prop_name: the string name of the property to add to
+        values: A list of the values to add to the given property (could be anything json-serializable)
+    :param intentstore: An IntentStore object to manipulate
+    :return: None
+    """
+    for value in args.values:
+        intentstore.add(args.prop_name, value)
+    print("Added {} to {}".format(args.values, args.prop_name))
+
+
+def remove_command(args, intentstore):
+    """
+    Uses the intentstore to remove one or more values from a particular property.
+    :param args: The parsed args from argparse, expected attributes are:
+        prop_name: the string name of the property to add to
+        values: A list of the values to remove from the given property (could be anything json-serializable)
+    :param intentstore: An IntentStore object to manipulate
+    :return: None
+    """
+    for value in args.values:
+        intentstore.remove(args.prop_name, value)
+    print("Removed {} from {}".format(args.values, args.prop_name))
+
+
+def set_command(args, intentstore):
+    """
+    Uses the intentstore to set the prop_name to value.
+    :param args: The parsed args from argparse, expected attributes are:
+        prop_name: the string name of the property to set
+        value: An object to set the property to (could be anything json-serializable)
+    :param intentstore: An IntentStore object to manipulate
+    :return: None
+    """
+    intentstore.set(args.prop_name, args.value)
+    print("{} set to {}".format(args.prop_name, args.value))
+
+
+def unset_command(args, intentstore):
+    """
+    Uses the intentstore to unset (clear entirely) the prop_name.
+    :param args: The parsed args from argparse, expected attributes are:
+        prop_name: the string name of the property to unset (clear)
+    :param intentstore: An IntentStore object to manipulate
+    :return: None
+    """
+    intentstore.unset(args.prop_name)
+    print("{} unset.".format(args.prop_name))
+
+
+def show_contents(args, intentstore):
+    """
+    :param args:
+    :param intentstore:
+    :return:
+    """
+
+    contents = intentstore.contents
+    print(json.dumps(contents, indent=2))
+
+
+def setup_arg_parser():
+    """
+    Sets up argument parsing for the intentctl tool.
+    :return: An argparse.ArgumentParser ready to use to parse_args
+    """
+    parser = argparse.ArgumentParser(prog="intentctl", description="System Intent Management Tool")
+    parser.set_defaults(func=None, requires_write=False)
+
+    subparsers = parser.add_subparsers(help="sub-command help")
+
+    # Arguments shared by subcommands
+    add_options = argparse.ArgumentParser(add_help=False)
+    add_options.add_argument("values", help="The value(s) to add", nargs='+')
+    add_options.set_defaults(func=add_command, requires_write=True)
+
+    remove_options = argparse.ArgumentParser(add_help=False)
+    remove_options.add_argument("values", help="The value(s) to remove", nargs='+')
+    remove_options.set_defaults(func=remove_command, requires_write=True)
+
+    set_options = argparse.ArgumentParser(add_help=False)
+    set_options.add_argument("value", help="The value to set",
+                            action="store")
+    set_options.set_defaults(func=set_command, requires_write=True)
+
+    unset_options = argparse.ArgumentParser(add_help=False)
+    unset_options.set_defaults(func=unset_command, requires_write=True)
+
+    # Offerings
+    add_offering_parser = subparsers.add_parser("add-offerings",
+                                                help="Add one or more offerings to the system intent.",
+                                                parents=[add_options])
+    # TODO: Set prop_name from schema file
+    add_offering_parser.set_defaults(prop_name="offering_name")
+
+    remove_offering_parser = subparsers.add_parser("remove-offerings",
+                                                   help="Remove one or more offerings.",
+                                                   parents=[remove_options])
+    remove_offering_parser.set_defaults(prop_name="offering_name")
+
+    unset_offering_parser = subparsers.add_parser("unset-offerings",
+                                                  help="Unset all offerings.",
+                                                  parents=[unset_options])
+    unset_offering_parser.set_defaults(prop_name="offering_name")
+
+    # SLA
+    set_sla_parser = subparsers.add_parser("set-sla",
+                                           help="Set the system sla",
+                                           parents=[set_options])
+
+    set_sla_parser.set_defaults(prop_name="service_level_agreement")
+
+    unset_sla_parser = subparsers.add_parser("unset-sla",
+                                             help="Clear set sla",
+                                             parents=[unset_options])
+    unset_sla_parser.set_defaults(prop_name="service_level_agreement")
+
+    # USAGE
+
+    set_usage_parser = subparsers.add_parser("set-usage",
+                                           help="Set the system usage",
+                                           parents=[set_options])
+
+    set_usage_parser.set_defaults(prop_name="usage_type")
+
+    unset_usage_parser = subparsers.add_parser("unset-usage",
+                                             help="Clear set usage/",
+                                             parents=[unset_options])
+    unset_usage_parser.set_defaults(prop_name="usage_type")
+
+    # Pretty Print Json contents of default intent file
+
+    show_parser = subparsers.add_parser("show",
+                                        help="Show the current system intent")
+    show_parser.set_defaults(func=show_contents, requires_write=False)
+
+    return parser
+
+
+def main():
+    """
+    Run the cli (Do the intentctl tool thing!!)
+    :return: 0
+    """
+    parser = setup_arg_parser()
+    args = parser.parse_args()
+
+    intentstore = IntentStore.read(USER_INTENT)
+
+    if args.func is not None:
+        args.func(args, intentstore)
+    else:
+        parser.print_usage()
+
+    if args.requires_write:
+        intentstore.write()
+    return 0

--- a/src/intentctl/intentfiles.py
+++ b/src/intentctl/intentfiles.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+
+import json
+import os
+from intentctl.utils import system_exit, create_dir, create_file
+
+# This modules contains utilities for manipulating files pertaining to system intent
+
+# Constants for locations of the two system intent files
+USER_INTENT = "/etc/rhsm/intent/intent.json"
+VALID_FIELDS = "/etc/rhsm/intent/valid_fields.json"  # Will be used for future validation
+
+
+class IntentStore(object):
+    """
+    Represents and maintains a json intent file
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self.contents = {}
+
+    def read_file(self):
+        try:
+            with open(self.path, 'r') as f:
+                self.contents = json.load(f)
+        except ValueError:
+            return False
+        except OSError as e:
+            if e.errno == os.errno.EACCES:
+                system_exit(os.EX_NOPERM,
+                            'Cannot read intent file {}\nAre you root?'.format(self.path))
+
+    def create(self):
+        """
+        Create the files necessary for this store
+        :return: True if changes were made, false otherwise
+        """
+        return create_dir(os.path.dirname(self.path)) or \
+            self.read_file() or \
+            create_file(self.path, self.contents)
+
+    def add(self, key, value):
+        """
+        Add a value to a list of values specified by key
+        :param key: The name of the list
+        :param value: The value to append to the list
+        :return: None
+        """
+        try:
+            self.contents[key].append(value)
+        except (AttributeError, KeyError):
+            self.contents[key] = [value]
+        return True
+
+    def remove(self, key, value):
+        """
+        Remove a value from a list specified by key.
+        :param key: The name of the list parameter to manipulate
+        :param value: The value to attempt to remove
+        :return: True if the value was in the list, False if it was not
+        """
+        try:
+            self.contents[key].remove(value)
+            return True
+        except (AttributeError, KeyError, ValueError):
+            return False
+
+    def unset(self, key):
+        """
+        Unsets a key
+        :param key: The key to unset
+        :return: boolean
+        """
+        org = self.contents.get(key, None)
+        if org is not None:
+            self.contents[key] = None
+        return org is not None
+
+    def set(self, key, value):
+        """
+        Set a key (intent parameter) to value
+        :param key: The parameter of the intent file to set
+        :type key: str
+
+        :param value: The value to set that parameter to
+        :return: Whether any change was made
+        """
+        org = self.contents.get(key, None)
+        self.contents[key] = value
+        return org != value or org is None
+
+    def write(self, fp=None):
+        """
+        Write the current contents to the file at self.path
+        """
+        if not fp:
+            with open(self.path, 'w') as f:
+                json.dump(self.contents, f)
+                f.flush()
+        else:
+            json.dump(self.contents, fp)
+
+    @classmethod
+    def read(cls, path):
+        """
+        Read the file represented by path. If the file does not exist it is created.
+        :param path: The path on the file system to read, should be a json file
+        :return: new IntentStore with the contents read in
+        """
+        new_store = cls(path)
+
+        if not os.access(path, os.W_OK):
+            new_store.create()
+        else:
+            new_store.read_file()
+
+        return new_store

--- a/src/intentctl/main.py
+++ b/src/intentctl/main.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+import sys
+from intentctl import cli
+from intentctl.utils import system_exit
+
+
+def main():
+    try:
+        sys.exit(cli.main() or 0)
+    except KeyboardInterrupt:
+        system_exit(0, "User interrupted process")
+    except Exception as e:
+        system_exit(-1, str(e))
+
+if __name__ == "__main__":
+    main()

--- a/src/intentctl/utils.py
+++ b/src/intentctl/utils.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+# Utility methods for the intentctl command
+
+import json
+import os
+import sys
+
+
+# Borrowed from the subscription-manager cli script
+def system_exit(code, msgs=None):
+    """Exit with a code and optional message(s). Saved a few lines of code."""
+
+    if msgs:
+        if type(msgs) not in [type([]), type(())]:
+            msgs = (msgs, )
+        for msg in msgs:
+            sys.stderr.write(str(msg) + '\n')
+    sys.exit(code)
+
+
+def create_dir(path):
+    """
+    Attempts to create the path given (less any file)
+    :param path: path
+    :return: True if changes were made, false otherwise
+    """
+    try:
+        os.makedirs(path, mode=0o755)
+    except OSError as e:
+        if e.errno == os.errno.EEXIST:
+            # If the directory exists no changes necessary
+            return False
+        if e.errno == os.errno.EACCES:
+            system_exit(os.EX_NOPERM,
+                        'Cannot create directory {}\nAre you root?'.format(path))
+    return True
+
+
+def create_file(path, contents):
+    """
+    Attempts to create a file, with the given contents
+    :param path: The desired path to the file
+    :param contents: The contents to write to the file, should json-serializable
+    :return: True if the file was newly created, false otherwise
+    """
+    try:
+        with open(path, 'w') as f:
+            if contents:
+                json.dump(contents, f)
+            f.flush()
+    except OSError as e:
+        if e.errno == os.errno.EEXIST:
+            # If the file exists no changes necessary
+            return False
+        if e.errno == os.errno.EACCES:
+            system_exit(os.EX_NOPERM, "Cannot create file {}\nAre you root?".format(path))
+        else:
+            raise
+    return True

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -48,6 +48,7 @@
 %global __python %__python3
 %global py_package_prefix python%{python3_pkgversion}
 %global rhsm_package_name %{py_package_prefix}-subscription-manager-rhsm
+%define include_intentctl 1
 %else
 %global py_package_prefix python
 %global rhsm_package_name subscription-manager-rhsm
@@ -100,6 +101,8 @@
 %else
 %define with_systemd WITH_SYSTEMD=false
 %endif
+
+%define subpackages SUBPACKAGES="%{?include_intentctl:intentctl}"
 
 Name: subscription-manager
 Version: 1.21.2
@@ -222,11 +225,20 @@ BuildRequires: systemd-rpm-macros
 BuildRequires: systemd
 %endif
 
-
 %description
 The Subscription Manager package provides programs and libraries to allow users
 to manage subscriptions and yum repositories from the Red Hat entitlement
 platform.
+
+%if %{with python3}
+%package -n %{py_package_prefix}-intentctl
+Summary: A commandline utility for declaring system intent
+Group: System Environment/Base
+
+%description -n %{py_package_prefix}-intentctl
+Provides the intentctl commandline utility. This utility manages the
+system intent.
+%endif
 
 
 %package -n subscription-manager-plugin-container
@@ -440,7 +452,7 @@ Subscription Manager Cockpit UI
 
 %build
 make -f Makefile VERSION=%{version}-%{release} CFLAGS="%{optflags}" \
-    LDFLAGS="%{__global_ldflags}" OS_DIST="%{dist}" PYTHON="%{__python}" %{?gtk_version}
+    LDFLAGS="%{__global_ldflags}" OS_DIST="%{dist}" PYTHON="%{__python}" %{?gtk_version} %{?subpackages} %{?include_intentctl:INCLUDE_INTENTCTL="1"}
 
 %if %{with python2_rhsm}
 ./setup.py build --quiet --gtk-version=%{?gtk3:3}%{?!gtk3:2} --rpm-version=%{version}-%{release}
@@ -455,7 +467,9 @@ make -f Makefile install VERSION=%{version}-%{release} \
     %{?install_ostree} %{?post_boot_tool} %{?gtk_version} \
     %{?install_yum_plugins} %{?install_dnf_plugins} \
     %{?install_zypper_plugins} \
-    %{?with_systemd}
+    %{?with_systemd} \
+    %{?subpackages} \
+    %{?include_intentctl:INCLUDE_INTENTCTL="1"}
 
 %if %{with python2_rhsm}
 mkdir -p %{buildroot}%{python2_sitearch}
@@ -778,6 +792,17 @@ install -m 644 %{_builddir}/%{buildsubdir}/etc-conf/ca/redhat-uep.pem %{buildroo
 %doc README.Fedora
 %endif
 
+%if %{with python3}
+%files -n %{py_package_prefix}-intentctl
+%defattr(-,root,root,-)
+%dir %{python3_sitelib}/intentctl*.egg-info
+%{python3_sitelib}/intentctl*.egg-info/*
+%dir %{_sysconfdir}/rhsm/intent
+%dir %{python3_sitelib}/intentctl
+%{python3_sitelib}/intentctl/{*.py*,__pycache__/*}
+
+%attr(755, root, root) %{_sbindir}/intentctl
+%endif
 
 %files -n subscription-manager-plugin-container
 %defattr(-,root,root,-)

--- a/test/intentctl/base.py
+++ b/test/intentctl/base.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+import unittest
+import tempfile
+import shutil
+import sys
+import traceback
+
+
+class IntentCtlTestBase(unittest.TestCase):
+
+    def _mktmp(self):
+        """
+        A Utility function to create a temporary directory and ensure it is deleted at the end of
+        the test
+        :return: string path to a new temp directory
+        """
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+        return temp_dir
+
+    def assertRaisesNothing(self, *args, **kwargs):
+        """
+        Assert that the first arg given, when called with the remaining args amd kwargs
+        does not raise any exception
+        :return: Whatever the call to the method returns
+        """
+        method = args[0]
+        err_msg = None
+
+        try:
+            if kwargs:
+                return method(*args[1:], **kwargs)
+            else:
+                return method(*args[1:])
+        except Exception as e:
+            _, _, tb = sys.exc_info()
+            arguments = ""
+            if args[1:]:
+                arguments += ",".join([str(x) for x in args[1:]])
+            if kwargs:
+                arguments += str(kwargs)
+            err_msg = "Expected no exception from method call \"{method}({args})\"\n Got Exception: \"{msg}\"\nTraceback during target method call:\n"\
+                .format(method=method.__name__, args=arguments, msg=str(e)) + "".join(traceback.format_tb(tb))
+
+        if err_msg:
+            self.fail(err_msg)

--- a/test/intentctl/test_intentfiles.py
+++ b/test/intentctl/test_intentfiles.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+from base import IntentCtlTestBase
+import json
+import os
+
+from intentctl import intentfiles
+
+
+class IntentStoreTests(IntentCtlTestBase):
+
+    def test_new_intent_store(self):
+        """
+        A smoke test to ensure nothing bizarre happens on IntentStore object creation
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'intentfile.json')
+        intent_store = self.assertRaisesNothing(intentfiles.IntentStore, temp_dir)
+        self.assertEqual(intent_store.contents, {})
+        self.assertEqual(intent_store.path, temp_dir)
+
+    def test_read_file_non_existent_file(self):
+        """
+        Can the IntentStore.read_file method handle attempting to read a file which does not exist?
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'intentfile.json')
+        self.assertFalse(os.path.exists(temp_dir))
+
+        intent_store = self.assertRaisesNothing(intentfiles.IntentStore, temp_dir)
+        res = self.assertRaisesNothing(intent_store.read_file)
+        self.assertFalse(bool(res))
+
+    def _read_file(self, file_contents=None, expected_contents=None):
+        """
+        Utility method for logic common to the *read_file* tests.
+        :param file_contents:
+        :param expected_contents:
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'intentfile.json')
+        with open(temp_dir, 'w') as f:
+            if file_contents and not isinstance(file_contents, str):
+                json.dump(file_contents, f)
+            else:
+                f.write(file_contents or '')
+            f.flush()
+        self.assertTrue(os.path.exists(temp_dir), "Unable to create test file in temp dir")
+
+        # Actually do the test
+        intent_store = self.assertRaisesNothing(intentfiles.IntentStore, temp_dir)
+        self.assertRaisesNothing(intent_store.read_file)
+        self.assertEqual(intent_store.contents, expected_contents)
+
+    def test_read_file_empty_file(self):
+        """
+        Can the IntentStore.read_file method handle attempting to read an empty file?
+        :return:
+        """
+        self._read_file(file_contents='', expected_contents={})
+
+    def test_read_file_non_empty(self):
+        """
+        Lets see if we can read a file that is non-empty
+        :return:
+        """
+        test_data = {"arbitrary": "data"}
+        self._read_file(file_contents=test_data, expected_contents=test_data)
+
+    def test_create(self):
+        """
+        Verify that the create method will create the directory (if needed), and that the resulting
+        file in the directory is writable by us.
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'intentfile.json')
+
+        intent_store = self.assertRaisesNothing(intentfiles.IntentStore, temp_dir)
+        self.assertRaisesNothing(intent_store.create)
+        # We should have a new file in the temp_dir that we can access for writing
+        self.assertTrue(os.path.exists(temp_dir))
+        self.assertTrue(os.access(temp_dir, os.W_OK))
+
+    def test_add(self):
+        """
+        Verify that the add method of IntentStore is able to add items to lists of items
+        in the store, whether they existed prior or not.
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'intentfile.json')
+        test_data = {"already_present_key": ["preexisting_value"]}
+        with open(temp_dir, 'w') as f:
+            json.dump(test_data, f)
+
+        intent_store = self.assertRaisesNothing(intentfiles.IntentStore, temp_dir)
+        intent_store.contents = dict(**test_data)
+
+        # Brand new unseen key is added
+        res = self.assertRaisesNothing(intent_store.add, "new_key", "new_value")
+        self.assertIn("new_key", intent_store.contents)
+        self.assertEqual(intent_store.contents["new_key"], ["new_value"])
+        self.assertTrue(res, "The add method should return true when the store has changed")
+
+        # Add to an already seen existing key
+        res = self.assertRaisesNothing(intent_store.add, "already_present_key", "new_value_2")
+        self.assertIn("already_present_key", intent_store.contents)
+        self.assertEqual(intent_store.contents["already_present_key"], ["preexisting_value", "new_value_2"])
+        self.assertTrue(res, "The add method should return true when the store has changed")
+
+    def test_remove(self):
+        """
+        Verify that the remove method can remove items from the store.
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'intentfile.json')
+        test_data = {"already_present_key": ["preexisting_value"]}
+        with open(temp_dir, 'w') as f:
+            json.dump(test_data, f)
+
+        intent_store = self.assertRaisesNothing(intentfiles.IntentStore, temp_dir)
+        intent_store.contents = dict(**test_data)
+
+        # Remove an item from the store which we have previously seen
+        res = self.assertRaisesNothing(intent_store.remove, "already_present_key", "preexisting_value")
+        self.assertIn("already_present_key", intent_store.contents)
+        self.assertEqual(intent_store.contents["already_present_key"], [])
+        self.assertTrue(res, "The remove method should return true when the store has changed")
+
+        # Try to remove an item that we've previously not seen
+        res = self.assertRaisesNothing(intent_store.remove, "new_key", "any_value")
+        self.assertFalse(res, "The remove method should return false when the store has not changed")
+
+    def test_unset(self):
+        """
+        Verify the operation of the unset method of IntentStore
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'intentfile.json')
+        test_data = {"already_present_key": ["preexisting_value"]}
+
+        intent_store = self.assertRaisesNothing(intentfiles.IntentStore, temp_dir)
+        intent_store.contents = dict(**test_data)
+
+        res = self.assertRaisesNothing(intent_store.unset, "already_present_key")
+        # We expect a value of true from this method when the store was changed
+        self.assertTrue(res, "The unset method should return true when the store has changed")
+        self.assertIn("already_present_key", intent_store.contents, msg="Expected the key to still be in the contents, but reset to None")
+        # We expect the item to have been unset to None
+        self.assertEqual(intent_store.contents["already_present_key"], None)
+
+        res = self.assertRaisesNothing(intent_store.unset, "unseen_key")
+        # We expect falsey values when the store was not modified
+        self.assertFalse(res, "The unset method should return false when the store has not changed")
+        self.assertNotIn("unseen_key", intent_store.contents, msg="The key passed to unset, has been added to the store")
+
+    def test_set(self):
+        """
+        Verify the operation of the set method of IntentStore
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'intentfile.json')
+        test_data = {"already_present_key": "old_value"}
+
+        intent_store = self.assertRaisesNothing(intentfiles.IntentStore, temp_dir)
+        intent_store.contents = dict(**test_data)
+
+        # Check the behaviour of manipulating an existing key with an identical value (no update)
+        res = self.assertRaisesNothing(intent_store.set, "already_present_key", "old_value")
+        self.assertFalse(res, "When a value is not actually changed, set should return false")
+        self.assertIn("already_present_key", intent_store.contents)
+        self.assertEqual(intent_store.contents["already_present_key"], "old_value")
+
+        # Modify existing item
+        res = self.assertRaisesNothing(intent_store.set, "already_present_key", "new_value")
+        self.assertTrue(res, "When an item is set to a new value, set should return true")
+        self.assertIn("already_present_key", intent_store.contents)
+        self.assertEqual(intent_store.contents["already_present_key"], "new_value")
+
+        # Add new item set to a new value
+        res = self.assertRaisesNothing(intent_store.set, "new_key", "new_value_2")
+        self.assertTrue(res, "When an item is set to a new value, set should return true")
+        self.assertIn("new_key", intent_store.contents)
+        self.assertEqual(intent_store.contents["new_key"], "new_value_2")
+
+    def test_write(self):
+        """
+        Verify that the IntentStore can write changes to the expected file.
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'intentfile.json')
+        test_data = {"arbitrary_key": "arbitrary_value"}
+        intent_store = self.assertRaisesNothing(intentfiles.IntentStore, temp_dir)
+        intent_store.contents = dict(**test_data)
+
+        self.assertRaisesNothing(intent_store.write)
+
+        with open(temp_dir, 'r') as f:
+            actual_contents = self.assertRaisesNothing(json.load, f)
+
+        self.assertDictEqual(actual_contents, test_data)
+
+    def test_read(self):
+        """
+        Does read properly initialize a new IntentStore?
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'intentfile.json')
+        test_data = {"arbitrary_key": "arbitrary_value"}
+
+        with open(temp_dir, 'w') as f:
+            json.dump(test_data, f)
+
+        intent_store = self.assertRaisesNothing(intentfiles.IntentStore.read, temp_dir)
+        self.assertDictEqual(intent_store.contents, test_data)

--- a/test/intentctl/test_utils.py
+++ b/test/intentctl/test_utils.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+# A group of tests for the miscellaneous utilities in the utils module of intentctl
+
+from base import IntentCtlTestBase
+import os
+import json
+import mock
+
+from intentctl import utils
+
+
+class UtilsTests(IntentCtlTestBase):
+
+    @mock.patch('intentctl.utils.system_exit')
+    def test_create_dir(self, mock_system_exit):
+        """
+        Verify that the create_dir utility method creates directories as we expect.
+        :return:
+        """
+        temp_dir = self._mktmp()
+
+        # A directory that does not exist yet
+        new_dir = os.path.join(temp_dir, "new_dir")
+        res = self.assertRaisesNothing(utils.create_dir, new_dir)
+        self.assertTrue(os.path.exists(new_dir))
+        # There was a change, so the result should be True
+        self.assertTrue(res)
+
+        # Create another directory
+        existing_dir = os.path.join(temp_dir, "existing")
+        os.mkdir(existing_dir, 0o644)
+        res = self.assertRaisesNothing(utils.create_dir, existing_dir)
+        # Should have been no change, so the result should be false
+        self.assertFalse(res)
+
+        # Create one more directory that does not have the right permissions
+        bad_perm_dir = os.path.join(temp_dir, "bad_perm_dir")
+        os.mkdir(bad_perm_dir, 0o400)
+
+        impossible_sub_dir = os.path.join(bad_perm_dir, "any_sub_dir")
+
+        self.assertRaisesNothing(utils.create_dir, impossible_sub_dir)
+        self.assertFalse(os.path.exists(impossible_sub_dir))
+        # Should try to exit when the directory could not be created due to bad permissions
+        mock_system_exit.assert_called_once()
+
+    @mock.patch('intentctl.utils.system_exit')
+    def test_create_file(self, mock_system_exit):
+        temp_dir = self._mktmp()
+        to_create = os.path.join(temp_dir, "my_cool_file.json")
+
+        test_data = {"arbitrary_key": "arbitrary_value"}
+
+        res = self.assertRaisesNothing(utils.create_file, to_create, test_data)
+        self.assertTrue(res)
+        self.assertTrue(os.path.exists(to_create))
+
+        with open(to_create, 'r') as fp:
+            actual_contents = json.load(fp)
+
+        self.assertDictEqual(actual_contents, test_data)
+
+        to_create = os.path.join(temp_dir, "my_super_chill_file.json")
+
+        # And now when the file appears to exist
+        with mock.patch('intentctl.utils.open') as mock_open:
+            error_to_raise = OSError()
+            error_to_raise.errno = os.errno.EEXIST
+            mock_open.side_effect = error_to_raise
+
+            res = self.assertRaisesNothing(utils.create_file, to_create, test_data)
+            self.assertFalse(res)
+
+        to_create = os.path.join(temp_dir, "my_other_cool_file.json")
+
+        # And now with an unexpected OSError
+        with mock.patch('intentctl.utils.open') as mock_open:
+            error_to_raise = OSError()
+            error_to_raise.errno = os.errno.E2BIG  # Anything aside from the ones expected
+            mock_open.side_effect = error_to_raise
+
+            self.assertRaises(OSError, utils.create_file, to_create, test_data)
+            self.assertFalse(os.path.exists(to_create))


### PR DESCRIPTION
This PR adds a new cli utility to the subman/rhsm universe that allows for tracking a system's intended product offerings, service level agreement, and usage.

In order to support tracking this package along with the other pieces of the subman, but allow for it to be installed / developed separately, I have added the relevant ./setup.py and support files under a new packages directory. This PR also includes a new VersionTagger for tito that supports keeping the version in multiple setup.py files in subdirectories of a project in sync (as I think we might like to keep the version of all these utilities in sync) (if we were to release this utility completely independently I might suggest having a truly independent version).

The utility itself is rather simple: It manipulates and maintains a json file /etc/rhsm/intent/intent.json

For this subpackage I had been using pipenv to maintain a virtual env and related requirements.

## Getting started
To get started (from the packages/intentctl dir) install pipenv using pip: `pip install --user pipenv`
Then run `pipenv --three` followed by `pipenv install` and `pipenv shell`.
After this you should be in a virtual env that has all required deps for intentctl (which are minimal).

To install and test (once in the virtual env):
`python ./setup.py install`
and
`python ./setup.py test`

Please checkout the readme for more detail.

## Cli utility details
The command can be run (after installed) as `intentctl`.
Due to the files this utility manipulates, you must run it as root.

It has the following subcommands:
add-offerings : Adds one or more offerings to the system intent. Presently does not check for duplicates (up for debate).
remove-offerings : Removes one or more offerings. Succeeds whether or not the offering was in the file.
unset-offerings : Sets the offering_name key to None

set-sla : sets the "service_level_agreement" key to the value passed
unset-sla : sets the "service_level_agreement" key to None

set-usage : sets the "usage_type" key to the value passed
unset-usage : sets the "usage_type" key to None


## Packaging it up
A new package is included in the subscription-manager.spec file. It has been added in such a way (when combined with the new tito VersionTagger) as to continue to allow building all the rpms of the rhsm ecosystem with `tito tag` and `tito build --rpm`.


Please NOTE: I will squash and tidy up the single commit message post review.

