### PR TITLE
1661414: No message display when set service level by subscription manager[ENT-1106]

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1117,12 +1117,14 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
             super(ServiceLevelCommand, self).set()
         else:
             self.update_service_level(self.options.set)
+            print(_("Service level set to: \"{val}\".".format(val=self.options.set)))
 
     def unset(self):
         if self.cp.has_capability("syspurpose"):
             super(ServiceLevelCommand, self).unset()
         else:
             self.update_service_level("")
+            print(_("Service level preference has been unset"))
 
     def update_service_level(self, service_level):
         consumer = self.cp.getConsumer(self.identity.uuid)


### PR DESCRIPTION
When Candlepin doesn't have a 'syspurpose' capability, subman uses different branch of code to set service level. This code doesn't print the result of the operation.

- Add output message for the successful setting of service level
- Add output message for the successful unsetting of service level