### PR TITLE
1654531: Add proxy_scheme to rhsm.conf

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -21,6 +21,10 @@ ssl_verify_depth = 3
 # an http proxy server to use
 proxy_hostname =
 
+# The scheme to use for the proxy when updating repo definitions, if needed
+# e.g. http or https
+proxy_scheme =
+
 # port for http proxy server
 proxy_port =
 

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -69,7 +69,16 @@ proxy_hostname
 .RS 4
 Set this to a non\-blank value if
 \fBsubscription\-manager\fR
-should use a reverse proxy to access the subscription service\&. This sets the host for the reverse proxy\&. Overrides hostname from \fBHTTP_PROXY\fR and \fBHTTPS_PROXY\fR environment variables\&.
+should use a reverse proxy to access the subscription service\&. This sets the host for the reverse proxy\&. Overrides hostname from \fBHTTP_PROXY\fR and \fBHTTPS_PROXY\fR environment variables\&. This value
+.B should not
+contain the scheme to be used with the proxy (e.g. http or https)\&. To specify that use the
+.B proxy_scheme
+option\&.
+.RE
+.PP
+proxy_scheme
+.RS 4
+This sets the scheme for the reverse proxy when writing out the proxy to repo definitions\&. Set this to a non\-blank value if you want to specify the scheme used by your package manager for subscription\-manager managed repos\&. This defaults to "http"\&.
 .RE
 .PP
 proxy_port
@@ -78,7 +87,7 @@ Set this to a non\-blank value if
 \fBsubscription\-manager\fR
 should use a reverse proxy to access the subscription service\&. This sets the port for the reverse proxy\&. Overrides port from \fBHTTP_PROXY\fR and \fBHTTPS_PROXY\fR environment variables\&.
 
-Please note that setting this to any value other than 3128 (depending on your selinux configuration) will require an update to that policy.
+Please note that setting this to any value other than 3128 (depending on your SELinux configuration) will require an update to that policy.
 
 To add a local policy:
 

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -54,6 +54,7 @@ SERVER_DEFAULTS = {
         'insecure': '0',
         'ssl_verify_depth': '3',
         'proxy_hostname': '',
+        'proxy_scheme': 'http',
         'proxy_user': '',
         'proxy_port': '',
         'proxy_password': '',

--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -157,19 +157,22 @@ class Repo(dict):
     def _set_proxy_info(repo):
         proxy = ""
 
+        proxy_scheme = conf['server']['proxy_scheme']
+
+        if proxy_scheme.endswith("://"):
+            proxy_scheme = proxy_scheme[:-3]
+
         # Worth passing in proxy config info to from_ent_cert_content()?
         # That would decouple Repo some
         proxy_host = conf['server']['proxy_hostname']
+
         # proxy_port as string is fine here
         proxy_port = conf['server']['proxy_port']
+
         if proxy_host != "":
-            if proxy_host.startswith('http://') or proxy_host.startswith('HTTP://') or \
-                proxy_host.startswith('https://') or proxy_host.startswith('HTTPS://'):
-                proxy = proxy_host
-            else:
-                proxy = "http://%s" % proxy_host
-            if proxy_port != "":
-                proxy = "%s:%s" % (proxy, proxy_port)
+            if proxy_port:
+                proxy_host = proxy_host + ":" + proxy_port
+            proxy = proxy_scheme + "://" + proxy_host
 
         # These could be empty string, in which case they will not be
         # set in the yum repo file:

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -126,13 +126,22 @@ proxy_port = 3129
 
 PROXY_HTTP_PROTOCOL = """
 [server]
-proxy_hostname = http://fake.server.com
+proxy_hostname = fake.server.com
+proxy_scheme = http
 proxy_port = 3129
 """
 
 PROXY_HTTPS_PROTOCOL = """
 [server]
-proxy_hostname = https://fake.server.com
+proxy_hostname = fake.server.com
+proxy_scheme = https
+proxy_port = 3129
+"""
+
+PROXY_EXTRA_SCHEME = """
+[server]
+proxy_hostname = fake.server.com
+proxy_scheme = https://
 proxy_port = 3129
 """
 
@@ -192,6 +201,12 @@ class RepoTests(unittest.TestCase):
 
     @patch.object(repofile, 'conf', ConfigFromString(config_string=PROXY_HTTPS_PROTOCOL))
     def test_https(self):
+        repo = Repo('testrepo')
+        r = Repo._set_proxy_info(repo)
+        self.assertEqual(r['proxy'], "https://fake.server.com:3129")
+
+    @patch.object(repofile, 'conf', ConfigFromString(config_string=PROXY_EXTRA_SCHEME))
+    def test_extra_chars_in_scheme(self):
         repo = Repo('testrepo')
         r = Repo._set_proxy_info(repo)
         self.assertEqual(r['proxy'], "https://fake.server.com:3129")


### PR DESCRIPTION
This adds a new proxy_scheme option to rhsm.conf.
It allows users to specify what scheme should be used for the proxy url when writing repo definitions. It defaults to http (as that appears to be most common and will solve this bug).