### PR TITLE
For tito build, clean the yarn cache

### DIFF
--- a/.tito/cockpit-build.sh
+++ b/.tito/cockpit-build.sh
@@ -6,6 +6,7 @@ if [ ! $(which yarn) ] ; then
   exit 1
 fi
 pushd cockpit
+yarn cache clean
 yarn install --frozen-lockfile
 make dist-gzip
 popd


### PR DESCRIPTION
We have noticed twice now, at least, that the yarn cache can get into a
bad state. Once, @cnsnyder ran out of disk space, and the cache ended up
with empty directories where there should have been node modules.

`yarn cache clean` ensures we don't run into these issues in the case
that the yarn cache is bad.