### PR TITLE
1651669: Remove dbus-python from egg requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,7 @@ install-via-setup: install-subpackages-via-setup
 	if [[ "$(INCLUDE_SYSPURPOSE)" = "1" ]]; then \
 		mv $(DESTDIR)/$(PREFIX)/bin/syspurpose $(DESTDIR)/$(PREFIX)/sbin/; \
 	fi;
+	find $(DESTDIR)/$(PYTHON_SITELIB) -name requires.txt -exec sed -i '/dbus-python/d' {} \;
 
 
 .PHONY: install-subpackages-via-setup


### PR DESCRIPTION
Currently dbus-python does not install egg metadata if installed via
RPM. As a result, setuptools entrypoints (i.e. all our bin files) fail
to discover the dbus-python package and refuse to start.

This hack simply drops the line afterwards from requires.txt