### PR TITLE
More reliable PXE server and PXE client; ENT-1121

### DIFF
--- a/scripts/autobuild_updates_img.sh
+++ b/scripts/autobuild_updates_img.sh
@@ -74,10 +74,10 @@ fi
 while inotifywait -r "${SRC_DIR}"; do
 	pushd "${SRC_DIR}"
 	echo "Building new updates.img ..."
-	${0%/*}/build_updates_img.sh --python ${PYTHON_BIN}
+	sudo -u vagrant ${0%/*}/build_updates_img.sh --python ${PYTHON_BIN}
 	echo "Done"
 	if [ $? -eq 0 ]; then
-		mv updates.img "${DEST_DIR}"
+		cp updates.img "${DEST_DIR}"
 	fi
 	popd
 	# Wait 10 seconds.

--- a/scripts/build_updates_img.sh
+++ b/scripts/build_updates_img.sh
@@ -51,6 +51,9 @@ if [ "$PYTHON_BIN" = "" ]; then
     echo "Python interpreter not specified, using ${PYTHON_BIN}"
 fi
 
+# Delete all *.pyc file, because Python 2.7 .pyc files can break building of subman at system
+# using Python 3.x and vice versa
+find . -name "*.pyc" -delete
 
 # Install files to the temporary build dir
 export DESTDIR=$UPDATE_DIR
@@ -64,23 +67,50 @@ make -e install
 PYTHON_SITE_PACKAGE_DIRS=`${PYTHON_BIN} -c "import site; print(' '.join(site.getsitepackages()))"`
 
 # List of required Python packages
-PY_PACKAGES="dateutil"
+PY_PACKAGES="dateutil ethtool"
 
 # Copy required Python modules to updates.img too
 for pkg in `echo ${PY_PACKAGES}`
 do
+        echo "Trying to find: ${pkg} in directory ..."
         for site_pkg_dir in `echo ${PYTHON_SITE_PACKAGE_DIRS}`
         do
+                echo -e "\t${site_pkg_dir}"
+                # Common package
                 if [ -d "${site_pkg_dir}/${pkg}" ]
                 then
                         mkdir -p "${UPDATE_DIR}/${site_pkg_dir}"
-                        echo "copying ${site_pkg_dir}/${pkg} to ${UPDATE_DIR}/${site_pkg_dir}"
+                        echo "Copying ${site_pkg_dir}/${pkg} to ${UPDATE_DIR}/${site_pkg_dir}"
                         cp -R "${site_pkg_dir}/${pkg}" "${UPDATE_DIR}/${site_pkg_dir}"
-                        break
+                fi
+                # Binary module
+                if [ -f "${site_pkg_dir}/${pkg}"*".so" ]
+                then
+                        mkdir -p "${UPDATE_DIR}/${site_pkg_dir}"
+                        echo "Copying ${site_pkg_dir}/${pkg}"*".so to ${UPDATE_DIR}/${site_pkg_dir}"
+                        cp "${site_pkg_dir}/${pkg}"*".so" "${UPDATE_DIR}/${site_pkg_dir}"
                 fi
         done
 done
 
+# List of Python eggs (yes, names can be different from package names)
+PY_PACKAGES="python_dateutil ethtool"
+
+# Copy required Python eggs to updates.img too
+for pkg in `echo ${PY_PACKAGES}`
+do
+        echo "Trying to find: ${pkg} in directory ..."
+        for site_pkg_dir in `echo ${PYTHON_SITE_PACKAGE_DIRS}`
+        do
+                # Python egg
+                if [ -d "${site_pkg_dir}/${pkg}"*".egg-info" ]
+                then
+                        mkdir -p "${UPDATE_DIR}/${site_pkg_dir}"
+                        echo "Copying ${site_pkg_dir}/${pkg}"*".egg-info to ${UPDATE_DIR}/${site_pkg_dir}"
+                        cp -R "${site_pkg_dir}/${pkg}"*".egg-info" "${UPDATE_DIR}/${site_pkg_dir}"
+                fi
+        done
+done
 pushd $UPDATE_DIR
 
 # Build img file (See https://fedoraproject.org/wiki/Anaconda/Updates)

--- a/vagrant/roles/pxe-server/defaults/main.yml
+++ b/vagrant/roles/pxe-server/defaults/main.yml
@@ -25,6 +25,7 @@ required_rpms:
   - m2crypto
   - librsvg2
   - python3-dateutil
+  - python3-ethtool
   - inotify-tools
 
 ##### CentOS 7 #####

--- a/vagrant/roles/pxe-server/tasks/main.yml
+++ b/vagrant/roles/pxe-server/tasks/main.yml
@@ -116,6 +116,18 @@
   with_items: "{{kernel_files}}"
   become: true
 
+- name: create service for automatic building of updates.img
+  copy:
+    src: autobuild_updates_img.service
+    dest: "{{systemd_service_dir}}"
+  become: yes
+
+- name: stop service for automatic building of updates.img
+  service:
+    name: autobuild_updates_img
+    state: stopped
+  become: true
+
 - name: create updates.img file
   command: "./scripts/build_updates_img.sh --python python3"
   args:
@@ -127,12 +139,6 @@
     remote_src: yes
     dest: /var/ftp/pub/updates.img
   become: true
-
-- name: create service for automatic building of updates.img
-  copy:
-    src: autobuild_updates_img.service
-    dest: "{{systemd_service_dir}}"
-  become: yes
 
 - name: enable and start service for automatic building of updates.img
   service:

--- a/vagrant/roles/pxe-server/templates/ks_fedora29.cfg.j2
+++ b/vagrant/roles/pxe-server/templates/ks_fedora29.cfg.j2
@@ -14,7 +14,7 @@ keyboard --vckeymap=us --xlayouts='us'
 lang en_US.UTF-8
 
 # Network information
-network  --bootproto=dhcp --device=ens3 --ipv6=auto --activate
+network  --bootproto=dhcp --device=ens6 --ipv6=auto --activate
 network  --hostname=pxe-client.localdomain
 
 # Root password


### PR DESCRIPTION
* I had to do following updates during my testing of #2018
* Subman requires more modules on Fedora 29 (ethtool)
* Updated build script to copy Python eggs
* Stop autobuild service during provisioning, because
  command: `vagrant provision pxe-server` did not work properly
* Clean all *.pyc file, because `vagrant rsync pxe-server`
  copy all files to VM. *.pyc files in ./build directory can
  break bulding of updates.img