### PR TITLE
1673973: Do not override the user SLA syspurpose on registration using cockpit

### DIFF
--- a/src/rhsmlib/dbus/objects/attach.py
+++ b/src/rhsmlib/dbus/objects/attach.py
@@ -49,7 +49,7 @@ class AttachDBusObject(base_object.BaseObject):
     @util.dbus_handle_exceptions
     def AutoAttach(self, service_level, proxy_options, locale, sender=None):
         self.ensure_registered()
-        service_level = dbus_utils.dbus_to_python(service_level, expected_type=str)
+        service_level = dbus_utils.dbus_to_python(service_level, expected_type=str) or None
         proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
         locale = dbus_utils.dbus_to_python(locale, expected_type=str)
         Locale.set(locale)

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -96,7 +96,10 @@ class RegisterService(object):
 
         # Now that we are registered, load the new identity
         self.identity.reload()
-        store = syspurposelib.get_sys_purpose_store()
+        # We want a new SyncedStore every time as we otherwise can hold onto bad state in
+        # long-lived services in dbus
+        uep = inj.require(inj.CP_PROVIDER).get_consumer_auth_cp()
+        store = syspurposelib.SyncedStore(uep, consumer_uuid=self.identity.uuid)
         if store:
             store.sync()
         return consumer


### PR DESCRIPTION
Using a singleton for the SyncedStore (as the get_sys_purpose_store method does) causes us to hold onto the old consumer uuid when unregistered and the dbus service is still running. This causes nasty exceptions to surface on cockpit when registering and unregistering repeatedly.

The proposed fix is to create the SyncedStore objects with the correct uep / consumer_uuid as needed in the dbus usages of SyncedStore.

There is one additional issue that was uncovered for this bug by QE. The current implementation of our cockpit pieces overrides the SLA set everytime regardless of the syncing logic put in. The prior PR addressed the issue for all aspects of syspurpose aside from SLA.

Update: This PR now ignores the '' passed in to the attach service from cockpit.