### PR TITLE
1666512: Add some details on dnf uploadprofile to rhsm.conf man page

### DIFF
--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -184,7 +184,7 @@ Set to
 \fI1\fR
 if
 \fBrhsmcertd\fR
-should report the system's current package profile to the subscription service\&. This report helps the subscription service provide better errata notifications\&. If supported by the entitlement server, enabled repos, enabled modules, and packages present will be reported\&.
+should report the system's current package profile to the subscription service\&. This report helps the subscription service provide better errata notifications\&. If supported by the entitlement server, enabled repos, enabled modules, and packages present will be reported\&. This configuration also governs package profile reporting when the "dnf uploadprofile" command is executed\&.
 .RE
 .PP
 package_profile_on_trans


### PR DESCRIPTION
This adds a single line to the description of the report_package_profile entry of the rhsm.conf man page clarifying that options interaction and governance over the behaviour of the "dnf uploadprofile" command.