### PR TITLE
1673838: Set trailing character '\0' at the end of cert content

### DIFF
--- a/src/dnf-plugins/product-id/product-id.c
+++ b/src/dnf-plugins/product-id/product-id.c
@@ -563,6 +563,9 @@ gpointer getProductIdContent(DnfRepo *repo) {
     gboolean productid_downloaded;
     productid_downloaded = dnf_repo_get_metadata_content(repo, "productid", &content, &length, &tmp_err);
     if (productid_downloaded) {
+        // Make sure that end of string contains trailing character: '\0'. Library libdnf cannot do that
+        // because the library doesn't know anything about content of downloaded metadata
+        ((char*)content)[length] = '\0';
         return content;
     } else {
         printError("Unable to get productid certificate from DnfRepo structure", tmp_err);


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1673838