### PR TITLE
1612472: Add back items removed during latest build

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -66,6 +66,12 @@
 %else
 %global py_package_prefix python
 %global rhsm_package_name subscription-manager-rhsm
+
+%if !(0%{?suse_version})
+%global __python __python2
+%global python_sitearch %python2_sitearch
+%endif
+
 %endif
 
 %global _hardened_build 1
@@ -151,7 +157,7 @@ Source1: %{name}-cockpit-%{version}.tar.gz
 Source2: subscription-manager-rpmlintrc
 %endif
 
-%if 0%{?suse_version} < 1200
+%if 0%{?suse_version} && 0%{?suse_version} < 1200
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 %endif
 
@@ -578,7 +584,6 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 # base/cli tools use the gettext domain 'rhsm', while the
 # gnome-help tools use domain 'subscription-manager'
 %files -f rhsm.lang
-%defattr(-,root,root,-)
 %if 0%{?suse_version}
 %dir %{_sysconfdir}/pki
 
@@ -804,7 +809,6 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 
 %if %{use_rhsm_gtk}
 %files -n rhsm-gtk
-%defattr(-,root,root,-)
 %dir %{python_sitearch}/subscription_manager/gui
 %{python_sitearch}/subscription_manager/gui/*.py*
 %{python_sitearch}/subscription_manager/gui/data/ui/*.ui
@@ -827,7 +831,6 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 %if %{use_subman_gui}
 #%files -n subscription-manager-gui -f subscription-manager.lang
 %files -n subscription-manager-gui
-%defattr(-,root,root,-)
 %attr(755,root,root) %{_sbindir}/subscription-manager-gui
 %if 0%{?suse_version}
 %dir %{python_sitearch}/subscription_manager/gui/data
@@ -874,7 +877,6 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 %if %use_initial_setup
 
 %files -n subscription-manager-initial-setup-addon
-%defattr(-,root,root,-)
 %dir %{_datadir}/anaconda/addons/com_redhat_subscription_manager/
 %{_datadir}/anaconda/addons/com_redhat_subscription_manager/*.py*
 %{_datadir}/anaconda/addons/com_redhat_subscription_manager/gui/*.py*
@@ -894,7 +896,6 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 
 
 %files -n subscription-manager-migration
-%defattr(-,root,root,-)
 %dir %{python_sitearch}/subscription_manager/migrate
 %{python_sitearch}/subscription_manager/migrate/*.py*
 %if %{with python3}
@@ -911,7 +912,6 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 
 %if %{with python3}
 %files -n %{py_package_prefix}-syspurpose
-%defattr(-,root,root,-)
 %dir %{python3_sitelib}/syspurpose*.egg-info
 %{python3_sitelib}/syspurpose*.egg-info/*
 %dir %{_sysconfdir}/rhsm/syspurpose
@@ -921,11 +921,9 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 %doc LICENSE
 
 %attr(755, root, root) %{_sbindir}/syspurpose
-%attr(644,root,root) %{_sysconfdir}/rhsm/syspurpose/valid_fields.json
 %endif
 
 %files -n subscription-manager-plugin-container
-%defattr(-,root,root,-)
 %if 0%{?suse_version}
 %dir %{_sysconfdir}/docker
 %dir %{_sysconfdir}/docker/certs.d
@@ -947,7 +945,6 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 
 %if %has_ostree
 %files -n subscription-manager-plugin-ostree
-%defattr(-,root,root,-)
 %{_sysconfdir}/rhsm/pluginconf.d/ostree_content.OstreeContentPlugin.conf
 %{rhsm_plugins_dir}/ostree_content.py*
 %{python_sitearch}/subscription_manager/plugin/ostree/*.py*
@@ -959,7 +956,6 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 
 %if %use_firstboot
 %files -n subscription-manager-firstboot
-%defattr(-,root,root,-)
 %if 0%{?suse_version}
 %dir %{_datadir}/rhn
 %dir %{_datadir}/rhn/up2date_client
@@ -973,19 +969,16 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 
 %if %use_dnf
 %files -n dnf-plugin-subscription-manager
-%defattr(-,root,root,-)
 %{python_sitelib}/dnf-plugins/*
 %endif
 
 
 %files -n %{rhsm_package_name}
-%defattr(-,root,root,-)
 %dir %{python_sitearch}/rhsm
 %{python_sitearch}/rhsm/*
 
 %if %{with python2_rhsm}
 %files -n python2-subscription-manager-rhsm
-%defattr(-,root,root,-)
 %dir %{python2_sitearch}/rhsm
 %{python2_sitearch}/rhsm/*
 %endif
@@ -998,7 +991,6 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 
 %if %use_cockpit
 %files -n subscription-manager-cockpit
-%defattr(-,root,root,-)
 %dir %{_datadir}/cockpit/subscription-manager
 %{_datadir}/cockpit/subscription-manager/index.html
 %{_datadir}/cockpit/subscription-manager/index.min.js.gz
@@ -1181,6 +1173,9 @@ gtk-update-icon-cache -f %{_datadir}/icons/hicolor &>/dev/null || :
 - 1576423: Polished changes provided in #1816 and added unit test.
   (jhnidek@redhat.com)
 
+* Sat Jul 14 2018 Fedora Release Engineering <releng@fedoraproject.org> - 1.21.5-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_29_Mass_Rebuild
+
 * Fri Jun 22 2018 Christopher Snyder <csnyder@redhat.com> 1.22.1-1
 - 1571998: Ignore HTB repos (nmoumoul@redhat.com)
 - 1589296: subman list option --after now named --afterdate
@@ -1207,6 +1202,9 @@ gtk-update-icon-cache -f %{_datadir}/icons/hicolor &>/dev/null || :
 - 1510920: Allow access to job cancellation API (wpoteat@redhat.com)
 - ENT-447 Add icons to RPM package for subman cockpit plugin
   (jhnidek@redhat.com)
+
+* Tue Jun 19 2018 Miro Hrončok <mhroncok@redhat.com> - 1.21.5-2
+- Rebuilt for Python 3.7
 
 * Fri Jun 08 2018 Christopher Snyder <csnyder@redhat.com> 1.22.0-1
 - Remove F26 from releasers (Fedora 26 EOL) (csnyder@redhat.com)


### PR DESCRIPTION
This adds back the equivalent of the changes from the following commits which were removed accidentally during a build.
Commits:

https://src.fedoraproject.org/rpms/subscription-manager/c/b5adf3c36513d38378c21b85e0e812a8cab67982
https://src.fedoraproject.org/rpms/subscription-manager/c/bb002d86e73ab6e401f6f03dd8eeb4bd0c1aec00
https://src.fedoraproject.org/rpms/subscription-manager/c/86ba5e1bf699e4ca2a7b8e2c157677a1f275f1a6
https://src.fedoraproject.org/rpms/subscription-manager/c/aa3278fa5e431516f6f771a156bb97955c4e2fc4
https://src.fedoraproject.org/rpms/subscription-manager/c/618e9703cbd8c7d9b4ded5409fb7066c8fd2ce22
https://src.fedoraproject.org/rpms/subscription-manager/c/af2ac8684eafd3d10f3d4e32077b8e7304af384b

Also note the builds in the changelog are a bit out of order as the spec file for the upstream project (in this repo) had produced new build which were not released concurrently as changes were made in the fedora spec file.

I'd propose that for any new release of subman we first merge any changes made to the spec file made in the fedora repo before creating a new build at all.