### PR TITLE
1633216: Use new libdnf API to reuse connection to repo; ENT-1111

### DIFF
--- a/src/dnf-plugins/product-id/CMakeLists.txt
+++ b/src/dnf-plugins/product-id/CMakeLists.txt
@@ -46,7 +46,6 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(GLIB REQUIRED glib-2.0>=2.44.0)
 pkg_check_modules(GIO REQUIRED gio-2.0>=2.54.3)
 pkg_check_modules(LIBDNF REQUIRED libdnf>=0.22.0)
-pkg_check_modules(ZLIB REQUIRED zlib>=1.2.0)
 pkg_check_modules(OPENSSL libcrypto libssl REQUIRED)
 pkg_check_modules(JSONC json-c REQUIRED)
 

--- a/src/dnf-plugins/product-id/product-id.h
+++ b/src/dnf-plugins/product-id/product-id.h
@@ -19,11 +19,11 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wvariadic-macros"
 #include <libdnf/libdnf.h>
-#include <zlib.h>
 #pragma GCC diagnostic pop
 
 #define PRODUCTDB_FILE "/var/lib/rhsm/productid.js"
 #define PRODUCT_CERT_DIR "/etc/pki/product/"
+#define DEFAULT_PRODUCT_CERT_DIR "/etc/pki/product-default/"
 
 #define SUPPORTED_LIBDNF_PLUGIN_API_VERSION 1
 
@@ -72,7 +72,6 @@ void getDisabled(const GPtrArray *repos, GPtrArray *disabledRepos);
 GPtrArray *getAvailPackageList(DnfSack *dnfSack, DnfRepo *repo);
 GPtrArray *getInstalledPackages(DnfSack *rpmDbSack);
 void getActive(DnfPluginHookData *hookData, const GPtrArray *repoAndProductIds, GPtrArray *activeRepoAndProductIds);
-int decompress(gzFile input, GString *output) ;
 int findProductId(GString *certContent, GString *result);
 int fetchProductId(DnfRepo *repo, RepoProductId *repoProductId);
 int installProductId(RepoProductId *repoProductId, ProductDb *productDb, const char *product_cert_dir);

--- a/src/dnf-plugins/product-id/test-product-id.c
+++ b/src/dnf-plugins/product-id/test-product-id.c
@@ -220,33 +220,6 @@ void testProductNullPointers(productFixture *fixture, gconstpointer testData) {
     g_assert_cmpint(ret, ==, 0);
 }
 
-void testWrongPathToCompressedProductCert(productFixture *fixture, gconstpointer testData) {
-    (void)testData;
-    fixture->repoProductId->productIdPath = "/path/to/non-existing-compressed-cert.gz";
-    int ret = installProductId(fixture->repoProductId, fixture->productDb, "/tmp");
-    g_assert_cmpint(ret, ==, 0);
-}
-
-void testCorruptedCompressedProductCert(productFixture *fixture, gconstpointer testData) {
-    (void)testData;
-    fixture->repoProductId->productIdPath = "./test_data/corrupted_compressed_productid.pem.gz";
-    int ret = installProductId(fixture->repoProductId, fixture->productDb, "/tmp");
-    g_assert_cmpint(ret, ==, 0);
-}
-
-void testInstallingCompressedProductCert(productFixture *fixture, gconstpointer testData) {
-    (void)testData;
-    // Set path to correct productid certificate
-    fixture->repoProductId->productIdPath = "./test_data/59803427316a729fb1d67fd08e7d0c8ccd2a4a5377729b747b76345851bdba6c-productid.gz";
-    // Create dummy repository
-    DnfContext *dnfContext = dnf_context_new();
-    fixture->repoProductId->repo = dnf_repo_new(dnfContext);
-    int ret = installProductId(fixture->repoProductId, fixture->productDb, "./");
-    g_object_unref(fixture->repoProductId->repo);
-    g_object_unref(dnfContext);
-    g_assert_cmpint(ret, ==, 1);
-}
-
 void testFetchingProductId(productFixture *fixture, gconstpointer testData) {
     (void) testData;
     // Create dummy repository
@@ -375,7 +348,6 @@ void testInstalledPackages(installedPackageFixture *fixture, gconstpointer testD
     GPtrArray *installedPackages = getInstalledPackages(fixture->rpmDbSack);
     // We expect that the length of the list will be bigger than zero :-)
     g_assert_cmpint(installedPackages->len, >, 0);
-    g_object_unref(installedPackages);
 }
 
 typedef struct {
@@ -431,9 +403,6 @@ int main(int argc, char **argv) {
     g_test_add("/set2/test corrupted certificate", handleFixture, NULL, setup, testFindProductIdInCorruptedPEM, teardown);
     g_test_add("/set2/test consumer certificate", handleFixture, NULL, setup, testFindProductIdInConsumerPEM, teardown);
     g_test_add("/set2/test installProductId null pointers", productFixture, NULL, setupProduct, testProductNullPointers, teardownProduct);
-    g_test_add("/set2/test invalid repoProductId", productFixture, NULL, setupProduct, testWrongPathToCompressedProductCert, teardownProduct);
-    g_test_add("/set2/test corrupted compressed productid cert", productFixture, NULL, setupProduct, testCorruptedCompressedProductCert, teardownProduct);
-    g_test_add("/set2/test installing product-id cert", productFixture, NULL, setupProduct, testInstallingCompressedProductCert, teardownProduct);
     g_test_add("/set2/test fetching of product-id cert", productFixture, NULL, setupProduct, testFetchingProductId, teardownProduct);
     g_test_add("/set2/test getting enabled repos", enabledReposFixture, NULL, setupEnabledRepos, testGetEnabledRepos, teardownEnabledRepos);
     g_test_add("/set2/test getting active repos", activeReposFixture, NULL, setupActiveRepos, testGetActiveRepos, teardownActiveRepos);


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1633216#c15
* When RHEL production repository is used, then any dnf client
  has to use client certificate to authentication. We used
  librepo for downloading productid certificate in new connection,
  but this connection didn't use client certificate for
  authentication.
* New librepo API introduced in this PR:
  https://github.com/rpm-software-management/libdnf/pull/652
  is used for downloading productid certificate
* New API also provides decompresing of any downloaded file
  including productid certificate. We use benefits of thi API too.
* Removed dependency on zlib.
* Several unit tests were modified.