### PR TITLE
1623262: Make automatic enablement of yum plugins working again; ENT-820

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,11 +112,7 @@ build: rhsmcertd rhsm-icon
 # Install doesn't perform a build if it doesn't have too.  Best to clean out
 # any cruft so developers don't end up install old builds.
 	$(PYTHON) ./setup.py clean --all
-	if [ "$(OS)" = "RHEL" -a "$(OS_VERSION)" -gt 7 ] || [ "$(OS)" = "FEDORA" -a "$(OS_VERSION)" -gt 21 ] ; then \
-            $(PYTHON) ./setup.py build --quiet --gtk-version=$(GTK_VERSION) --rpm-version=$(VERSION) --use-dnf=true; \
-        else \
-            $(PYTHON) ./setup.py build --quiet --gtk-version=$(GTK_VERSION) --rpm-version=$(VERSION) --use-dnf=false; \
-        fi; \
+	$(PYTHON) ./setup.py build --quiet --gtk-version=$(GTK_VERSION) --rpm-version=$(VERSION)
 
 # we never "remake" this makefile, so add a target so
 # we stop searching for implicit rules on how to remake it

--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -67,7 +67,7 @@ pluginDir = /usr/share/rhsm-plugins
 # The directory to search for plugin configuration files
 pluginConfDir = /etc/rhsm/pluginconf.d
 
-# Manage automatic enabling of yum plugins (product-id, subscription-manager)
+# Manage automatic enabling of yum/dnf plugins (product-id, subscription-manager)
 auto_enable_yum_plugins = 1
 
 # Inotify is used for monitoring changes in directories with certificates.

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -189,7 +189,7 @@ The directory to search for plug-in configuration files
 .PP
 auto_enable_yum_plugins
 .RS 4
-When this option is enabled, then yum plugins subscription-manager and product-id are enabled every-time subscription-manager or subscription-manager-gui is executed.
+When this option is enabled, then yum/dnf plugins subscription-manager and product-id are enabled every-time subscription-manager or subscription-manager-gui is executed.
 .RE
 .PP
 inotify

--- a/setup.py
+++ b/setup.py
@@ -45,23 +45,25 @@ from build_ext import i18n, lint, template, utils
 class rpm_version_release_build_py(_build_py):
     user_options = _build_py.user_options + [
         ('gtk-version=', None, 'GTK version this is built for'),
-        ('rpm-version=', None, 'version and release of the RPM this is built for'),
-        ('use-dnf=', None, 'True if dnf is used, False if yum is used')]
+        ('rpm-version=', None, 'version and release of the RPM this is built for')]
 
     def initialize_options(self):
         _build_py.initialize_options(self)
         self.rpm_version = None
         self.gtk_version = None
         self.versioned_packages = []
-        self.use_dnf = None
 
     def finalize_options(self):
         _build_py.finalize_options(self)
-        self.set_undefined_options('build', ('rpm_version', 'rpm_version'), ('gtk_version', 'gtk_version'),
-            ('use_dnf', 'use_dnf'))
+        self.set_undefined_options(
+            'build',
+            ('rpm_version', 'rpm_version'),
+            ('gtk_version', 'gtk_version')
+        )
 
     def run(self):
-        log.info("Building with GTK_VERSION=%s, RPM_VERSION=%s and USE_DNF = %s" % (self.gtk_version, self.rpm_version, self.use_dnf))
+        log.info("Building with GTK_VERSION=%s, RPM_VERSION=%s" %
+                 (self.gtk_version, self.rpm_version))
         _build_py.run(self)
         # create a "version.py" that includes the rpm version
         # info passed to our new build_py args
@@ -75,7 +77,6 @@ class rpm_version_release_build_py(_build_py):
                         for l in f.readlines():
                             l = l.replace("RPM_VERSION", str(self.rpm_version))
                             l = l.replace("GTK_VERSION", str(self.gtk_version))
-                            l = l.replace("USE_DNF", str(self.use_dnf))
                             lines.append(l)
 
                     with open(version_file, 'w') as f:
