### PR TITLE
ENT-447 Create .desktop file that opens web page with our cockpit plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ INSTALL_OSTREE_PLUGIN ?= true
 
 WITH_SYSTEMD ?= true
 WITH_SUBMAN_GUI ?= true
+WITH_COCKPIT ?= true
 
 # Default differences between el6 and el7
 ifeq ($(OS_DIST),.el6)
@@ -286,7 +287,8 @@ install-post-boot: install-firstboot install-initial-setup
 
 .PHONY: install-via-setup
 install-via-setup: install-subpackages-via-setup
-	$(PYTHON) ./setup.py install --root $(DESTDIR) --gtk-version=$(GTK_VERSION) --rpm-version=$(VERSION) --with-systemd=$(WITH_SYSTEMD) --prefix=$(PREFIX) --with-subman-gui=${WITH_SUBMAN_GUI}
+	$(PYTHON) ./setup.py install --root $(DESTDIR) --gtk-version=$(GTK_VERSION) --rpm-version=$(VERSION) --prefix=$(PREFIX) \
+	--with-systemd=$(WITH_SYSTEMD) --with-subman-gui=${WITH_SUBMAN_GUI} --with-cockpit-desktop-entry=${WITH_COCKPIT}
 	mkdir -p $(DESTDIR)/$(PREFIX)/sbin/
 	mkdir -p $(DESTDIR)/$(LIBEXEC_DIR)/
 	mv $(DESTDIR)/$(PREFIX)/bin/subscription-manager $(DESTDIR)/$(PREFIX)/sbin/

--- a/etc-conf/subscription-manager-cockpit.desktop.in
+++ b/etc-conf/subscription-manager-cockpit.desktop.in
@@ -1,0 +1,7 @@
+[Desktop Entry]
+_Name=Red Hat Subscription Manager
+Icon=subscription-manager
+Type=Application
+Exec=xdg-open "http://localhost:9090/subscriptions"
+Terminal=false
+Categories=System;X-Red-Hat-Base;

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -123,6 +123,12 @@
 %define with_subman_gui WITH_SUBMAN_GUI=false
 %endif
 
+%if %{use_cockpit} && !0%{use_subman_gui}
+%define with_cockpit WITH_COCKPIT=true
+%else
+%define with_cockpit WITH_COCKPIT=false
+%endif
+
 %define subpackages SUBPACKAGES="%{?include_intentctl:intentctl}"
 
 Name: subscription-manager
@@ -508,6 +514,7 @@ make -f Makefile install VERSION=%{version}-%{release} \
     %{?install_zypper_plugins} \
     %{?with_systemd} \
     %{?with_subman_gui} \
+    %{?with_cockpit} \
     %{?subpackages} \
     %{?include_intentctl:INCLUDE_INTENTCTL="1"}
 
@@ -523,6 +530,10 @@ cp -r %{buildroot}%{python_sitearch}/rhsm %{buildroot}%{python2_sitearch}/rhsm
 %if %use_subman_gui
 desktop-file-validate %{buildroot}/etc/xdg/autostart/rhsm-icon.desktop
 desktop-file-validate %{buildroot}/usr/share/applications/subscription-manager-gui.desktop
+%else
+%if %use_cockpit
+desktop-file-validate %{buildroot}/usr/share/applications/subscription-manager-cockpit.desktop
+%endif
 %endif
 
 %find_lang rhsm
@@ -973,6 +984,9 @@ install -m 644 %{_builddir}/%{buildsubdir}/etc-conf/ca/redhat-uep.pem %{buildroo
 %{_datadir}/cockpit/subscription-manager/po.js
 %{_datadir}/cockpit/subscription-manager/node_modules/*
 %{_datadir}/metainfo/org.cockpit-project.subscription-manager.metainfo.xml
+%if ! %use_subman_gui
+%{_datadir}/applications/subscription-manager-cockpit.desktop
+%endif
 %endif
 
 %post


### PR DESCRIPTION
* When subman cockpit plugin is installed and subman gui is not
  installed, then install subscription-manager-cockpit.desktop
  file to /usr/share/application.
* Clicking on icon should just open http://localhost:9090/subscriptions
  in default browser
* The .desktop file include one [Desktop Entry], but type is not
  Link, because icon with Subscription Manager is not displayed
  in Gnome 3. Thus type is Application and URL is opened using
  xdg-open. This should open URL with default web browser on all
  desktop environments following freedesktop.org specification.