### PR TITLE
Remove freezegun

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -298,7 +298,6 @@ test_require = [
       'nose-randomly',
       'coverage',
       'polib',
-      'freezegun',
       'flake8',
       'lxml',
     ] + install_requires + setup_requires

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,6 @@ polib
 pep8==1.5.7
 pyflakes
 flake8==3.0.4
-freezegun
 simplejson
 mock
 Sphinx

--- a/test/test_format_time.py
+++ b/test/test_format_time.py
@@ -6,18 +6,10 @@ except ImportError:
     import unittest
 
 import locale
-import sys
 
 from datetime import datetime
 from dateutil.tz import tzutc, tzstr
 from mock import patch
-
-try:
-    from freezegun import freeze_time
-except ImportError:
-    from nose.plugins.skip import SkipTest
-    sys.stderr.write("TestFormatTime is skipped: A package unavailable. Please 'pip install freezegun'.")
-    raise SkipTest("Missing freezegun module")
 
 from subscription_manager import managerlib
 
@@ -30,7 +22,6 @@ class TestFormatTime(unittest.TestCase):
     def tearDown(self):
         locale.setlocale(locale.LC_ALL, self.locale)
 
-    @freeze_time("2013-9-14")  # During DST
     @patch('subscription_manager.managerlib.tzlocal')
     def test_system_dst(self, mock_tz):
         mock_tz.return_value = tzstr(u'EST5EDT')
@@ -60,7 +51,6 @@ class TestFormatTime(unittest.TestCase):
         test = datetime(2014, 5, 21, 4, 1, 0, tzinfo=tzutc())
         self.assertEqual(managerlib.format_date(test), '05/21/2014')
 
-    @freeze_time("2013-12-14")  # During EST
     @patch('subscription_manager.managerlib.tzlocal')
     def test_system_est(self, mock_tz):
         mock_tz.return_value = tzstr(u'EST5EDT')


### PR DESCRIPTION
Looks to no longer be necessary.

See #882

It looks like when the tests were changed to use a mocked tz, the local
time no longer impacts tests.