### PR TITLE
1609048: Replacement of imp module with importlib; ENT-758

### DIFF
--- a/src/rhsmlib/__init__.py
+++ b/src/rhsmlib/__init__.py
@@ -12,18 +12,12 @@ from __future__ import print_function, division, absolute_import
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-import imp
+
+import importlib
 
 
 def import_class(name):
-    """Load a class from a string.  Thanks http://stackoverflow.com/a/547867/61248 """
-    components = name.split('.')
-    current_level = components[0]
-    module_tuple = imp.find_module(current_level)
-    module = imp.load_module(current_level, *module_tuple)
-    for comp in components[1:-1]:
-        # import all the way down to the class
-        module_tuple = imp.find_module(comp, module.__path__)
-        module = imp.load_module(comp, *module_tuple)
-    # the class will be an attribute on the lowest level module
-    return getattr(module, components[-1])
+    """Load a class from the string"""
+    comps = name.split('.')
+    module = importlib.import_module(".".join(comps[0:-1]))
+    return getattr(module, comps[-1])

--- a/src/subscription_manager/ga_loader.py
+++ b/src/subscription_manager/ga_loader.py
@@ -15,7 +15,7 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 #
 
-import imp
+import types
 import os
 import sys
 
@@ -129,7 +129,7 @@ class GaImporter(object):
 
     def _new_module(self, fullname):
         """Create a an empty module, we can populate with impl specific."""
-        ret = sys.modules.setdefault(fullname, imp.new_module(fullname))
+        ret = sys.modules.setdefault(fullname, types.ModuleType(fullname))
         ret.__name__ = fullname
         ret.__loader__ = self
         ret.__filename__ = fullname

--- a/test/rhsmlib_test/test_import_class.py
+++ b/test/rhsmlib_test/test_import_class.py
@@ -1,0 +1,37 @@
+from __future__ import print_function, division, absolute_import
+
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+
+import unittest
+import inspect
+
+from rhsmlib import import_class
+
+
+class TestImportClass(unittest.TestCase):
+
+    def test_import_class(self):
+        """
+        Simple test of importing class. It seems that we cannot use mock,
+        but it is necessary to use some real package with module containing class.
+        This unit test was created due to rewriting import_class to use
+        importlib and not deprecated imp module.
+        """
+        clazz = import_class("rhsmlib.file_monitor.FilesystemWatcher")
+        self.assertTrue(inspect.isclass(clazz))
+
+    # def test_import_new_class(self):
+    #     clazz = new_import_class("rhsmlib.file_monitor.FilesystemWatcher")
+    #     print(clazz)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1609048
* Module imp is deprecated and it can be replaced with
  importlib. The imp is used for Python 2.7 in plugins.py,
  because the implementation of importlib in Python 2.7
  is limited.
* Added one unit test for import_class method.