### PR TITLE
1642271: Do not set a None lang

### DIFF
--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -50,7 +50,10 @@ def configure_i18n():
         os.environ['LC_ALL'] = 'C.UTF-8'
         locale.setlocale(locale.LC_ALL, 'C.UTF-8')
     configure_gettext()
-    Locale.set(os.environ.get("LANG"))
+    # RHBZ 1642271  Don't set a None lang
+    lang = os.environ.get("LANG")
+    if lang is not None:
+        Locale.set(lang)
 
 
 def configure_gettext():

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 from nose.plugins.attrib import attr
+from mock import patch
 
 try:
     import unittest2 as unittest
@@ -9,6 +10,7 @@ except ImportError:
 
 import codecs
 import glob
+import os
 
 from subscription_manager.i18n import configure_i18n
 from subscription_manager.unicode_width import textual_width
@@ -32,3 +34,33 @@ class TestI18N(unittest.TestCase):
                     self.assertEqual(actual, expected, msg='mismatch on line {} of file {}, {} vs. {}'.format(
                          number, po_file, expected, actual
                     ))
+
+    @patch('subscription_manager.i18n.Locale')
+    def test_configure_i18n_lang(self, locale):
+        """
+        Ensure the method i18n does not pass a None from the environment to Locale
+        :return:
+        """
+        new_lang = 'en-US.UTF-8'
+
+        with patch.dict(os.environ, {'LANG': new_lang}):
+            try:
+                configure_i18n()
+            except:
+                self.fail()
+
+        locale.set.assert_called_with(new_lang)
+
+    @patch('subscription_manager.i18n.Locale')
+    def test_configure_i18n_lang_none(self, locale):
+        """
+        Ensure the method i18n does not pass a None from the environment to Locale
+        :return:
+        """
+        with patch.dict(os.environ, clear=True):
+            try:
+                configure_i18n()
+            except:
+                self.fail()
+
+        locale.set.assert_not_called()


### PR DESCRIPTION
Just a quick fix. No longer call Locale.set if the LANG env variable is unset (causes unexpected behaviour).