### PR TITLE
1655778: Increase RHEL major version detection reliability

### DIFF
--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -431,7 +431,14 @@ class MigrationEngine(object):
         f = open('/etc/redhat-release')
         lines = f.readlines()
         f.close()
-        release = "RHEL-" + str(lines).split(' ')[6].split('.')[0]
+        try:
+            major_version = re.search("[0-9]+(?=\.[0-9]+)*", str(lines)).group(0)
+        except AttributeError:
+            log.error("Could not determine RHEL release from /etc/redhat-release")
+            # Leaving no message to stdout/stderr as it's past string freeze
+            system_exit(1, "")
+        else:
+            release = "RHEL-" + major_version
         return release
 
     def read_channel_cert_mapping(self, mappingfile):


### PR DESCRIPTION
This uses regex to find the likely RHEL version from /etc/redhat-release. Should be more flexible than earlier iterations.
As we cannot proceed very far in the migration process if we can't determine the release, we exit on error with the regex.