### PR TITLE
ENT-584 syspurpose UTF-8 support & better formatting

### DIFF
--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -17,7 +17,7 @@ from __future__ import print_function, division, absolute_import
 
 import argparse
 from syspurpose.files import SyspurposeStore, USER_SYSPURPOSE
-from syspurpose.utils import in_container
+from syspurpose.utils import in_container, make_utf8
 from syspurpose.i18n import ugettext as _
 import json
 
@@ -33,10 +33,9 @@ def add_command(args, syspurposestore):
     """
     for value in args.values:
         if syspurposestore.add(args.prop_name, value):
-            print(_("Added {} to {}.").format(value, args.prop_name))
+            print(_("Added {} to {}.").format(make_utf8(value), make_utf8(args.prop_name)))
         else:
-            print(_("Not adding value {} to {}; it already exists.").format(value, args.prop_name))
-
+            print(_("Not adding value {} to {}; it already exists.").format(make_utf8(value), make_utf8(args.prop_name)))
 
 def remove_command(args, syspurposestore):
     """
@@ -49,9 +48,9 @@ def remove_command(args, syspurposestore):
     """
     for value in args.values:
         if syspurposestore.remove(args.prop_name, value):
-            print(_("Removed {} from {}.").format(value, args.prop_name))
+            print(_("Removed {} from {}.").format(make_utf8(value), make_utf8(args.prop_name)))
         else:
-            print(_("Not removing value {} from {}; it was not there.").format(value, args.prop_name))
+            print(_("Not removing value {} from {}; it was not there.").format(make_utf8(value), make_utf8(args.prop_name)))
 
 def set_command(args, syspurposestore):
     """
@@ -63,7 +62,7 @@ def set_command(args, syspurposestore):
     :return: None
     """
     syspurposestore.set(args.prop_name, args.value)
-    print(_("{} set to {}").format(args.prop_name, args.value))
+    print(_("{} set to {}").format(make_utf8(args.prop_name), make_utf8(args.value)))
 
 
 def unset_command(args, syspurposestore):
@@ -75,7 +74,7 @@ def unset_command(args, syspurposestore):
     :return: None
     """
     syspurposestore.unset(args.prop_name)
-    print(_("{} unset").format(args.prop_name))
+    print(_("{} unset").format(make_utf8(args.prop_name)))
 
 
 def show_contents(args, syspurposestore):
@@ -86,7 +85,7 @@ def show_contents(args, syspurposestore):
     """
 
     contents = syspurposestore.contents
-    print(json.dumps(contents, indent=2))
+    print(json.dumps(contents, indent=2, ensure_ascii=False))
 
 
 def setup_arg_parser():

--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -18,7 +18,8 @@ from __future__ import print_function, division, absolute_import
 
 import json
 import os
-from syspurpose.utils import system_exit, create_dir, create_file
+import io
+from syspurpose.utils import system_exit, create_dir, create_file, make_utf8, write_to_file_utf8
 from syspurpose.i18n import ugettext as _
 
 # This modules contains utilities for manipulating files pertaining to system syspurpose
@@ -44,8 +45,8 @@ class SyspurposeStore(object):
         :return: False if the contents of the file were empty, or the file doesn't exist; otherwise, nothing.
         """
         try:
-            with open(self.path, 'r') as f:
-                self.contents = json.load(f)
+            with io.open(self.path, 'r', encoding='utf-8') as f:
+                self.contents = json.load(f, encoding='utf-8')
                 return True
         except ValueError:
             return False
@@ -74,6 +75,8 @@ class SyspurposeStore(object):
         :param value: The value to append to the list
         :return: None
         """
+        value = make_utf8(value)
+        key = make_utf8(key)
         try:
             current_value = self.contents[key]
             if current_value is not None and not isinstance(current_value, list):
@@ -95,6 +98,8 @@ class SyspurposeStore(object):
         :param value: The value to attempt to remove
         :return: True if the value was in the list, False if it was not
         """
+        value = make_utf8(value)
+        key = make_utf8(key)
         try:
             current_value = self.contents[key]
             if current_value is not None and not isinstance(current_value, list) and current_value == value:
@@ -115,6 +120,7 @@ class SyspurposeStore(object):
         :param key: The key to unset
         :return: boolean
         """
+        key = make_utf8(key)
         org = self.contents.get(key, None)
         if org is not None:
             self.contents[key] = None
@@ -129,7 +135,9 @@ class SyspurposeStore(object):
         :param value: The value to set that parameter to
         :return: Whether any change was made
         """
