### PR TITLE
Add missing buildrequires to fix upstream fedora python2 builds

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -439,6 +439,8 @@ entitlements, certificates, and access to content.
 Summary: A Python library to communicate with a Red Hat Unified Entitlement Platform
 Group: Development/Libraries
 
+BuildRequires: python2-devel
+
 %if %use_m2crypto
 Requires: %{?suse_version:python-m2crypto} %{!?suse_version:m2crypto}
 %endif


### PR DESCRIPTION
Our upstream python2 builds of python2-subscription-manager-rhsm have been broken due to a missing BuildRequires... This adds the missing requirement.
See the following for an example of this change producing a successful build.

[Upstream scratch build including this spec file change](https://koji.fedoraproject.org/koji/taskinfo?taskID=26707134)