### PR TITLE
Fix several issues with os.errno

### DIFF
--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -21,6 +21,7 @@ This module contains utilities for manipulating files pertaining to system syspu
 
 import json
 import os
+import errno
 import io
 from syspurpose.utils import system_exit, create_dir, create_file, make_utf8, write_to_file_utf8
 from syspurpose.i18n import ugettext as _
@@ -58,14 +59,14 @@ class SyspurposeStore(object):
 
             return False
         except OSError as e:
-            if e.errno == os.errno.EACCES and not self.raise_on_error:
+            if e.errno == errno.EACCES and not self.raise_on_error:
                 system_exit(os.EX_NOPERM,
                     _('Cannot read syspurpose file {}\nAre you root?').format(self.path))
 
             if self.raise_on_error:
                 raise e
         except IOError as ioerr:
-            if ioerr.errno == os.errno.ENOENT:
+            if ioerr.errno == errno.ENOENT:
                 return False
             if self.raise_on_error:
                 raise ioerr

--- a/syspurpose/src/syspurpose/utils.py
+++ b/syspurpose/src/syspurpose/utils.py
@@ -22,6 +22,7 @@ Utility methods for the syspurpose command
 import io
 import json
 import os
+import errno
 import sys
 import six
 from syspurpose.i18n import ugettext as _
@@ -50,10 +51,10 @@ def create_dir(path):
     try:
         os.makedirs(path, mode=0o755)
     except OSError as e:
-        if e.errno == os.errno.EEXIST:
+        if e.errno == errno.EEXIST:
             # If the directory exists no changes necessary
             return False
-        if e.errno == os.errno.EACCES:
+        if e.errno == errno.EACCES:
             system_exit(os.EX_NOPERM,
                         _('Cannot create directory {}\nAre you root?').format(path))
     return True
@@ -72,10 +73,10 @@ def create_file(path, contents):
             f.flush()
 
     except OSError as e:
-        if e.errno == os.errno.EEXIST:
+        if e.errno == errno.EEXIST:
             # If the file exists no changes necessary
             return False
-        if e.errno == os.errno.EACCES:
+        if e.errno == errno.EACCES:
             system_exit(os.EX_NOPERM, _("Cannot create file {}\nAre you root?").format(path))
         else:
             raise

--- a/syspurpose/test/syspurpose/test_utils.py
+++ b/syspurpose/test/syspurpose/test_utils.py
@@ -20,6 +20,7 @@ from __future__ import print_function, division, absolute_import
 from .base import SyspurposeTestBase
 import io
 import os
+import errno
 import json
 import mock
 
@@ -85,7 +86,7 @@ class UtilsTests(SyspurposeTestBase):
         # And now when the file appears to exist
         with mock.patch('syspurpose.utils.io.open') as mock_open:
             error_to_raise = OSError()
-            error_to_raise.errno = os.errno.EEXIST
+            error_to_raise.errno = errno.EEXIST
             mock_open.side_effect = error_to_raise
 
             res = self.assertRaisesNothing(utils.create_file, to_create, test_data)
@@ -96,7 +97,7 @@ class UtilsTests(SyspurposeTestBase):
         # And now with an unexpected OSError
         with mock.patch('syspurpose.utils.io.open') as mock_open:
             error_to_raise = OSError()
-            error_to_raise.errno = os.errno.E2BIG  # Anything aside from the ones expected
+            error_to_raise.errno = errno.E2BIG  # Anything aside from the ones expected
             mock_open.side_effect = error_to_raise
 
             self.assertRaises(OSError, utils.create_file, to_create, test_data)


### PR DESCRIPTION
* Look at this document about Python 3.7:
  https://docs.python.org/3/whatsnew/3.7.html
* Several undocumented internal imports were removed. One example
  is that `os.errno` is no longer available; use `import errno`
  directly instead.
* Note: `errno` module is available in Python 2.7