### PR TITLE
Sync the syspurpose on runs of each relevant command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Due to unintuitive behavior with `sys.path`
 as expected. One can run the script like this instead:
 
 ```bash
-PYTHONPATH=./src python -m subscription_manager.scripts.subscription_manager
+PYTHONPATH=./src:./syspurpose/src python -m subscription_manager.scripts.subscription_manager
 ```
 
 Similar for other bin scripts:

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -856,6 +856,7 @@ def clean_all_data(backup=True):
     # for deleting persistent caches
     cache.ProfileManager.delete_cache()
     cache.InstalledProductsManager.delete_cache()
+    cache.SyspurposeCache.delete_cache()
 
     # FIXME: implement as dbus client to facts service DeleteCache() once implemented
     #Facts.delete_cache()

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -92,7 +92,7 @@ def save_role_to_syspurpose_metadata(role):
     :return: None
     """
 
-    if SyspurposeStore:
+    if 'SyspurposeStore' in globals() and SyspurposeStore is not None:
         store = SyspurposeStore.read(USER_SYSPURPOSE)
 
         if role is None or role == "":
@@ -299,7 +299,7 @@ class SyspurposeSyncActionReport(certlib.ActionReport):
                     key=change.key, value=change.new_value, source=source
             )
         elif change.in_base and change.previous_value != change.new_value:
-            msg = "'{key}' updated from '{old_value}' to '{old_value}' due to change in {source}"\
+            msg = "'{key}' updated from '{old_value}' to '{new_value}' due to change in {source}"\
                 .format(key=change.key, new_value=change.new_value,
                         old_value=change.previous_value, source=source)
 
@@ -320,19 +320,23 @@ class SyspurposeSyncActionCommand(object):
         self.cp_provider = inj.require(inj.CP_PROVIDER)
         self.uep = self.cp_provider.get_consumer_auth_cp()
 
-    def perform(self):
+    def perform(self, include_result=False):
         """
         Perform the action that this Command represents.
         :return:
         """
+        result = {}
         try:
-            self.sync()
+            result = self.sync()
         except ConnectionException as e:
             self.report._exceptions.append('Unable to sync syspurpose with server: %s' % str(e))
             self.report._status = 'Failed to sync system purpose'
         self.report._updates = "\n\t\t ".join(self.report._updates)
         log.debug("Syspurpose updated: %s" % self.report)
-        return self.report
+        if not include_result:
+            return self.report
+        else:
+            return self.report, result
 
     def sync(self):
         """
@@ -342,7 +346,7 @@ class SyspurposeSyncActionCommand(object):
         """
         if not self.uep.has_capability('syspurpose'):
             log.debug('Server does not support syspurpose, not syncing')
-            return
+            return read_syspurpose()
 
         consumer_identity = inj.require(inj.IDENTITY)
         consumer = self.uep.getConsumer(consumer_identity.uuid)
@@ -351,7 +355,10 @@ class SyspurposeSyncActionCommand(object):
         sp_cache = SyspurposeCache()
         # Translate from the remote values to the local, filtering out items not known
         for attr in ATTRIBUTES:
-            server_sp[attr] = consumer.get(LOCAL_TO_REMOTE[attr])
+            value = consumer.get(LOCAL_TO_REMOTE[attr])
+            if value is None:
+                value = ""
+            server_sp[attr] = value
 
         try:
             filesystem_sp = read_syspurpose(raise_on_error=True)
@@ -371,11 +378,14 @@ class SyspurposeSyncActionCommand(object):
         sp_cache.write_cache()
 
         write_syspurpose(result)
-
-        self.uep.updateConsumer(consumer_identity.uuid, role=result[ROLE],
-                                addons=result[ADDONS],
-                                service_level=result[SERVICE_LEVEL],
-                                usage=result[USAGE])
+        addons = result.get(ADDONS)
+        self.uep.updateConsumer(
+                consumer_identity.uuid,
+                role=result.get(ROLE) or "",
+                addons=addons if addons is not None else "",
+                service_level=result.get(SERVICE_LEVEL) or "",
+                usage=result.get(USAGE) or ""
+        )
 
         self.report._status = 'Successfully synced system purpose'
 

--- a/test/gui/test_registrationgui.py
+++ b/test/gui/test_registrationgui.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from mock import Mock, patch
 
-from test.fixture import SubManFixture
+from test.fixture import SubManFixture, set_up_mock_sp_store
 
 from test.stubs import StubBackend, StubFacts
 from subscription_manager.gui.registergui import RegisterWidget, RegisterInfo,  \
@@ -235,6 +235,10 @@ class AsyncBackendTests(SubManFixture):
         super(AsyncBackendTests, self).setUp()
         self.backend = StubBackend()
         self.asyncBackend = AsyncBackend(self.backend)
+        syspurpose_patch = patch('subscription_manager.syspurposelib.SyspurposeStore')
+        self.mock_sp_store = syspurpose_patch.start()
+        self.mock_sp_store, self.mock_sp_store_contents = set_up_mock_sp_store(self.mock_sp_store)
+        self.addCleanup(syspurpose_patch.stop)
 
     def test_auto_system_complete(self):
         self.backend.cp_provider.get_consumer_auth_cp().getConsumer = \

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -462,7 +462,7 @@ class StubUEP(object):
 
     def updateConsumer(self, consumer, facts=None, installed_products=None,
                        guest_uuids=None, service_level=None, release=None, autoheal=None,
-                       content_tags=None, usage=None):
+                       content_tags=None, addons=None, role=None, usage=None):
         return consumer
 
     def setEnvironmentList(self, env_list):

--- a/test/test_syspurposelib.py
+++ b/test/test_syspurposelib.py
@@ -223,7 +223,7 @@ class SyspurposeSyncActionCommandTests(SubManFixture):
 
             mock_merge.assert_not_called()
             mock_write.assert_not_called()
-            self.assertEqual(result, None)
+            self.assertEqual(result, self.local_sp)
 
             update.assert_not_called()
 


### PR DESCRIPTION
This revises the Role, Usage, Addons, and ServiceLevel Commands.
Each of these now perform the sync action and display a message with a course of action if the result is not as expected.

The way to get this message to show up is in the reproducer steps in [This bug](https://bugzilla.redhat.com/show_bug.cgi?id=1615404)