### PR TITLE
1668947: set enable_metadata to 0 for disabled repos; ENT-1146

### DIFF
--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -47,8 +47,8 @@ def configure_i18n():
         locale.setlocale(locale.LC_ALL, '')
     except locale.Error:
         print("You are attempting to use a locale that is not installed.")
-        os.environ['LC_ALL'] = 'C.UTF-8'
-        locale.setlocale(locale.LC_ALL, 'C.UTF-8')
+        os.environ['LC_ALL'] = 'C'
+        locale.setlocale(locale.LC_ALL, 'C')
     configure_gettext()
     # RHBZ 1642271  Don't set a None lang
     lang = os.environ.get("LANG")

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2338,6 +2338,8 @@ class ReposCommand(CliCommand):
 
             if self.is_registered() and self.use_overrides:
                 overrides = [{'contentLabel': repo.id, 'name': 'enabled', 'value': repos_to_modify[repo]} for repo in repos_to_modify]
+                metadata_overrides = [{'contentLabel': repo.id, 'name': 'enable_metadata', 'value': repos_to_modify[repo]} for repo in repos_to_modify]
+                overrides.extend(metadata_overrides)
                 results = self.cp.setContentOverrides(self.identity.uuid, overrides)
 
                 cache = inj.require(inj.OVERRIDE_STATUS_CACHE)
@@ -2352,6 +2354,7 @@ class ReposCommand(CliCommand):
                 changed_repos = [repo for repo in matches if repo['enabled'] != status]
                 for repo in changed_repos:
                     repo['enabled'] = status
+                    repo['enable_metadata'] = status
                 if changed_repos:
                     repo_file = YumRepoFile()
                     repo_file.read()

--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -62,6 +62,7 @@ class Repo(dict):
             'sslclientkey': (0, None),
             'sslclientcert': (0, None),
             'metadata_expire': (1, None),
+            'enable_metadata': (1, '0'),
             'proxy': (0, None),
             'proxy_username': (0, None),
             'proxy_password': (0, None),
@@ -112,8 +113,10 @@ class Repo(dict):
 
         if content.enabled:
             repo['enabled'] = "1"
+            repo['enable_metadata'] = "1"
         else:
             repo['enabled'] = "0"
+            repo['enable_metadata'] = "0"
 
         expanded_url_path = Repo._expand_releasever(release_source, content.url)
         repo['baseurl'] = utils.url_base_join(baseurl, expanded_url_path)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -145,7 +145,7 @@ class TestProfileManager(unittest.TestCase):
         self.profile_mgr.has_changed = Mock(return_value=True)
         self.profile_mgr.write_cache = Mock()
 
-        self.profile_mgr.update_check(uep, uuid)
+        self.profile_mgr.update_check(uep, uuid, True)
 
         uep.updatePackageProfile.assert_called_with(uuid,
                 FACT_MATCHER)
@@ -159,7 +159,7 @@ class TestProfileManager(unittest.TestCase):
         self.profile_mgr.has_changed = Mock(return_value=True)
         self.profile_mgr.write_cache = Mock()
 
-        self.profile_mgr.update_check(uep, uuid)
+        self.profile_mgr.update_check(uep, uuid, True)
 
         uep.updateCombinedProfile.assert_called_with(uuid,
                 FACT_MATCHER)
@@ -236,7 +236,7 @@ class TestProfileManager(unittest.TestCase):
         # Throw an exception when trying to upload:
         uep.updatePackageProfile = Mock(side_effect=Exception('BOOM!'))
 
-        self.assertRaises(Exception, self.profile_mgr.update_check, uep, uuid)
+        self.assertRaises(Exception, self.profile_mgr.update_check, uep, uuid, True)
         uep.updatePackageProfile.assert_called_with(uuid,
                 FACT_MATCHER)
         self.assertEqual(0, self.profile_mgr.write_cache.call_count)
@@ -251,7 +251,7 @@ class TestProfileManager(unittest.TestCase):
         # Throw an exception when trying to upload:
         uep.updateCombinedProfile = Mock(side_effect=Exception('BOOM!'))
 
-        self.assertRaises(Exception, self.profile_mgr.update_check, uep, uuid)
+        self.assertRaises(Exception, self.profile_mgr.update_check, uep, uuid, True)
         uep.updateCombinedProfile.assert_called_with(uuid,
                 FACT_MATCHER)
         self.assertEqual(0, self.profile_mgr.write_cache.call_count)
@@ -492,7 +492,7 @@ class TestInstalledProductsCache(SubManFixture):
         self.mgr.has_changed = Mock(return_value=True)
         self.mgr.write_cache = Mock()
 
