### PR TITLE
ENT-590 Enhanced SyspurposeStore add/remove operations

### DIFF
--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -32,8 +32,10 @@ def add_command(args, syspurposestore):
     :return: None
     """
     for value in args.values:
-        syspurposestore.add(args.prop_name, value)
-    print(_("Added {} to {}").format(args.values, args.prop_name))
+        if syspurposestore.add(args.prop_name, value):
+            print(_("Added {} to {}.").format(value, args.prop_name))
+        else:
+            print(_("Not adding value {} to {}; it already exists.").format(value, args.prop_name))
 
 
 def remove_command(args, syspurposestore):
@@ -46,9 +48,10 @@ def remove_command(args, syspurposestore):
     :return: None
     """
     for value in args.values:
-        syspurposestore.remove(args.prop_name, value)
-    print(_("Removed {} from {}").format(args.values, args.prop_name))
-
+        if syspurposestore.remove(args.prop_name, value):
+            print(_("Removed {} from {}.").format(value, args.prop_name))
+        else:
+            print(_("Not removing value {} from {}; it was not there.").format(value, args.prop_name))
 
 def set_command(args, syspurposestore):
     """

--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -68,13 +68,21 @@ class SyspurposeStore(object):
 
     def add(self, key, value):
         """
-        Add a value to a list of values specified by key
+        Add a value to a list of values specified by key. If the current value specified by the key is scalar/non-list,
+        it is not overridden, but maintained in the list, along with the new value.
         :param key: The name of the list
         :param value: The value to append to the list
         :return: None
         """
         try:
-            self.contents[key].append(value)
+            current_value = self.contents[key]
+            if current_value is not None and not isinstance(current_value, list):
+                self.contents[key] = [current_value]
+
+            if value not in self.contents[key]:
+                self.contents[key].append(value)
+            else:
+                return False
         except (AttributeError, KeyError):
             self.contents[key] = [value]
         return True
@@ -82,12 +90,21 @@ class SyspurposeStore(object):
     def remove(self, key, value):
         """
         Remove a value from a list specified by key.
+        If the current value specified by the key is not a list, unset the value.
         :param key: The name of the list parameter to manipulate
         :param value: The value to attempt to remove
         :return: True if the value was in the list, False if it was not
         """
         try:
-            self.contents[key].remove(value)
+            current_value = self.contents[key]
+            if current_value is not None and not isinstance(current_value, list) and current_value == value:
+                self.contents[key] = None
+                return True
+
+            if value in self.contents[key]:
+                self.contents[key].remove(value)
+            else:
+                return False
             return True
         except (AttributeError, KeyError, ValueError):
             return False


### PR DESCRIPTION
- 'add' will now not override an existing value, if that turns out to be scalar (added by the 'set' command), but it will be maintained and added in a list along with the newly added value.
- 'remove' will now unset the current value, if that turns out to be scalar instead of being contained in a list.