### PR TITLE
1596294: Fix displayin RHSM Spoke in Initial Setup, ENT-753

### DIFF
--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
@@ -22,7 +22,6 @@ import logging
 
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.ui.gui.spokes import NormalSpoke
-from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
 from pyanaconda.ui.gui.utils import really_hide
@@ -52,7 +51,7 @@ __all__ = ["RHSMSpoke"]
 configure_gettext()
 
 
-class RHSMSpoke(FirstbootSpokeMixIn, NormalSpoke):
+class RHSMSpoke(NormalSpoke):
     """
     Spoke used for registration of system in Anaconda or Initial Setup
     """
@@ -69,6 +68,11 @@ class RHSMSpoke(FirstbootSpokeMixIn, NormalSpoke):
         category = SystemCategory
     icon = "subscription-manager"
     title = "_Subscription Manager"
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Run this spoke for Anaconda and InitialSetup"""
+        return True
 
     def __init__(self, data, storage, payload, instclass):
         NormalSpoke.__init__(self, data, storage, payload, instclass)

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -798,6 +798,14 @@ install -m 644 %{_builddir}/%{buildsubdir}/etc-conf/ca/redhat-uep.pem %{buildroo
 %{python_sitearch}/subscription_manager/gui/data/ui/*.ui
 %{python_sitearch}/subscription_manager/gui/data/glade/*.glade
 %{python_sitearch}/subscription_manager/gui/data/icons/*.svg
+%{_datadir}/icons/hicolor/16x16/apps/*.png
+%{_datadir}/icons/hicolor/22x22/apps/*.png
+%{_datadir}/icons/hicolor/24x24/apps/*.png
+%{_datadir}/icons/hicolor/32x32/apps/*.png
+%{_datadir}/icons/hicolor/48x48/apps/*.png
+%{_datadir}/icons/hicolor/96x96/apps/*.png
+%{_datadir}/icons/hicolor/256x256/apps/*.png
+%{_datadir}/icons/hicolor/scalable/apps/*.svg
 %if %{with python3}
 %{python_sitearch}/subscription_manager/gui/__pycache__
 %endif
@@ -833,14 +841,6 @@ install -m 644 %{_builddir}/%{buildsubdir}/etc-conf/ca/redhat-uep.pem %{buildroo
 %{_datadir}/omf/subscription-manager/subscription-manager-C.omf
 
 %{_datadir}/applications/subscription-manager-gui.desktop
-%{_datadir}/icons/hicolor/16x16/apps/*.png
-%{_datadir}/icons/hicolor/22x22/apps/*.png
-%{_datadir}/icons/hicolor/24x24/apps/*.png
-%{_datadir}/icons/hicolor/32x32/apps/*.png
-%{_datadir}/icons/hicolor/48x48/apps/*.png
-%{_datadir}/icons/hicolor/96x96/apps/*.png
-%{_datadir}/icons/hicolor/256x256/apps/*.png
-%{_datadir}/icons/hicolor/scalable/apps/*.svg
 %{_datadir}/appdata/subscription-manager-gui.appdata.xml
 
 # desktop config files


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1596294
* It was necessary to implement own should_run() method to be
  sure that RHSM Spoke is visible in Anaconda and Initial Setup
* Moved icons to rhsm-gtk, because icons are required by
  subman-gui as well by RHSM Spoke