### PR TITLE
ENT-717: Syncing of syspurpose store with candlepin

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1052,7 +1052,10 @@ class UEPConnection(object):
         if role is not None:
             params['role'] = role
         if addons is not None:
-            params['addOns'] = addons
+            if isinstance(addons, list):
+                params['addOns'] = addons
+            elif isinstance(addons, str):
+                params['addOns'] = [addons]
         if usage is not None:
             params['usage'] = usage
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1183,10 +1183,10 @@ class RegisterCommand(UserPassCommand):
             if self.options.consumerid:
                 log.info("Registering as existing consumer: %s" % self.options.consumerid)
                 consumer = service.register(None, consumerid=self.options.consumerid,
-                                            role=syspurpose.get('role'),
-                                            addons=syspurpose.get('addons'),
-                                            service_level=syspurpose.get('service_level_agreement'),
-                                            usage=syspurpose.get('usage')
+                                            role=syspurpose.get('role') or '',
+                                            addons=syspurpose.get('addons') or [''],
+                                            service_level=syspurpose.get('service_level_agreement') or '',
+                                            usage=syspurpose.get('usage') or ''
                                             )
             else:
                 owner_key = self._determine_owner_key(admin_cp)
@@ -1199,10 +1199,10 @@ class RegisterCommand(UserPassCommand):
                     force=self.options.force,
                     name=self.options.consumername,
                     type=self.options.consumertype,
-                    role=syspurpose.get('role'),
-                    addons=syspurpose.get('addons'),
-                    service_level=syspurpose.get('service_level_agreement'),
-                    usage=syspurpose.get('usage')
+                    role=syspurpose.get('role') or '',
+                    addons=syspurpose.get('addons') or [''],
+                    service_level=syspurpose.get('service_level_agreement') or '',
+                    usage=syspurpose.get('usage') or ''
                 )
         except (connection.RestlibException, exceptions.ServiceError) as re:
             log.exception(re)

--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -17,6 +17,7 @@ from __future__ import print_function, division, absolute_import
 
 import argparse
 from syspurpose.files import SyspurposeStore, USER_SYSPURPOSE
+from syspurpose.sync import SyspurposeSync
 from syspurpose.utils import in_container, make_utf8
 from syspurpose.i18n import ugettext as _
 import json
@@ -238,4 +239,15 @@ def main():
 
     if args.requires_write:
         syspurposestore.write()
+
+        try:
+            syspurpose_sync = SyspurposeSync()
+        except ImportError:
+            print(_("Warning: Unable to sync system purpose with candlepin server: rhsm module is not available."))
+        else:
+            ret = syspurpose_sync.send_syspurpose_to_candlepin(syspurposestore)
+            if ret:
+                print(_("System purpose successfully sent to candlepin server."))
+            else:
+                print(_("Unable to sent system purpose to candlepin server"))
     return 0

--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -15,14 +15,15 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
+"""
+This module contains utilities for manipulating files pertaining to system syspurpose
+"""
 
 import json
 import os
 import io
 from syspurpose.utils import system_exit, create_dir, create_file, make_utf8, write_to_file_utf8
 from syspurpose.i18n import ugettext as _
-
-# This modules contains utilities for manipulating files pertaining to system syspurpose
 
 # Constants for locations of the two system syspurpose files
 USER_SYSPURPOSE = "/etc/rhsm/syspurpose/syspurpose.json"
@@ -165,6 +166,7 @@ class SyspurposeStore(object):
         """
         Read the file represented by path. If the file does not exist it is created.
         :param path: The path on the file system to read, should be a json file
+        :param raise_on_error: When it is set to True, then exceptions are raised as expected.
         :return: new SyspurposeStore with the contents read in
         """
         new_store = cls(path, raise_on_error=raise_on_error)

