### PR TITLE
Fix up our Centos 7 Vagrant setup

### DIFF
--- a/vagrant/roles/subman-devel/tasks/main.yml
+++ b/vagrant/roles/subman-devel/tasks/main.yml
@@ -265,3 +265,13 @@
   become: yes
   ignore_errors: yes
   when: subman_add_vagrant_candlepin_to_hosts
+
+- name: update glibc-common if not already latest
+  package:
+    name: glibc-common
+    state: latest
+
+- name: reinstall glibc-common to lay down langs
+  become: true
+  become_method: sudo
+  command: yum -y reinstall glibc-common

--- a/vagrant/vagrant.yml
+++ b/vagrant/vagrant.yml
@@ -14,11 +14,21 @@
   gather_facts: no
   become: yes
   tasks:
+    - name: Make fake Xauthority (if needed)
+      copy:
+        content: ""
+        owner: vagrant
+        group: vagrant
+        dest: /home/vagrant/.Xauthority
+        force: no
+      tags:
+        - xauth
+
     - name: link vagrant's Xauthority to root user
       file:
         src: /home/vagrant/.Xauthority
         dest: /root/.Xauthority
-        owner: root
-        group: root
         state: link
-        force: yes
+      tags:
+        - xauth
+


### PR DESCRIPTION
Prior to this PR, running `vagrant up` on fedora 28 could result in false unit test failures involving missing locales or X11 initialization failure.

The glibc-common bits are to solve the locale issue (thanks for the fix JC!).
The Xauth issue can be reproduced by running `vagrant up` twice. This causes the /home/vagrant/.Xauthority file to be modified to be owned by root:root. This causes the vagrant user to be unable to touch this file.

The fix was to ensure the /home/vagrant/.Xauthority file exists prior to attempting to make the symbolic link.