-        org = self.contents.get(key, None)
+        value = make_utf8(value)
+        key = make_utf8(key)
+        org = make_utf8(self.contents.get(key, None))
         self.contents[key] = value
         return org != value or org is None
 
@@ -138,11 +146,11 @@ class SyspurposeStore(object):
         Write the current contents to the file at self.path
         """
         if not fp:
-            with open(self.path, 'w') as f:
-                json.dump(self.contents, f)
+            with io.open(self.path, 'w', encoding='utf-8') as f:
+                write_to_file_utf8(f, self.contents)
                 f.flush()
         else:
-            json.dump(self.contents, fp)
+            write_to_file_utf8(fp, self.contents)
 
     @classmethod
     def read(cls, path):

--- a/syspurpose/test/syspurpose/test_syspurposefiles.py
+++ b/syspurpose/test/syspurpose/test_syspurposefiles.py
@@ -16,10 +16,11 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 
 from base import SyspurposeTestBase
+import io
 import json
 import os
 
-from syspurpose import files
+from syspurpose import files, utils
 
 
 class SyspurposeStoreTests(SyspurposeTestBase):
@@ -53,8 +54,24 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         """
         temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
         test_data = {}
-        with open(temp_dir, 'w') as f:
-            json.dump(test_data, f)
+        with io.open(temp_dir, 'w', encoding='utf-8') as f:
+            utils.write_to_file_utf8(f, test_data)
+
+        self.assertTrue(os.path.exists(temp_dir))
+
+        syspurpose_store = self.assertRaisesNothing(files.SyspurposeStore, temp_dir)
+        res = self.assertRaisesNothing(syspurpose_store.read_file)
+        self.assertTrue(bool(res))
+
+    def test_read_file_with_unicode_content(self):
+        """
+        The SyspurposeStore.read_file method should return True if the file with unicode content was successfully read.
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
+        test_data = {'key1': u'Νίκος', 'key2': [u'value_with_ř']}
+        with io.open(temp_dir, 'w', encoding='utf-8') as f:
+            utils.write_to_file_utf8(f, test_data)
 
         self.assertTrue(os.path.exists(temp_dir))
 
@@ -70,11 +87,11 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         :return:
         """
         temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
-        with open(temp_dir, 'w') as f:
+        with io.open(temp_dir, 'w', encoding='utf-8') as f:
             if file_contents and not isinstance(file_contents, str):
-                json.dump(file_contents, f)
+                utils.write_to_file_utf8(f, file_contents)
             else:
-                f.write(file_contents or '')
+                f.write(utils.make_utf8(file_contents or ''))
             f.flush()
         self.assertTrue(os.path.exists(temp_dir), "Unable to create test file in temp dir")
 
@@ -120,8 +137,8 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         """
         temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
         test_data = {"already_present_key": ["preexisting_value"]}
-        with open(temp_dir, 'w') as f:
-            json.dump(test_data, f)
+        with io.open(temp_dir, 'w', encoding='utf-8') as f:
+            utils.write_to_file_utf8(f, test_data)
 
         syspurpose_store = self.assertRaisesNothing(files.SyspurposeStore, temp_dir)
         syspurpose_store.contents = dict(**test_data)
@@ -159,6 +176,26 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         self.assertEqual(syspurpose_store.contents["already_present_key"], ["preexisting_scalar_value", "new_value_2"])
         self.assertTrue(res, "The add method should return true when the store has changed")
 
+    def test_add_with_unicode_strings(self):
+        """
+        Verify that the add method of SyspurposeStore is able to add unicode strings to lists of items
+        in the store.
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
+        test_data = {u'ονόματα': [u'Νίκος']}
+        with io.open(temp_dir, 'w', encoding='utf-8') as f:
+            utils.write_to_file_utf8(f, test_data)
+
+        syspurpose_store = self.assertRaisesNothing(files.SyspurposeStore, temp_dir)
+        syspurpose_store.contents = dict(**test_data)
+
+        # Add to an already seen existing key
+        res = self.assertRaisesNothing(syspurpose_store.add, 'ονόματα', 'Κώστας')
+        self.assertIn(u'ονόματα', syspurpose_store.contents)
+        self.assertEqual(syspurpose_store.contents[u'ονόματα'], [u'Νίκος', u'Κώστας'])
+        self.assertTrue(res, "The add method should return true when the store has changed")
+
     def test_add_does_not_duplicate_existing_value(self):
         """
         Verify that the add method of SyspurposeStore will not add an item to a list, if that list already contains
@@ -186,8 +223,8 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         """
         temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
         test_data = {"already_present_key": ["preexisting_value"]}
