### PR TITLE
Small fixes of libdnf product-id plugin

### DIFF
--- a/src/dnf-plugins/product-id/product-id.c
+++ b/src/dnf-plugins/product-id/product-id.c
@@ -211,15 +211,14 @@ int pluginHook(PluginHandle *handle, PluginHookId id, void *hookData, PluginHook
         for (guint i = 0; i < enabledRepos->len; i++) {
             DnfRepo *repo = g_ptr_array_index(enabledRepos, i);
             LrResult *lrResult = dnf_repo_get_lr_result(repo);
-            LrYumRepoMd *repoMd;
+            LrYumRepoMd *repoMd = NULL;
             GError *tmp_err = NULL;
 
             debug("Enabled: %s", dnf_repo_get_id(repo));
             lr_result_getinfo(lrResult, &tmp_err, LRR_YUM_REPOMD, &repoMd);
             if (tmp_err) {
                 printError("Unable to get information about repository", tmp_err);
-            }
-            else {
+            } else if (repoMd != NULL) {
                 LrYumRepoMdRecord *repoMdRecord = lr_yum_repomd_get_record(repoMd, "productid");
                 if (repoMdRecord) {
                     debug("Repository %s has a productid", dnf_repo_get_id(repo));
@@ -239,6 +238,8 @@ int pluginHook(PluginHandle *handle, PluginHookId id, void *hookData, PluginHook
                         free(repoProductId);
                     }
                 }
+            } else {
+                error("Unable to get valid information about repository");
             }
         }
 

--- a/src/dnf-plugins/product-id/productdb.h
+++ b/src/dnf-plugins/product-id/productdb.h
@@ -18,6 +18,7 @@
 
 #include <glib.h>
 
+#define PRODUCTDB_DIR "/var/lib/rhsm/"
 #define PRODUCTDB_FILE "/var/lib/rhsm/productid.js"
 
 typedef struct {

--- a/src/dnf-plugins/product-id/util.c
+++ b/src/dnf-plugins/product-id/util.c
@@ -44,10 +44,18 @@ __attribute__ ((format (printf, 2, 3)));
 
 void r_log (const char *level, const char *message, ...) {
     gboolean use_stdout = FALSE;
+    gint ret;
     va_list argp;
-    FILE *log_file = fopen (LOGFILE, "a");
-    if (!log_file) {
-        // redirect message to stdout
+    FILE *log_file;
+    ret = g_mkdir_with_parents(RHSM_LOG_DIR, 0755);
+    if (ret == 0) {
+        log_file = fopen(LOGFILE, "a");
+        if (!log_file) {
+            // redirect message to stdout
+            log_file = stdout;
+            use_stdout = TRUE;
+        }
+    } else {
         log_file = stdout;
         use_stdout = TRUE;
     }

--- a/src/dnf-plugins/product-id/util.h
+++ b/src/dnf-plugins/product-id/util.h
@@ -17,8 +17,14 @@
 
 #include <glib.h>
 
-#define LOGFILE "/var/log/rhsm/productid.log"
+#define RHSM_LOG_DIR "/var/log/rhsm/"
+#define LOGFILE RHSM_LOG_DIR "productid.log"
+
+#ifndef NDEBUG
 #define SHOW_DEBUG TRUE
+#else
+#define SHOW_DEBUG FALSE
+#endif
 
 #define info(msg, ...) r_log ("INFO", msg, ##__VA_ARGS__)
 #define warn(msg, ...) r_log ("WARN", msg, ##__VA_ARGS__)


### PR DESCRIPTION
* When some directories does not exist, then create these
  direcotiries including parent all parent directories.
* Do not print debug messages to productid.log, when
  CMAKE_BUILD_TYPE is set to Release
* Changed type of some log messages
* Fixed bug that caused crashes of PackageKit daemon.