### PR TITLE
Raise ioerr when necessary during sp read

### DIFF
--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -61,7 +61,7 @@ class SyspurposeStore(object):
             if ioerr.errno == os.errno.ENOENT:
                 return False
             if self.raise_on_error:
-                raise e
+                raise ioerr
 
     def create(self):
         """


### PR DESCRIPTION
We were raising the wrong thing 'e' at this point, it should be 'ioerr'.