-        with open(temp_dir, 'w') as f:
-            json.dump(test_data, f)
+        with io.open(temp_dir, 'w', encoding='utf-8') as f:
+            utils.write_to_file_utf8(f, test_data)
 
         syspurpose_store = self.assertRaisesNothing(files.SyspurposeStore, temp_dir)
         syspurpose_store.contents = dict(**test_data)
@@ -222,6 +259,26 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         self.assertEqual(syspurpose_store.contents["already_present_key"], None)
         self.assertTrue(res, "The remove method should return true when the store has changed")
 
+    def test_remove_with_unicode_strings(self):
+        """
+        Verify that the remove method of SyspurposeStore is able to remove unicode strings from lists of items
+        in the store.
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
+        test_data = {u'ονόματα': [u'Νίκος', u'Κώστας']}
+        with io.open(temp_dir, 'w', encoding='utf-8') as f:
+            utils.write_to_file_utf8(f, test_data)
+
+        syspurpose_store = self.assertRaisesNothing(files.SyspurposeStore, temp_dir)
+        syspurpose_store.contents = dict(**test_data)
+
+        # Remove from an already seen existing key
+        res = self.assertRaisesNothing(syspurpose_store.remove, 'ονόματα', 'Κώστας')
+        self.assertIn(u'ονόματα', syspurpose_store.contents)
+        self.assertEqual(syspurpose_store.contents[u'ονόματα'], [u'Νίκος'])
+        self.assertTrue(res, "The add method should return true when the store has changed")
+
     def test_unset(self):
         """
         Verify the operation of the unset method of SyspurposeStore
@@ -244,6 +301,32 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         # We expect falsey values when the store was not modified
         self.assertFalse(res, "The unset method should return false when the store has not changed")
         self.assertNotIn("unseen_key", syspurpose_store.contents, msg="The key passed to unset, has been added to the store")
+
+    def test_unset_with_unicode_strings(self):
+        """
+        Verify that the unset method of SyspurposeStore is able to unset unicode strings from items
+        in the store.
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
+        test_data = {u'ονόματα': [u'Νίκος']}
+        with io.open(temp_dir, 'w', encoding='utf-8') as f:
+            utils.write_to_file_utf8(f, test_data)
+
+        syspurpose_store = self.assertRaisesNothing(files.SyspurposeStore, temp_dir)
+        syspurpose_store.contents = dict(**test_data)
+
+        res = self.assertRaisesNothing(syspurpose_store.unset, "ονόματα")
+        # We expect a value of true from this method when the store was changed
+        self.assertTrue(res, "The unset method should return true when the store has changed")
+        self.assertIn(u'ονόματα', syspurpose_store.contents, msg="Expected the key to still be in the contents, but reset to None")
+        # We expect the item to have been unset to None
+        self.assertEqual(syspurpose_store.contents[u'ονόματα'], None)
+
+        res = self.assertRaisesNothing(syspurpose_store.unset, 'άκυρο_κλειδί')
+        # We expect falsey values when the store was not modified
+        self.assertFalse(res, "The unset method should return false when the store has not changed")
+        self.assertNotIn(u'άκυρο_κλειδί', syspurpose_store.contents, msg="The key passed to unset, has been added to the store")
 
     def test_set(self):
         """
@@ -274,6 +357,35 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         self.assertIn("new_key", syspurpose_store.contents)
         self.assertEqual(syspurpose_store.contents["new_key"], "new_value_2")
 
