### PR TITLE
1633264: Ensure we sync syspurpose on register

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1309,10 +1309,10 @@ class RegisterCommand(UserPassCommand):
             if self.options.consumerid:
                 log.info("Registering as existing consumer: %s" % self.options.consumerid)
                 consumer = service.register(None, consumerid=self.options.consumerid,
-                                            role=syspurpose.get('role') or '',
+                                            role=syspurpose.get('role'),
                                             addons=syspurpose.get('addons') or [],
                                             service_level=syspurpose.get('service_level_agreement') or '',
-                                            usage=syspurpose.get('usage') or ''
+                                            usage=syspurpose.get('usage')
                                             )
             else:
                 owner_key = self._determine_owner_key(admin_cp)
@@ -1325,11 +1325,16 @@ class RegisterCommand(UserPassCommand):
                     force=self.options.force,
                     name=self.options.consumername,
                     type=self.options.consumertype,
-                    role=syspurpose.get('role') or '',
+                    role=syspurpose.get('role'),
                     addons=syspurpose.get('addons') or [],
                     service_level=syspurpose.get('service_level_agreement') or '',
-                    usage=syspurpose.get('usage') or ''
+                    usage=syspurpose.get('usage')
                 )
+
+                store = syspurposelib.SyncedStore
+                if store:
+                    store = store(admin_cp, consumer_uuid=consumer['uuid'])
+                    store.sync()
         except (connection.RestlibException, exceptions.ServiceError) as re:
             log.exception(re)
             system_exit(os.EX_SOFTWARE, re)

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -84,8 +84,8 @@ class CliRegistrationTests(SubManFixture):
         self._inject_ipm()
 
         cmd.main(['register', '--consumerid=123456', '--username=testuser1', '--password=password', '--org=test_org'])
-        self.mock_register.register.assert_called_once_with(None, consumerid='123456', role='',
-                                                            addons=[], service_level='', usage='')
+        self.mock_register.register.assert_called_once_with(None, consumerid='123456', role=None,
+                                                            addons=[], service_level='', usage=None)
         mock_entcertlib.update.assert_called_once()
 
     def test_consumerid_with_distributor_id(self):


### PR DESCRIPTION
There was one case that was left out of the last PR for this BZ, that of registration.

If there is no syspurpose defined for a system, and a user registers and then attempts to set some attribute of syspurpose, they are met with an incorrect message warning about conflicting changes made serverside.

This PR updates the local and cached syspurpose with the values returned from the server (as they were already submitted during registration). This prevents the issue and ensures the existing values from local (or the defaulted values from the server) do not conflict with one another.