### PR TITLE
1641577: Use cached values if server is unavailable

### DIFF
--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -254,6 +254,7 @@ def main():
         uuid = identity.uuid
         uep = CPProvider().get_consumer_auth_cp()
     except ImportError:
+        identity = None
         uuid = None
         uep = None
         print(_("Warning: Unable to sync system purpose with subscription management server:"
@@ -269,7 +270,7 @@ def main():
     if result:
         if result.remote_changed:
             print(_("System purpose successfully sent to subscription management server."))
-        else:
+        elif identity and identity.is_valid():
             print(_("Unable to send system purpose to subscription management server"))
 
     return 0

--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -270,7 +270,11 @@ class SyncedStore(object):
         cached_contents = self.get_cached_contents()
 
         result = self.merge(local=local_contents,
-                            remote=remote_contents,
+                            # RHBZ 1641577 Only compare against remote values if there are some
+                            # otherwise use only local merged with cached_contents
+                            # This prevents a singular change to the local contents emptying out
+                            # all other values.
+                            remote=remote_contents or cached_contents,
                             base=cached_contents)
 
         sync_result = SyncResult(result, self.update_remote(result),


### PR DESCRIPTION
Using cached values as the values from the server (if all we've got
is an empty dictionary) allows us to make stable modifications to
the local file (in other words, to not remove all other attributes
of syspurpose in the event that the server has nothing for us).

This commit also suppresses the syspurpose tool warning that it is
unable to send syspurpose to subscription management server when
the system appears not to be registered as it makes no sense to
display such a message in that case.