### PR TITLE
1633575: Update error message when syspurpose is not supported by server

### DIFF
--- a/syspurpose/src/syspurpose/sync.py
+++ b/syspurpose/src/syspurpose/sync.py
@@ -87,6 +87,10 @@ class SyspurposeSync(object):
                 key_file=key_file_path
             )
 
+            if not self.connection.has_capability("syspurpose"):
+                print("Note: The currently configured entitlement server does not support System Purpose")
+                return False
+
             try:
                 consumer_cert = rhsm.certificate.create_from_file(cert_file_path)
             except rhsm.certificate.CertificateException as err:


### PR DESCRIPTION
Now when the syspurpose tool attempts to sync the syspurpose with CP, it checks that CP has the "syspurpose" capability. If it does not it outputs a suitable error message.