@@ -89,7 +90,6 @@ class install(_install):
     user_options = _install.user_options + [
         ('gtk-version=', None, 'GTK version this is built for'),
         ('rpm-version=', None, 'version and release of the RPM this is built for'),
-        ('use-dnf=', None, 'True if dnf is used, False if yum is used'),
         ('with-systemd=', None, 'whether to install w/ systemd support or not'),
         ('with-subman-gui=', None, 'whether to install subman GUI or not'),
         ('with-cockpit-desktop-entry=', None, 'whether to install desktop entry for subman cockpit plugin or not')
@@ -99,28 +99,29 @@ class install(_install):
         _install.initialize_options(self)
         self.rpm_version = None
         self.gtk_version = None
-        self.use_dnf = None
         self.with_systemd = None
         self.with_subman_gui = None
         self.with_cockpit_desktop_entry = None
 
     def finalize_options(self):
         _install.finalize_options(self)
-        self.set_undefined_options('build', ('rpm_version', 'rpm_version'), ('gtk_version', 'gtk_version'),
-            ('use_dnf', 'use_dnf'))
+        self.set_undefined_options(
+            'build',
+            ('rpm_version', 'rpm_version'),
+            ('gtk_version', 'gtk_version')
+        )
 
 
 class build(_build):
     user_options = _build.user_options + [
         ('gtk-version=', None, 'GTK version this is built for'),
-        ('rpm-version=', None, 'version and release of the RPM this is built for'),
-        ('use-dnf=', None, 'True if dnf is used, False if yum is used')]
+        ('rpm-version=', None, 'version and release of the RPM this is built for')
+    ]
 
     def initialize_options(self):
         _build.initialize_options(self)
         self.rpm_version = None
         self.gtk_version = None
-        self.use_dnf = None
         self.git_tag_prefix = "subscription-manager-"
 
     def finalize_options(self):
@@ -130,9 +131,6 @@ class build(_build):
 
         if not self.gtk_version:
             self.gtk_version = self.get_gtk_version()
-
-        if not self.use_dnf:
-            self.use_dnf = False
 
     def get_git_describe(self):
         try:

--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -323,7 +323,7 @@ class MainWindow(widgets.SubmanBaseWidget):
         if auto_launch_registration and not self.registered():
             self._register_item_clicked(None)
 
