### PR TITLE
Use Combined Profile reporting; ENT-832

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1111,8 +1111,18 @@ class UEPConnection(object):
         package headers we're interested in. See profile.py.
         """
         method = "/consumers/%s/packages" % self.sanitize(consumer_uuid)
-        ret = self.conn.request_put(method, pkg_dicts)
-        return ret
+        return self.conn.request_put(method, pkg_dicts)
+
+    def updateCombinedProfile(self, consumer_uuid, profile):
+        """
+        Updates the costumers' combined profile containing package profile,
+        enabled repositories and dnf/yum modules.
+        :param consumer_uuid: UUID of consumer
+        :param profile: Combined profile
+        :return: Dict containing response from HTTP server
+        """
+        method = "/consumers/%s/profiles" % self.sanitize(consumer_uuid)
+        return self.conn.request_put(method, profile)
 
     # FIXME: username and password not used here
     def getConsumer(self, uuid, username=None, password=None):

--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -33,8 +33,7 @@ class Package(object):
     """
     Represents a package installed on the system.
     """
-    def __init__(self, name, version, release, arch, epoch=0, vendor=None,
-                 from_dict=None):
+    def __init__(self, name, version, release, arch, epoch=0, vendor=None):
         self.name = name
         self.version = version
         self.release = release
@@ -81,6 +80,30 @@ class Package(object):
         return value
 
 
+class ModuleProfile(object):
+
+    def collect(self):
+        """
+        Gather list of modules reported to candlepin server
+        :return: List of modules
+        """
+        module_list = []
+        # TODO: gather list of modules
+        return module_list
+
+
+class EnabledReposProfile(object):
+
+    def collect(self):
+        """
+        Gather list of enabled repositories
+        :return: List of enabled repositories
+        """
+        enabled_repos_list = []
+        # TODO: gather list of enabled repos
+        return enabled_repos_list
+
+
 class RPMProfile(object):
 
     def __init__(self, from_file=None):
@@ -91,7 +114,7 @@ class RPMProfile(object):
         """
         self.packages = []
         if from_file:
-            log.debug("Loading RPM profile from file.")
+            log.debug("Loading RPM profile from file: %s" % from_file.name)
             json_buffer = from_file.read()
             pkg_dicts = json.loads(json_buffer)
             for pkg_dict in pkg_dicts:
@@ -110,7 +133,8 @@ class RPMProfile(object):
             installed = ts.dbMatch()
             self.packages = self._accumulate_profile(installed)
 
-    def _accumulate_profile(self, rpm_header_list):
+    @staticmethod
+    def _accumulate_profile(rpm_header_list):
         """
         Accumulates list of installed rpm info
         @param rpm_header_list: list of rpm headers
@@ -122,8 +146,8 @@ class RPMProfile(object):
         pkg_list = []
         for h in rpm_header_list:
             if h['name'] == "gpg-pubkey":
-                #dbMatch includes imported gpg keys as well
-                # skip these for now as there isnt compelling
+                # dbMatch includes imported gpg keys as well
+                # skip these for now as there isn't compelling
                 # reason for server to know this info
                 continue
             pkg_list.append(Package(
@@ -163,7 +187,7 @@ class RPMProfile(object):
             return False
 
         for pkg in self.packages:
-            if not pkg in other.packages:
+            if pkg not in other.packages:
                 return False
 
         return True
@@ -172,8 +196,8 @@ class RPMProfile(object):
 def get_profile(profile_type):
     """
     Returns an instance of a Profile object
-    @param type: profile type
-    @type type: string
+    @param profile_type: profile type
+    @type profile_type: string
     Returns an instance of a Profile object
     """
     if profile_type not in PROFILE_MAP:
@@ -185,4 +209,6 @@ def get_profile(profile_type):
 # Profile types we support:
 PROFILE_MAP = {
     "rpm": RPMProfile,
+    "enabled_repos": EnabledReposProfile,
+    "modulemd": ModuleProfile
 }

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -444,7 +444,7 @@ class ProfileManager(CacheManager):
         and it also has to be able to send only profile containing list of installed RPMs.
         """
         combined_profile = self.current_profile
