### PR TITLE
1652870: handle new syspurpose status states [ENT-1011]

### DIFF
--- a/src/rhsmlib/services/syspurpose.py
+++ b/src/rhsmlib/services/syspurpose.py
@@ -21,9 +21,12 @@ from subscription_manager import injection as inj
 from subscription_manager.i18n import ugettext as _
 
 
-STATUS_MAP = {'valid': _('Current'),
-        'partial': _('Insufficient'),
+STATUS_MAP = {'valid': _('Valid'),
         'invalid': _('Invalid'),
+        'partial': _('Partial'),
+        'matched': _('Matched'),
+        'mismatched': _('Mismatched'),
+        'not specified': _('Not Specified'),
         'unknown': _('Unknown')}
 
 

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -338,7 +338,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.options.on_date = None
         with Capture() as cap:
             self.cc._do_command()
-        self.assertTrue('System Purpose Status: Current' in cap.out)
+        self.assertTrue('System Purpose Status: Valid' in cap.out)
 
     def test_purpose_status_consumer_lack(self):
         self.cc.consumerIdentity = StubConsumerIdentity


### PR DESCRIPTION
- Now, the new syspurpose statuses 'matched', 'mismatched' and
'not specified' returned by the server will also be handled and shown.
- In addition, for backwards compatibility, if the server returns one of
'valid', 'invalid' or 'partial' status, those will still be handled and
shown too by subscription-manager.