### PR TITLE
1663254: Remove "Red Hat Enterprise Linux Client/Desktop" role option

### DIFF
--- a/etc-conf/syspurpose/valid_fields.json
+++ b/etc-conf/syspurpose/valid_fields.json
@@ -2,8 +2,7 @@
     "role": [
       "Red Hat Enterprise Linux Server",
       "Red Hat Enterprise Linux Workstation",
-      "Red Hat Enterprise Linux Compute Node",
-      "Red Hat Enterprise Linux Client/Desktop"
+      "Red Hat Enterprise Linux Compute Node"
     ],
     "service_level_agreement": [
       "Premium",


### PR DESCRIPTION
Removes the "Red Hat Enterprise Linux Client/Desktop" option from the vaild_fields.json file installed with syspurpose.