### PR TITLE
Update the license of the subman-cockpit-plugin to GPLv2

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -483,7 +483,7 @@ and to receive access to content.
 %if %use_cockpit
 %package -n subscription-manager-cockpit
 Summary: Subscription Manager Cockpit UI
-License: LGPLv2.1+
+License: GPLv2
 BuildArch: noarch
 
 Requires: subscription-manager


### PR DESCRIPTION
This updates the license of the subscription-manager-cockpit-plugin to be GPLv2.