### PR TITLE
Use new API of libdnf to be able to work with PackageKit

### DIFF
--- a/src/dnf-plugins/product-id/product-id.h
+++ b/src/dnf-plugins/product-id/product-id.h
@@ -50,7 +50,7 @@ typedef struct _PluginHandle {
     // Data provided by the init method
     int version;
     PluginMode mode;
-    void* initData;
+    DnfContext *context;
 
     // Add plugin-specific "private" data here
 } _PluginHandle;
@@ -70,7 +70,7 @@ void printError(const char *msg, GError *err);
 void getEnabled(const GPtrArray *repos, GPtrArray *enabledRepos);
 GPtrArray *getAvailPackageList(DnfSack *dnfSack, DnfRepo *repo);
 GPtrArray *getInstalledPackages(DnfSack *rpmDbSack);
-void getActive(DnfContext *context, const GPtrArray *repoAndProductIds, GPtrArray *activeRepoAndProductIds);
+void getActive(DnfPluginHookData *hookData, const GPtrArray *repoAndProductIds, GPtrArray *activeRepoAndProductIds);
 int decompress(gzFile input, GString *output) ;
 int findProductId(GString *certContent, GString *result);
 int fetchProductId(DnfRepo *repo, RepoProductId *repoProductId);

--- a/src/dnf-plugins/product-id/test-product-id.c
+++ b/src/dnf-plugins/product-id/test-product-id.c
@@ -308,6 +308,7 @@ void testGetEnabledRepos(enabledReposFixture *fixture, gconstpointer testData) {
 }
 
 typedef struct {
+    DnfPluginHookData *hookData;
     DnfContext *dnfContext;
     GPtrArray *repoAndProductIds;
     GPtrArray *activeRepoAndProductIds;
@@ -318,6 +319,7 @@ typedef struct {
 
 void setupActiveRepos(activeReposFixture *fixture, gconstpointer testData) {
     (void)testData;
+    fixture->hookData = NULL;
     fixture->dnfContext = dnf_context_new();
     int max_size = 3;
     fixture->repoAndProductIds = g_ptr_array_sized_new(max_size);
@@ -347,7 +349,7 @@ void teardownActiveRepos(activeReposFixture *fixture, gconstpointer testData) {
 
 void testGetActiveRepos(activeReposFixture *fixture, gconstpointer testData) {
     (void)testData;
-    getActive(fixture->dnfContext, fixture->repoAndProductIds, fixture->activeRepoAndProductIds);
+    getActive(fixture->hookData, fixture->repoAndProductIds, fixture->activeRepoAndProductIds);
     // TODO: improve this unit test to get at least one active repository
     g_assert_cmpint(fixture->activeRepoAndProductIds->len, ==, 0);
 }


### PR DESCRIPTION
* The API of libdnf is going to be changed. See this PR:
  https://github.com/rpm-software-management/libdnf/pull/642
* Our plugin was tested with development version of libdnf
  and PackageKit linked against this development version
  of libdnf. Microdnf was tested with development version
  of libdnf too.
* Fixed some unit tests to use new API.