### PR TITLE
ENT-447 Add icons to RPM package for subman cockpit plugin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -213,6 +213,7 @@ class install_data(_install_data):
             self.add_gui_doc_files()
         if self.with_cockpit_desktop_entry:
             self.add_cockpit_desktop_entry()
+            self.add_icons()
         self.add_dbus_service_files()
         self.add_systemd_services()
         _install_data.run(self)

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -991,6 +991,14 @@ install -m 644 %{_builddir}/%{buildsubdir}/etc-conf/ca/redhat-uep.pem %{buildroo
 %{_datadir}/metainfo/org.cockpit-project.subscription-manager.metainfo.xml
 %if ! %use_subman_gui
 %{_datadir}/applications/subscription-manager-cockpit.desktop
+%{_datadir}/icons/hicolor/16x16/apps/*.png
+%{_datadir}/icons/hicolor/22x22/apps/*.png
+%{_datadir}/icons/hicolor/24x24/apps/*.png
+%{_datadir}/icons/hicolor/32x32/apps/*.png
+%{_datadir}/icons/hicolor/48x48/apps/*.png
+%{_datadir}/icons/hicolor/96x96/apps/*.png
+%{_datadir}/icons/hicolor/256x256/apps/*.png
+%{_datadir}/icons/hicolor/scalable/apps/*.svg
 %endif
 %endif
 


### PR DESCRIPTION
- When subman cockpit plugin is installed, then icons has to be
  installed too.
- When I created #1826, then I tested it on old fedora installation
  and these icons were already installed in the system.