### PR TITLE
Update man page for report_package_profile option

### DIFF
--- a/man/asciidoc/rhsm.conf.5.asciidoc
+++ b/man/asciidoc/rhsm.conf.5.asciidoc
@@ -118,7 +118,9 @@ full_refresh_on_yum::
 report_package_profile::
   Set to '1' if *rhsmcertd* should report the system's current package
   profile to the subscription service. This report helps the subscription
-  service provide better errata notifications.
+  service provide better errata notifications. If supported by the
+  entitlement server, enabled repos, enabled modules, and packages present
+  will be reported.
 
 pluginDir::
   The directory to search for subscription manager plugins

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -174,7 +174,7 @@ Set to
 \fI1\fR
 if
 \fBrhsmcertd\fR
-should report the system's current package profile to the subscription service\&. This report helps the subscription service provide better errata notifications\&.
+should report the system's current package profile to the subscription service\&. This report helps the subscription service provide better errata notifications\&. If supported by the entitlement server, enabled repos, enabled modules, and packages present will be reported\&.
 .RE
 .PP
 pluginDir


### PR DESCRIPTION
The report_package_profile option in /etc/rhsm/rhsm.conf's manpage
will now also show that if the server supports it, the report will
include enabled repos and modules, in addition to packages.