### PR TITLE
Use the "service_level_agreement" attribute for the SlaCommand

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1016,8 +1016,7 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
         shortdesc = _("Manage service levels for this system")
         self._org_help_text = _("specify an organization when listing available service levels using the organization key, only used with --list")
         super(ServiceLevelCommand, self).__init__("service-level", shortdesc,
-                                                  False)
-
+                                                  False, attr="service_level_agreement")
         self._add_url_options()
         self.parser.add_option(
             "--show",


### PR DESCRIPTION
Noticed this while reviewing some test cases with John. The Service-level command did not seem to be outputting the correct messages as it never set the name of the attribute it was manipulating through the attr keyword arg.

You can see these failures yourself just as simply as running the Service-level command. The output (in the event that the option is unset) will be similar to "None not set" instead of "service_level_agreement not set".