### PR TITLE
1553266: When d-bus methods are unavailable, show appropriate message (ENT-576)

### DIFF
--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -194,7 +194,13 @@ class SubscriptionsPage extends React.Component {
         let icon;
         let description;
         let message;
-        if (this.props.status === undefined || !subscriptionsClient.config.loaded) {
+        if (this.props.status === "service-unavailable") {
+            icon = <div className="fa fa-exclamation-circle"/>;
+            message = _("The rhsm service is unavailable. Make sure subscription-manager is installed " +
+                "and try reloading the page. Additionally, make sure that you have checked the " +
+                "'Reuse my password for privileged tasks' checkbox on the login page.");
+            description = _("Unable to the reach the rhsm service.");
+        } else if (this.props.status === undefined || !subscriptionsClient.config.loaded) {
             icon = <div className="spinner spinner-lg" />;
             message = _("Updating");
             description = _("Retrieving subscription status...");


### PR DESCRIPTION
* Added a "safe call" mechanism that makes the initial dbus calls (entitlementService, configService, productsService) only if the service is available, tries to restart the rhsm service if possible, and otherwise failing gracefully.
* Added new UI curtain that provides a meaningful message and advice to the end user.
* Re-added utility method statusUpdateFailed that was accidentally deleted.