### PR TITLE
1527727: Add proc_stat.btime fact

### DIFF
--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -107,6 +107,7 @@ class HardwareCollector(collector.FactsCollector):
             self.get_release_info,
             self.get_mem_info,
             self.get_proc_cpuinfo,
+            self.get_proc_stat,
             self.get_cpu_info,
             self.get_ls_cpu_info,
             self.get_network_info,
@@ -351,6 +352,24 @@ class HardwareCollector(collector.FactsCollector):
         # we could enumerate each processor here as proc_cpuinfo.cpu.3.key =
         # value, but that is a lot of fact table entries
         return proc_cpuinfo
+
+    def get_proc_stat(self):
+        proc_stat = {}
+        fact_namespace = 'proc_stat'
+        proc_stat_path = '/proc/stat'
+
+        btime_re = r'btime\W*([0-9]+)\W*$'
+        try:
+            with open(proc_stat_path, 'r') as proc_stat_file:
+                for line in proc_stat_file.readlines():
+                    match = re.match(btime_re, line.strip())
+                    if match:
+                        proc_stat['%s.btime' % (fact_namespace)] = match.group(1)
+                        break  # We presently only care about the btime fact
+        except Exception as e:
+            # This fact is not required, only log failure to gather it at the debug level
+            log.debug("Could not gather proc_stat facts: %s", e)
+        return proc_stat
 
     def get_cpu_info(self):
         cpu_info = {}

--- a/test/rhsmlib_test/test_hwprobe.py
+++ b/test/rhsmlib_test/test_hwprobe.py
@@ -80,6 +80,24 @@ Permanent HW addr: 52:54:00:66:20:f7
 Slave queue ID: 0
 """
 
+PROC_STAT = """cpu  1251631 1521 234099 26677635 43020 53378 18245 0 136791 0
+cpu0 170907 672 36975 5235552 21053 18369 7169 0 8215 0
+cpu1 162918 87 22790 3049644 2898 7180 2735 0 37398 0
+cpu2 167547 104 36469 3045029 6222 6375 2022 0 5443 0
+cpu3 116384 86 21325 3103226 2006 3503 999 0 3330 0
+cpu4 214747 243 36747 3002774 3602 6008 1688 0 51985 0
+cpu5 116967 88 20921 3104477 1791 3092 875 0 4196 0
+cpu6 182738 158 37153 3035995 3449 6016 1926 0 19461 0
+cpu7 119420 79 21716 3100934 1997 2833 828 0 6759 0
+intr 69987280 31 176 0 0 0 0 0 0 1 11832 0 0 723 0 0 0 67 0 26095 0 0 0 0 77 0 0 733270 16903338 0 305 2485413 22 35708 147 618373 6713 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ctxt 176256990
+btime 1524062304
+processes 66111
+procs_running 2
+procs_blocked 1
+softirq 40290891 49 19260365 9256 986071 674800 7 521934 11078954 0 7759455
+"""
+
 OS_RELEASE = """NAME="Awesome OS"
 VERSION="42 (Go4It)"
 ID="awesomeos"
@@ -467,6 +485,14 @@ class HardwareProbeTest(test.fixture.SubManFixture):
         self.assertEqual(4, ret['book_count'])
         self.assertEqual(6, ret['sockets_per_book'])
         self.assertEqual(4, ret['cores_per_socket'])
+
+    @patch(OPEN_FUNCTION, mock_open(read_data=PROC_STAT))
+    def test_parse_proc_stat_btime(self):
+        expected_btime = "1524062304"
+
+        hw = hwprobe.HardwareCollector()
+        ret = hw.get_proc_stat()
+        self.assertEqual(expected_btime, ret['proc_stat.btime'])
 
     @patch.object(hwprobe.HardwareCollector, 'count_cpumask_entries')
     @patch("os.listdir")


### PR DESCRIPTION
Last system boot time is now reported as proc_stat.btime

[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1527727) 