### PR TITLE
1439645: Perform a full entitlement refresh in the yum/dnf/zypper plugins

### DIFF
--- a/src/dnf-plugins/subscription-manager.py
+++ b/src/dnf-plugins/subscription-manager.py
@@ -19,6 +19,7 @@ import os
 
 from subscription_manager import injection as inj
 from subscription_manager.repolib import RepoActionInvoker
+from subscription_manager.entcertlib import EntCertActionInvoker
 from rhsmlib.facts.hwprobe import ClassicCheck
 from subscription_manager.utils import chroot
 from subscription_manager.injectioninit import init_dep_injection
@@ -102,7 +103,10 @@ class SubscriptionManager(dnf.Plugin):
         if config.in_container():
             logger.info(_("Subscription Manager is operating in container mode."))
 
-        rl = RepoActionInvoker(cache_only=cache_only)
+        if not cache_only:
+            rl = EntCertActionInvoker()
+        else:
+            rl = RepoActionInvoker(cache_only=cache_only)
         rl.update()
 
     def _warnExpired(self):

--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -22,6 +22,7 @@ from yum.plugins import TYPE_CORE
 
 from subscription_manager import injection as inj
 from subscription_manager.repolib import RepoActionInvoker
+from subscription_manager.entcertlib import EntCertActionInvoker
 from rhsmlib.facts.hwprobe import ClassicCheck
 from subscription_manager.certlib import Locker
 from subscription_manager.utils import chroot
@@ -110,7 +111,10 @@ def update(conduit, cache_only):
     if config.in_container():
         conduit.info(3, "Subscription Manager is operating in container mode.")
 
-    rl = RepoActionInvoker(cache_only=cache_only, locker=YumRepoLocker(conduit=conduit))
+    if not cache_only:
+        rl = EntCertActionInvoker(locker=YumRepoLocker(conduit=conduit))
+    else:
+        rl = RepoActionInvoker(cache_only=cache_only, locker=YumRepoLocker(conduit=conduit))
     rl.update()
 
 

--- a/src/zypper/services/subscription-manager
+++ b/src/zypper/services/subscription-manager
@@ -20,6 +20,7 @@ import sys
 
 from subscription_manager import injection as inj
 from subscription_manager.repolib import RepoActionInvoker, ZYPPER_REPO_DIR
+from subscription_manager.entcertlib import EntCertActionInvoker
 from subscription_manager.certlib import Locker
 from subscription_manager.injectioninit import init_dep_injection
 from subscription_manager import logutil
@@ -102,8 +103,12 @@ class ZypperService(object):
         key_file = ConsumerIdentity.keypath()
 
         connection.UEPConnection(cert_file=cert_file, key_file=key_file)
+        cache_only = not self.full_refresh_on_yum
 
-        rl = RepoActionInvoker(cache_only=not self.full_refresh_on_yum, locker=RepoLocker())
+        if not cache_only:
+            rl = EntCertActionInvoker(locker=RepoLocker())
+        else:
+            rl = RepoActionInvoker(cache_only=cache_only, locker=RepoLocker())
         rl.update()
 
         # Rehash CA-certificates since zypper accepts only capath


### PR DESCRIPTION
This enables new content to be utilized by a system when the full_refresh_on_yum setting is used.
This should allow content from new environments or content views to be retrieved when new packages are installed (or updated).

Based on branch awood/1439645-yum-plugin

[RFE Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1439645)