### PR TITLE
Respecting proxy port configured in rhsm.conf

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -265,7 +265,7 @@ class CliCommand(AbstractCLICommand):
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.settimeout(10)
-            result = s.connect_ex((self.proxy_hostname or conf["server"]["proxy_hostname"], int(self.proxy_port or rhsm.config.DEFAULT_PROXY_PORT)))
+            result = s.connect_ex((self.proxy_hostname or conf["server"]["proxy_hostname"], int(self.proxy_port or conf["server"]["proxy_port"] or rhsm.config.DEFAULT_PROXY_PORT)))
         except Exception as e:
             log.info("Attempted bad proxy: %s" % e)
             return False


### PR DESCRIPTION
Without this, default proxy port is used, which breaks deployments that need proxy to register with rhn.