### PR TITLE
[M] Updated how syspurpose handles unsetting values (ENT-902)

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -607,7 +607,8 @@ class SyspurposeCommand(CliCommand):
         )
 
     def _unset(self):
-        self._set("")
+        syspurposelib.unset(self.attr)
+        syspurposelib.write()
 
     def add(self):
         self._add(self.options.to_add)
@@ -686,7 +687,6 @@ class SyspurposeCommand(CliCommand):
 
 
 class UserPassCommand(CliCommand):
-
     """
     Abstract class for commands that require a username and password
     """
@@ -1129,17 +1129,12 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
 class UsageCommand(SyspurposeCommand):
 
     def __init__(self):
-
         shortdesc = _("Manage usage setting for this system")
         self._org_help_text = _("use set and unset to define the value for this field")
-        super(UsageCommand, self).__init__("usage", shortdesc, False, attr='usage',
-                                           commands=('set', 'unset'))
+        super(UsageCommand, self).__init__("usage", shortdesc, False, attr='usage', commands=('set', 'unset'))
 
     def _set(self, usage):
         save_usage_to_syspurpose_metadata(usage)
-
-    def _unset(self):
-        self._set("")
 
 
 class RegisterCommand(UserPassCommand):
@@ -1496,12 +1491,7 @@ class AddonsCommand(SyspurposeCommand):
     def __init__(self):
         shortdesc = _("Modify or view the addons attribute of the system purpose")
         super(AddonsCommand, self).__init__("addons", shortdesc=shortdesc, primary=False,
-                                            attr='addons', commands=['unset', 'add',
-                                                                     'remove'])
-
-    def _unset(self):
-        syspurposelib.set("addons", [])
-        syspurposelib.write()
+                                            attr='addons', commands=['unset', 'add', 'remove'])
 
     def _remove(self, val):
         syspurposelib.remove_all("addons", val)

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -139,15 +139,10 @@ def detect_changed(base, other, key):
     base = base or {}
     other = other or {}
 
-    if key in base and key in other:
-        if base[key] == other[key]:
-            return False
-        else:
-            return True
-    elif key not in base and key not in other:
-        return False
-    else:
-        return True
+    base_val = base.get(key)
+    other_val = other.get(key)
+
+    return base_val != other_val
 
 
 def parse_server_info(local_server_entry, config=None):

--- a/syspurpose/src/syspurpose/sync.py
+++ b/syspurpose/src/syspurpose/sync.py
@@ -102,7 +102,7 @@ class SyspurposeSync(object):
                 self.connection.updateConsumer(
                     uuid=consumer_uuid,
                     role=syspurpose_store.contents.get('role') or '',
-                    addons=syspurpose_store.contents.get('addons') or [''],
+                    addons=syspurpose_store.contents.get('addons') or [],
                     service_level=syspurpose_store.contents.get('service_level_agreement') or '',
                     usage=syspurpose_store.contents.get('usage') or ''
                 )

--- a/syspurpose/test/syspurpose/test_syspurpose_sync.py
+++ b/syspurpose/test/syspurpose/test_syspurpose_sync.py
@@ -152,6 +152,6 @@ class SyspurposeStoreTests(SyspurposeTestBase):
             uuid="9d4778ae-80fe-4eed-a631-6be35fded7fe",
             role="",
             service_level="",
-            addons=[""],
+            addons=[],
             usage=""
         )

--- a/syspurpose/test/syspurpose/test_syspurposefiles.py
+++ b/syspurpose/test/syspurpose/test_syspurposefiles.py
@@ -260,8 +260,7 @@ class SyspurposeStoreTests(SyspurposeTestBase):
 
         # Remove an item from the store which we have previously seen, whose value is scalar / not contained in a list
         res = self.assertRaisesNothing(syspurpose_store.remove, "already_present_key", "preexisting_scalar_value")
-        self.assertIn("already_present_key", syspurpose_store.contents)
-        self.assertEqual(syspurpose_store.contents["already_present_key"], None)
+        self.assertNotIn("already_present_key", syspurpose_store.contents)
         self.assertTrue(res, "The remove method should return true when the store has changed")
 
     def test_remove_with_unicode_strings(self):
@@ -296,9 +295,7 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         res = self.assertRaisesNothing(syspurpose_store.unset, "already_present_key")
         # We expect a value of true from this method when the store was changed
         self.assertTrue(res, "The unset method should return true when the store has changed")
-        self.assertIn("already_present_key", syspurpose_store.contents, msg="Expected the key to still be in the contents, but reset to None")
-        # We expect the item to have been unset to None
-        self.assertEqual(syspurpose_store.contents["already_present_key"], None)
+        self.assertNotIn("already_present_key", syspurpose_store.contents, msg="Expected the key to no longer be present")
 
         res = self.assertRaisesNothing(syspurpose_store.unset, "unseen_key")
         # We expect falsey values when the store was not modified
@@ -321,14 +318,29 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         res = self.assertRaisesNothing(syspurpose_store.unset, "ονόματα")
         # We expect a value of true from this method when the store was changed
         self.assertTrue(res, "The unset method should return true when the store has changed")
-        self.assertIn(u'ονόματα', syspurpose_store.contents, msg="Expected the key to still be in the contents, but reset to None")
-        # We expect the item to have been unset to None
-        self.assertEqual(syspurpose_store.contents[u'ονόματα'], None)
+        self.assertNotIn(u'ονόματα', syspurpose_store.contents, msg="Expected the key to no longer be present")
 
         res = self.assertRaisesNothing(syspurpose_store.unset, 'άκυρο_κλειδί')
         # We expect falsey values when the store was not modified
         self.assertFalse(res, "The unset method should return false when the store has not changed")
         self.assertNotIn(u'άκυρο_κλειδί', syspurpose_store.contents, msg="The key passed to unset, has been added to the store")
+
+    def test_unset_sla(self):
+        """
+        Verify the unset operation handles the special case for the SLA field
+        """
+        temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
+        test_data = {"service_level_agreement": "preexisting_value"}
+
+        syspurpose_store = self.assertRaisesNothing(files.SyspurposeStore, temp_dir)
+        syspurpose_store.contents = dict(**test_data)
+
+        res = self.assertRaisesNothing(syspurpose_store.unset, "service_level_agreement")
+        # We expect a value of true from this method when the store was changed
+        self.assertTrue(res, "The unset method should return true when the store has changed")
+        self.assertIn("service_level_agreement", syspurpose_store.contents, msg="Expected the key to still be in the contents, but reset to an empty string")
+        # We expect the item to have been unset to None
+        self.assertEqual(syspurpose_store.contents["service_level_agreement"], '')
 
     def test_set(self):
         """


### PR DESCRIPTION
- The unset command now removes keys from the backing dictionary
  rather than setting the values to an empty value
- syspurpose syncronization now considers missing keys and null
  valued keys to be the same
- The unset command now makes an exception for the
  service_level_agreement field to retain an empty string rather
  than None or unsetting the key entirely, for consistency with
  its non-standard behavior in Candlepin
- The remove command now calls into unset for scalar values to
  retain consistent behavior
- syspurposelib has been updated with standardized behavior for
  some of its utility methods
- Standardized some of the syspurpose command behavior within
  subscription manager
- Updated a few tests in accordance with the new behavior