+    def test_set_with_unicode_strings(self):
+        """
+        Verify the operation of the set method of SyspurposeStore when using unicode strings
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
+        test_data = {u'ονόματα': u'Νίκος'}
+
+        syspurpose_store = self.assertRaisesNothing(files.SyspurposeStore, temp_dir)
+        syspurpose_store.contents = dict(**test_data)
+
+        # Check the behaviour of manipulating an existing key with an identical value (no update)
+        res = self.assertRaisesNothing(syspurpose_store.set, 'ονόματα', 'Νίκος')
+        self.assertFalse(res, "When a value is not actually changed, set should return false")
+        self.assertIn(u'ονόματα', syspurpose_store.contents)
+        self.assertEqual(syspurpose_store.contents[u'ονόματα'], u'Νίκος')
+
+        # Modify existing item
+        res = self.assertRaisesNothing(syspurpose_store.set, 'ονόματα', 'Κώστας')
+        self.assertTrue(res, "When an item is set to a new value, set should return true")
+        self.assertIn(u'ονόματα', syspurpose_store.contents)
+        self.assertEqual(syspurpose_store.contents[u'ονόματα'], u'Κώστας')
+
+        # Add new item set to a new value
+        res = self.assertRaisesNothing(syspurpose_store.set, 'καινούργιο', 'Άλεξανδρος')
+        self.assertTrue(res, "When an item is set to a new value, set should return true")
+        self.assertIn(u'καινούργιο', syspurpose_store.contents)
+        self.assertEqual(syspurpose_store.contents[u'καινούργιο'], u'Άλεξανδρος')
+
     def test_write(self):
         """
         Verify that the SyspurposeStore can write changes to the expected file.
@@ -286,8 +398,25 @@ class SyspurposeStoreTests(SyspurposeTestBase):
 
         self.assertRaisesNothing(syspurpose_store.write)
 
-        with open(temp_dir, 'r') as f:
-            actual_contents = self.assertRaisesNothing(json.load, f)
+        with io.open(temp_dir, 'r', encoding='utf-8') as f:
+            actual_contents = self.assertRaisesNothing(json.load, f, encoding='utf-8')
+
+        self.assertDictEqual(actual_contents, test_data)
+
+    def test_write_with_unicode_content(self):
+        """
+        Verify that the SyspurposeStore can write changes that include unicode strings to the expected file.
+        :return:
+        """
+        temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
+        test_data = {u'όνομα': u'Νίκος'}
+        syspurpose_store = self.assertRaisesNothing(files.SyspurposeStore, temp_dir)
+        syspurpose_store.contents = dict(**test_data)
+
+        self.assertRaisesNothing(syspurpose_store.write)
+
+        with io.open(temp_dir, 'r', encoding='utf-8') as f:
+            actual_contents = self.assertRaisesNothing(json.load, f, encoding='utf-8')
 
         self.assertDictEqual(actual_contents, test_data)
 
@@ -299,8 +428,8 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
         test_data = {"arbitrary_key": "arbitrary_value"}
 
-        with open(temp_dir, 'w') as f:
-            json.dump(test_data, f)
+        with io.open(temp_dir, 'w', encoding='utf-8') as f:
+            utils.write_to_file_utf8(f, test_data)
 
         syspurpose_store = self.assertRaisesNothing(files.SyspurposeStore.read, temp_dir)
         self.assertDictEqual(syspurpose_store.contents, test_data)

--- a/syspurpose/test/syspurpose/test_utils.py
+++ b/syspurpose/test/syspurpose/test_utils.py
@@ -18,6 +18,7 @@ from __future__ import print_function, division, absolute_import
 # A group of tests for the miscellaneous utilities in the utils module of syspurpose
 
 from base import SyspurposeTestBase
+import io
 import os
 import json
 import mock
@@ -74,15 +75,15 @@ class UtilsTests(SyspurposeTestBase):
         self.assertTrue(res)
         self.assertTrue(os.path.exists(to_create))
 
-        with open(to_create, 'r') as fp:
-            actual_contents = json.load(fp)
+        with io.open(to_create, 'r', encoding='utf-8') as fp:
+            actual_contents = json.load(fp, encoding='utf-8')
 
         self.assertDictEqual(actual_contents, test_data)
 
         to_create = os.path.join(temp_dir, "my_super_chill_file.json")
 
         # And now when the file appears to exist
-        with mock.patch('syspurpose.utils.open') as mock_open:
+        with mock.patch('syspurpose.utils.io.open') as mock_open:
             error_to_raise = OSError()
             error_to_raise.errno = os.errno.EEXIST
             mock_open.side_effect = error_to_raise
@@ -93,7 +94,7 @@ class UtilsTests(SyspurposeTestBase):
         to_create = os.path.join(temp_dir, "my_other_cool_file.json")
 
         # And now with an unexpected OSError
-        with mock.patch('syspurpose.utils.open') as mock_open:
+        with mock.patch('syspurpose.utils.io.open') as mock_open:
             error_to_raise = OSError()
             error_to_raise.errno = os.errno.E2BIG  # Anything aside from the ones expected
             mock_open.side_effect = error_to_raise


### PR DESCRIPTION
- All syspurpose operations now support UTF-8
- syspurpose.json now has user-friendly indentation