### PR TITLE
1623368: Register a system without a syspurpose.json file

### DIFF
--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -237,7 +237,7 @@ def read_syspurpose(raise_on_error=False):
     else:
         try:
             syspurpose = json.load(open(USER_SYSPURPOSE))
-        except (os.error, ValueError):
+        except (os.error, ValueError, IOError):
             # In the event this file could not be read treat it as empty
             if raise_on_error:
                 raise


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1623368