-        enabled_yum_plugins = YumPluginManager.enable_yum_plugins()
+        enabled_yum_plugins = YumPluginManager.enable_pkg_plugins()
         if len(enabled_yum_plugins) > 0:
             messageWindow.InfoDialog(
                 YumPluginManager.warning_message(enabled_yum_plugins),

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2885,7 +2885,7 @@ class ManagerCLI(CLI):
         managerlib.check_identity_cert_perms()
         ret = CLI.main(self)
         # Try to enable all yum plugins (subscription-manager and plugin-id)
-        enabled_yum_plugins = YumPluginManager.enable_yum_plugins()
+        enabled_yum_plugins = YumPluginManager.enable_pkg_plugins()
         if len(enabled_yum_plugins) > 0:
             print('\n' + _('WARNING') + '\n\n' + YumPluginManager.warning_message(enabled_yum_plugins) + '\n')
         # Try to flush all outputs, see BZ: 1350402

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -994,7 +994,7 @@ def main(args=None, five_to_six_script=False):
     MigrationEngine(options).main()
 
     # Try to enable yum plugins: subscription-manager and product-id
-    enabled_yum_plugins = repolib.YumPluginManager.enable_yum_plugins()
+    enabled_yum_plugins = repolib.YumPluginManager.enable_pkg_plugins()
     if len(enabled_yum_plugins) > 0:
         print(_('WARNING') + '\n\n' + repolib.YumPluginManager.warning_message(enabled_yum_plugins) + '\n')
 

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -237,7 +237,7 @@ def read_syspurpose(raise_on_error=False):
     else:
         try:
             syspurpose = json.load(open(USER_SYSPURPOSE))
-        except (os.error, ValueError):
+        except (os.error, ValueError, IOError):
             # In the event this file could not be read treat it as empty
             if raise_on_error:
                 raise

--- a/src/subscription_manager/version.py
+++ b/src/subscription_manager/version.py
@@ -3,4 +3,3 @@ from __future__ import print_function, division, absolute_import
 # The values in this file are populated by setup.py build
 rpm_version = "RPM_VERSION"
 gtk_version = "GTK_VERSION"
-use_dnf = "USE_DNF"

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -96,14 +96,14 @@
 %define install_zypper_plugins INSTALL_ZYPPER_PLUGINS=false
 %endif
 
-# makefile defaults to INSTALL_DNF_PLUGIN=false
+# makefile defaults to INSTALL_DNF_PLUGINS=false
 %if %{use_dnf}
 %define install_dnf_plugins INSTALL_DNF_PLUGINS=true
 %else
 %define install_dnf_plugins INSTALL_DNF_PLUGINS=false
 %endif
 
-# makefile defaults to INSTALL_DNF_PLUGIN=true
+# makefile defaults to INSTALL_YUM_PLUGINS=true
 %if %{use_yum}
 %define install_yum_plugins INSTALL_YUM_PLUGINS=true
 %else
@@ -498,7 +498,8 @@ Subscription Manager Cockpit UI
 
 %build
 make -f Makefile VERSION=%{version}-%{release} CFLAGS="%{optflags}" \
-    LDFLAGS="%{__global_ldflags}" OS_DIST="%{dist}" PYTHON="%{__python}" %{?gtk_version} %{?subpackages} %{?include_syspurpose:INCLUDE_SYSPURPOSE="1"}
+    LDFLAGS="%{__global_ldflags}" OS_DIST="%{dist}" PYTHON="%{__python}" \
+    %{?gtk_version} %{?subpackages} %{?include_syspurpose:INCLUDE_SYSPURPOSE="1"}
 
 %if %{with python2_rhsm}
 python2 ./setup.py build --quiet --gtk-version=%{?gtk3:3}%{?!gtk3:2} --rpm-version=%{version}-%{release}

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -886,57 +886,57 @@ class TestManageReposEnabled(fixture.SubManFixture):
         self.assertEqual(manage_repos_enabled, True)
 
 
-AUTO_ENABLE_YUM_PLUGINS_ENABLED = """
+AUTO_ENABLE_PKG_PLUGINS_ENABLED = """
 [rhsm]
 auto_enable_yum_plugins = 1
 """
 
-AUTO_ENABLE_YUM_PLUGINS_DISABLED = """
+AUTO_ENABLE_PKG_PLUGINS_DISABLED = """
 [rhsm]
 auto_enable_yum_plugins = 0
 """
 
-YUM_PLUGIN_CONF_FILE_ENABLED_INT = """
+PKG_PLUGIN_CONF_FILE_ENABLED_INT = """
 [main]
 enabled = 1
 """
 
-YUM_PLUGIN_CONF_FILE_ENABLED_BOOL = """
+PKG_PLUGIN_CONF_FILE_ENABLED_BOOL = """
 [main]
 enabled = true
 """
 
-YUM_PLUGIN_CONF_FILE_DISABLED_INT = """
+PKG_PLUGIN_CONF_FILE_DISABLED_INT = """
 [main]
 enabled = 0
 """
 
-YUM_PLUGIN_CONF_FILE_DISABLED_BOOL = """
+PKG_PLUGIN_CONF_FILE_DISABLED_BOOL = """
 [main]
 enabled = false
 """
 
-YUM_PLUGIN_CONF_FILE_WRONG_VALUE = """
+PKG_PLUGIN_CONF_FILE_WRONG_VALUE = """
 [main]
 enabled = 4
 """
 
-YUM_PLUGIN_CONF_FILE_INVALID_VALUE = """
+PKG_PLUGIN_CONF_FILE_INVALID_VALUE = """
 [main]
 enabled = 1.0
 """
 
-YUM_PLUGIN_CONF_MISSING_MAIN_SECTION = """
+PKG_PLUGIN_CONF_MISSING_MAIN_SECTION = """
 [test]
 option = value
 """
 
-YUM_PLUGIN_CONF_MISSING_ENABLED_OPTION = """
+PKG_PLUGIN_CONF_MISSING_ENABLED_OPTION = """
 [main]
 option = value
 """
 
-YUM_PLUGIN_CONF_FILE_CORRUPTED = """
+PKG_PLUGIN_CONF_FILE_CORRUPTED = """
 [main
 enable =
 """
@@ -948,161 +948,208 @@ class TestYumPluginManager(unittest.TestCase):
     """
 
     ORIGINAL_DNF_PLUGIN_DIR = YumPluginManager.DNF_PLUGIN_DIR
-    ORIGINAL_YUM_PLUGINS = YumPluginManager.YUM_PLUGINS
+    ORIGINAL_YUM_PLUGIN_DIR = YumPluginManager.YUM_PLUGIN_DIR
+    ORIGINAL_PLUGINS = YumPluginManager.PLUGINS
 
-    def init_plugin_conf_files(self, conf_string):
+    def init_yum_plugin_conf_files(self, conf_string):
         """
         Mock configuration files of plugins
         """
-        tmp_dir = tempfile.mkdtemp()
-        f, plug_file_name_01 = tempfile.mkstemp(prefix='', suffix='.conf', dir=tmp_dir, text=True)
-        f, plug_file_name_02 = tempfile.mkstemp(prefix='', suffix='.conf', dir=tmp_dir, text=True)
+        yum_tmp_dir = tempfile.mkdtemp()
+        f, plug_file_name_01 = tempfile.mkstemp(prefix='', suffix='.conf', dir=yum_tmp_dir, text=True)
+        f, plug_file_name_02 = tempfile.mkstemp(prefix='', suffix='.conf', dir=yum_tmp_dir, text=True)
         with open(plug_file_name_01, "w") as plug_file_01:
             plug_file_01.write(conf_string)
         with open(plug_file_name_02, "w") as plug_file_02:
             plug_file_02.write(conf_string)
         self.plug_file_name_01 = plug_file_name_01
         self.plug_file_name_02 = plug_file_name_02
-        self.tmp_dir = tmp_dir
-        YumPluginManager.DNF_PLUGIN_DIR = tmp_dir
-        YumPluginManager.YUM_PLUGINS = [
-            plug_file_name_01.replace(tmp_dir, '').replace('.conf', ''),
-            plug_file_name_02.replace(tmp_dir, '').replace('.conf', '')
+        self.tmp_dir = yum_tmp_dir
+        YumPluginManager.YUM_PLUGIN_DIR = yum_tmp_dir
+        YumPluginManager.PLUGINS = [
+            plug_file_name_01.replace(yum_tmp_dir, '').replace('.conf', ''),
+            plug_file_name_02.replace(yum_tmp_dir, '').replace('.conf', '')
         ]
 
-    def restore_plugin_conf_files(self):
+    def restore_yum_plugin_conf_files(self):
         """
         Restore original constants in YumPluginManager
         """
-        YumPluginManager.DNF_PLUGIN_DIR = self.ORIGINAL_DNF_PLUGIN_DIR
-        YumPluginManager.YUM_PLUGINS = self.ORIGINAL_YUM_PLUGINS
+        YumPluginManager.YUM_PLUGIN_DIR = self.ORIGINAL_YUM_PLUGIN_DIR
+        YumPluginManager.PLUGINS = self.ORIGINAL_PLUGINS
         os.unlink(self.plug_file_name_01)
         os.unlink(self.plug_file_name_02)
         os.rmdir(self.tmp_dir)
 
-    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_YUM_PLUGINS_ENABLED))
+    def init_dnf_plugin_conf_files(self, conf_string):
+        """
+        Mock configuration files of plugins
+        """
+        dnf_tmp_dir = tempfile.mkdtemp()
+        f, plug_file_name_01 = tempfile.mkstemp(prefix='', suffix='.conf', dir=dnf_tmp_dir, text=True)
+        f, plug_file_name_02 = tempfile.mkstemp(prefix='', suffix='.conf', dir=dnf_tmp_dir, text=True)
+        with open(plug_file_name_01, "w") as plug_file_01:
+            plug_file_01.write(conf_string)
+        with open(plug_file_name_02, "w") as plug_file_02:
+            plug_file_02.write(conf_string)
+        self.plug_file_name_01 = plug_file_name_01
+        self.plug_file_name_02 = plug_file_name_02
+        self.tmp_dir = dnf_tmp_dir
+        YumPluginManager.DNF_PLUGIN_DIR = dnf_tmp_dir
+        YumPluginManager.PLUGINS = [
+            plug_file_name_01.replace(dnf_tmp_dir, '').replace('.conf', ''),
+            plug_file_name_02.replace(dnf_tmp_dir, '').replace('.conf', '')
+        ]
+
+    def restore_dnf_plugin_conf_files(self):
+        """
+        Restore original constants in YumPluginManager
+        """
+        YumPluginManager.DNF_PLUGIN_DIR = self.ORIGINAL_DNF_PLUGIN_DIR
+        YumPluginManager.PLUGINS = self.ORIGINAL_PLUGINS
+        os.unlink(self.plug_file_name_01)
+        os.unlink(self.plug_file_name_02)
+        os.rmdir(self.tmp_dir)
+
+    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
     def test_enabling_disabled_yum_plugin(self):
         """
         Test automatic enabling of configuration files of disabled plugins
         """
-        self.init_plugin_conf_files(conf_string=YUM_PLUGIN_CONF_FILE_DISABLED_INT)
-        plugin_list = YumPluginManager.enable_yum_plugins()
+        self.init_yum_plugin_conf_files(conf_string=PKG_PLUGIN_CONF_FILE_DISABLED_INT)
+        plugin_list = YumPluginManager.enable_pkg_plugins()
         self.assertEqual(len(plugin_list), 2)
-        for plugin_conf_file_name in YumPluginManager.YUM_PLUGINS:
+        for plugin_conf_file_name in YumPluginManager.PLUGINS:
             yum_plugin_config = ConfigParser()
-            result = yum_plugin_config.read(YumPluginManager.DNF_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
+            result = yum_plugin_config.read(YumPluginManager.YUM_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
             self.assertGreater(len(result), 0)
             is_plugin_enabled = yum_plugin_config.getint('main', 'enabled')
             self.assertEqual(is_plugin_enabled, 1)
-        self.restore_plugin_conf_files()
+        self.restore_yum_plugin_conf_files()
 
-    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_YUM_PLUGINS_DISABLED))
+    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_DISABLED))
     def test_not_enabling_disabled_yum_plugin(self):
         """
         Test not enabling (disabled in rhsm.conf) of configuration files of disabled plugins
         """