--- a/syspurpose/src/syspurpose/sync.py
+++ b/syspurpose/src/syspurpose/sync.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+"""
+This module contains utilities for syncing system syspurpose with candlepin server
+"""
+
+# We do not want to have hard dependency on rhsm module nor subscription_manager
+try:
+    import rhsm
+    import rhsm.connection
+    import rhsm.certificate2
+    import rhsm.config
+except ImportError:
+    rhsm = None
+
+
+class SyspurposeSync(object):
+    """
+    Sync local, remote and cached system purpose
+    """
+
+    def __new__(cls, *args, **kwargs):
+        """
+        We do not want to create instance of SyspurposeSync, when rhsm module is not available,
+        because it would be useless. When rhsm module is not available, then exception is raised.
+        :return: Instance of Syspurpose, when rhsm module is available. Otherwise raise exception.
+        """
+        if rhsm:
+            return super(SyspurposeSync, cls).__new__(cls)
+        else:
+            raise ImportError('Module rhsm is not available')
+
+    def __init__(self, proxy_server=None, proxy_port=None, proxy_user=None, proxy_pass=None):
+        """
+        Initialization of SyspurposeSync has to have optional arguments with
+        proxy settings, because proxy settings can be part of e.g. command line arguments
+        """
+
+        self.config = rhsm.config.initConfig()
+
+        if proxy_server:
+            self.proxy_server = proxy_server
+            self.proxy_port = proxy_port or rhsm.config.DEFAULT_PROXY_PORT
+            self.proxy_user = proxy_user
+            self.proxy_pass = proxy_pass
+        else:
+            self.proxy_server = self.config.get('server', 'proxy_hostname')
+            self.proxy_port = self.config.get('server', 'proxy_port')
+            self.proxy_user = self.config.get('server', 'proxy_user')
+            self.proxy_pass = self.config.get('server', 'proxy_password')
+
+        self.connection = None
+        self.consumer_uuid = None
+
+    def send_syspurpose_to_candlepin(self, syspurpose_store):
+        """
+        Try to sync system purpose to candlepin server.
+        :param syspurpose_store: Instance of SystempurposeStore
+        :return: True, when system purpose was sent to candlepin server.
+        """
+
+        if rhsm:
+            cert_dir = self.config.get('rhsm', 'consumerCertDir')
+            cert_file_path = cert_dir + '/cert.pem'
+            key_file_path = cert_dir + '/key.pem'
+            self.connection = rhsm.connection.UEPConnection(
+                proxy_hostname=self.proxy_server,
+                proxy_port=self.proxy_port,
+                proxy_user=self.proxy_user,
+                proxy_password=self.proxy_pass,
+                cert_file=cert_file_path,
+                key_file=key_file_path
+            )
+
+            try:
+                consumer_cert = rhsm.certificate.create_from_file(cert_file_path)
+            except rhsm.certificate.CertificateException as err:
+                print('Unable to read consumer certificate: %s' % err)
+                return False
+            consumer_uuid = consumer_cert.subject.get('CN')
+
+            try:
+                self.connection.updateConsumer(
+                    uuid=consumer_uuid,
+                    role=syspurpose_store.contents.get('role') or '',
+                    addons=syspurpose_store.contents.get('addons') or [''],
+                    service_level=syspurpose_store.contents.get('service_level_agreement') or '',
+                    usage=syspurpose_store.contents.get('usage_type') or ''
+                )
+            except Exception as err:
+                print('Unable to update consumer with system purpose: %s' % err)
+                return False
+
+            return True

--- a/syspurpose/src/syspurpose/utils.py
+++ b/syspurpose/src/syspurpose/utils.py
@@ -15,7 +15,9 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
-# Utility methods for the syspurpose command
+"""
+Utility methods for the syspurpose command
+"""
 
 import io
 import json

