### PR TITLE
1666845: Always submit empty string for reset

### DIFF
--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -45,9 +45,9 @@ class RegisterService(object):
             raise exceptions.ValidationError(_("Unknown arguments: %s") % kwargs.keys())
 
         syspurpose = syspurposelib.read_syspurpose()
-        role = role or syspurpose.get('role')
+        role = role or syspurpose.get('role', '')
         addons = addons or syspurpose.get('addons', [])
-        usage = usage or syspurpose.get('usage')
+        usage = usage or syspurpose.get('usage', '')
         service_level = service_level or syspurpose.get('service_level_agreement', '')
 
         type = type or "system"

--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -373,10 +373,10 @@ class SyncedStore(object):
         addons = data.get(ADDONS)
         self.uep.updateConsumer(
                 self.consumer_uuid,
-                role=data.get(ROLE),
+                role=data.get(ROLE) or "",
                 addons=addons if addons is not None else [],
                 service_level=data.get(SERVICE_LEVEL) or "",
-                usage=data.get(USAGE)
+                usage=data.get(USAGE) or ""
         )
         log.debug('Successfully updated remote syspurpose on the server.')
         return True

--- a/syspurpose/test/syspurpose/test_syspurposefiles.py
+++ b/syspurpose/test/syspurpose/test_syspurposefiles.py
@@ -719,8 +719,8 @@ class TestSyncedStore(SyspurposeTestBase):
         self.assert_equal_dict(expected_local, local_result)
         self.assert_equal_dict(expected_cache, cache_result)
         self.uep.updateConsumer.assert_called_once_with(consumer_uuid,
-                                                        role=None,
-                                                        usage=None,
+                                                        role=u"",
+                                                        usage=u"",
                                                         service_level=u"",
                                                         addons=[])
 

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -140,10 +140,10 @@ class RegisterServiceTest(InjectionMockingTest):
             installed_products=[],
             content_tags=[],
             type="system",
-            role=None,
+            role="",
             addons=[],
-            service_level='',
-            usage=None)
+            service_level="",
+            usage="")
         self.mock_installed_products.write_cache.assert_called()
 
         mock_persist_consumer.assert_called_once_with(expected_consumer)
@@ -176,10 +176,10 @@ class RegisterServiceTest(InjectionMockingTest):
             installed_products=[],
             content_tags=[],
             type="system",
-            role=None,
+            role="",
             addons=[],
-            service_level='',
-            usage=None
+            service_level="",
+            usage=""
         )
         self.mock_installed_products.write_cache.assert_called()
 


### PR DESCRIPTION
As we have no way of setting the value in CP to null (in order to reset) we need to make sure to always send the empty string on register AND on syncing for reset. This will work either in the case that CP continues to actually store those values (the empty strings) OR CP resets those attributes to null when having received the empty string.

:man_facepalming: 