### PR TITLE
ENT-476: Add signal InstalledProductsChanged

### DIFF
--- a/src/rhsmlib/dbus/objects/products.py
+++ b/src/rhsmlib/dbus/objects/products.py
@@ -38,6 +38,19 @@ class ProductsDBusObject(base_object.BaseObject):
     def __init__(self, conn=None, object_path=None, bus_name=None):
         super(ProductsDBusObject, self).__init__(conn=conn, object_path=object_path, bus_name=bus_name)
 
+    @util.dbus_service_signal(
+        constants.PRODUCTS_INTERFACE,
+        signature=''
+    )
+    @util.dbus_handle_exceptions
+    def InstalledProductsChanged(self):
+        """
+        Signal fired, when installed products is created/deleted/changed
+        :return: None
+        """
+        log.debug("D-Bus signal %s emitted" % constants.PRODUCTS_INTERFACE)
+        return None
+
     @util.dbus_service_method(
         constants.PRODUCTS_INTERFACE,
         in_signature='sa{sv}s',


### PR DESCRIPTION
- integrated with filesystem watcher so that fired on creation,
deletion, or modification
- watches rhsm.productCertDir in /etc/rhsm/rhsm.conf
- added init_logger to start logging