### PR TITLE
Automatic rebuilding of updates.img on PXE Server

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,7 +48,7 @@ Vagrant.configure("2") do |config|
     "cockpit/node_modules",
     "updates.img",
     "vagrant/vagrant_data",
-  ]
+  ], rsync__args: ["--verbose", "--archive", "--delete", "-z", "--copy-links", "-W"]
 
   # Set up the hostmanager plugin to automatically configure host & guest hostnames
   if Vagrant.has_plugin?("vagrant-hostmanager")

--- a/scripts/autobuild_updates_img.sh
+++ b/scripts/autobuild_updates_img.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Bash script used for automatic rebuilding of updates.img used by Anaconda installer.
+# This script is usualy started as service by systemd, but it can be also started manualy
+# On PXE server providing updates.img to PXE client.
+
+usage() {
+    cat << USAGE
+
+Usage: $0 [options]
+OPTIONS:
+  -p | --python <python_interpreter>  Python interpreter to use. Use to differentiate between Python 2
+                                        and Python 3.
+  -s | --src <src_dir>                Directory with source code used for creating updates.img
+  -d | --dest <dest_dir>              Destination directory, where updates.img will be created.
+  -h | --help                         Print this help text
+
+USAGE
+}
+
+SHORT_OPTIONS="hs:d:p:"
+LONG_OPTIONS="help,src:,dest:,python:"
+
+ARGS=$(getopt -s bash --options $SHORT_OPTIONS --longoptions $LONG_OPTIONS -- "$@")
+
+eval set -- $ARGS
+
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        -p|--python)
+            # Note to future self, shift moves all positional parameters to n-1
+            # (e.g. after shift the value of $1 becomes whatever $2 was prior)
+            PYTHON_BIN=$2
+            shift
+            ;;
+        -s|--src)
+            SRC_DIR=$2
+            shift
+            ;;
+        -d|--dest)
+            DEST_DIR=$2
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit
+            ;;
+        *)
+            # Stop parsing on anything other than a long or short option we expected.
+            break
+            ;;
+    esac
+    shift
+done
+
+
+# Setting default values, when no arguments were provided
+if [ "${PYTHON_BIN}" = "" ]; then
+    PYTHON_BIN="python"
+    echo "Python interpreter not specified, using ${PYTHON_BIN}"
+fi
+if [ "${SRC_DIR}" = "" ]; then
+    SRC_DIR=$PWD
+    echo "Source directory not specified, using ${PWD}"
+fi
+if [ "${DEST_DIR}" = "" ]; then
+    DEST_DIR=$PWD
+    echo "Destination directory not specified, using ${PWD}"
+fi
+
+
+# Never ending loop
+while inotifywait -r "${SRC_DIR}"; do
+	pushd "${SRC_DIR}"
+	echo "Building new updates.img ..."
+	${0%/*}/build_updates_img.sh --python ${PYTHON_BIN}
+	echo "Done"
+	if [ $? -eq 0 ]; then
+		mv updates.img "${DEST_DIR}"
+	fi
+	popd
+	# Wait 10 seconds.
+	sleep 10
+done

--- a/scripts/build_updates_img.sh
+++ b/scripts/build_updates_img.sh
@@ -3,6 +3,7 @@
 # A script that wraps make install to create an updates.img suitable for anaconda.
 # Note: This script must be run on Fedora 27 to produce an updates image suitable for Fedora 27
 #       due to compatibility of binary modules.
+
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 UPDATE_DIR=$(mktemp -d)
 pushd $PROJECT_ROOT
@@ -10,12 +11,14 @@ pushd $PROJECT_ROOT
 rm -f ./updates.img 2>/dev/null
 
 usage() {
-    cat <<USAGE
-usage: build_updates_img.sh [options]
+    cat << USAGE
+
+Usage: build_updates_img.sh [options]
 OPTIONS:
   -p | --python <python_interpreter>  Python interpreter to use. Use to differentiate between Python 2
                                         and Python 3.
   -h | --help                         Print this help text
+
 USAGE
 }
 

--- a/vagrant/roles/pxe-server/defaults/main.yml
+++ b/vagrant/roles/pxe-server/defaults/main.yml
@@ -23,6 +23,7 @@ required_rpms:
   - librsvg2
   - python3-dateutil
   - python3-kitchen
+  - inotify-tools
 
 ##### CentOS 7 #####
 
@@ -53,6 +54,9 @@ iso_img_mount_path: "/mnt/iso_img"
 # by ansible.extra_vars, because IP address of PXE server has to
 # be known during definition of private network used by PXE server.
 pxe_server_ip_addr: "192.168.111.5/24"
+
+# Directory with systemd service files
+systemd_service_dir: "/usr/lib/systemd/system/"
 
 syslinux_files:
   - pxelinux.0

--- a/vagrant/roles/pxe-server/files/autobuild_updates_img.service
+++ b/vagrant/roles/pxe-server/files/autobuild_updates_img.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Automatic rebuilding of subscription-manager updates.img used by Anaconda installer
+After=network.target
+
+[Service]
+WorkingDirectory=/vagrant
+ExecStart=/bin/bash /vagrant/scripts/autobuild_updates_img.sh --python python3 --src /vagrant --dest /var/ftp/pub/
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/vagrant/roles/pxe-server/tasks/main.yml
+++ b/vagrant/roles/pxe-server/tasks/main.yml
@@ -128,6 +128,19 @@
     dest: /var/ftp/pub/updates.img
   become: true
 
+- name: create service for automatic building of updates.img
+  copy:
+    src: autobuild_updates_img.service
+    dest: "{{systemd_service_dir}}"
+  become: yes
+
+- name: enable and start service for automatic building of updates.img
+  service:
+    name: autobuild_updates_img
+    enabled: yes
+    state: started
+  become: true
+
 - name: create default file containing boot menu
   template:
     src: default.j2


### PR DESCRIPTION
* When PXE server is provisioned, then new service is started.
  This service starts shell script watching for changes in
  source code of subscription-manager using inotify. When
  source is changed, then new updates.img for Anaconda installer
  is build.
* Source code of subscription-manager has to be synced using
  "vagrant rsync pxe-server" or "vagrant rsync-auto pxe-server"
* Note: I added option: "-W" to vagrant rsync configuration,
  because command: "vagrant rsync pxe-server" was failing due to
  inotify running on pxe-server.