-        if uep.has_capability("combined reporting"):
+        if uep.has_capability("combined_reporting"):
             _combined_profile = [
                 {
                     "content_type": "rpm",

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -28,7 +28,7 @@ from rhsm.https import ssl
 
 from rhsm.config import initConfig
 import rhsm.connection as connection
-from rhsm.profile import get_profile, RPMProfile
+from rhsm.profile import get_profile
 import subscription_manager.injection as inj
 from subscription_manager.jsonwrapper import PoolWrapper
 from rhsm import ourjson as json
@@ -366,40 +366,53 @@ class ReleaseStatusCache(StatusCache):
 # this is injected normally
 class ProfileManager(CacheManager):
     """
-    Manages the profile of packages installed on this system.
+    Manages profile of installed packages, enabled repositories and plugins
     """
-    CACHE_FILE = "/var/lib/rhsm/packages/packages.json"
 
-    def __init__(self, current_profile=None):
+    CACHE_FILE = "/var/lib/rhsm/cache/profile.json"
 
+    def __init__(self):
         # Could be None, we'll read the system's current profile later once
         # we're sure we actually need the data.
-        self._current_profile = current_profile
+        self._current_profile = None
         self._report_package_profile = conf['rhsm'].get_int('report_package_profile')
 
     # give tests a chance to use something other than RPMProfile
     def _get_profile(self, profile_type):
         return get_profile(profile_type)
 
-    def _get_current_profile(self):
-        # If we weren't given a profile, load the current systems packages:
-        if not self._current_profile:
-            self._current_profile = self._get_profile('rpm')
-        return self._current_profile
-
-    def _set_current_profile(self, value):
-        self._current_profile = value
-
     def _set_report_package_profile(self, value):
         self._report_package_profile = value
 
-    current_profile = property(_get_current_profile, _set_current_profile)
+    @staticmethod
+    def _assembly_profile(rpm_profile, enabled_repos_profile, module_profile):
+        combined_profile = {
+            'rpm': rpm_profile,
+            'enabled_repos': enabled_repos_profile,
+            'modulemd': module_profile
+        }
+        return combined_profile
+
+    @property
+    def current_profile(self):
+        if not self._current_profile:
+            rpm_profile = get_profile('rpm').collect()
+            enabled_repos = get_profile('enabled_repos').collect()
+            module_profile = get_profile('modulemd').collect()
+            combined_profile = self._assembly_profile(rpm_profile, enabled_repos, module_profile)
+            self._current_profile = combined_profile
+        return self._current_profile
+
+    @current_profile.setter
+    def current_profile(self, new_profile):
+        self._current_profile = new_profile
 
     def to_dict(self):
-        return self.current_profile.collect()
+        return self.current_profile
 
     def _load_data(self, open_file):
-        return RPMProfile(from_file=open_file)
+        json_str = open_file.read()
+        return json.loads(json_str)
 
     def update_check(self, uep, consumer_uuid, force=False):
         """
@@ -426,8 +439,35 @@ class ProfileManager(CacheManager):
         return not cached_profile == self.current_profile
 
     def _sync_with_server(self, uep, consumer_uuid, *args, **kwargs):
-        uep.updatePackageProfile(consumer_uuid,
-                self.current_profile.collect())
+        """
+        This method has to be able to sync combined profile, when server supports this functionality
+        and it also has to be able to send only profile containing list of installed RPMs.
+        """
+        combined_profile = self.current_profile
+        if uep.has_capability("combined reporting"):
+            _combined_profile = [
+                {
+                    "content_type": "rpm",
+                    "profile": combined_profile["rpm"]
+                },
+                {
+                    "content_type": "enabled_repos",
+                    "profile": combined_profile["enabled_repos"]
+                },
+                {
+                    "content_type": "modulemd",
+                    "profile": combined_profile["modulemd"]
+                },
+            ]
+            uep.updateCombinedProfile(
+                consumer_uuid,
+                _combined_profile
+            )
+        else:
+            uep.updatePackageProfile(
+                consumer_uuid,
+                combined_profile["rpm"]
+            )
 
 
 class InstalledProductsManager(CacheManager):

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -95,6 +95,20 @@ class TestProfileManager(unittest.TestCase):
                 FACT_MATCHER)
         self.assertEqual(1, self.profile_mgr.write_cache.call_count)
 
+    def test_combined_profile_update_check_has_changed(self):
+        uuid = 'FAKEUUID'
+        uep = Mock()
+        uep.has_capability = Mock(return_value=True)
+        uep.updateCombinedProfile = Mock()
+        self.profile_mgr.has_changed = Mock(return_value=True)
+        self.profile_mgr.write_cache = Mock()
+
+        self.profile_mgr.update_check(uep, uuid)
+
+        uep.updateCombinedProfile.assert_called_with(uuid,
+                FACT_MATCHER)
+        self.assertEqual(1, self.profile_mgr.write_cache.call_count)
+
     def test_update_check_packages_not_supported(self):
         uuid = 'FAKEUUID'
         uep = Mock()
@@ -135,6 +149,21 @@ class TestProfileManager(unittest.TestCase):
 
         self.assertRaises(Exception, self.profile_mgr.update_check, uep, uuid)
         uep.updatePackageProfile.assert_called_with(uuid,
+                FACT_MATCHER)
+        self.assertEqual(0, self.profile_mgr.write_cache.call_count)
+
+    def test_combined_profile_update_check_error_uploading(self):
+        uuid = 'FAKEUUID'
+        uep = Mock()
+        uep.has_capability = Mock(return_value=True)
+
+        self.profile_mgr.has_changed = Mock(return_value=True)
+        self.profile_mgr.write_cache = Mock()
+        # Throw an exception when trying to upload:
+        uep.updateCombinedProfile = Mock(side_effect=Exception('BOOM!'))
+
+        self.assertRaises(Exception, self.profile_mgr.update_check, uep, uuid)
+        uep.updateCombinedProfile.assert_called_with(uuid,
                 FACT_MATCHER)
         self.assertEqual(0, self.profile_mgr.write_cache.call_count)
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -63,9 +63,11 @@ class TestProfileManager(unittest.TestCase):
     def setUp(self):
         current_pkgs = [
                 Package(name="package1", version="1.0.0", release=1, arch="x86_64"),
-                Package(name="package2", version="2.0.0", release=2, arch="x86_64")]
+                Package(name="package2", version="2.0.0", release=2, arch="x86_64")
+        ]
         self.current_profile = self._mock_pkg_profile(current_pkgs)
-        self.profile_mgr = ProfileManager(current_profile=self.current_profile)
+        self.profile_mgr = ProfileManager()
+        self.profile_mgr.current_profile = self.current_profile
 
     def test_update_check_no_change(self):
         uuid = 'FAKEUUID'
@@ -82,6 +84,7 @@ class TestProfileManager(unittest.TestCase):
     def test_update_check_has_changed(self):
         uuid = 'FAKEUUID'
         uep = Mock()
+        uep.has_capability = Mock(return_value=False)
         uep.updatePackageProfile = Mock()
         self.profile_mgr.has_changed = Mock(return_value=True)
         self.profile_mgr.write_cache = Mock()
@@ -123,6 +126,7 @@ class TestProfileManager(unittest.TestCase):
     def test_update_check_error_uploading(self):
         uuid = 'FAKEUUID'
         uep = Mock()
+        uep.has_capability = Mock(return_value=False)
 
         self.profile_mgr.has_changed = Mock(return_value=True)
         self.profile_mgr.write_cache = Mock()
@@ -210,7 +214,12 @@ class TestProfileManager(unittest.TestCase):
         mock_file = Mock()
         mock_file.read = Mock(return_value=json.dumps(dict_list))
 
-        mock_profile = RPMProfile(from_file=mock_file)
+        mock_rpm_profile = RPMProfile(from_file=mock_file)
+        mock_profile = {
+            "rpm": mock_rpm_profile,
+            "enabled_repos": [],
+            "modulemd": []
+        }
         return mock_profile
 
 


### PR DESCRIPTION
* rhsmcertd did send profile containing list of installed RPMs, but it
  didn't send some another information e.g. list of enabled repositories
  and other tools had to be used for this purpose
* This commit adds functionality that allows to send list of dictionaries
  containing desired data
* ProfileManager can be backward compatible and it can report only list
  of installed packages, when candlepin server does not have capability
  "combined reporting"
* Added two blind classes: EnabledReposProfile and ModuleProfile.
  Functionality for these classes will be added in next commits.
* Fixed several unit tests