### PR TITLE
1613968: DNF product-id plugin can install product cert; ENT-789

### DIFF
--- a/src/plugins/product-id.py
+++ b/src/plugins/product-id.py
@@ -87,7 +87,7 @@ class YumProductManager(ProductManager):
                 # the ones we create, or anaconda doesn't install it.
                 self.meta_data_errors.append(repo.id)
             except Exception as e:
-                log.warn("Error loading productid metadata for %s." % repo)
+                log.warning("Error loading productid metadata for %s." % repo)
                 log.exception(e)
                 self.meta_data_errors.append(repo.id)
 

--- a/test/test_yum_content_plugin.py
+++ b/test/test_yum_content_plugin.py
@@ -119,7 +119,7 @@ class TestYumProductManager(fixture.SubManFixture):
         self.mock_yb.repos.listEnabled.return_value = [mock_repo]
         enabled = pm.get_enabled()
 
-        self.assertTrue(mock_log.warn.called)
+        self.assertTrue(mock_log.warning.called)
         self.assertEqual([], enabled)
 
     @mock.patch('yum_product_id.log')


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1613968
* Temporary directory was deleted too early (with statement)
* It is necessary to refresh list of installed packages to get
  new repository in list of active repositories
* Replaced warn with warning and fixed one unit test