### PR TITLE
1673973: Read syspurpose on register using cockpit

### DIFF
--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -19,6 +19,7 @@ from rhsmlib.services import exceptions
 
 from subscription_manager import injection as inj
 from subscription_manager import managerlib
+from subscription_manager import syspurposelib
 from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
@@ -42,6 +43,12 @@ class RegisterService(object):
         # signature we want to consider that an error.
         if kwargs:
             raise exceptions.ValidationError(_("Unknown arguments: %s") % kwargs.keys())
+
+        syspurpose = syspurposelib.read_syspurpose()
+        role = role or syspurpose.get('role')
+        addons = addons or syspurpose.get('addons', [])
+        usage = usage or syspurpose.get('usage')
+        service_level = service_level or syspurpose.get('service_level_agreement', '')
 
         type = type or "system"
 
@@ -89,6 +96,9 @@ class RegisterService(object):
 
         # Now that we are registered, load the new identity
         self.identity.reload()
+        store = syspurposelib.get_sys_purpose_store()
+        if store:
+            store.sync()
         return consumer
 
     def validate_options(self, options):

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1315,16 +1315,10 @@ class RegisterCommand(UserPassCommand):
             # This is blocking and not async, which aside from blocking here, also
             # means things like following name owner changes gets weird.
             service = register.RegisterService(admin_cp)
-            syspurpose = syspurposelib.read_syspurpose()
 
             if self.options.consumerid:
                 log.info("Registering as existing consumer: %s" % self.options.consumerid)
-                consumer = service.register(None, consumerid=self.options.consumerid,
-                                            role=syspurpose.get('role'),
-                                            addons=syspurpose.get('addons') or [],
-                                            service_level=syspurpose.get('service_level_agreement') or '',
-                                            usage=syspurpose.get('usage')
-                                            )
+                consumer = service.register(None, consumerid=self.options.consumerid)
             else:
                 owner_key = self._determine_owner_key(admin_cp)
                 environment_id = self._get_environment_id(admin_cp, owner_key, self.options.environment)
@@ -1335,16 +1329,8 @@ class RegisterCommand(UserPassCommand):
                     environment=environment_id,
                     force=self.options.force,
                     name=self.options.consumername,
-                    type=self.options.consumertype,
-                    role=syspurpose.get('role'),
-                    addons=syspurpose.get('addons') or [],
-                    service_level=syspurpose.get('service_level_agreement') or '',
-                    usage=syspurpose.get('usage')
+                    type=self.options.consumertype
                 )
-
-                store = syspurposelib.get_sys_purpose_store()
-                if store:
-                    store.sync()
         except (connection.RestlibException, exceptions.ServiceError) as re:
             log.exception(re)
             system_exit(os.EX_SOFTWARE, re)

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -30,6 +30,8 @@ from subscription_manager.facts import Facts
 from subscription_manager.identity import Identity
 from subscription_manager.plugins import PluginManager
 
+from ..fixture import set_up_mock_sp_store
+
 from test.rhsmlib_test.base import DBusObjectTest, InjectionMockingTest
 
 from rhsm import connection
@@ -84,11 +86,25 @@ class RegisterServiceTest(InjectionMockingTest):
         self.mock_cp.username = "username"
         self.mock_cp.password = "password"
 
+        # Add a mock cp_provider
+        self.mock_cp_provider = mock.Mock(spec=CPProvider, name="CPProvider")
+
+        # For the tests in which it's used, the consumer_auth cp and basic_auth cp can be the same
+        self.mock_cp_provider.get_consumer_auth_cp.return_value = self.mock_cp
+        self.mock_cp_provider.get_basic_auth_cp.return_value = self.mock_cp
+
         self.mock_pm = mock.Mock(spec=PluginManager, name="PluginManager")
         self.mock_installed_products = mock.Mock(spec=InstalledProductsManager,
             name="InstalledProductsManager")
         self.mock_facts = mock.Mock(spec=Facts, name="Facts")
         self.mock_facts.get_facts.return_value = {}
+
+        syspurpose_patch = mock.patch('subscription_manager.syspurposelib.SyncedStore')
+        self.mock_sp_store = syspurpose_patch.start()
+        self.mock_sp_store, self.mock_sp_store_contents = set_up_mock_sp_store(self.mock_sp_store)
+        self.addCleanup(syspurpose_patch.stop)
+
+        self.mock_syspurpose = mock.Mock()
 
     def injection_definitions(self, *args, **kwargs):
         if args[0] == inj.IDENTITY:
@@ -99,6 +115,8 @@ class RegisterServiceTest(InjectionMockingTest):
             return self.mock_installed_products
         elif args[0] == inj.FACTS:
             return self.mock_facts
+        elif args[0] == inj.CP_PROVIDER:
+            return self.mock_cp_provider
         else:
             return None
 
@@ -123,8 +141,8 @@ class RegisterServiceTest(InjectionMockingTest):
             content_tags=[],
             type="system",
             role=None,
-            addons=None,
-            service_level=None,
+            addons=[],
+            service_level='',
             usage=None)
         self.mock_installed_products.write_cache.assert_called()
 
@@ -159,8 +177,8 @@ class RegisterServiceTest(InjectionMockingTest):
             content_tags=[],
             type="system",
             role=None,
-            addons=None,
-            service_level=None,
+            addons=[],
+            service_level='',
             usage=None
         )
         self.mock_installed_products.write_cache.assert_called()
@@ -213,6 +231,36 @@ class RegisterServiceTest(InjectionMockingTest):
         self.mock_identity.is_valid.return_value = True
         options = self._build_options(force=True)
         register.RegisterService(self.mock_cp).validate_options(options)
+
+    @mock.patch("rhsmlib.services.register.managerlib.persist_consumer_cert")
+    def test_reads_syspurpose(self, mock_persist_consumer):
+        self.mock_installed_products.format_for_server.return_value = []
+        self.mock_installed_products.tags = []
+        self.mock_identity.is_valid.return_value = False
+        self.mock_sp_store_contents["role"] = "test_role"
+        self.mock_sp_store_contents["service_level_agreement"] = "test_sla"
+        self.mock_sp_store_contents["addons"] = ["addon1"]
+        self.mock_sp_store_contents["usage"] = "test_usage"
+
+        expected_consumer = json.loads(CONTENT_JSON)
+        self.mock_cp.registerConsumer.return_value = expected_consumer
+
+        register_service = register.RegisterService(self.mock_cp)
+        register_service.register("org", name="name")
+
+        self.mock_cp.registerConsumer.assert_called_once_with(
+            addons=["addon1"],
+            content_tags=[],
+            environment=None,
+            facts={},
+            installed_products=[],
+            keys=None,
+            name="name",
+            owner="org",
+            role="test_role",
+            service_level="test_sla",
+            type="system",
+            usage="test_usage")
 
     def test_does_not_require_basic_auth_with_activation_keys(self):
         self.mock_cp.username = None

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -84,8 +84,7 @@ class CliRegistrationTests(SubManFixture):
         self._inject_ipm()
 
         cmd.main(['register', '--consumerid=123456', '--username=testuser1', '--password=password', '--org=test_org'])
-        self.mock_register.register.assert_called_once_with(None, consumerid='123456', role=None,
-                                                            addons=[], service_level='', usage=None)
+        self.mock_register.register.assert_called_once_with(None, consumerid='123456')
         mock_entcertlib.update.assert_called_once()
 
     def test_consumerid_with_distributor_id(self):


### PR DESCRIPTION
This moves our syspurpose reading and syncing done for registration down into the register service.
This consequently causes syspurpose info not to be lost on registration using cockpit.