### PR TITLE
1607955: Try to use all entitlement certs for connection with CDN; ENT-757

### DIFF
--- a/src/subscription_manager/release.py
+++ b/src/subscription_manager/release.py
@@ -118,6 +118,7 @@ class CdnReleaseVersionProvider(object):
         entitlements = self.entitlement_dir.list_for_product(release_product.id)
 
         listings = []
+        ent_cert_key_pairs = []
         for entitlement in entitlements:
             contents = entitlement.content
             for content in contents:
@@ -129,6 +130,7 @@ class CdnReleaseVersionProvider(object):
                                          content.required_tags):
                     listing_path = self._build_listing_path(content.url)
                     listings.append(listing_path)
+                    ent_cert_key_pairs.append((entitlement.path, entitlement.key_path()))
 
         # FIXME: not sure how to get the "base" content if we have multiple
         # entitlements for a product
@@ -142,7 +144,7 @@ class CdnReleaseVersionProvider(object):
         listings = sorted(set(listings))
         for listing_path in listings:
             try:
-                data = self.content_connection.get_versions(listing_path)
+                data = self.content_connection.get_versions(listing_path, ent_cert_key_pairs)
             except (socket.error,
                     six.moves.http_client.HTTPException,
                     ssl.SSLError) as e:

--- a/src/subscription_manager/release.py
+++ b/src/subscription_manager/release.py
@@ -24,6 +24,7 @@ import six
 
 import six.moves.http_client
 from rhsm.https import ssl
+from rhsm.connection import NoValidEntitlement
 
 import rhsm.config
 
@@ -118,7 +119,7 @@ class CdnReleaseVersionProvider(object):
         entitlements = self.entitlement_dir.list_for_product(release_product.id)
 
         listings = []
-        ent_cert_key_pairs = []
+        ent_cert_key_pairs = set()
         for entitlement in entitlements:
             contents = entitlement.content
             for content in contents:
@@ -130,7 +131,7 @@ class CdnReleaseVersionProvider(object):
                                          content.required_tags):
                     listing_path = self._build_listing_path(content.url)
                     listings.append(listing_path)
-                    ent_cert_key_pairs.append((entitlement.path, entitlement.key_path()))
+                    ent_cert_key_pairs.add((entitlement.path, entitlement.key_path()))
 
         # FIXME: not sure how to get the "base" content if we have multiple
         # entitlements for a product
@@ -144,10 +145,11 @@ class CdnReleaseVersionProvider(object):
         listings = sorted(set(listings))
         for listing_path in listings:
             try:
-                data = self.content_connection.get_versions(listing_path, ent_cert_key_pairs)
+                data = self.content_connection.get_versions(listing_path, list(ent_cert_key_pairs))
             except (socket.error,
                     six.moves.http_client.HTTPException,
-                    ssl.SSLError) as e:
+                    ssl.SSLError,
+                    NoValidEntitlement) as e:
                 # content connection doesn't handle any exceptions
                 # and the code that invokes this doesn't either, so
                 # swallow them here.

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -270,7 +270,7 @@ class SubManFixture(unittest.TestCase):
 
     # The ContentConnection used for reading release versions from
     # the cdn. The injected one uses this.
-    def _get_release_versions(self, listing_path):
+    def _get_release_versions(self, listing_path, ent_cert_key_pairs):
         return self._release_versions
 
     # For changing injection consumer id to one that fails "is_valid"

--- a/test/rhsm/unit/connection-tests.py
+++ b/test/rhsm/unit/connection-tests.py
@@ -342,13 +342,20 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(expected_guestIds, resultGuestIds)
 
     def test_bad_ca_cert(self):
-        f = open(os.path.join(self.temp_ent_dir, "foo.pem"), 'w+')
-        f.write('xxxxxx\n')
-        f.close()
+        cert = open(os.path.join(self.temp_ent_dir, "foo.pem"), 'w+')
+        cert.write('xxxxxx\n')
+        cert.close()
+        key = open(os.path.join(self.temp_ent_dir, "foo-key.pem"), 'w+')
+        key.write('xxxxxx\n')
+        key.close()
         cont_conn = ContentConnection(host="foobar", username="dummy", password="dummy", insecure=True)
         cont_conn.ent_dir = self.temp_ent_dir
         with self.assertRaises(BadCertificateException):
-            cont_conn._load_ca_certificates(ssl.SSLContext(ssl.PROTOCOL_SSLv23))
+            cont_conn._load_ca_certificate(
+                ssl.SSLContext(ssl.PROTOCOL_SSLv23),
+                self.temp_ent_dir + '/foo.pem',
+                self.temp_ent_dir + '/foo-key.pem'
+            )
         restlib = Restlib("somehost", "123", "somehandler")
         restlib.ca_dir = self.temp_ent_dir
         with self.assertRaises(BadCertificateException):

--- a/test/rhsm/unit/connection-tests.py
+++ b/test/rhsm/unit/connection-tests.py
@@ -342,12 +342,10 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(expected_guestIds, resultGuestIds)
 
     def test_bad_ca_cert(self):
-        cert = open(os.path.join(self.temp_ent_dir, "foo.pem"), 'w+')
-        cert.write('xxxxxx\n')
-        cert.close()
-        key = open(os.path.join(self.temp_ent_dir, "foo-key.pem"), 'w+')
-        key.write('xxxxxx\n')
-        key.close()
+        with open(os.path.join(self.temp_ent_dir, "foo.pem"), 'w+') as cert:
+            cert.write('xxxxxx\n')
+        with open(os.path.join(self.temp_ent_dir, "foo-key.pem"), 'w+') as key:
+            key.write('xxxxxx\n')
         cont_conn = ContentConnection(host="foobar", username="dummy", password="dummy", insecure=True)
         cont_conn.ent_dir = self.temp_ent_dir
         with self.assertRaises(BadCertificateException):


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1607955
* When all entitlement certificates and key are loaded to SSL
  context, then only last loaded pair of certificate and key
  is used during TLS handshake
* We have to try all entitlement certificates until we get 200
  status from CDN server (we try to do several connections to
  server)
* It is possible to provide limited list of cert-key pairs to
  method _request
* Fixed two unit tests