### PR TITLE
1645205: Do not update ent certs inside containers

### DIFF
--- a/src/dnf-plugins/subscription-manager.py
+++ b/src/dnf-plugins/subscription-manager.py
@@ -104,7 +104,7 @@ class SubscriptionManager(dnf.Plugin):
         if config.in_container():
             logger.info(_("Subscription Manager is operating in container mode."))
 
-        if not cache_only:
+        if not cache_only and not config.in_container():
             cert_action_invoker = EntCertActionInvoker()
             cert_action_invoker.update()
 

--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -111,7 +111,7 @@ def update(conduit, cache_only):
     if config.in_container():
         conduit.info(3, "Subscription Manager is operating in container mode.")
 
-    if not cache_only:
+    if not cache_only and not config.in_container():
         cert_action_invoker = EntCertActionInvoker(locker=YumRepoLocker(conduit=conduit))
         cert_action_invoker.update()
 

--- a/src/zypper/services/rhsm
+++ b/src/zypper/services/rhsm
@@ -105,7 +105,7 @@ class ZypperService(object):
         connection.UEPConnection(cert_file=cert_file, key_file=key_file)
         cache_only = not self.full_refresh_on_yum
 
-        if not cache_only:
+        if not cache_only and not config.in_container():
             cert_action_invoker = EntCertActionInvoker(locker=RepoLocker())
             cert_action_invoker.update()
 


### PR DESCRIPTION
For the yum, dnf, and zypper subscription-manager plugins, do not attempt to update the entitlement certificates on the system if it appears that we are in a container.

Without this, running yum repolist - or equivalent in other package managers - will cause all entitlement certificates to be removed from within the container causing loss of access to all repos granted thereby when pointing to a Satellite.