### PR TITLE
1685037: Ignore null repos when running using packagekit

### DIFF
--- a/src/dnf-plugins/product-id/product-id.c
+++ b/src/dnf-plugins/product-id/product-id.c
@@ -634,6 +634,9 @@ void getActive(DnfContext *dnfContext, DnfPluginHookData *hookData, const GPtrAr
         for (guint k = 0; k < installedPackages->len; k++) {
             DnfPackage *instPkg = g_ptr_array_index(installedPackages, k);
             gchar *repo_name = dnf_package_get_origin(instPkg);
+            if (!repo_name) {
+                continue;
+            }
             if (g_hash_table_contains(activeRepos, repo_name) == FALSE) {
                 g_hash_table_add(activeRepos, repo_name);
                 for (guint i = 0; i < enabledRepoAndProductIds->len; i++) {


### PR DESCRIPTION
The issue can be reproduced via the steps in this comment: https://bugzilla.redhat.com/show_bug.cgi?id=1685037#c11

Before those steps install the following (as it is required for the reproducer): `dnf install createrepo_c rpm-build PackageKit`