-        self.init_plugin_conf_files(conf_string=YUM_PLUGIN_CONF_FILE_DISABLED_BOOL)
-        plugin_list = YumPluginManager.enable_yum_plugins()
+        self.init_yum_plugin_conf_files(conf_string=PKG_PLUGIN_CONF_FILE_DISABLED_BOOL)
+        plugin_list = YumPluginManager.enable_pkg_plugins()
         self.assertEqual(len(plugin_list), 0)
-        for plugin_conf_file_name in YumPluginManager.YUM_PLUGINS:
+        for plugin_conf_file_name in YumPluginManager.PLUGINS:
             yum_plugin_config = ConfigParser()
-            result = yum_plugin_config.read(YumPluginManager.DNF_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
+            result = yum_plugin_config.read(YumPluginManager.YUM_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
             self.assertGreater(len(result), 0)
             is_plugin_enabled = yum_plugin_config.getboolean('main', 'enabled')
             self.assertEqual(is_plugin_enabled, False)
-        self.restore_plugin_conf_files()
+        self.restore_yum_plugin_conf_files()
 
-    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_YUM_PLUGINS_ENABLED))
+    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
+    def test_enabling_disabled_dnf_plugin(self):
+        """
+        Test automatic enabling of configuration files of disabled plugins
+        """
+        self.init_dnf_plugin_conf_files(conf_string=PKG_PLUGIN_CONF_FILE_DISABLED_INT)
+        plugin_list = YumPluginManager.enable_pkg_plugins()
+        self.assertEqual(len(plugin_list), 2)
+        for plugin_conf_file_name in YumPluginManager.PLUGINS:
+            dnf_plugin_config = ConfigParser()
+            result = dnf_plugin_config.read(YumPluginManager.DNF_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
+            self.assertGreater(len(result), 0)
+            is_plugin_enabled = dnf_plugin_config.getint('main', 'enabled')
+            self.assertEqual(is_plugin_enabled, 1)
+        self.restore_dnf_plugin_conf_files()
+
+    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
     def test_enabling_enabled_yum_plugin_int(self):
         """
         Test automatic enabling of configuration files of already enabled plugins
         """
-        self.init_plugin_conf_files(conf_string=YUM_PLUGIN_CONF_FILE_ENABLED_INT)
-        plugin_list = YumPluginManager.enable_yum_plugins()
+        self.init_yum_plugin_conf_files(conf_string=PKG_PLUGIN_CONF_FILE_ENABLED_INT)
+        plugin_list = YumPluginManager.enable_pkg_plugins()
         self.assertEqual(len(plugin_list), 0)
-        for plugin_conf_file_name in YumPluginManager.YUM_PLUGINS:
+        for plugin_conf_file_name in YumPluginManager.PLUGINS:
             yum_plugin_config = ConfigParser()
-            result = yum_plugin_config.read(YumPluginManager.DNF_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
+            result = yum_plugin_config.read(YumPluginManager.YUM_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
             self.assertGreater(len(result), 0)
             is_plugin_enabled = yum_plugin_config.getint('main', 'enabled')
             self.assertEqual(is_plugin_enabled, 1)
-        self.restore_plugin_conf_files()
+        self.restore_yum_plugin_conf_files()
 
-    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_YUM_PLUGINS_ENABLED))
+    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
     def test_enabling_enabled_yum_plugin_bool(self):
         """
         Test automatic enabling of configuration files of already enabled plugins
         """
-        self.init_plugin_conf_files(conf_string=YUM_PLUGIN_CONF_FILE_ENABLED_BOOL)
-        plugin_list = YumPluginManager.enable_yum_plugins()
+        self.init_yum_plugin_conf_files(conf_string=PKG_PLUGIN_CONF_FILE_ENABLED_BOOL)
+        plugin_list = YumPluginManager.enable_pkg_plugins()
         self.assertEqual(len(plugin_list), 0)
-        for plugin_conf_file_name in YumPluginManager.YUM_PLUGINS:
+        for plugin_conf_file_name in YumPluginManager.PLUGINS:
             yum_plugin_config = ConfigParser()
-            result = yum_plugin_config.read(YumPluginManager.DNF_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
+            result = yum_plugin_config.read(YumPluginManager.YUM_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
             self.assertGreater(len(result), 0)
             # The file was not modified. We have to read value with with getboolean()
             is_plugin_enabled = yum_plugin_config.getboolean('main', 'enabled')
             self.assertEqual(is_plugin_enabled, True)
-        self.restore_plugin_conf_files()
+        self.restore_yum_plugin_conf_files()
 
-    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_YUM_PLUGINS_ENABLED))
+    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
     def test_enabling_yum_plugin_with_invalid_values(self):
         """
         Test automatic enabling of configuration files of already enabled plugins
         """
-        self.init_plugin_conf_files(conf_string=YUM_PLUGIN_CONF_FILE_INVALID_VALUE)
-        plugin_list = YumPluginManager.enable_yum_plugins()
+        self.init_yum_plugin_conf_files(conf_string=PKG_PLUGIN_CONF_FILE_INVALID_VALUE)
+        plugin_list = YumPluginManager.enable_pkg_plugins()
         self.assertEqual(len(plugin_list), 2)
-        for plugin_conf_file_name in YumPluginManager.YUM_PLUGINS:
+        for plugin_conf_file_name in YumPluginManager.PLUGINS:
             yum_plugin_config = ConfigParser()
-            result = yum_plugin_config.read(YumPluginManager.DNF_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
+            result = yum_plugin_config.read(YumPluginManager.YUM_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
             self.assertGreater(len(result), 0)
             is_plugin_enabled = yum_plugin_config.getint('main', 'enabled')
             self.assertEqual(is_plugin_enabled, 1)
-        self.restore_plugin_conf_files()
+        self.restore_yum_plugin_conf_files()
 
-    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_YUM_PLUGINS_ENABLED))
+    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
     def test_enabling_yum_plugin_with_wrong_conf(self):
         """
         Test automatic enabling of configuration files of already plugins with wrong values in conf file.
         """
-        self.init_plugin_conf_files(conf_string=YUM_PLUGIN_CONF_FILE_WRONG_VALUE)
-        plugin_list = YumPluginManager.enable_yum_plugins()
+        self.init_yum_plugin_conf_files(conf_string=PKG_PLUGIN_CONF_FILE_WRONG_VALUE)
+        plugin_list = YumPluginManager.enable_pkg_plugins()
         self.assertEqual(len(plugin_list), 2)
-        for plugin_conf_file_name in YumPluginManager.YUM_PLUGINS:
+        for plugin_conf_file_name in YumPluginManager.PLUGINS:
             yum_plugin_config = ConfigParser()
-            result = yum_plugin_config.read(YumPluginManager.DNF_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
+            result = yum_plugin_config.read(YumPluginManager.YUM_PLUGIN_DIR + '/' + plugin_conf_file_name + '.conf')
             self.assertGreater(len(result), 0)
             is_plugin_enabled = yum_plugin_config.getint('main', 'enabled')
             self.assertEqual(is_plugin_enabled, 1)
-        self.restore_plugin_conf_files()
+        self.restore_yum_plugin_conf_files()
 
-    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_YUM_PLUGINS_ENABLED))
+    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
     def test_enabling_yum_plugin_with_corrupted_conf_file(self):
         """
         This test only test YumPluginManager.enable_yum_plugins() can survive reading of corrupted
         yum plugin configuration file
         """
