### PR TITLE
ENT-478 com.redhat.RHSM1.Consumer D-Bus service object

### DIFF
--- a/etc-conf/dbus/system.d/com.redhat.RHSM1.conf
+++ b/etc-conf/dbus/system.d/com.redhat.RHSM1.conf
@@ -51,6 +51,9 @@
         <allow send_destination="com.redhat.RHSM1"
             send_interface="com.redhat.RHSM1.Entitlement"/>
 
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.Consumer"/>
+
         <!-- Basic D-Bus API stuff -->
         <allow send_destination="com.redhat.RHSM1"
             send_interface="org.freedesktop.DBus.Introspectable"/>

--- a/src/rhsmlib/dbus/constants.py
+++ b/src/rhsmlib/dbus/constants.py
@@ -32,6 +32,8 @@ __all__ = [
     'PRODUCTS_DBUS_PATH',
     'ENTITLEMENT_INTERFACE',
     'ENTITLEMENT_DBUS_PATH',
+    'CONSUMER_INTERFACE',
+    'CONSUMER_DBUS_PATH'
 ]
 
 # The base of the 'well known name' used for bus and service names, as well
@@ -74,3 +76,6 @@ PRODUCTS_DBUS_PATH = '%s/%s' % (ROOT_DBUS_PATH, 'Products')
 
 ENTITLEMENT_INTERFACE = '%s.%s' % (INTERFACE_BASE, 'Entitlement')
 ENTITLEMENT_DBUS_PATH = '%s/%s' % (ROOT_DBUS_PATH, 'Entitlement')
+
+CONSUMER_INTERFACE = '%s.%s' % (INTERFACE_BASE, 'Consumer')
+CONSUMER_DBUS_PATH = '%s/%s' % (ROOT_DBUS_PATH, 'Consumer')

--- a/src/rhsmlib/dbus/objects/consumer.py
+++ b/src/rhsmlib/dbus/objects/consumer.py
@@ -1,0 +1,85 @@
+from __future__ import print_function, division, absolute_import
+
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+"""
+This module contains implementation of D-Bus object representing consumer.
+It uses interface: com.redhat.RHSM1.Consumer and path:
+/com/redhat/RHSM1/Consumer
+"""
+
+import dbus
+import logging
+
+from rhsmlib.dbus import constants, base_object, util, dbus_utils
+from rhsmlib.services.consumer import Consumer
+
+from subscription_manager.injectioninit import init_dep_injection
+from subscription_manager.i18n import Locale
+
+init_dep_injection()
+
+log = logging.getLogger(__name__)
+
+
+class ConsumerDBusObject(base_object.BaseObject):
+    """
+    A D-Bus object interacting with subscription-manager to get
+    information about current consumer.
+    """
+    default_dbus_path = constants.CONSUMER_DBUS_PATH
+    interface_name = constants.CONSUMER_INTERFACE
+
+    def __init__(self, conn=None, object_path=None, bus_name=None):
+        super(ConsumerDBusObject, self).__init__(conn=conn, object_path=object_path, bus_name=bus_name)
+
+    @util.dbus_service_method(
+        constants.CONSUMER_INTERFACE,
+        in_signature='s',
+        out_signature='s')
+    @util.dbus_handle_exceptions
+    def GetUuid(self, locale, sender=None):
+        """
+        D-Bus method for getting current consumer UUID
+        :param locale: string with locale
+        :param sender:
+        :return: string with UUID
+        """
+
+        locale = dbus_utils.dbus_to_python(locale, expected_type=str)
+        Locale.set(locale)
+
+        consumer = Consumer()
+        try:
+            uuid = consumer.get_consumer_uuid()
+        except Exception as err:
+            raise dbus.DBusException(str(err))
+
+        return str(uuid)
+
+    @util.dbus_service_signal(
+        constants.CONSUMER_INTERFACE,
+        signature='i'
+    )
+    @util.dbus_handle_exceptions
+    def ConsumerChanged(self, status_code):
+        """
+        Signal fired, when consumer is created/deleted/changed
+        :param sender:
+        :return: None
+        """
+        log.debug("D-Bus signal %s emitted with signature %i" % (
+            constants.CONSUMER_INTERFACE, status_code
+        ))
+        return None

