### PR TITLE
1560727: Search for proxy auth message in whole error string

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -569,7 +569,7 @@ class BaseRestLib(object):
                                         err))
             raise
         except socket.error as err:
-            if str(err)[-3:] == str(httplib.PROXY_AUTHENTICATION_REQUIRED):
+            if str(httplib.PROXY_AUTHENTICATION_REQUIRED) in str(err):
                 raise ProxyException(err)
             raise
         response = conn.getresponse()


### PR DESCRIPTION
* https://bugzilla.redhat.com/show_bug.cgi?id=1560727
* Proxy authentication failures are handled the same way on RHEL6 and RHEL7.