### PR TITLE
Upload combined profile report on config hook[ENT-985]

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -75,7 +75,7 @@ pluginConfDir = /etc/rhsm/pluginconf.d
 auto_enable_yum_plugins = 1
 
 # Run the package profile on each yum/dnf transaction
-package_profile_on_trans = 0
+package_profile_after_command = 0
 
 # Inotify is used for monitoring changes in directories with certificates.
 # Currently only the /etc/pki/consumer directory is monitored by the

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -196,7 +196,7 @@ if
 should report the system's current package profile to the subscription service\&. This report helps the subscription service provide better errata notifications\&. If supported by the entitlement server, enabled repos, enabled modules, and packages present will be reported\&. This configuration also governs package profile reporting when the "dnf uploadprofile" command is executed\&.
 .RE
 .PP
-package_profile_on_trans
+package_profile_after_command
 .RS 4
 Set to
 \fI1\fR

--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -21,6 +21,7 @@ import os
 from yum.plugins import TYPE_CORE
 
 from subscription_manager import injection as inj
+from subscription_manager.action_client import ProfileActionClient
 from subscription_manager.repolib import RepoActionInvoker
 from subscription_manager.entcertlib import EntCertActionInvoker
 from rhsmlib.facts.hwprobe import ClassicCheck
@@ -183,3 +184,13 @@ def postconfig_hook(conduit):
         warnExpired(conduit)
     except Exception as e:
         conduit.error(2, str(e))
+
+
+def close_hook(conduit):
+    """
+    Call Package Profile
+    """
+    cfg = config.initConfig()
+    if '1' == cfg.get('rhsm', 'package_profile_after_command'):
+        package_profile_client = ProfileActionClient()
+        package_profile_client.update()

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -74,7 +74,7 @@ RHSM_DEFAULTS = {
         'plugindir': '/usr/share/rhsm-plugins',
         'pluginconfdir': '/etc/rhsm/pluginconf.d',
         'auto_enable_yum_plugins': '1',
-        'package_profile_on_trans': '0',
+        'package_profile_after_command': '0',
         'inotify': '1'
         }
 


### PR DESCRIPTION
- DNF: Upload the combined profile report on sack hook as required properties are not yet resolved during config hook
- YUM: Upload the combined profile report on close_hook
- Generalize the flag for enabling of the profile reporting after transaction to enable reporting after every command