### PR TITLE
1643128: Do not execute subscription-manager dnf plugin twice; ENT-987

### DIFF
--- a/src/dnf-plugins/subscription-manager.py
+++ b/src/dnf-plugins/subscription-manager.py
@@ -54,9 +54,9 @@ class SubscriptionManager(dnf.Plugin):
         super(SubscriptionManager, self).__init__(base, cli)
         self.base = base
         self.cli = cli
-        self.config()
+        self._config()
 
-    def config(self):
+    def _config(self):
         """ update """
         logutil.init_logger_for_yum()
 


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1643128
* `config()` is name of hook.