### PR TITLE
Fix synchronization of usage with candlepin

### DIFF
--- a/syspurpose/src/syspurpose/sync.py
+++ b/syspurpose/src/syspurpose/sync.py
@@ -100,7 +100,7 @@ class SyspurposeSync(object):
                     role=syspurpose_store.contents.get('role') or '',
                     addons=syspurpose_store.contents.get('addons') or [''],
                     service_level=syspurpose_store.contents.get('service_level_agreement') or '',
-                    usage=syspurpose_store.contents.get('usage_type') or ''
+                    usage=syspurpose_store.contents.get('usage') or ''
                 )
             except Exception as err:
                 print('Unable to update consumer with system purpose: %s' % err)

--- a/syspurpose/test/syspurpose/test_syspurpose_sync.py
+++ b/syspurpose/test/syspurpose/test_syspurpose_sync.py
@@ -98,7 +98,7 @@ class SyspurposeStoreTests(SyspurposeTestBase):
             "role": "foo-role",
             "service_level_agreement": "foo-sla",
             "addons": ["foo-addons", "bar-addon"],
-            "usage_type": "foo-usage"
+            "usage": "foo-usage"
         }
         with io.open(temp_file, 'w', encoding='utf-8') as f:
             utils.write_to_file_utf8(f, test_data)


### PR DESCRIPTION
* Caused by #1887 (renaming 'usage_type' to 'usage').