### PR TITLE
1658409: Stop redhat.repo from growing exponentially

### DIFF
--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -579,20 +579,20 @@ class ZypperRepoFile(YumRepoFile):
         return cls('var/lib/rhsm/repo_server_val/', 'zypper_{}'.format(cls.NAME))
 
 
-def init_repo_files():
+def init_repo_file_classes():
     repo_file_classes = [YumRepoFile, ZypperRepoFile]
     if HAS_DEB822:
         repo_file_classes.append(AptRepoFile)
     repo_files = [
-        (RepoFile(), RepoFile.server_value_repo_file())
+        (RepoFile, RepoFile.server_value_repo_file)
         for RepoFile in repo_file_classes
         if RepoFile.installed()
     ]
     return repo_files
 
 
-def get_repo_files():
+def get_repo_file_classes():
     global repo_files
     if not repo_files:
-        repo_files = init_repo_files()
+        repo_files = init_repo_file_classes()
     return repo_files

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -262,13 +262,14 @@ class RepoUpdateActionTests(fixture.SubManFixture):
         self.assertEqual('blah', old_repo['gpgcheck'])
         self.assertEqual('some_key', old_repo['gpgkey'])
 
-    @patch("subscription_manager.repolib.get_repo_files")
-    def test_update_when_new_repo(self, mock_get_repo_files):
+    @patch("subscription_manager.repolib.get_repo_file_classes")
+    def test_update_when_new_repo(self, mock_get_repo_file_classes):
         mock_file = MagicMock()
         mock_file.CONTENT_TYPES = [None]
         mock_file.fix_content = lambda x: x
         mock_file.section.return_value = None
-        mock_get_repo_files.return_value = [(mock_file, mock_file)]
+        mock_class = MagicMock(return_value=mock_file)
+        mock_get_repo_file_classes.return_value = [(mock_class, mock_class)]
 
         def stub_content():
             return [Repo('x', [('gpgcheck', 'original'), ('gpgkey', 'some_key')])]
@@ -281,8 +282,8 @@ class RepoUpdateActionTests(fixture.SubManFixture):
         self.assertEqual('some_key', written_repo['gpgkey'])
         self.assertEqual(1, update_report.updates())
 
-    @patch("subscription_manager.repolib.get_repo_files")
-    def test_update_when_repo_not_modified_on_mutable(self, mock_get_repo_files):
+    @patch("subscription_manager.repolib.get_repo_file_classes")
+    def test_update_when_repo_not_modified_on_mutable(self, mock_get_repo_file_classes):
         self._inject_mock_invalid_consumer()
         modified_repo = Repo('x', [('gpgcheck', 'original'), ('gpgkey', 'some_key')])
         server_repo = Repo('x', [('gpgcheck', 'original')])
@@ -290,7 +291,8 @@ class RepoUpdateActionTests(fixture.SubManFixture):
         mock_file.CONTENT_TYPES = [None]
         mock_file.fix_content = lambda x: x
         mock_file.section.side_effect = [modified_repo, server_repo]
-        mock_get_repo_files.return_value = [(mock_file, mock_file)]
+        mock_class = MagicMock(return_value=mock_file)
+        mock_get_repo_file_classes.return_value = [(mock_class, mock_class)]
 
         def stub_content():
             return [Repo('x', [('gpgcheck', 'new'), ('gpgkey', 'new_key'), ('name', 'test')])]
@@ -307,8 +309,8 @@ class RepoUpdateActionTests(fixture.SubManFixture):
         self.assertEqual('new', written_repo['gpgcheck'])
         self.assertEqual(None, written_repo['gpgkey'])
 
-    @patch("subscription_manager.repolib.get_repo_files")
-    def test_update_when_repo_modified_on_mutable(self, mock_get_repo_files):
+    @patch("subscription_manager.repolib.get_repo_file_classes")
+    def test_update_when_repo_modified_on_mutable(self, mock_get_repo_file_classes):
         self._inject_mock_invalid_consumer()
         modified_repo = Repo('x', [('gpgcheck', 'unoriginal'), ('gpgkey', 'some_key')])
         server_repo = Repo('x', [('gpgcheck', 'original')])
@@ -316,7 +318,8 @@ class RepoUpdateActionTests(fixture.SubManFixture):
         mock_file.CONTENT_TYPES = [None]
         mock_file.fix_content = lambda x: x
         mock_file.section.side_effect = [modified_repo, server_repo]
-        mock_get_repo_files.return_value = [(mock_file, mock_file)]
+        mock_class = MagicMock(return_value=mock_file)
+        mock_get_repo_file_classes.return_value = [(mock_class, mock_class)]
 
         def stub_content():
             return [Repo('x', [('gpgcheck', 'new'), ('gpgkey', 'new_key'), ('name', 'test')])]


### PR DESCRIPTION
Thanks long-lived instances of the RepoFile class, subscription-manager
was reading the underlying file twice.  The duplicate reads resulted in
the number of comment nodes doubling in the instance and then getting
written out when it was time to save the file.  Every write of the
redhat.repo file culminated in a doubling of the comment nodes leading
to an exponential growth in file size.

This patch fixes the issue but instantiating the RepoFile class late
into the process and then letting the object get GCed at the end of the
perform method in RepoUpdateActionCommand.