-        self.init_plugin_conf_files(conf_string=YUM_PLUGIN_CONF_FILE_CORRUPTED)
-        plugin_list = YumPluginManager.enable_yum_plugins()
+        self.init_yum_plugin_conf_files(conf_string=PKG_PLUGIN_CONF_FILE_CORRUPTED)
+        plugin_list = YumPluginManager.enable_pkg_plugins()
         self.assertEqual(len(plugin_list), 0)
 
-    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_YUM_PLUGINS_ENABLED))
+    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
     def test_enabling_yum_plugin_with_missing_main_section(self):
         """
         This test only test YumPluginManager.enable_yum_plugins() can survive reading of corrupted
         yum plugin configuration file (missing main section)
         """
-        self.init_plugin_conf_files(conf_string=YUM_PLUGIN_CONF_MISSING_MAIN_SECTION)
-        plugin_list = YumPluginManager.enable_yum_plugins()
+        self.init_yum_plugin_conf_files(conf_string=PKG_PLUGIN_CONF_MISSING_MAIN_SECTION)
+        plugin_list = YumPluginManager.enable_pkg_plugins()
         self.assertEqual(len(plugin_list), 2)
 
-    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_YUM_PLUGINS_ENABLED))
+    @patch.object(repolib, 'conf', ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
     def test_enabling_yum_plugin_with_missing_enabled_option(self):
         """
         This test only test YumPluginManager.enable_yum_plugins() can survive reading of corrupted
         yum plugin configuration file (missing option 'enabled')
         """
-        self.init_plugin_conf_files(conf_string=YUM_PLUGIN_CONF_MISSING_ENABLED_OPTION)
-        plugin_list = YumPluginManager.enable_yum_plugins()
+        self.init_yum_plugin_conf_files(conf_string=PKG_PLUGIN_CONF_MISSING_ENABLED_OPTION)
+        plugin_list = YumPluginManager.enable_pkg_plugins()
         self.assertEqual(len(plugin_list), 2)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1623262
* subscription-manager can autoenable yum as well dnf plugins
* Modified unit tests and added one unit test to be dnf specific
* Removed `use_dnf` from `version.py`.