### PR TITLE
Explict requires added for package we use directly

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -353,8 +353,10 @@ Requires: %{name} = %{version}-%{release}
 Requires: dnf >= 1.0.0
 %if %{with python3}
 Requires: python3-dnf-plugins-core
+Requires: python3-librepo
 %else
 Requires: python2-dnf-plugins-core
+Requires: python2-librepo
 %endif
 
 %description -n dnf-plugin-subscription-manager


### PR DESCRIPTION
We had an issue where the package was removed from the rhel 8 build. It was
reinstated, but this will ensure that the need is documented and enforced.