### PR TITLE
1625214: send ConfigChanged event when file replaced [ENT-838]

### DIFF
--- a/src/rhsmlib/file_monitor.py
+++ b/src/rhsmlib/file_monitor.py
@@ -180,13 +180,14 @@ class DirectoryWatch(object):
         """
         self.IN_DELETE = 0x00000200
         self.IN_MODIFY = 0x00000002
+        self.IN_MOVED_TO = 0x00000080
 
         self.path = os.path.abspath(path)
         self.is_file = not os.path.isdir(self.path)  # used isdir because if path does not exist, assumed to be file
         self.timestamp = None
         self.is_glob = is_glob
         self.callbacks = callbacks
-        self.mask = self.IN_DELETE | self.IN_MODIFY
+        self.mask = self.IN_DELETE | self.IN_MODIFY | self.IN_MOVED_TO
 
     def notify(self):
         """

--- a/test/rhsmlib_test/test_file_monitor.py
+++ b/test/rhsmlib_test/test_file_monitor.py
@@ -238,7 +238,11 @@ class TestDirectoryWatch(fixture.SubManFixture):
     def test_file_modified(self, mock_event):
         mock_event.mask = 1
         self.assertFalse(self.dw3.file_modified(mock_event.mask))
-        mock_event.mask = 2
+        mock_event.mask = self.dw3.IN_MODIFY
+        self.assertTrue(self.dw3.file_modified(mock_event.mask))
+        mock_event.mask = self.dw3.IN_DELETE
+        self.assertTrue(self.dw3.file_modified(mock_event.mask))
+        mock_event.mask = self.dw3.IN_MOVED_TO
         self.assertTrue(self.dw3.file_modified(mock_event.mask))
 
 


### PR DESCRIPTION
- Now, the ConfigChanged event will be sent not only when a monitored
  file is edited in place, but also when the whole file is replaced
  with another who is moved/renamed to the same location & name.