### PR TITLE
1660224: Allow setting and unsetting of addons and service level

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -696,7 +696,7 @@ class SyspurposeCommand(CliCommand):
 
     def _check_result(self, expectation, success_msg, command, attr):
         if self.store:
-            self.store.finish()
+            self.store.sync()
             result = self.store.get_cached_contents()
         else:
             result = {}

--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -90,7 +90,8 @@ def show_contents(args, syspurposestore):
     """
 
     contents = syspurposestore.sync().result
-    print(json.dumps(contents, indent=2, ensure_ascii=False))
+    contents = {key: contents[key] for key in contents if contents[key]}
+    print(json.dumps(contents, indent=2, ensure_ascii=False, sort_keys=True))
 
 
 def setup_arg_parser():

--- a/syspurpose/src/syspurpose/utils.py
+++ b/syspurpose/src/syspurpose/utils.py
@@ -119,4 +119,4 @@ def write_to_file_utf8(file, data):
     :param data: The data to be written
     :return:
     """
-    file.write(make_utf8(json.dumps(data, indent=2, ensure_ascii=False)))
+    file.write(make_utf8(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True)))

--- a/syspurpose/test/syspurpose/base.py
+++ b/syspurpose/test/syspurpose/base.py
@@ -15,10 +15,12 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
+import json
 import pprint
 import unittest
 import tempfile
 import shutil
+import six
 import sys
 import traceback
 
@@ -100,3 +102,30 @@ class SyspurposeTestBase(unittest.TestCase):
 
         if mismatches or missing_keys or extra:
             self.fail(message)
+
+
+# utility functions from syspurpose.utils to help ensure data written to files is utf-8
+def make_utf8(obj):
+    """
+    Transforms the provided string into unicode if it is not already
+    :param obj: the string to decode
+    :return: the unicode format of the string
+    """
+    if six.PY3:
+        return obj
+    elif obj is not None and isinstance(obj, str) and not isinstance(obj, unicode):
+        obj = obj.decode('utf-8')
+        return obj
+    else:
+        return obj
+
+
+def write_to_file_utf8(file, data):
+    """
+    Writes out the provided data to the specified file, with user-friendly indentation,
+    and in utf-8 encoding.
+    :param file: The file to write to
+    :param data: The data to be written
+    :return:
+    """
+    file.write(make_utf8(json.dumps(data, indent=2, ensure_ascii=False)))

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1654,7 +1654,7 @@ class TestRoleCommand(TestCliCommand):
 
         self.assertIn('role set to "Foo"', cap.out)
         instance_syspurpose_store.set.assert_called_once_with('role', 'Foo')
-        instance_syspurpose_store.finish.assert_called_once()
+        instance_syspurpose_store.sync.assert_called_once()
 
     @patch("subscription_manager.syspurposelib.SyncedStore")
     @patch("subscription_manager.syspurposelib.SyspurposeSyncActionCommand")
@@ -1680,7 +1680,7 @@ class TestRoleCommand(TestCliCommand):
 
         self.assertIn("role unset", cap.out)
         instance_syspurpose_store.unset.assert_called_once_with('role')
-        instance_syspurpose_store.finish.assert_called_once()
+        instance_syspurpose_store.sync.assert_called_once()
 
 
 class TestVersionCommand(TestCliCommand):


### PR DESCRIPTION
This does a couple things to make syspurpose syncing finally work
as intended.

1) Values for keys of syspurpose which are not truthy are not stored
   in /etc/rhsm/syspurpose/syspurpose.json.
2) Values for keys of syspurpose which are not truthy ARE stored in
   /var/lib/rhsm/cache/syspurpose.json
3) Keys with dict or list like data are compared in an order agnostic
   manner. (Apparently Candlepin doesn't always return lists in the
   same order)
4) Setting a value to something falsey server side constitutes a
   removal or resetting of the value. This will result in that key
   being removed entirely from /etc/rhsm/syspurpose/syspurpose.json.
5) Keys added to /etc/rhsm/syspurpose/syspurpose.json which are not
   tracked are not touched by our tooling.
6) When registered to an entitlement platform which does not support
   syspurpose, any updates using subscription-manager or syspurpose tool
   will result only in an updated /etc/rhsm/syspurpose/syspurpose.json file.
   There will be no updates to the /var/lib/rhsm/cache/syspurpose.json file or
   to anything server side. Support is determined via the presence or absence
   of the "syspurpose" capability in the status message from the server.
7) When system is registered to an entitlement platform that does not support
   syspurpose which then later is upgraded to support syspurpose,
   subscription-manager and syspurpose tooling will begin reporting the existing
   syspurpose values located in /etc/rhsm/syspurpose/syspurpose.json (and updating
   the cache as necessary).
8) The values in /etc/rhsm/syspurpose/syspurpose.json are not touched when unregistering
   from an entitlement platform.