### PR TITLE
1624859: Add bash completion for syspurpose aspects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ install-conf:
 	install -m 644 etc-conf/dbus/polkit/com.redhat.SubscriptionManager.policy $(DESTDIR)/$(POLKIT_ACTIONS_INST_DIR)
 	if [[ "$(INCLUDE_SYSPURPOSE)" = "1" ]]; then \
 		install -m 644 etc-conf/syspurpose/valid_fields.json $(DESTDIR)/etc/rhsm/syspurpose/valid_fields.json; \
+		install -m 644 etc-conf/syspurpose.completion.sh $(DESTDIR)/etc/bash_completion.d/syspurpose; \
 	fi;
 	if [[ "$(WITH_SUBMAN_GUI)" == "true" ]]; then \
 		install -m 644 etc-conf/subscription-manager-gui.appdata.xml $(DESTDIR)/$(INSTALL_DIR)/appdata/subscription-manager-gui.appdata.xml; \

--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -199,6 +199,7 @@ _subscription_manager_version()
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }
 
+
 # main complete function
 _subscription_manager()
 {
@@ -209,11 +210,12 @@ _subscription_manager()
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
   # top-level commands and options
-  opts="attach auto-attach clean config environments facts identity import list orgs
-        repo-override plugins redeem refresh register release remove repos service-level status
-        subscribe unregister unsubscribe version ${_subscription_manager_help_opts}"
+  opts="addons attach auto-attach clean config environments facts identity import list orgs
+        repo-override plugins redeem refresh register release remove repos role service-level status
+        subscribe unregister unsubscribe usage version ${_subscription_manager_help_opts}"
 
   case "${first}" in
+      addons|\
       clean|\
       config|\
       environments|\
@@ -228,8 +230,10 @@ _subscription_manager()
       register|\
       release|\
       repos|\
+      role|\
       status|\
       unregister|\
+      usage|\
       version)
       "_subscription_manager_$first" "${cur}" "${prev}"
       return 0

--- a/etc-conf/syspurpose.completion.sh
+++ b/etc-conf/syspurpose.completion.sh
@@ -1,0 +1,73 @@
+#
+# syspurpose bash completion script
+#   based on subscription-manager script
+# vim:ts=2:sw=2:et:
+#
+
+# Known and shared constants of syspurpose
+_syspurpose_help_opts="-h --help"
+
+# complete functions for subcommands ($1 - current opt, $2 - previous opt)
+_syspurpose_add()
+{
+  # This list should include all known names of keys which are handled by the rhsm ecosystem
+  # that can be treated as a list
+  local opts="${_syspurpose_help_opts} addons"
+  COMPREPLY=($(compgen -W "${opts}" -- ${1}))
+}
+
+_syspurpose_remove()
+{
+  # This list should include all known names of keys which are handled by the rhsm ecosystem
+  # that can be treated as a list
+  local opts="${_syspurpose_help_opts} addons"
+  COMPREPLY=($(compgen -W "${opts}" -- ${1}))
+}
+
+_syspurpose_set()
+{
+  # This list should include all known names of keys which are handled by the rhsm ecosystem
+  # that can be treated as a singular value
+  local opts="${_syspurpose_help_opts} role usage service_level_agreement"
+  COMPREPLY=($(compgen -W "${opts}" -- ${1}))
+}
+
+_syspurpose_unset()
+{
+  # This list should include all known names of keys which are handled by the rhsm ecosystem
+  # that can be unset
+  local opts="${_syspurpose_help_opts} role usage service_level_agreement addons"
+  COMPREPLY=($(compgen -W "${opts}" -- ${1}))
+}
+
+
+# main complete function
+_syspurpose()
+{
+  local first cur prev opts base
+  COMPREPLY=()
+  first=${COMP_WORDS[1]}
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  # top-level commands and options
+  opts="set unset add remove set-role unset-role set-usage unset-usage add-addons remove-addons
+  set-sla unset-sla show -h --help"
+
+  case "${first}" in
+    add|\
+    remove|\
+    set|\
+    unset)
+    "_syspurpose_$first" "${cur}" "${prev}"
+    return 0
+    ;;
+    *)
+    ;;
+  esac
+
+  COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+  return 0
+}
+
+complete -F _syspurpose syspurpose

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -956,6 +956,7 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 
 %attr(755, root, root) %{_sbindir}/syspurpose
 %attr(644,root,root) %{_sysconfdir}/rhsm/syspurpose/valid_fields.json
+%attr(644,root,root) %{_sysconfdir}/bash_completion.d/syspurpose
 %endif
 
 %files -n subscription-manager-plugin-container


### PR DESCRIPTION
This adds fairly simple bash completion for the syspurpose tool and for the new subscription-manager subcommands relating to syspurpose.