### PR TITLE
ENT-715 Sync syspurpose with server

### DIFF
--- a/src/subscription_manager/action_client.py
+++ b/src/subscription_manager/action_client.py
@@ -29,7 +29,7 @@ from subscription_manager.factlib import FactsActionInvoker
 from subscription_manager.packageprofilelib import PackageProfileActionInvoker
 from subscription_manager.installedproductslib import InstalledProductsActionInvoker
 from subscription_manager.content_action_client import ContentActionClient
-
+from subscription_manager.syspurposelib import SyspurposeSyncActionInvoker
 
 log = logging.getLogger(__name__)
 
@@ -45,13 +45,14 @@ class ActionClient(base_action_client.BaseActionClient):
         self.profilelib = PackageProfileActionInvoker()
         self.installedprodlib = InstalledProductsActionInvoker()
         self.idcertlib = IdentityCertActionInvoker()
+        self.syspurposelib = SyspurposeSyncActionInvoker()
 
         # WARNING: order is important here, we need to update a number
         # of things before attempting to autoheal, and we need to autoheal
         # before attempting to fetch our certificates:
         lib_set = [self.entcertlib, self.idcertlib, self.content_client,
                    self.factlib, self.profilelib,
-                   self.installedprodlib]
+                   self.installedprodlib, self.syspurposelib]
 
         return lib_set
 
@@ -61,9 +62,10 @@ class HealingActionClient(base_action_client.BaseActionClient):
 
         self.entcertlib = EntCertActionInvoker()
         self.installedprodlib = InstalledProductsActionInvoker()
+        self.syspurposelib = SyspurposeSyncActionInvoker()
         self.healinglib = HealingActionInvoker()
 
-        lib_set = [self.installedprodlib, self.healinglib, self.entcertlib]
+        lib_set = [self.installedprodlib, self.syspurposelib, self.healinglib, self.entcertlib]
 
         return lib_set
 

--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -149,3 +149,7 @@ def main():
         print(_('Unable to update entitlement certificates and repositories'))
         log.exception(e)
         sys.exit(-1)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -22,6 +22,12 @@ This module is an interface to syspurpose's SyspurposeStore class from subscript
 It contains methods for accessing/manipulating the local syspurpose.json metadata file through SyspurposeStore.
 """
 
+from rhsm.connection import ConnectionException
+from subscription_manager.cache import SyspurposeCache
+from subscription_manager import certlib
+from subscription_manager import injection as inj
+from subscription_manager.utils import three_way_merge
+
 import logging
 import json
 import os
@@ -36,6 +42,23 @@ except ImportError:
 
 store = None
 syspurpose = None
+
+# All names that represent syspurpose values locally
+ROLE = 'role'
+ADDONS = 'addons'
+SERVICE_LEVEL = 'service_level_agreement'
+USAGE = 'usage'
+
+# Remote values keyed on the local ones
+LOCAL_TO_REMOTE = {
+    ROLE: 'role',
+    ADDONS: 'addOns',
+    SERVICE_LEVEL: 'serviceLevel',
+    USAGE: 'usage'
+}
+
+# All known syspurpose attributes
+ATTRIBUTES = [ROLE, ADDONS, SERVICE_LEVEL, USAGE]
 
 
 def save_sla_to_syspurpose_metadata(service_level):
@@ -200,7 +223,7 @@ def write():
         return store.write()
 
 
-def read_syspurpose():
+def read_syspurpose(raise_on_error=False):
     """
     Reads the system purpose from the correct location on the file system.
     Makes an attempt to use a SyspurposeStore if available falls back to reading the json directly.
@@ -216,5 +239,146 @@ def read_syspurpose():
             syspurpose = json.load(open(USER_SYSPURPOSE))
         except (os.error, ValueError):
             # In the event this file could not be read treat it as empty
+            if raise_on_error:
+                raise
             syspurpose = {}
     return syspurpose
