### PR TITLE
ENT-169 Get Initial Setup Addon to run during installation in Vagrant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ OS_DIST ?= $(shell rpm --eval='%dist')
 
 PYTHON_VER ?= $(shell $(PYTHON) -c 'import sys; print("python%s.%s" % sys.version_info[:2])')
 
-PYTHON_SITELIB ?= $(PREFIX)/lib/$(PYTHON_VER)/site-packages
+PYTHON_SITELIB ?= $(PREFIX)/lib64/$(PYTHON_VER)/site-packages
 # Note the underscore used instead of a hyphen
 PYTHON_INST_DIR = $(PYTHON_SITELIB)/subscription_manager
 

--- a/scripts/autobuild_updates_img.sh
+++ b/scripts/autobuild_updates_img.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Bash script used for automatic rebuilding of updates.img used by Anaconda installer.
-# This script is usualy started as service by systemd, but it can be also started manualy
+# This script is usually started as service by systemd, but it can be also started manually
 # On PXE server providing updates.img to PXE client.
 
 usage() {

--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
@@ -22,9 +22,12 @@ import logging
 
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.ui.gui.spokes import NormalSpoke
-from pyanaconda.ui.common import FirstbootOnlySpokeMixIn
+from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.ui.categories.system import SystemCategory
+from pyanaconda.ui.categories.user_settings import UserSettingsCategory
 from pyanaconda.ui.gui.utils import really_hide
+from pyanaconda.flags import flags
+from pyanaconda.constants import ANACONDA_ENVIRON
 
 log = logging.getLogger(__name__)
 
@@ -49,12 +52,21 @@ __all__ = ["RHSMSpoke"]
 configure_gettext()
 
 
-class RHSMSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
+class RHSMSpoke(FirstbootSpokeMixIn, NormalSpoke):
+    """
+    Spoke used for registration of system in Anaconda or Initial Setup
+    """
     buildrObjects = ["RHSMSpokeWindow"]
     mainWidgetName = "RHSMSpokeWindow"
     uiFile = "rhsm_gui.ui"
     helpFile = "SubscriptionManagerSpoke.xml"
-    category = SystemCategory
+    # Display our spoke in second hub for testing purpose. There is also
+    # no more space in first hub. See this bug report:
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1584160
+    if ANACONDA_ENVIRON in flags.environs:
+        category = UserSettingsCategory
+    else:
+        category = SystemCategory
     icon = "subscription-manager"
     title = "_Subscription Manager"
 

--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -35,7 +35,7 @@ ethtool = None
 try:
     import ethtool
 except ImportError as e:
-    log.warn("Unable to import the 'ethtool' module.")
+    log.warning("Unable to import the 'ethtool' module.")
 
 # For python2.6 that doesn't have subprocess.check_output
 from rhsmlib.compat import check_output as compat_check_output
@@ -216,7 +216,7 @@ class HardwareCollector(collector.FactsCollector):
                     nkey = '.'.join(["memory", key.lower()])
                     meminfo[nkey] = "%s" % int(value)
         except Exception as e:
-            log.warn("Error reading system memory information: %s", e)
+            log.warning("Error reading system memory information: %s", e)
         return meminfo
 
     def count_cpumask_entries(self, cpu, field):
@@ -561,7 +561,7 @@ class HardwareCollector(collector.FactsCollector):
                                             env=lscpu_env)
         except CalledProcessError as e:
             log.exception(e)
-            log.warn('Error with lscpu (%s) subprocess: %s', lscpu_cmd_string, e)
+            log.warning('Error with lscpu (%s) subprocess: %s', lscpu_cmd_string, e)
             return lscpu_info
 
         errors = []
@@ -578,7 +578,7 @@ class HardwareCollector(collector.FactsCollector):
                     errors.append(e)
 
         except Exception as e:
-            log.warn('Error reading system CPU information: %s', e)
+            log.warning('Error reading system CPU information: %s', e)
         if errors:
             log.debug('Errors while parsing lscpu output: %s', errors)
 
@@ -669,7 +669,7 @@ class HardwareCollector(collector.FactsCollector):
                 net_info['network.ipv6_address'] = ', '.join(self._get_ipv6_addr_list())
 
         except Exception as err:
-            log.warn('Error reading networking information: %s', err)
+            log.warning('Error reading networking information: %s', err)
 
         return net_info
 
@@ -770,7 +770,7 @@ class HardwareCollector(collector.FactsCollector):
 
         except Exception as e:
             log.exception(e)
-            log.warn("Error reading network interface information: %s", e)
+            log.warning("Error reading network interface information: %s", e)
         return netinfdict
 
     # from rhn-client-tools  hardware.py

--- a/vagrant/roles/pxe-server/tasks/main.yml
+++ b/vagrant/roles/pxe-server/tasks/main.yml
@@ -152,3 +152,7 @@
     src: "ks_{{distro_name}}{{distro_version}}.cfg.j2"
     dest: /var/ftp/pub/ks.cfg
   become: true
+
+- name: disable SELinux
+  shell: "setenforce 0"
+  become: true


### PR DESCRIPTION
* Fixed instalation of ga_impls. It is installed to
  /usr/lib64/... and not to /usr/lib/python/... The Anaconda
  wasn't able to display our Addon for this reason.
* Fixed some typo in comments
* Temporary display our Addon on ProgressHub (second screen).
  It is necessary to do so, because Anaconda skips SummaryHub
  quicky (first screen) due to loading all required options
  from kickstart file (in our testing environment). We could
  move our Addon back to SummaryHub, when this
  https://bugzilla.redhat.com/show_bug.cgi?id=1584160
  is implemented in Anaconda.
* Replaces log.warn with log.warning in hwprobe.py, because
  log.warn is marked as deprecated (lot of warnings in
  /tmp/anaconda.log)
* Disabled SELinux on PXE server, because vsftpd wasn't able to
  provide updates.img (this file has became too big).
* TODO: use different scalable icon from Adwaita theme or
  create new one to fit style of other icons in Anaconda.