### PR TITLE
1661219: Do not delete product certs for disabled repos; ENT-1034

### DIFF
--- a/src/dnf-plugins/product-id.py
+++ b/src/dnf-plugins/product-id.py
@@ -140,7 +140,7 @@ class DnfProductManager(ProductManager):
                             continue
                         lst.append((cert, repo.id))
                         cache[repo.id] = cert.pem
-                    elif repo.id in cache:
+                    elif repo.id in cache and cache[repo.id] is not None:
                         cert = create_from_pem(cache[repo.id])
                         lst.append((cert, repo.id))
                     else:


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1661219
* This bug fix is not specific for DNF, but it fixes same issue
  for YUM too.
* When repository in redhat.repo is disabled using:
    `subscription-manager repos --disable=repo-id`
  then corresponding product certificate should not be removed
* When cached certificate for given repository is "null", then
  do not try to create new certificate from None