### PR TITLE
Add scripts to setup local development environment

### DIFF
--- a/scripts/localhost.yml
+++ b/scripts/localhost.yml
@@ -1,0 +1,7 @@
+---
+- hosts: localhost
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+    setup_xforwarding: no
+  roles:
+    - subman-devel

--- a/scripts/setup_local_devel_environment.sh
+++ b/scripts/setup_local_devel_environment.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+CHECKOUT=$(git rev-parse --show-toplevel)
+which ansible >/dev/null || sudo dnf -y install ansible
+ansible-galaxy install --ignore-errors -r "$CHECKOUT/vagrant/requirements.yml"
+ansible-playbook -e subman_checkout_dir="$CHECKOUT" -K "$CHECKOUT/scripts/localhost.yml"
+echo "**** NOTE ****"
+echo Some configuration written to .bashrc.
+echo You may need to launch a new login shell, source .bashrc, or re-login.
+echo "**************"


### PR DESCRIPTION
Uses the same role as the Vagrant environment.

The role itself will require some related changes. (see candlepin/ansible-role-subman-devel#4)