### PR TITLE
Module MD - Show installed profiles only for enabled modules

### DIFF
--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -80,6 +80,9 @@ class ModulesProfile(object):
                     status = "enabled"
                 elif modules.isDisabled(module_pkg.getName()):
                     status = "disabled"
+                installed_profiles = []
+                if status == "enabled":
+                    installed_profiles = modules.getInstalledProfiles(module_pkg.getName())
                 module_list.append({
                     "name": module_pkg.getName(),
                     "stream": module_pkg.getStream(),
@@ -87,7 +90,7 @@ class ModulesProfile(object):
                     "context": module_pkg.getContext(),
                     "arch": module_pkg.getArch(),
                     "profiles": [profile.getName() for profile in module_pkg.getProfiles()],
-                    "installed_profiles": modules.getInstalledProfiles(module_pkg.getName()),
+                    "installed_profiles": installed_profiles,
                     "status": status
                 })
 


### PR DESCRIPTION
This commit fixes an issue where the installed profiles was selected for
all modules without checking on the stream information. This commit will curate installed_profiles only if the module stream is enabled.