### PR TITLE
Remove kitchen from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -240,7 +240,6 @@ setup_requires = []
 
 install_requires = [
         'six',
-        'kitchen',
     ]
 
 test_require = [


### PR DESCRIPTION
This fixes compatibility with platforms that don't have kitchen
available, such as EL6 and SUSE.