### PR TITLE
1632384: Sync SLA regardless of capability (ENT-912):

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -653,7 +653,7 @@ class SyspurposeCommand(CliCommand):
             print(_("{name} not set.".format(name=self.name.capitalize())))
 
     def sync(self):
-        return syspurposelib.SyspurposeSyncActionCommand().perform(include_result=True)[1]
+        return syspurposelib.SyspurposeSyncActionCommand(self.attr).perform(include_result=True)[1]
 
     def _do_command(self):
         self._validate_options()
@@ -676,7 +676,7 @@ class SyspurposeCommand(CliCommand):
     def _check_result(self, expectation, success_msg, command, attr):
         result = None
         if self.is_registered():
-            result = syspurposelib.SyspurposeSyncActionCommand().perform(include_result=True)[1]
+            result = syspurposelib.SyspurposeSyncActionCommand(self.attr).perform(include_result=True)[1]
 
         if result and not expectation(result):
             advice = SP_ADVICE.format(command=command)

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -315,10 +315,11 @@ class SyspurposeSyncActionCommand(object):
       - The current values on the file system
     """
 
-    def __init__(self):
+    def __init__(self, command_name=None):
         self.report = SyspurposeSyncActionReport()
         self.cp_provider = inj.require(inj.CP_PROVIDER)
         self.uep = self.cp_provider.get_consumer_auth_cp()
+        self.command = command_name
 
     def perform(self, include_result=False):
         """
@@ -344,7 +345,7 @@ class SyspurposeSyncActionCommand(object):
         Saves the merged changes between client and server in the SyspurposeCache.
         :return: The synced values
         """
-        if not self.uep.has_capability('syspurpose'):
+        if not self.uep.has_capability('syspurpose') and self.command != 'service_level_agreement':
             log.debug('Server does not support syspurpose, not syncing')
             return read_syspurpose()
 


### PR DESCRIPTION
To make subman versions that have syspurpose compatible with older
candlepins, when setting the SLA on the server, dont check the
syspurpose capability, since SLA pre-dates the syspurpose feature.