--- a/src/rhsmlib/dbus/util.py
+++ b/src/rhsmlib/dbus/util.py
@@ -26,6 +26,7 @@ log = logging.getLogger(__name__)
 __all__ = [
     'dbus_handle_exceptions',
     'dbus_service_method',
+    'dbus_service_signal'
 ]
 
 
@@ -56,3 +57,13 @@ def dbus_service_method(*args, **kwargs):
     # defined.
     kwargs.setdefault("sender_keyword", "sender")
     return dbus.service.method(*args, **kwargs)
+
+
+def dbus_service_signal(*args, **kwargs):
+    """
+    Decorator used for signal
+    :param args:
+    :param kwargs:
+    :return:
+    """
+    return dbus.service.signal(*args, **kwargs)

--- a/src/rhsmlib/services/consumer.py
+++ b/src/rhsmlib/services/consumer.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
-# Copyright (c) 2016 Red Hat, Inc.
+# Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,
 # version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,12 +12,31 @@ from __future__ import print_function, division, absolute_import
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-#
-from rhsmlib.dbus.objects.config import ConfigDBusObject  # NOQA
-from rhsmlib.dbus.objects.main import Main  # NOQA
-from rhsmlib.dbus.objects.register import RegisterDBusObject, DomainSocketRegisterDBusObject  # NOQA
-from rhsmlib.dbus.objects.attach import AttachDBusObject  # NOQA
-from rhsmlib.dbus.objects.products import ProductsDBusObject  # NOQA
-from rhsmlib.dbus.objects.unregister import UnregisterDBusObject  # NOQA
-from rhsmlib.dbus.objects.entitlement import EntitlementDBusObject  # NOQA
-from rhsmlib.dbus.objects.consumer import ConsumerDBusObject  # NOQA
+
+"""
+This module provides service for consumer identity.
+"""
+
+
+from subscription_manager import injection as inj
+
+
+class Consumer(object):
+    def __init__(self):
+        """
+        Initialization of Consumer instance.
+        """
+        pass
+
+    def get_consumer_uuid(self):
+        """
+        Method for getting UUID of consumer
+        :return: string representing UUID
+        """
+
+        identity = inj.require(inj.IDENTITY)
+
+        if identity.uuid is None:
+            return ""
+        else:
+            return identity.uuid

--- a/src/subscription_manager/scripts/rhsm_service.py
+++ b/src/subscription_manager/scripts/rhsm_service.py
@@ -45,6 +45,7 @@ def main():
             objects.ProductsDBusObject,
             objects.UnregisterDBusObject,
             objects.EntitlementDBusObject,
+            objects.ConsumerDBusObject,
             objects.Main
         ]
         sys.exit(service_wrapper.main(sys.argv, object_classes=object_classes))

