### PR TITLE
1665409: Update syspurpose status in cockpit addon; ENT-1096

### DIFF
--- a/cockpit/src/subscriptions-client.js
+++ b/cockpit/src/subscriptions-client.js
@@ -592,8 +592,16 @@ client.init = () => {
     entitlementService.addEventListener("EntitlementChanged", requestSubscriptionStatusUpdate);
     productsService.addEventListener("InstalledProductsChanged", requestSubscriptionStatusUpdate);
     consumerService.addEventListener("ConsumerChanged", requestSubscriptionStatusUpdate);
+
     configService.addEventListener("ConfigChanged", updateConfig);
     syspurposeService.addEventListener("SyspurposeChanged", requestSyspurposeUpdate);
+
+    // We want to get notified if syspurpose status of the system changes (when either the syspurpose.json changed,
+    // or our subscriptions changed, or we registered/unregistered).
+    syspurposeService.addEventListener("SyspurposeChanged", requestSyspurposeStatusUpdate);
+    entitlementService.addEventListener("EntitlementChanged", requestSyspurposeStatusUpdate);
+    consumerService.addEventListener("ConsumerChanged", requestSyspurposeStatusUpdate);
+
     // get initial status
     requestSubscriptionStatusUpdate();
     requestSyspurposeUpdate();


### PR DESCRIPTION
- Now the syspurpose status in the cockpit UI will get updated
every time either the syspurpose.json changed, our subscriptions
changed, or the system got registered/unregistered.