+
+
+def write_syspurpose(values):
+    """
+    Write the syspurpose to the file system.
+    :param values:
+    :return:
+    """
+    if SyspurposeStore is not None:
+        sp = SyspurposeStore(USER_SYSPURPOSE)
+        sp.contents = values
+        sp.write()
+    else:
+        # Simple backup in case the syspurpose tooling is not installed.
+        try:
+            json.dump(values, open(USER_SYSPURPOSE), ensure_ascii=True, indent=2)
+        except OSError:
+            log.warning('Could not write syspurpose to %s' % USER_SYSPURPOSE)
+            return False
+    return True
+
+
+class SyspurposeSyncActionInvoker(certlib.BaseActionInvoker):
+    """
+    Used by rhsmcertd to sync the syspurpose values locally with those from the Server.
+    """
+
+    def _do_update(self):
+        action = SyspurposeSyncActionCommand()
+        return action.perform()
+
+
+class SyspurposeSyncActionReport(certlib.ActionReport):
+    name = "Syspurpose Sync"
+
+    def record_change(self, change):
+        """
+        Records the change detected by the three_way_merge function into a record in the report.
+        :param change: A util.DiffChange object containing the recorded changes.
+        :return: None
+        """
+        if change.source == 'remote':
+            source = 'Entitlement Server'
+        elif change.source == 'local':
+            source = USER_SYSPURPOSE
+        else:
+            source = 'cached system purpose values'
+        msg = None
+        if change.in_base and not change.in_result:
+            msg = "'{key}' removed by change from {source}".format(key=change.key,
+                                                                     source=source)
+        elif not change.in_base and change.in_result:
+            msg = "'{key}' added with value '{value}' from change in {source}".format(
+                    key=change.key, value=change.new_value, source=source
+            )
+        elif change.in_base and change.previous_value != change.new_value:
+            msg = "'{key}' updated from '{old_value}' to '{old_value}' due to change in {source}"\
+                .format(key=change.key, new_value=change.new_value,
+                        old_value=change.previous_value, source=source)
+
+        if msg:
+            self._updates.append(msg)
+
+
+class SyspurposeSyncActionCommand(object):
+    """
+    Sync the system purpose values, by performing a three-way merge between:
+      - The last known shared state (SyspurposeCache)
+      - The current values on the server
+      - The current values on the file system
+    """
+
+    def __init__(self):
+        self.report = SyspurposeSyncActionReport()
+        self.cp_provider = inj.require(inj.CP_PROVIDER)
+        self.uep = self.cp_provider.get_consumer_auth_cp()
+
+    def perform(self):
+        """
+        Perform the action that this Command represents.
+        :return:
+        """
+        try:
+            self.sync()
+        except ConnectionException as e:
+            self.report._exceptions.append('Unable to sync syspurpose with server: %s' % str(e))
+            self.report._status = 'Failed to sync system purpose'
+        self.report._updates = "\n\t\t ".join(self.report._updates)
+        log.debug("Syspurpose updated: %s" % self.report)
+        return self.report
+
+    def sync(self):
+        """
+        Actually do the sync between client and server.
+        Saves the merged changes between client and server in the SyspurposeCache.
+        :return: The synced values
+        """
+        if not self.uep.has_capability('syspurpose'):
+            log.debug('Server does not support syspurpose, not syncing')
+            return
+
+        consumer_identity = inj.require(inj.IDENTITY)
+        consumer = self.uep.getConsumer(consumer_identity.uuid)
+
+        server_sp = {}
+        sp_cache = SyspurposeCache()
+        # Translate from the remote values to the local, filtering out items not known
+        for attr in ATTRIBUTES:
+            server_sp[attr] = consumer.get(LOCAL_TO_REMOTE[attr])
+
+        try:
+            filesystem_sp = read_syspurpose(raise_on_error=True)
+        except (os.error, ValueError):
+            self.report._exceptions.append(
+                    'Cannot read local syspurpose, trying to update from server only'
+            )
+            result = server_sp
+            log.debug('Unable to read local system purpose at  \'%s\'\nUsing the server values.'
+                      % USER_SYSPURPOSE)
+        else:
+            cached_values = sp_cache.read_cache_only()
+            result = three_way_merge(local=filesystem_sp, base=cached_values, remote=server_sp,
+                                     on_change=self.report.record_change)
+
+        sp_cache.syspurpose = result
+        sp_cache.write_cache()
+
+        write_syspurpose(result)
+
+        self.uep.updateConsumer(consumer_identity.uuid, role=result[ROLE],
+                                addons=result[ADDONS],
+                                service_level=result[SERVICE_LEVEL],
+                                usage=result[USAGE])
+
+        self.report._status = 'Successfully synced system purpose'
+
+        log.debug('Updated syspurpose located at \'%s\'' % USER_SYSPURPOSE)
+
+        return result

--- a/test/test_certmgr.py
+++ b/test/test_certmgr.py
@@ -34,7 +34,7 @@ from rhsm.profile import RPMProfile
 from rhsm.connection import GoneException
 from rhsm.certificate import GMT
 
