### PR TITLE
ENT-978: Upgrade pxe-server/client to fedora29

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -135,7 +135,12 @@ Vagrant.configure("2") do |config|
   # PXE server
   config.vm.define 'pxe-server', autostart: false do |host|
     host.vm.hostname = 'pxe-server'
-    host.vm.box = 'fedora/27-cloud-base'
+    host.vm.box = 'fedora/29-cloud-base'
+
+    # dnf requires more memory on fedora 29
+    host.vm.provider :libvirt do |domain|
+      domain.memory = 1024
+    end
 
     host.vm.provision "ansible", run: "always" do |ansible|
       ansible.playbook = "vagrant/vagrant_pxe_server.yml"

--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
@@ -31,6 +31,9 @@ try:
 except ImportError:
     from pyanaconda.core.constants import ANACONDA_ENVIRON
 
+from subscription_manager import logutil
+
+logutil.init_logger()
 log = logging.getLogger(__name__)
 
 from subscription_manager import ga_loader

--- a/vagrant/roles/pxe-server/defaults/main.yml
+++ b/vagrant/roles/pxe-server/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 required_rpms:
-  - dhcp
+  - dhcp-compat
+  - dhcp-devel
+  - dhcp-relay
+  - dhcp-server
   - tftp
   - tftp-server
   - syslinux
@@ -35,16 +38,16 @@ required_rpms:
 # # http://ftp.cvut.cz/centos/7/isos/x86_64/sha256sum.txt
 # iso_img_checksum: "sha256:bba314624956961a2ea31dd460cd860a77911c1e0a56e4820a12b9c5dad363f5"
 
-##### Fedora 27 #####
+##### Fedora 29 #####
 
 distro_name: "fedora"
-distro_version: "27"
+distro_version: "29"
 # Newer version is available e.g. here: https://download.fedoraproject.org/pub/fedora/linux/releases/
-iso_img_server: "https://download.fedoraproject.org/pub/fedora/linux/releases/27/Server/x86_64/iso"
-iso_img_file: "Fedora-Server-dvd-x86_64-27-1.6.iso"
+iso_img_server: "https://download.fedoraproject.org/pub/fedora/linux/releases/29/Server/x86_64/iso"
+iso_img_file: "Fedora-Server-dvd-x86_64-29-1.2.iso"
 # Fresh sha256 checksums of Fedora images can be found here:
-# https://download.fedoraproject.org/pub/fedora/linux/releases/27/Server/x86_64/iso/Fedora-Server-27-1.6-x86_64-CHECKSUM
-iso_img_checksum: "sha256:e383dd414bb57231b20cbed11c4953cac71785f7d4f5990b0df5ad534a0ba95c"
+# https://download.fedoraproject.org/pub/fedora/linux/releases/29/Server/x86_64/iso/Fedora-Server-29-1.2-x86_64-CHECKSUM
+iso_img_checksum: "sha256:129d131a55e5bd518f593f0eacdce095f7c795fe7ccbef1f3f6aeb2ff9f99f35"
 
 iso_img_url: "{{iso_img_server}}/{{iso_img_file}}"
 iso_img_mount_path: "/mnt/iso_img"

--- a/vagrant/roles/pxe-server/tasks/main.yml
+++ b/vagrant/roles/pxe-server/tasks/main.yml
@@ -6,17 +6,10 @@
   become: yes
   with_items: "{{required_rpms}}"
 
-- name: create configuration file for eth1
-  template:
-    src: ifcfg-eth1.j2
-    dest: /etc/sysconfig/network-scripts/ifcfg-eth1
+- name: set static ip with network manager
+  shell: |
+    nmcli dev mod eth1 ipv4.method manual ipv4.addr "{{pxe_server_ip_addr}}"
   become: yes
-
-- name: restart network
-  service:
-    name: network
-    state: restarted
-  become: true
 
 - name: modify configuration file of dhcp server
   template:
@@ -36,6 +29,13 @@
     name: tftp.socket
     enabled: yes
     state: started
+  become: true
+
+- lineinfile:
+    path: /etc/vsftpd/vsftpd.conf
+    state: present
+    regexp: '^anonymous_enable'
+    line: 'anonymous_enable=YES'
   become: true
 
 - name: start and enable vsftpd service

--- a/vagrant/roles/pxe-server/templates/ifcfg-eth1.j2
+++ b/vagrant/roles/pxe-server/templates/ifcfg-eth1.j2
@@ -1,6 +1,0 @@
-DEVICE="eth1"
-BOOTPROTO="static"
-ONBOOT="yes"
-TYPE="Ethernet"
-IPADDR={{pxe_server_ip_addr | ipaddr('address')}}
-NETMASK={{pxe_server_ip_addr | ipaddr('netmask')}}

--- a/vagrant/roles/pxe-server/templates/ks_fedora29.cfg.j2
+++ b/vagrant/roles/pxe-server/templates/ks_fedora29.cfg.j2
@@ -47,3 +47,8 @@ pwpolicy root --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
 pwpolicy user --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
 pwpolicy luks --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
 %end
+
+%post --nochroot --log=/mnt/sysimage/root/ks-post.log
+cp /var/log/rhsm/rhsm.log /mnt/sysimage/root/rhsm.log
+
+%end


### PR DESCRIPTION
- Also, now the RHSM spoke in anaconda initializes and logs
in the rhsm.log.