### PR TITLE
1425766: Additional message in status to indicate content access

### DIFF
--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -543,7 +543,10 @@ class EntitlementCertificate(ProductCertificate):
 
     @property
     def entitlement_type(self):
-        return self.extensions.get(EXT_ENT_TYPE) or 'Basic'
+        if self.extensions.get(EXT_ENT_TYPE):
+            return self.extensions.get(EXT_ENT_TYPE).decode('utf-8')
+        else:
+            return 'Basic'
 
     @property
     def _path_tree(self):


### PR DESCRIPTION
Not able to present content access mode, as it is an attribute of
 the organization that is not shared in the certificate.

To enable the content access mode you need your system to be set to 'hosted':

Execute this on the candlepin machine:
curl -k -u admin:admin --request PUT --data '{"contentAccessMode":"org_environment"}' --header 'accept:application/json' --header 'content-type: application/json' https://localhost:8443/candlepin/owners/snowwhite

Then register the client system against the org snowwhite.

When you run subsctiption-manager status you should get the content access message.