### PR TITLE
1638153: Restore service-level command for older servers

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -674,7 +674,7 @@ class SyspurposeCommand(CliCommand):
             print(_("{name} not set.".format(name=self.name.capitalize())))
 
     def sync(self):
-        return syspurposelib.SyspurposeSyncActionCommand(self.attr).perform(include_result=True)[1]
+        return syspurposelib.SyspurposeSyncActionCommand().perform(include_result=True)[1]
 
     def _do_command(self):
         self._validate_options()
@@ -1113,8 +1113,20 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
         if self.cp.has_capability("syspurpose"):
             super(ServiceLevelCommand, self).set()
         else:
-            # TODO Find old impl of service level command.
-            pass
+            self.update_service_level(self.options.set)
+
+    def unset(self):
+        if self.cp.has_capability("syspurpose"):
+            super(ServiceLevelCommand, self).unset()
+        else:
+            self.update_service_level("")
+
+    def update_service_level(self, service_level):
+        consumer = self.cp.getConsumer(self.identity.uuid)
+        if 'serviceLevel' not in consumer:
+            system_exit(os.EX_UNAVAILABLE,
+                        _("Error: The service-level command is not supported by the server."))
+        self.cp.updateConsumer(self.identity.uuid, service_level=service_level)
 
     def show_service_level(self):
         consumer = self.cp.getConsumer(self.identity.uuid)

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -178,11 +178,10 @@ class SyspurposeSyncActionCommand(object):
       - The current values on the file system
     """
 
-    def __init__(self, command_name=None):
+    def __init__(self):
         self.report = SyspurposeSyncActionReport()
         self.cp_provider = inj.require(inj.CP_PROVIDER)
         self.uep = self.cp_provider.get_consumer_auth_cp()
-        self.command = command_name
 
     def perform(self, include_result=False):
         """


### PR DESCRIPTION
This uses the old method of setting the service-level when the server does not have the "syspurpose" capability. it was due to a failure of setting that the --show option also appeared to be broken.


This can be tested by removing the "syspurpose" capability from candlepin and registering to that instance then running `subscription-manager service-level --set Premium` (with no value previously set).
After that `subscription-manager service-level --show` should show "Premium".