### PR TITLE
ENT-949: run the package profile reporting on the post_trans_hook for…

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -70,6 +70,9 @@ pluginConfDir = /etc/rhsm/pluginconf.d
 # Manage automatic enabling of yum/dnf plugins (product-id, subscription-manager)
 auto_enable_yum_plugins = 1
 
+# Run the package profile on each yum/dnf transaction
+package_profile_on_trans = 0
+
 # Inotify is used for monitoring changes in directories with certificates.
 # Currently only the /etc/pki/consumer directory is monitored by the
 # rhsm.service. When this directory is mounted using a network file system

--- a/src/dnf-plugins/subscription-manager.py
+++ b/src/dnf-plugins/subscription-manager.py
@@ -18,6 +18,7 @@ from __future__ import print_function, division, absolute_import
 import os
 
 from subscription_manager import injection as inj
+from subscription_manager.action_client import ProfileActionClient
 from subscription_manager.repolib import RepoActionInvoker
 from subscription_manager.entcertlib import EntCertActionInvoker
 from rhsmlib.facts.hwprobe import ClassicCheck
@@ -140,3 +141,15 @@ class SubscriptionManager(dnf.Plugin):
         finally:
             if msg:
                 logger.info(msg)
+
+    def transaction(self):
+        """
+        Call Package Profile
+        """
+        cfg = config.initConfig()
+        if '1' == cfg.get('rhsm', 'package_profile_on_trans'):
+            package_profile_client = ProfileActionClient()
+            package_profile_client.update()
+        else:
+            # do nothing
+            return

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -73,6 +73,7 @@ RHSM_DEFAULTS = {
         'plugindir': '/usr/share/rhsm-plugins',
         'pluginconfdir': '/etc/rhsm/pluginconf.d',
         'auto_enable_yum_plugins': '1',
+        'package_profile_on_trans': '0',
         'inotify': '1'
         }
 

--- a/src/subscription_manager/action_client.py
+++ b/src/subscription_manager/action_client.py
@@ -87,3 +87,16 @@ class UnregisterActionClient(base_action_client.BaseActionClient):
 
         lib_set = [self.entcertlib, self.content_action_client]
         return lib_set
+
+
+class ProfileActionClient(base_action_client.BaseActionClient):
+    """
+    This class should not need a consumer id, or a uep connection, since it
+    is running post unregister.
+    """
+    def _get_libset(self):
+
+        self.profilelib = PackageProfileActionInvoker()
+
+        lib_set = [self.profilelib]
+        return lib_set


### PR DESCRIPTION
… each transaction



To test: Set the new config entry to 1.

Observe the log for an attempt to update the package profile at the server.
If the server does not support this, you will get something like this in the log:

2018-11-13 11:07:37,018 [INFO] dnf:28245:MainThread @cache.py:446 - Server does not support packages, skipping profile upload.