-        self.mgr.update_check(uep, uuid)
+        self.mgr.update_check(uep, uuid, True)
 
         expected = ["product", "product-a", "product-b", "product-c"]
         uep.updateConsumer.assert_called_with(uuid,
@@ -509,7 +509,7 @@ class TestInstalledProductsCache(SubManFixture):
         # Throw an exception when trying to upload:
         uep.updateConsumer = Mock(side_effect=Exception('BOOM!'))
 
-        self.assertRaises(Exception, self.mgr.update_check, uep, uuid)
+        self.assertRaises(Exception, self.mgr.update_check, uep, uuid, True)
         expected = ["product", "product-a", "product-b", "product-c"]
         uep.updateConsumer.assert_called_with(uuid,
                 content_tags=set(expected),

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1017,8 +1017,9 @@ class TestReposCommand(TestCliCommand):
         self.cc.use_overrides = True
         self.cc._set_repo_status(repos, repolib_instance, items)
 
-        expected_overrides = [{'contentLabel': i, 'name': 'enabled', 'value':
-            '0'} for (_action, i) in items]
+        expected_overrides = [{'contentLabel': i, 'name': 'enabled', 'value': '0'} for (_action, i) in items]
+        metadata_overrides = [{'contentLabel': i, 'name': 'enable_metadata', 'value': '0'} for (_action, i) in items]
+        expected_overrides.extend(metadata_overrides)
 
         # The list of overrides sent to setContentOverrides is really a set of
         # dictionaries (since we don't know the order of the overrides).
@@ -1040,11 +1041,11 @@ class TestReposCommand(TestCliCommand):
         self.cc.use_overrides = True
         self.cc._set_repo_status(repos, repolib_instance, items)
 
-        expected_overrides = [{'contentLabel': i.id, 'name': 'enabled', 'value':
-            '0'} for i in repos]
+        expected_overrides = [{'contentLabel': i.id, 'name': 'enabled', 'value': '0'} for i in repos]
+        metadata_overrides = [{'contentLabel': i.id, 'name': 'enable_metadata', 'value': '0'} for i in repos]
+        expected_overrides.extend(metadata_overrides)
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
-        self.cc.cp.setContentOverrides.assert_called_once_with('fake_id',
-                match_dict_list)
+        self.cc.cp.setContentOverrides.assert_called_once_with('fake_id', match_dict_list)
         self.assertTrue(repolib_instance.update.called)
 
     @patch("subscription_manager.managercli.RepoActionInvoker")
@@ -1060,8 +1061,11 @@ class TestReposCommand(TestCliCommand):
 
         expected_overrides = [
             {'contentLabel': 'zebra', 'name': 'enabled', 'value': '0'},
+            {'contentLabel': 'zebra', 'name': 'enable_metadata', 'value': '0'},
             {'contentLabel': 'zoo', 'name': 'enabled', 'value': '1'},
-            {'contentLabel': 'zip', 'name': 'enabled', 'value': '1'}
+            {'contentLabel': 'zoo', 'name': 'enable_metadata', 'value': '1'},
+            {'contentLabel': 'zip', 'name': 'enabled', 'value': '1'},
+            {'contentLabel': 'zip', 'name': 'enable_metadata', 'value': '1'}
         ]
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
         self.cc.cp.setContentOverrides.assert_called_once_with('fake_id',
@@ -1081,8 +1085,11 @@ class TestReposCommand(TestCliCommand):
 
         expected_overrides = [
             {'contentLabel': 'zebra', 'name': 'enabled', 'value': '1'},
+            {'contentLabel': 'zebra', 'name': 'enable_metadata', 'value': '1'},
             {'contentLabel': 'zoo', 'name': 'enabled', 'value': '0'},
-            {'contentLabel': 'zip', 'name': 'enabled', 'value': '0'}
+            {'contentLabel': 'zoo', 'name': 'enable_metadata', 'value': '0'},
+            {'contentLabel': 'zip', 'name': 'enabled', 'value': '0'},
+            {'contentLabel': 'zip', 'name': 'enable_metadata', 'value': '0'}
         ]
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
         self.cc.cp.setContentOverrides.assert_called_once_with('fake_id',
@@ -1101,8 +1108,11 @@ class TestReposCommand(TestCliCommand):
 
         expected_overrides = [
             {'contentLabel': 'zebra', 'name': 'enabled', 'value': '0'},
+            {'contentLabel': 'zebra', 'name': 'enable_metadata', 'value': '0'},
             {'contentLabel': 'zoo', 'name': 'enabled', 'value': '0'},
-            {'contentLabel': 'zip', 'name': 'enabled', 'value': '0'}
+            {'contentLabel': 'zoo', 'name': 'enable_metadata', 'value': '0'},
+            {'contentLabel': 'zip', 'name': 'enabled', 'value': '0'},
+            {'contentLabel': 'zip', 'name': 'enable_metadata', 'value': '0'}
         ]
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
         self.cc.cp.setContentOverrides.assert_called_once_with('fake_id',


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1668947
* We should set 'enable_metadata' to "0" for disabled repositories.
  Otherwise PackageKit tries to download metadata for all
  repositories.