### PR TITLE
1666516: Allow reporting of profile info on dnf transactions

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -453,11 +453,13 @@ class ProfileManager(CacheManager):
             log.info("Server does not support packages, skipping profile upload.")
             return 0
 
-        if not force or not self.report_package_profile:
+        if force or self.report_package_profile:
+            return CacheManager.update_check(self, uep, consumer_uuid, force)
+        elif not self.report_package_profile:
             log.info("Skipping package profile upload due to report_package_profile setting.")
             return 0
-
-        return CacheManager.update_check(self, uep, consumer_uuid, force)
+        else:
+            return 0
 
     def has_changed(self):
         if not self._cache_exists():


### PR DESCRIPTION
Our previous attempt to solve this broke one of our dnf/yum usecases (see [this](https://bugzilla.redhat.com/show_bug.cgi?id=1650157#c13))

This should allow the following:
Only report on the transaction hook of dnf actions when the report_package_profile setting *and* the package_profile_on_trans setting are set to 1. Should either of them be set to 0 this should not report package profile info.

With the previous fix, if report_package_profile was set to 1 and we were not forcing the package profile upload subman would not report any package profile info.