-from .fixture import SubManFixture
+from .fixture import SubManFixture, set_up_mock_sp_store
 
 
 CONSUMER_DATA = {'releaseVer': {'id': 1, 'releaseVer': '123123'},
@@ -131,10 +131,14 @@ class ActionClientTestBase(SubManFixture):
 
         injection.provide(injection.CERT_SORTER, self.mock_cert_sorter)
 
+        syspurpose_patch = mock.patch('subscription_manager.syspurposelib.SyspurposeStore')
+        self.mock_sp_store = syspurpose_patch.start()
+        self.mock_sp_store, self.mock_sp_store_contents = set_up_mock_sp_store(self.mock_sp_store)
+        self.addCleanup(syspurpose_patch.stop)
+
     def tearDown(self):
         self.patcher3.stop()
         self.patcher6.stop()
-        #self.patcher8.stop()
 
         self.patcher_entcertlib_writer.stop()
 

--- a/test/test_syspurposelib.py
+++ b/test/test_syspurposelib.py
@@ -1,0 +1,283 @@
+from .fixture import SubManFixture, open_mock
+import mock
+import subscription_manager.injection as inj
+from subscription_manager import syspurposelib
+from subscription_manager.syspurposelib import SyspurposeSyncActionCommand, \
+    SyspurposeSyncActionReport, ROLE, ADDONS, SERVICE_LEVEL, USAGE
+import json
+
+
+class SyspurposeLibTests(SubManFixture):
+    """
+    Tests various functions of the syspurposelib module.
+    """
+
+    def setUp(self):
+        super(SyspurposeLibTests, self).setUp()
+
+        patch1 = mock.patch('subscription_manager.syspurposelib.json', wraps=json)
+        self.mock_json = patch1.start()
+        self.addCleanup(patch1.stop)
+
+        patch2 = mock.patch.object(syspurposelib, 'USER_SYSPURPOSE', new="/test/value")
+        self.mock_sp_path = patch2.start()
+        self.addCleanup(patch2.stop)
+
+    def test_write_syspurpose(self):
+        """
+        Test that shows that the write_syspurpose method uses the SyspurposeStore when possible.
+        :return:
+        """
+        test_values = {"role": "Test Role",
+                       "addons": ["Some addon"],
+                       "service_level_agreement": "Premium",
+                       "usage": "Dev",
+                       }
+
+        # First mock out the SyspurposeStore
+        with mock.patch.object(syspurposelib, 'SyspurposeStore') as sp_store:
+            result = syspurposelib.write_syspurpose(test_values)
+
+            sp_store.assert_called_with(syspurposelib.USER_SYSPURPOSE)
+            self.assert_equal_dict(sp_store.return_value.contents, test_values)
+
+            # The current syspurposelib code assumes that the SyspurposeStore.write method
+            # actually writes the values to the correct file.
+            sp_store.return_value.write.assert_called_once()
+
+            self.assertEqual(result, True)
+
+    def test_write_syspurpose_with_no_syspurpose_store(self):
+        """
+        Test that shows the backup method of writing to the syspurpose.json file works.
+        :return:
+        """
+        test_values = {"role": "Test Role",
+                       "addons": ["Some addon"],
+                       "service_level_agreement": "Premium",
+                       "usage": "Dev",
+                       }
+
+        with mock.patch.object(syspurposelib, 'SyspurposeStore', new=None):
+            with open_mock() as mock_open:
+                result = syspurposelib.write_syspurpose(test_values)
+                self.mock_json.dump.assert_called_with(test_values, mock_open, ensure_ascii=True,
+                                                       indent=2)
+                self.assertEqual(result, True)
+                self.assert_equal_dict(json.loads(mock_open.content_out()), test_values)
+
+    def test_write_syspurpose_with_no_syspurpose_store_and_os_error(self):
+        """
+        Test that shows how the write_syspurpose method works with an error opening the file
+        :return:
+        """
+        test_values = {"role": "Test Role",
+                       "addons": ["Some addon"],
+                       "service_level_agreement": "Premium",
+                       "usage": "Dev",
+                       }
+
+        self.mock_json.dump.side_effect = OSError
+
+        with mock.patch.object(syspurposelib, 'SyspurposeStore', new=None):
+            with open_mock() as mock_open:
+                result = syspurposelib.write_syspurpose(test_values)
+                self.mock_json.dump.assert_called_with(test_values, mock_open, ensure_ascii=True,
+                                                       indent=2)
+                self.assertEqual(result, False)
+
+                # We expect the file not to have been modified.
+                self.assertEqual(mock_open.content_out(), "")
+
+
+class SyspurposeSyncActionCommandTests(SubManFixture):
+
+    def setUp(self):
+        super(SyspurposeSyncActionCommandTests, self).setUp()
+
+        self.command = SyspurposeSyncActionCommand()
+        # Some mock data to use in tests
+        self.remote_sp = {"role": "The best role",
+                          "addOns": ["Super shiny Addon 1"],
+                          "serviceLevel": "Topmost",
+                          "usage": "Deviousness",
+                          }
+        self.base = {"role": self.remote_sp["role"],
+                     "addons": self.remote_sp["addOns"],
+                     "service_level_agreement": self.remote_sp["serviceLevel"],
+                     "usage": self.remote_sp["usage"],
+                     }
+        self.local_sp = {"role": "Some Other Role",
+                         "addons": self.remote_sp["addOns"],
+                         "service_level_agreement": self.remote_sp["serviceLevel"],
+                         "usage": self.remote_sp["usage"],
+                         }
+
+    def test_perform(self):
+        """
+        Super simple test to show that the perform method is running sync.
+        :return:
+        """
+        with mock.patch.object(self.command, 'sync') as sync_mock:
+            result = self.command.perform()
+            sync_mock.assert_called_once()
+            self.assertTrue(isinstance(result, SyspurposeSyncActionReport))
+
+    @mock.patch('subscription_manager.syspurposelib.write_syspurpose')
+    @mock.patch('subscription_manager.syspurposelib.three_way_merge')
+    @mock.patch('subscription_manager.syspurposelib.SyspurposeCache')
+    @mock.patch('subscription_manager.syspurposelib.read_syspurpose')
+    def test_sync(self, mock_read_sp, mock_cache, mock_merge, mock_write):
+        """
+        Ensure that sync updates the cache with the result of a three-way-merge with the values
+        from the server, the values from the local file and the cache as the base.
+        :return:
+        """
+        self._inject_mock_valid_consumer()
+
+        # We expect that the remote keys have been mapped to the names used locally
+        # e.g. addOns -> addons.
+        #      serviceLevel -> service_level_agreement
+        translated_remote = self.base
+
+        # We want the cache instance not the class from which it is created
+        mock_cache = mock_cache.return_value
+        mock_cache.read_cache_only.return_value = self.base
+
+        self.stub_cp_provider.consumer_auth_cp._capabilities.append('syspurpose')
+        # We shouldn't expect that there are other values than those that are for syspurpose
+        # although the real return value would include many more attributes
+        self.stub_cp_provider.consumer_auth_cp.registered_consumer_info = self.remote_sp
+        mock_read_sp.return_value = self.local_sp
+
+        # To illustrate the effect of a three way merge in this case, only local changed the role.
+        expected = {
+            "role": self.local_sp["role"],
+            "addons": self.remote_sp["addOns"],
+            "service_level_agreement": self.remote_sp["serviceLevel"],
+            "usage": self.remote_sp["usage"],
+        }
+
+        mock_merge.return_value = expected
+        with mock.patch.object(self.stub_cp_provider.consumer_auth_cp, 'updateConsumer') as update:
+
+            result = self.command.sync()
+
+            mock_cache.read_cache_only.assert_called_once()
+            mock_cache.write_cache.assert_called_once()
+
+            mock_merge.assert_called_once_with(local=self.local_sp,
+                                           base=self.base,
+                                           remote=translated_remote,
+                                           on_change=self.command.report.record_change)
+
+            # The return value of sync should be the return value of the three_way_merge
+            self.assert_equal_dict(result, mock_merge.return_value)
+
+            # The value of the syspurpose attribute is written to the cache on write_cache.
+            # So if these two are the same then the cache will have been updated with the new result.
+            self.assert_equal_dict(mock_cache.syspurpose, mock_merge.return_value)
+
+            mock_write.assert_called_once_with(mock_merge.return_value)
+            ident = inj.require(inj.IDENTITY)
+            update.assert_called_once_with(ident.uuid, role=result[ROLE],
+                                           addons=result[ADDONS],
+                                           service_level=result[SERVICE_LEVEL],
+                                           usage=result[USAGE])
+
+    @mock.patch('subscription_manager.syspurposelib.write_syspurpose')
+    @mock.patch('subscription_manager.syspurposelib.three_way_merge')
+    @mock.patch('subscription_manager.syspurposelib.SyspurposeCache')
+    @mock.patch('subscription_manager.syspurposelib.read_syspurpose')
+    def test_sync_missing_capability(self, mock_read_sp, mock_cache, mock_merge, mock_write):
+        """
+        Show that nothing is done if the server does not support the 'syspurpose' capability.
+        Everything else that would otherwise need to be in place is in place. We are asserting
+        that nothing that would otherwise have been done such as updating the cache, is done.
+        :return:
+        """
+
+        # We want the cache instance not the class from which it is created
+        mock_cache = mock_cache.return_value
+        mock_cache.read_cache_only.return_value = self.base
+        # We shouldn't expect that there are other values than those that are for syspurpose
+        # although the real return value would include many more attributes
+        self.stub_cp_provider.consumer_auth_cp.registered_consumer_info = self.remote_sp
+
+        mock_read_sp.return_value = self.local_sp
+
+        merged = {
+            "role": self.local_sp["role"],
+            "addons": self.remote_sp["addOns"],
+            "service_level_agreement": self.remote_sp["serviceLevel"],
+            "usage": self.remote_sp["usage"],
+        }
+
+        mock_merge.return_value = merged
+
+        with mock.patch.object(self.stub_cp_provider.consumer_auth_cp, 'updateConsumer') as update:
+            result = self.command.sync()
+
+            mock_cache.read_cache_only.assert_not_called()
+            mock_cache.write_cache.assert_not_called()
+
+            mock_merge.assert_not_called()
+            mock_write.assert_not_called()
+            self.assertEqual(result, None)
+
+            update.assert_not_called()
+
+    @mock.patch('subscription_manager.syspurposelib.write_syspurpose')
+    @mock.patch('subscription_manager.syspurposelib.three_way_merge')
+    @mock.patch('subscription_manager.syspurposelib.SyspurposeCache')
+    @mock.patch('subscription_manager.syspurposelib.read_syspurpose')
+    def test_sync_no_syspurpose_file(self, mock_read_sp, mock_cache, mock_merge, mock_write):
+        """
+        Ensure that sync updates the cache with the result of a three-way-merge with the values
+        from the server, the values from the local file and the cache as the base.
+        :return:
+        """
+        self._inject_mock_valid_consumer()
+
+        # We want the cache instance not the class from which it is created
+        mock_cache = mock_cache.return_value
+        mock_cache.read_cache_only.return_value = self.base
+
+        self.stub_cp_provider.consumer_auth_cp._capabilities.append('syspurpose')
+        # We shouldn't expect that there are other values than those that are for syspurpose
+        # although the real return value would include many more attributes
+        self.stub_cp_provider.consumer_auth_cp.registered_consumer_info = self.remote_sp
+
+        mock_read_sp.side_effect = OSError
+
+        # To illustrate the effect of a three way merge in this case, only local changed the role.
+        expected = {
+            "role": self.remote_sp["role"],
+            "addons": self.remote_sp["addOns"],
+            "service_level_agreement": self.remote_sp["serviceLevel"],
+            "usage": self.remote_sp["usage"],
+        }
+
+        mock_merge.return_value = expected
+
+        with mock.patch.object(self.stub_cp_provider.consumer_auth_cp, 'updateConsumer') as update:
+            result = self.command.sync()
+
+            mock_cache.read_cache_only.assert_not_called()
+            mock_cache.write_cache.assert_called_once()
+
+            mock_merge.assert_not_called()
+
+            # The return value of sync should be the return value of the three_way_merge
+            self.assert_equal_dict(result, expected)
+
+            # The value of the syspurpose attribute is written to the cache on write_cache.
+            # So if these two are the same then the cache will have been updated with the new result.
+            self.assert_equal_dict(mock_cache.syspurpose, expected)
+
+            mock_write.assert_called_once_with(expected)
+            ident = inj.require(inj.IDENTITY)
+            update.assert_called_once_with(ident.uuid, role=result[ROLE],
+                                           addons=result[ADDONS],
+                                           service_level=result[SERVICE_LEVEL],
+                                           usage=result[USAGE])


### PR DESCRIPTION
Adds the necessary pieces to allow the system purpose values to be synced
with the server the system is registered to on each run on rhsmcertd as well
as any run of ReposCommand or AttachCommand.

* Adds SyspurposeSyncActionCommand
  - This is the ActionCommand responsible for syncing the local system purpose
    values with the latest available on the server.
    It performs a three-way-merge between the contents of USER_SYSPURPOSE file
    and the remote values from the server with a base of the last cached
    values.

* Adds SyspurposeSyncActionReport for compatibility with the existing
  - ActionClient expectations. Used to report expections that occur
    during the sync.

* Adds SyspurposeSyncActionInvoker
  - This allows the SyspurposeSyncActionCommand to be performed
    for both the regular ActionClient and the HealingActionClient.