### PR TITLE
Sync system purpose for sub-man subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Due to unintuitive behavior with `sys.path`
 as expected. One can run the script like this instead:
 
 ```bash
-PYTHONPATH=./src python -m subscription_manager.scripts.subscription_manager
+PYTHONPATH=./src:./syspurpose/src python -m subscription_manager.scripts.subscription_manager
 ```
 
 Similar for other bin scripts:

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -92,7 +92,7 @@ def save_role_to_syspurpose_metadata(role):
     :return: None
     """
 
-    if SyspurposeStore:
+    if 'SyspurposeStore' in globals() and SyspurposeStore is not None:
         store = SyspurposeStore.read(USER_SYSPURPOSE)
 
         if role is None or role == "":

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -462,7 +462,7 @@ class StubUEP(object):
 
     def updateConsumer(self, consumer, facts=None, installed_products=None,
                        guest_uuids=None, service_level=None, release=None, autoheal=None,
-                       content_tags=None, usage=None):
+                       content_tags=None, addons=None, role=None, usage=None):
         return consumer
 
     def setEnvironmentList(self, env_list):

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1581,6 +1581,8 @@ class TestRoleCommand(TestCliCommand):
     def setUp(self):
         super(TestRoleCommand, self).setUp(False)
         self.cc = self.command_class()
+        self.cc.cp = StubUEP()
+        self.cc.cp.registered_consumer_info['role'] = None
 
     def test_wrong_options_syspurpose_role(self):
         """It is possible to use --set or --unset options. It's not possible to use both of them together."""


### PR DESCRIPTION
* When system purpose is changed using followinf subcommands:
   service-level, role, usage, addons, then system purpose
   is synchronized with candlepin server
* TODO: fix debug log of report message for this case