### PR TITLE
1616366: Use LANG from environment (ENT-803)

### DIFF
--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -18,6 +18,8 @@ import locale
 import logging
 from threading import local
 
+import os
+
 import six
 
 # Localization domain:
@@ -46,6 +48,7 @@ def configure_i18n():
     except locale.Error:
         locale.setlocale(locale.LC_ALL, 'C')
     configure_gettext()
+    Locale.set(os.environ.get("LANG"))
 
 
 def configure_gettext():


### PR DESCRIPTION
Ended up being fairly straightforward.

This sets the language used with our Locale class to that read from the environment. This can still be overwritten by the dbus interfaces.