### PR TITLE
1634033: do not install conf file for non-existant dnf plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,8 @@ install-plugins:
 		install -d $(DESTDIR)/$(DNF_PLUGIN_PYTHON_SITELIB)/dnf-plugins/ ; \
 		install -d $(DESTDIR)/etc/dnf/plugins/ ; \
 		install -m 644 -p src/dnf-plugins/*.py $(DESTDIR)/$(DNF_PLUGIN_PYTHON_SITELIB)/dnf-plugins/ ; \
-		install -m 644 etc-conf/plugin/*.conf $(DESTDIR)/etc/dnf/plugins/ ; \
+		install -m 644 etc-conf/plugin/product-id.conf $(DESTDIR)/etc/dnf/plugins/ ; \
+		install -m 644 etc-conf/plugin/subscription-manager.conf $(DESTDIR)/etc/dnf/plugins/ ; \
 	fi;
 
 	# ostree stuff

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -700,7 +700,6 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
     # remove the repo file when we are deleted
     %config(noreplace) %attr(644,root,root) %{_sysconfdir}/dnf/plugins/subscription-manager.conf
     %config(noreplace) %attr(644,root,root) %{_sysconfdir}/dnf/plugins/product-id.conf
-    %config(noreplace) %attr(644,root,root) %{_sysconfdir}/dnf/plugins/search-disabled-repos.conf
 %endif
 
 # misc system config


### PR DESCRIPTION
When using dnf we do not need to include the configuration file for the no longer included search-disabled-repos plugin.