### PR TITLE
1615944: Show help when no args are provided

### DIFF
--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -95,6 +95,7 @@ def setup_arg_parser():
     :return: An argparse.ArgumentParser ready to use to parse_args
     """
     parser = argparse.ArgumentParser(prog="syspurpose", description="System Syspurpose Management Tool")
+    parser.set_defaults(func=None, requires_write=False)
 
     subparsers = parser.add_subparsers(help="sub-command help")
 
@@ -252,7 +253,7 @@ def main():
     if args.func is not None:
         args.func(args, syspurposestore)
     else:
-        parser.print_usage()
+        parser.print_help()
 
     if args.requires_write:
         syspurposestore.write()


### PR DESCRIPTION
This is an alternative to #1925. It also prints the help when there are no args provided to the syspurpose cli tool.