### PR TITLE
Fix builds of product-id plugin

### DIFF
--- a/src/dnf-plugins/product-id/CMakeLists.txt
+++ b/src/dnf-plugins/product-id/CMakeLists.txt
@@ -2,6 +2,8 @@ CMAKE_MINIMUM_REQUIRED (VERSION 3.11.2)
 
 project(product-id C)
 
+include(GNUInstallDirs)
+
 # Warn user because CLion is upset by in source builds
 MACRO(MACRO_ENSURE_OUT_OF_SOURCE_BUILD MSG)
     STRING(COMPARE EQUAL "${CMAKE_SOURCE_DIR}"
@@ -69,7 +71,7 @@ target_link_libraries(product-id
     ${JSONC_LIBRARIES}
 )
 
-install(TARGETS product-id LIBRARY DESTINATION /usr/lib64/libdnf/plugins)
+install(TARGETS product-id LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/libdnf/plugins)
 
 enable_testing()
 

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -353,7 +353,9 @@ Group: System Environment/Base
 %if (0%{?fedora} >= 29 || 0%{?rhel} >= 8)
 BuildRequires: cmake
 BuildRequires: gcc
+BuildRequires: json-c-devel
 BuildRequires: libdnf-devel >= 0.22.0
+Requires: json-c
 Requires: libdnf >= 0.22.0
 %endif
 # See BZ 1581410 - avoid a circular dependency


### PR DESCRIPTION
- Add json-c dependencies to spec file
- Use arch-specific lib directory for CMake build