--- a/test/rhsmlib_test/test_consumer.py
+++ b/test/rhsmlib_test/test_consumer.py
@@ -1,0 +1,100 @@
+from __future__ import print_function, division, absolute_import
+
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+import mock
+import dbus
+
+from rhsmlib.services import consumer
+from rhsmlib.dbus import constants
+from rhsmlib.dbus.objects.consumer import ConsumerDBusObject
+
+from subscription_manager import injection as inj
+from subscription_manager.identity import Identity
+from test.rhsmlib_test.base import InjectionMockingTest, DBusObjectTest
+
+
+class TestConsumerService(InjectionMockingTest):
+    def setUp(self):
+        super(TestConsumerService, self).setUp()
+        self.mock_identity = mock.Mock(spec=Identity, name="Identity").return_value
+        self.mock_identity.is_valid.return_value = True
+        self.mock_identity.uuid = "43b30b32-86cf-459e-9310-cb4182c23c4a"
+
+    def injection_definitions(self, *args, **kwargs):
+        if args[0] == inj.IDENTITY:
+            return self.mock_identity
+        else:
+            return None
+
+    def test_get_consumer_uuid(self):
+        """
+        Test of getting UUID
+        """
+        test_concumer = consumer.Consumer()
+        uuid = test_concumer.get_consumer_uuid()
+        self.assertEqual(uuid, "43b30b32-86cf-459e-9310-cb4182c23c4a")
+
+    def test_get_consumer_uuid_unregistered_system(self):
+        """
+        When system is not registered, then get_consumer_uuid should
+        return empty string.
+        :return:
+        """
+        self.mock_identity.uuid = None
+        test_concumer = consumer.Consumer()
+        uuid = test_concumer.get_consumer_uuid()
+        self.assertEqual(uuid, "")
+
+
+class TestConsumerDBusObject(DBusObjectTest, InjectionMockingTest):
+    def setUp(self):
+        super(TestConsumerDBusObject, self).setUp()
+        self.proxy = self.proxy_for(ConsumerDBusObject.default_dbus_path)
+        self.interface = dbus.Interface(self.proxy, constants.CONSUMER_INTERFACE)
+
+        consumer_patcher = mock.patch('rhsmlib.dbus.objects.consumer.Consumer', autospec=True)
+        self.mock_consumer = consumer_patcher.start().return_value
+        self.addCleanup(consumer_patcher.stop)
+
+    def _create_mock_identity(self):
+        self.mock_identity = mock.Mock(spec=Identity, name="Identity").return_value
+        self.mock_identity.is_valid.return_value = True
+        self.mock_identity.uuid = "43b30b32-86cf-459e-9310-cb4182c23c4a"
+
+    def injection_definitions(self, *args, **kwargs):
+        if args[0] == inj.IDENTITY:
+            if not hasattr(self, 'mock_identity'):
+                self._create_mock_identity()
+            return self.mock_identity
+        else:
+            return None
+
+    def dbus_objects(self):
+        return [ConsumerDBusObject]
+
+    def test_get_consumer_uuid(self):
+        """
+        Test of getting consumer UUID
+        """
+        expected_result = "43b30b32-86cf-459e-9310-cb4182c23c4a"
+
+        def assertions(*args):
+            result = args[0]
+            self.assertEqual(result, expected_result)
+
+        self.mock_consumer.get_consumer_uuid.return_value = expected_result
+
+        dbus_method_args = ['']
+        self.dbus_request(assertions, self.interface.GetUuid, dbus_method_args)


### PR DESCRIPTION
* Added new path: `/com/redhat/RHSM1/Consumer`
* Added new interface `com.redhat.RHSM1.Consumer`
* This new interface has new method `GetUuid` and signal
  `ConsumerChanged`
* Method requires one string argument with locale and it
  returns string with UUID of consumer
* Signal returns integer with status of change
* To test new feature you have to install configuration files:

```console
    $ sudo make dbus-install
    $ sudo make install-conf
```

* To test new feature start rhsm service using:

```console
    $ PYTHONPATH=./src sudo python -m subscription_manager.scripts.rhsm_service
```

* You can view new path using:

```console
    $ sudo busctl tree com.redhat.RHSM1`
```

* You can introspec method using:

```console
    $ sudo busctl introspect com.redhat.RHSM1 /com/redhat/RHSM1/Consumer
```

* To test getting UUID of consumer run:

```console
    $ sudo busctl call com.redhat.RHSM1 /com/redhat/RHSM1/Consumer \
      com.redhat.RHSM1.Consumer GetUuid s ""
```

* Signal can be triggered using following Python code:

```python
    import dbus
    from rhsmlib.dbus.objects.consumer import ConsumerDBusObject
    dbus_consumer = ConsumerDBusObject(dbus.SystemBus())
    dbus_consumer.ConsumerChanged(1)
```