### PR TITLE
1656598: Treat false as disabled when listing repos

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2272,8 +2272,10 @@ class ReposCommand(CliCommand):
             if len(repos):
                 # TODO: Perhaps this should be abstracted out as well...?
                 def filter_repos(repo):
-                    show_enabled = (self.options.list_enabled and repo["enabled"] != '0')
-                    show_disabled = (self.options.list_disabled and repo["enabled"] == '0')
+                    disabled_values = ['false', '0']
+                    repo_enabled = repo['enabled'].lower()
+                    show_enabled = (self.options.list_enabled and repo_enabled not in disabled_values)
+                    show_disabled = (self.options.list_disabled and repo_enabled in disabled_values)
 
                     return show_enabled or show_disabled
 

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -960,14 +960,16 @@ class TestReposCommand(TestCliCommand):
         self.cc.main(["--list-enabled"])
         self.cc._validate_options()
 
-        repos = [Repo("x", [("enabled", "1")]), Repo("y", [("enabled", "0")]), Repo("z", [("enabled", "0")])]
+        repos = [Repo("x", [("enabled", "1")]), Repo("y", [("enabled", "0")]), Repo("z", [("enabled", "0")]),
+                 Repo("a", [("enabled", "false")]), Repo("b", [("enabled", "False")]), Repo("c", [("enabled", "true")])
+                 ]
         mock_invoker.return_value.get_repos.return_value = repos
 
         with Capture() as cap:
             self.cc._do_command()
 
         result = self.check_output_for_repos(cap.out, repos)
-        self.assertEqual((True, False, False), result)
+        self.assertEqual((True, False, False, False, False, True), result)
 
     @patch("subscription_manager.managercli.RepoActionInvoker")
     def test_list_disabled(self, mock_invoker):


### PR DESCRIPTION
When listing repos, prior to this PR, we were treating anything that wasn't '0' as if it were enabled. This PR expands that list to include items whose enabled value are "false".