### PR TITLE
1594733: Fix GetStatus in com.redhat.RHSM1.Entitlement ENT-641

### DIFF
--- a/src/rhsmlib/dbus/objects/entitlement.py
+++ b/src/rhsmlib/dbus/objects/entitlement.py
@@ -17,8 +17,6 @@ import dbus
 import json
 import logging
 
-from datetime import datetime
-
 from rhsmlib.dbus import constants, base_object, util, dbus_utils
 from rhsmlib.services.entitlement import EntitlementService
 
@@ -113,9 +111,16 @@ class EntitlementDBusObject(base_object.BaseObject):
 
     @staticmethod
     def _parse_date(on_date):
-        on_date = datetime.strptime(on_date, '%Y-%m-%d')
-        if on_date.date() < datetime.now().date():
-            raise dbus.DBusException("Past dates are not allowed")
+        """
+        Return new datetime parsed from date
+        :param on_date: String representing date
+        :return It returns datetime.datime structure representing date
+        """
+        try:
+            on_date = EntitlementService.parse_date(on_date)
+        except ValueError as err:
+            raise dbus.DBusException(err)
+        return on_date
 
     @util.dbus_service_method(
         constants.ENTITLEMENT_INTERFACE,

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2604,11 +2604,9 @@ class StatusCommand(CliCommand):
         on_date = None
         if self.options.on_date:
             try:
-                on_date = datetime.datetime.strptime(self.options.on_date, '%Y-%m-%d')
-                if on_date.date() < datetime.datetime.now().date():
-                    system_exit(os.EX_USAGE, _("Past dates are not allowed"))
-            except Exception:
-                system_exit(os.EX_DATAERR, _("Date entered is invalid. Date should be in YYYY-MM-DD format (example: ") + strftime("%Y-%m-%d", localtime()) + " )")
+                on_date = entitlement.EntitlementService.parse_date(self.options.on_date)
+            except ValueError as err:
+                system_exit(os.EX_DATAERR, err)
 
         print("+-------------------------------------------+")
         print("   " + _("System Status Details"))

--- a/test/rhsmlib_test/test_entitlement.py
+++ b/test/rhsmlib_test/test_entitlement.py
@@ -387,6 +387,33 @@ class TestEntitlementService(InjectionMockingTest):
         self.assertEqual(expected_removed_serials, removed_serial)
         self.assertEqual(expected_unremoved_serials, unremoved_serials)
 
+    def test_parse_valid_date(self):
+        """
+        Test parsing valid date
+        """
+        on_date = datetime.date.today().strftime('%Y-%m-%d')
+        ent_service = EntitlementService(self.mock_cp)
+        expected_result = datetime.datetime.strptime(on_date, "%Y-%m-%d")
+        parsed_date = ent_service.parse_date(on_date)
+        self.assertEqual(expected_result, parsed_date)
+
+    def test_parse_invalid_date(self):
+        """
+        Test parsing invalid date (invalid format)
+        """
+        on_date = "2000-20-20"
+        ent_service = EntitlementService(self.mock_cp)
+        self.assertRaises(ValueError, ent_service.parse_date, on_date)
+
+    def test_parse_yesterday(self):
+        """
+        Test parsing invalid date (past dates are not allowed)
+        """
+        yesterday = datetime.date.today() - datetime.timedelta(1)
+        on_date = yesterday.strftime('%Y-%m-%d')
+        ent_service = EntitlementService(self.mock_cp)
+        self.assertRaises(ValueError, ent_service.parse_date, on_date)
+
 
 class TestEntitlementDBusObject(DBusObjectTest, InjectionMockingTest):
     def setUp(self):


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1594733
* When method GetStatus was called with first argument (on_date),
  then it could return wrong status.
* Refactored code a little bit. Thus parsing of on_date is
  shared between rhsm.service and subscription-manager
* Method get_status was also fixed. Calling GetStatus with
  different values of on_date returns correct results.
* Added some unit tests for testing of parsing date.