### PR TITLE
1581777: Reraise exception properly. ENT-566

### DIFF
--- a/src/rhsmlib/dbus/util.py
+++ b/src/rhsmlib/dbus/util.py
@@ -49,7 +49,7 @@ def dbus_handle_exceptions(func, *args, **kwargs):
                 "message": str(err)
             }
         )
-        six.reraise(exceptions.RHSM1DBusException, error_msg, trace)
+        six.reraise(exceptions.RHSM1DBusException, exceptions.RHSM1DBusException(error_msg), trace)
 
 
 def dbus_service_method(*args, **kwargs):


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1581777
* When exception is reraised, then it has to be reraised as
  instance of new exception in Python 3. It cannot be string.