### PR TITLE
1568214: rhsmcertd no longer uses reload on py3

### DIFF
--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -22,8 +22,10 @@ from __future__ import print_function, division, absolute_import
 # Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
 import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
+import six
+if six.PY2:
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
 
 import signal
 import logging


### PR DESCRIPTION
This is the same fix applied to rhsmcertd_worker as in other places in the codebase.

[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1568214)