### PR TITLE
Fix indeterminate unit test failure.

### DIFF
--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -21,9 +21,8 @@ import threading
 
 from rhsmlib.dbus import constants
 
-from subscription_manager import ga_loader, logutil
+from subscription_manager import ga_loader
 ga_loader.init_ga()
-logutil.init_logger()
 from subscription_manager.ga import GLib
 from functools import partial
 from rhsmlib.services import config


### PR DESCRIPTION
Loading the log facilities in module scope causes unicode decode errors
in the HandleExceptionTests class when the TestFactsDBusObject is loaded
after it.  Most likely because TestFactsDBusObject is importing the
rhsmlib.dbus.server module and causing some interference in how the
character encoding is set.

---
Test by running

```
nosetests --randomly-seed=1506092144 test.test_managercli test.rhsmlib_test.test_facts
```
