### PR TITLE
1555384: get_libexecdir now returns a string instead of bytes

### DIFF
--- a/build_ext/template.py
+++ b/build_ext/template.py
@@ -34,7 +34,7 @@ class BuildTemplate(BaseCommand):
         try:
             cmd = ['rpm', '--eval=%_libexecdir']
             process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-            return process.communicate()[0].strip()
+            return process.communicate()[0].strip().decode('UTF-8', 'strict')
         except OSError:
             return 'libexec'
 


### PR DESCRIPTION
-https://bugzilla.redhat.com/show_bug.cgi?id=1555384
-Function can be found in build_ext/template.py, produces the file
etc-conf/dbus/system-services/com.redhat.SubscriptionManager.service.template
-Added everything after "decode" in first return value of try statement