### PR TITLE
1654873: Add man entry for rhsmcertd.disable

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -88,6 +88,8 @@ certCheckInterval = 240
 autoAttachInterval = 1440
 # If set to zero, the checks done by the rhsmcertd daemon will not be splayed (randomly offset)
 splay = 1
+# If set to 1, rhsmcertd will not execute.
+disable = 0
 
 [logging]
 default_log_level = INFO

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -225,6 +225,11 @@ splay
 1 to enable splay. 0 to disable splay. If enabled, this feature delays the initial auto attach and cert check by an amount between 0 seconds and the interval given for the action being delayed. For example if the
 .B certCheckInterval
 were set to 3 minutes, the initial cert check would begin somewhere between 2 minutes after start up (minimum delay) and 5 minutes after start up. This is useful to reduce peak load on the Satellite or entitlement service used by a large number of machines.
+.RE
+.PP
+disable
+.RS 4
+set to 1 to disable rhsmcertd operation entirely.
 .SH "[LOGGING] OPTIONS"
 .PP
 default_log_level


### PR DESCRIPTION
This adds a rhsm.conf.5 man page entry for the new disable option in the rhsmcertd section.
In addition it adds an example/default for the disable option to the rhsm.conf template/default file.