### PR TITLE
Uniquify the module list

### DIFF
--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -60,6 +60,14 @@ class ModulesProfile(object):
         return self.content == other.content
 
     @staticmethod
+    def _uniquify(module_list):
+        ret = {}
+        for module in module_list:
+            key = (module["name"], module["stream"], module["version"], module["context"], module["arch"])
+            ret[key] = module
+        return list(ret.values())
+
+    @staticmethod
     def __generate():
         module_list = []
         if dnf is not None and libdnf is not None:
@@ -94,7 +102,7 @@ class ModulesProfile(object):
                     "status": status
                 })
 
-        return module_list
+        return ModulesProfile._uniquify(module_list)
 
     def collect(self):
         """

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -326,6 +326,35 @@ class TestProfileManager(unittest.TestCase):
         for attr in ['name', 'version', 'release', 'arch', 'vendor']:
             self.assertEqual(None, data[attr])
 
+    def test_module_md_uniquify(self):
+        modules_input = [
+            {
+                "name": "duck",
+                "stream": 0,
+                "version": "20180730233102",
+                "context": "deadbeef",
+                "arch": "noarch",
+                "profiles": ["default"],
+                "installed_profiles": [],
+                "status": "enabled"
+            },
+            {
+                "name": "duck",
+                "stream": 0,
+                "version": "20180707144203",
+                "context": "c0ffee42",
+                "arch": "noarch",
+                "profiles": ["default", "server"],
+                "installed_profiles": ["server"],
+                "status": "unknown"
+            }
+
+        ]
+
+        self.assertEqual(modules_input, ModulesProfile._uniquify(modules_input))
+        # now test dup modules
+        self.assertEqual(modules_input, ModulesProfile._uniquify(modules_input + [modules_input[0]]))
+
     @staticmethod
     def _mock_pkg_profile(packages, repo_file, enabled_modules):
         """


### PR DESCRIPTION
Prior to this commit
If there are duplicate repos in a list, subman will send duplicate
modules over the wire. 

This commit fixes that by uniquifying based on
"name", "stream", "version", "context", "arch"