### PR TITLE
1568609: Updated man page for --after list option

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -107,7 +107,7 @@ _subscription_manager_import()
 
 _subscription_manager_list()
 {
-  local opts="--all --available --consumed --installed
+  local opts="--after --all --available --consumed --installed
               --ondate --servicelevel
               --match-installed --no-overlap
               --matches

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -427,6 +427,12 @@ The
 command lists all of the subscriptions that are compatible with a system. The options allow the list to be filtered by subscriptions that are used by the system or unused subscriptions that are available to the system.
 
 .TP
+.B --after=YYYY-MM-DD
+Shows pools that are active on or after the given date. This is only used with the
+.B --available
+option.
+
+.TP
 .B --all
 Lists all possible subscriptions that have been purchased, even if they don't match the architecture of the system. This is used with the
 .B --available

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2253,7 +2253,7 @@ class ListCommand(CliCommand):
         self.parser.add_option("--pool-only", dest="pid_only", action="store_true",
                                help=_("lists only the pool IDs for applicable available or consumed subscriptions; only used with --available and --consumed"))
         self.parser.add_option('--after', dest="after",
-                               help=_("show pools that are active on or after the given date; only used with --available and --all"))
+                               help=_("show pools that are active on or after the given date; only used with --available"))
 
     def _validate_options(self):
         if self.options.all and not self.options.available:


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1568609
- help message now includes "...only used with --available"
- --after now exists in subscription-manager man page list options
- name is still --after, not --afterdate