### PR TITLE
1636381: Fix up our detection of missing org for service-level list

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1124,7 +1124,7 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
         except connection.RestlibException as e:
             if e.code == 404 and e.msg.find('/servicelevels') > 0:
                 system_exit(os.EX_UNAVAILABLE, _("Error: The service-level command is not supported by the server."))
-            elif e.code == 404 and e.msg.find('Organization') >= 0 and e.msg.find('could not be found') > 0:
+            elif e.code == 404:
                 system_exit(os.EX_DATAERR, _(e.msg))
             else:
                 raise e


### PR DESCRIPTION
The prior method assumed the locale was en-us or similar. The new form of displaying the error message does not work when the locale is anything else.

For an example try this reproducer:

(On a system that is not yet registered)

1) LANG=de_DE.UTF-8 subscription-manager service-level --list --org foobar --user <SOME_VALID_USERNAME> --pass <SOME_VALID_PASSWORD>

Observe that the http error code is still displayed in the translated resulting message.
Compare this to running the command as follows (with LANG set to en_US.UTF-8):
2) LANG=en_US.UTF-8 subscription-manager service-level --list --org foobar --user <SOME_VALID_USERNAME> --pass <SOME_VALID_PASSWORD>

