### PR TITLE
[M] syspurpose no longer supresses JSON malformation errors (ENT-907)

### DIFF
--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -51,11 +51,17 @@ class SyspurposeStore(object):
                 self.contents = json.load(f, encoding='utf-8')
                 return True
         except ValueError:
+            # Malformed JSON or empty file. Let's not error out on an empty file
+            if os.path.getsize(self.path):
+                system_exit(os.EX_CONFIG,
+                    _("Error: Malformed data in file {}; please review and correct.").format(self.path))
+
             return False
         except OSError as e:
             if e.errno == os.errno.EACCES and not self.raise_on_error:
                 system_exit(os.EX_NOPERM,
-                            _('Cannot read syspurpose file {}\nAre you root?').format(self.path))
+                    _('Cannot read syspurpose file {}\nAre you root?').format(self.path))
+
             if self.raise_on_error:
                 raise e
         except IOError as ioerr:

--- a/syspurpose/src/syspurpose/utils.py
+++ b/syspurpose/src/syspurpose/utils.py
@@ -68,9 +68,9 @@ def create_file(path, contents):
     """
     try:
         with io.open(path, 'w', encoding='utf-8') as f:
-            if contents:
-                write_to_file_utf8(f, contents)
+            write_to_file_utf8(f, contents)
             f.flush()
+
     except OSError as e:
         if e.errno == os.errno.EEXIST:
             # If the file exists no changes necessary


### PR DESCRIPTION
- Changed the behavior of the SyspurposeStore to no longer suppress
  data malformation errors in the backing JSON data store. If a
  ValueError occurs, an error will be generated via the system_exit
  call