### PR TITLE
1618498: cockpit will notify activation keys require org [ENT-790]

### DIFF
--- a/cockpit/src/subscriptions-client.js
+++ b/cockpit/src/subscriptions-client.js
@@ -190,6 +190,12 @@ client.registerSystem = subscriptionDetails => {
         handler: dbus_str(RHSM_DEFAULTS.prefix),
     };
 
+    if (subscriptionDetails.activation_keys && !subscriptionDetails.org) {
+        var error = new Error("'Organization' is required when using activation keys...");
+        dfd.reject(error);
+        return dfd.promise();
+    }
+
     if (subscriptionDetails.url !== 'default') {
         /*  parse url into host, port, handler; sorry about the ugly regex */
         const pattern = new RegExp(


### PR DESCRIPTION
- When trying to register with activation keys in cockpit, now the proper message
  will be displayed to the user when he doesn't also provide an organisation.