--- a/syspurpose/test/syspurpose/base.py
+++ b/syspurpose/test/syspurpose/base.py
@@ -41,7 +41,6 @@ class SyspurposeTestBase(unittest.TestCase):
         :return: Whatever the call to the method returns
         """
         method = args[0]
-        err_msg = None
 
         try:
             if kwargs:
@@ -57,6 +56,4 @@ class SyspurposeTestBase(unittest.TestCase):
                 arguments += str(kwargs)
             err_msg = "Expected no exception from method call \"{method}({args})\"\n Got Exception: \"{msg}\"\nTraceback during target method call:\n"\
                 .format(method=method.__name__, args=arguments, msg=str(e)) + "".join(traceback.format_tb(tb))
-
-        if err_msg:
             self.fail(err_msg)

--- a/syspurpose/test/syspurpose/test_syspurpose_sync.py
+++ b/syspurpose/test/syspurpose/test_syspurpose_sync.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+from mock import Mock, patch
+import io
+import os
+from .base import SyspurposeTestBase
+from syspurpose import sync, utils, files
+
+
+class SyspurposeStoreTests(SyspurposeTestBase):
+
+    def test_not_created_sync_object_without_rhsm(self):
+        """Test that SyncpurposeSync() will raise exception, when rhsm module is not available"""
+        with patch("syspurpose.sync.rhsm", None) as mock_rhsm:
+            self.assertRaises(ImportError, sync.SyspurposeSync)
+
+    @patch("syspurpose.sync.rhsm")
+    def test_create_sync_object_with_all_proxy_settings(self, mock_rhsm):
+        """Test creating SyspurposeSync with all arguments"""
+        mock_rhsm.config = Mock
+        mock_rhsm.config.DEFAULT_PROXY_PORT = "3128"
+        mock_rhsm.config.initConfig = Mock()
+        syspurpose_sync = sync.SyspurposeSync("proxy.example.com", "1234", "user", "secret")
+        self.assertEqual(syspurpose_sync.proxy_server, "proxy.example.com")
+        self.assertEqual(syspurpose_sync.proxy_port, "1234")
+        self.assertEqual(syspurpose_sync.proxy_user, "user")
+        self.assertEqual(syspurpose_sync.proxy_pass, "secret")
+
+    @patch("syspurpose.sync.rhsm")
+    def test_create_sync_object_with_rhsm_only_proxy_server(self, mock_rhsm):
+        mock_rhsm.config = Mock()
+        mock_rhsm.config.DEFAULT_PROXY_PORT = "3128"
+        mock_rhsm.config.initConfig = Mock()
+        syspurpose_sync = sync.SyspurposeSync("proxy.example.com")
+        self.assertEqual(syspurpose_sync.proxy_port, "3128")
+
+    @patch("syspurpose.sync.rhsm")
+    def test_create_sync_object_with_rhsm_no_args(self, mock_rhsm):
+        mock_rhsm.config.initConfig = Mock()
+        mock_rhsm.config.initConfig.return_value = Mock()
+        mock_config = mock_rhsm.config.initConfig.return_value
+
+        def rhsm_config_get(section, key):
+            config_proxy_settings = {
+                "proxy_hostname": "proxy.example.com",
+                "proxy_port": "1234",
+                "proxy_user": "user",
+                "proxy_password": "secret"
+            }
+            return config_proxy_settings[key]
+
+        mock_config.get = rhsm_config_get
+        syspurpose_sync = sync.SyspurposeSync()
+        self.assertEqual(syspurpose_sync.proxy_server, "proxy.example.com")
+        self.assertEqual(syspurpose_sync.proxy_port, "1234")
+        self.assertEqual(syspurpose_sync.proxy_user, "user")
+        self.assertEqual(syspurpose_sync.proxy_pass, "secret")
+
+    @patch("syspurpose.sync.rhsm")
+    def test_sync_object_update_consumer_set_data(self, mock_rhsm):
+        # Mocking of rhsm.config
+        mock_rhsm.config = Mock()
+        mock_rhsm.config.DEFAULT_PROXY_PORT = "3128"
+        mock_rhsm.config.initConfig = Mock()
+        instance_config = mock_rhsm.config.initConfig.return_value
+        instance_config.get = Mock(return_value="/path/to/cert")
+        # Mocking of rhsm.connection
+        mock_rhsm.connection = Mock()
+        mock_rhsm.connection.UEPConnection = Mock()
+        instance_uep_connection = mock_rhsm.connection.UEPConnection.return_value
+        instance_uep_connection.updateConsumer = Mock()
+        # Mocking of rhsm.certificate
+        mock_rhsm.certificate = Mock()
+        mock_rhsm.certificate.create_from_file = Mock()
+        instance_certificate = mock_rhsm.certificate.create_from_file.return_value
+        instance_certificate.subject = Mock()
+        instance_certificate.subject.get = Mock(return_value="9d4778ae-80fe-4eed-a631-6be35fded7fe")
+
+        syspurpose_sync = sync.SyspurposeSync("proxy.example.com", "1234", "user", "secret")
+
+        temp_file = os.path.join(self._mktmp(), 'syspurpose_file.json')
+        test_data = {
+            "role": "foo-role",
+            "service_level_agreement": "foo-sla",
+            "addons": ["foo-addons", "bar-addon"],
+            "usage_type": "foo-usage"
+        }
+        with io.open(temp_file, 'w', encoding='utf-8') as f:
+            utils.write_to_file_utf8(f, test_data)
+
+        syspurpose_store = files.SyspurposeStore(temp_file)
+        syspurpose_store.contents = dict(**test_data)
+
+        syspurpose_sync.send_syspurpose_to_candlepin(syspurpose_store)
+
+        instance_uep_connection.updateConsumer.assert_called_once_with(
+            uuid="9d4778ae-80fe-4eed-a631-6be35fded7fe",
+            role="foo-role",
+            service_level="foo-sla",
+            addons=["foo-addons", "bar-addon"],
+            usage="foo-usage"
+        )
+
+    @patch("syspurpose.sync.rhsm")
+    def test_sync_object_update_consumer_unset_data(self, mock_rhsm):
+        # Mocking of rhsm.config
+        mock_rhsm.config = Mock()
+        mock_rhsm.config.DEFAULT_PROXY_PORT = "3128"
+        mock_rhsm.config.initConfig = Mock()
+        instance_config = mock_rhsm.config.initConfig.return_value
+        instance_config.get = Mock(return_value="/path/to/cert")
+        # Mocking of rhsm.connection
+        mock_rhsm.connection = Mock()
+        mock_rhsm.connection.UEPConnection = Mock()
+        instance_uep_connection = mock_rhsm.connection.UEPConnection.return_value
+        instance_uep_connection.updateConsumer = Mock()
+        # Mocking of rhsm.certificate
+        mock_rhsm.certificate = Mock()
+        mock_rhsm.certificate.create_from_file = Mock()
+        instance_certificate = mock_rhsm.certificate.create_from_file.return_value
+        instance_certificate.subject = Mock()
+        instance_certificate.subject.get = Mock(return_value="9d4778ae-80fe-4eed-a631-6be35fded7fe")
+
+        syspurpose_sync = sync.SyspurposeSync("proxy.example.com", "1234", "user", "secret")
+
+        temp_file = os.path.join(self._mktmp(), 'syspurpose_file.json')
+        test_data = {}
+        with io.open(temp_file, 'w', encoding='utf-8') as f:
+            utils.write_to_file_utf8(f, test_data)
+
+        syspurpose_store = files.SyspurposeStore(temp_file)
+        syspurpose_store.contents = dict(**test_data)
+
+        syspurpose_sync.send_syspurpose_to_candlepin(syspurpose_store)
+
+        instance_uep_connection.updateConsumer.assert_called_once_with(
+            uuid="9d4778ae-80fe-4eed-a631-6be35fded7fe",
+            role="",
+            service_level="",
+            addons=[""],
+            usage=""
+        )

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -84,8 +84,8 @@ class CliRegistrationTests(SubManFixture):
         self._inject_ipm()
 
         cmd.main(['register', '--consumerid=123456', '--username=testuser1', '--password=password', '--org=test_org'])
-        self.mock_register.register.assert_called_once_with(None, consumerid='123456', role=None,
-                                                            addons=None, service_level=None, usage=None)
+        self.mock_register.register.assert_called_once_with(None, consumerid='123456', role='',
+                                                            addons=[''], service_level='', usage='')
         mock_entcertlib.update.assert_called_once()
 
     def test_consumerid_with_distributor_id(self):


### PR DESCRIPTION
* Added new module sync to package syspurpose. This module
  includes new class SyspurposeSync
* Class SyspurposeSync is created only in situation, when it is
  possible to import rhsm module. Otherwise exception is raised.
* Method for sending new syspurpose is implemented and
  behavior of updateConsumer was modified a little to be possible
  to reduce list od Add-ons.
* It is possible to set and unset role, sla, usage and addons.
  It is also possible to add new or remove existing values to/from
  list of Add-ons
* Fixed a little bit sending of syspurpose during registration.
* Implemented several unit tests.