### PR TITLE
allow offline repo management

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2258,7 +2258,10 @@ class ReposCommand(CliCommand):
             cert_action_client.update()
             self._request_validity_check()
 
-        self.use_overrides = self.cp.supports_resource('content_overrides')
+        if self.is_registered():
+            self.use_overrides = self.cp.supports_resource('content_overrides')
+        else:
+            self.use_overrides = False
 
         # specifically, yum repos, for now.
         rl = RepoActionInvoker()


### PR DESCRIPTION
subscription-manager currently creates the repo file if an entitlement
cert is imported on an offline system.  This change enables selecting
which of those repos are enabled without having to pass --enablerepo
to every yum invocation.  Should also allow use of the rhsm_repository
ansible module on these offline systems.