### PR TITLE
Allow subman yum plugin to disable all system repo

### DIFF
--- a/etc-conf/plugin/subscription-manager.conf
+++ b/etc-conf/plugin/subscription-manager.conf
@@ -1,2 +1,6 @@
 [main]
 enabled=1
+
+# Setting disable_system_repos to 1, disables all system repositories
+# (= repositories which are not mangaged by subscription-manager will NOT be used)
+disable_system_repos=0

--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -159,6 +159,23 @@ def warnOrGiveUsageMessage(conduit):
             conduit.info(2, msg)
 
 
+def init_hook(conduit):
+    """ Hook for disabling system repositories (= repositories which are
+        not mangaged by subscription-manager will NOT be used) """
+
+    disable_system_repos = conduit.confBool('main', 'disable_system_repos', default=False)
+
+    if disable_system_repos:
+        disable_count = 0
+        repo_storage = conduit.getRepos()
+        for repo in repo_storage.repos.values():
+            if os.path.basename(repo.repofile) != "redhat.repo" and repo.enabled is True:
+                conduit.info(2, 'Disabling system repository "%s" in file "%s"' % (repo.id, repo.repofile))
+                repo_storage.disableRepo(repo.id)
+                disable_count += 1
+        conduit.info(2, 'subscription-manager plugin disabled "%d" system repositories with respect of configuration in /etc/yum/pluginconf.d/subscription-manager.conf' % (disable_count))
+
+
 def postconfig_hook(conduit):
     """ update """
     # register rpm name for yum history recording"


### PR DESCRIPTION
In case the host repositories are managed by the subscription-manager
(e.g. with katello), it is expected that only the repositories activated
by the subscription-manager are enabled. This is even more important on
CentOS / Fedora distribution in which the basic repo files exists.