### PR TITLE
1639086: Fix vendor comparison

### DIFF
--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -216,7 +216,7 @@ class Package(object):
                 self.release == other.release and \
                 self.arch == other.arch and \
                 self.epoch == other.epoch and \
-                self.vendor == other.vendor:
+                self._normalize_string(self.vendor) == self._normalize_string(other.vendor):
             return True
 
         return False


### PR DESCRIPTION
Previously, if the vendor contains utf8 characters, the rpm
comparison will fail.