### PR TITLE
Added list of enabled repos to combined profile; ENT-833

### DIFF
--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -78,6 +78,9 @@ class EnabledRepos(object):
         self.repofile = repo_file
         self.content = self.__generate()
 
+    def __eq__(self, other):
+        return self.content == other.content
+
     def __str__(self):
         return str(self.content)
 


### PR DESCRIPTION
* Combined profile contain list of enabled repositories
* Part of code was copy pasted from Katello:

https://github.com/Katello/katello-host-tools/blob/master/src/katello/enabled_report.py

* Code was modified: e.g. our iniparse is used for parsin repo file.
* Making this PR against my feature branch ATM. #1915 is blocking this PR.