### PR TITLE
1621275: Less communication with candlepin server from sub-man plugin; ENT-923

### DIFF
--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -36,21 +36,24 @@ plugin_type = (TYPE_CORE,)
 
 # TODO: translate strings
 
-expired_warning = \
-"""
+expired_warning = """
 *** WARNING ***
 The subscription for following product(s) has expired:
 %s
-You no longer have access to the repositories that provide these products.  It is important that you apply an active subscription in order to resume access to security and other critical updates. If you don't have other active subscriptions, you can renew the expired subscription.  """
+You no longer have access to the repositories that provide these products.  It is important that you apply an active subscription in order to resume access to security and other critical updates. If you don't have other active subscriptions, you can renew the expired subscription.
+"""
 
-not_registered_warning = \
-"This system is not registered with an entitlement server. You can use subscription-manager to register."
+not_registered_warning = """
+This system is not registered with an entitlement server. You can use subscription-manager to register.
+"""
 
-no_subs_warning = \
-"This system is registered with an entitlement server, but is not receiving updates. You can use subscription-manager to assign subscriptions."
+no_subs_warning = """
+This system is registered with an entitlement server, but is not receiving updates. You can use subscription-manager to assign subscriptions.
+"""
 
-no_subs_container_warning = \
-"This system is not receiving updates. You can use subscription-manager on the host to register and assign subscriptions."
+no_subs_container_warning = """
+This system is not receiving updates. You can use subscription-manager on the host to register and assign subscriptions.
+"""
 
 
 # If running from the yum plugin, we want to avoid blocking
@@ -81,7 +84,9 @@ class YumRepoLocker(Locker):
 
 
 def update(conduit, cache_only):
-    """ update entitlement certificates """
+    """
+    Update entitlement certificates
+    """
     if os.getuid() != 0:
         conduit.info(3, 'Not root, Subscription Management repositories not updated')
         return
@@ -98,13 +103,13 @@ def update(conduit, cache_only):
     # In containers we have no identity, but we may have entitlements inherited
     # from the host, which need to generate a redhat.repo.
     if identity.is_valid():
-        try:
-            connection.UEPConnection(cert_file=cert_file, key_file=key_file)
-        # FIXME: catchall exception
-        except Exception:
-            # log
-            conduit.info(2, "Unable to connect to Subscription Management Service")
-            return
+        if not cache_only:
+            try:
+                connection.UEPConnection(cert_file=cert_file, key_file=key_file)
+            except Exception:
+                # log
+                conduit.info(2, "Unable to connect to Subscription Management Service")
+                return
     else:
         conduit.info(3, "Unable to read consumer identity")
 
@@ -119,49 +124,54 @@ def update(conduit, cache_only):
     repo_action_invoker.update()
 
 
-def warnExpired(conduit):
-    """ display warning for expired entitlements """
+def warn_expired_entitlements(conduit):
+    """
+    When some entitlement is expired, then display warning message about it
+    """
     ent_dir = inj.require(inj.ENT_DIR)
     products = set()
+
     for cert in ent_dir.list_expired():
-        for p in cert.products:
-            m = '  - %s' % p.name
+        for product in cert.products:
+            m = '  - %s' % product.name
             products.add(m)
+
     if products:
         msg = expired_warning % '\n'.join(sorted(products))
         conduit.info(2, msg)
 
 
-def warnOrGiveUsageMessage(conduit):
+def warn_or_usage_message(conduit):
+    """
+    Display warning message, when the system is not registered (no consumer cert) or then is no entitlement cert
+    """
 
-    # XXX: Importing inline as you must be root to read the config file
-
-    """ either output a warning, or a usage message """
-    msg = ""
-    # TODO: refactor so there are not two checks for this
     if os.getuid() != 0:
         return
     if ClassicCheck().is_registered_with_classic():
         return
+
+    msg = ""
     try:
         identity = inj.require(inj.IDENTITY)
         ent_dir = inj.require(inj.ENT_DIR)
-        # Don't warn people to register if we see entitelements, but no identity:
+        # Don't warn people to register if we see entitlements, but no identity:
         if not identity.is_valid() and len(ent_dir.list_valid()) == 0:
             msg = not_registered_warning
         elif len(ent_dir.list_valid()) == 0:
             msg = no_subs_warning
         if config.in_container() and len(ent_dir.list_valid()) == 0:
             msg = no_subs_container_warning
-
     finally:
         if msg:
             conduit.info(2, msg)
 
 
 def init_hook(conduit):
-    """ Hook for disabling system repositories (= repositories which are
-        not mangaged by subscription-manager will NOT be used) """
+    """
+    Hook for disabling system repositories (repositories which are
+    not mangaged by subscription-manager will NOT be used)
+    """
 
     disable_system_repos = conduit.confBool('main', 'disable_system_repos', default=False)
 
@@ -176,27 +186,52 @@ def init_hook(conduit):
         conduit.info(2, 'subscription-manager plugin disabled "%d" system repositories with respect of configuration in /etc/yum/pluginconf.d/subscription-manager.conf' % (disable_count))
 
 
-def postconfig_hook(conduit):
-    """ update """
-    # register rpm name for yum history recording"
-    # yum on 5.7 doesn't have this method, so check for it
-
+def config_hook(conduit):
+    """
+    This is the first hook of this yum plugin that is triggered by yum. So we do initialization
+    of all stuff that is necessary by other hooks
+    :param conduit: Reference on conduit object used by yum plugin API
+    :return: None
+    """
     logutil.init_logger_for_yum()
-
     init_dep_injection()
+
+    if hasattr(conduit, 'registerPackageName'):
+        conduit.registerPackageName("subscription-manager")
+
+
+def postconfig_hook(conduit):
+    """
+    Try to display some warning messages, when it is necessary.
+    :param conduit: Reference on conduit object used by yum plugin API
+    :return: None
+    """
 
     # If a tool (it's, e.g., Mock) manages a chroot via 'yum --installroot',
     # we must update entitlements in that directory.
+    # Note: conduit.getConf() is available in postconfig_hook
     chroot(conduit.getConf().installroot)
+
+    # It is save to display following warning messages for all yum commands, because following functions
+    # does not communicate with candlepin server. See: https://bugzilla.redhat.com/show_bug.cgi?id=1621275
+    try:
+        warn_or_usage_message(conduit)
+        warn_expired_entitlements(conduit)
+    except Exception as e:
+        conduit.error(2, str(e))
+
+
+def prereposetup_hook(conduit):
+    """
+    Try to update configuration of redhat.repo, before yum tries to load configuration of repositories.
+    :param conduit: Reference on conduit object used by yum plugin API
+    :return: None
+    """
 
     cfg = config.initConfig()
     cache_only = not bool(cfg.get_int('rhsm', 'full_refresh_on_yum'))
 
-    if hasattr(conduit, 'registerPackageName'):
-        conduit.registerPackageName("subscription-manager")
     try:
         update(conduit, cache_only)
-        warnOrGiveUsageMessage(conduit)
-        warnExpired(conduit)
     except Exception as e:
         conduit.error(2, str(e))

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -261,7 +261,6 @@ class YumReleaseverSource(object):
 
         self.identity = inj.require(inj.IDENTITY)
         self.cp_provider = inj.require(inj.CP_PROVIDER)
-        self.uep = self.cp_provider.get_consumer_auth_cp()
 
     # FIXME: these guys are really more of model helpers for the object
     #        represent a release.
@@ -298,8 +297,8 @@ class YumReleaseverSource(object):
         # access to content as the host they run on.)
         result = None
         if not in_container():
-            result = self.release_status_cache.read_status(self.uep,
-                                                           self.identity.uuid)
+            uep = self.cp_provider.get_consumer_auth_cp()
+            result = self.release_status_cache.read_status(uep, self.identity.uuid)
 
         # status cache returned None, which points to a failure.
         # Since we only have one value, use the default there and cache it
@@ -343,7 +342,6 @@ class RepoUpdateActionCommand(object):
         self.ent_source = ent_cert.EntitlementDirEntitlementSource()
 
         self.cp_provider = inj.require(inj.CP_PROVIDER)
-        self.uep = self.cp_provider.get_consumer_auth_cp()
 
         self.manage_repos = 1
         self.apply_overrides = apply_overrides
@@ -352,12 +350,16 @@ class RepoUpdateActionCommand(object):
         self.release = None
         self.overrides = {}
         self.override_supported = False
-        try:
-            self.override_supported = bool(self.identity.is_valid() and self.uep and self.uep.supports_resource('content_overrides'))
-        except (socket.error, connection.ConnectionException) as e:
-            # swallow the error to fix bz 1298327
-            log.exception(e)
-            pass
+        if not cache_only:
+            self.uep = self.cp_provider.get_consumer_auth_cp()
+            try:
+                self.override_supported = bool(self.identity.is_valid() and self.uep and self.uep.supports_resource('content_overrides'))
+            except (socket.error, connection.ConnectionException) as e:
+                # swallow the error to fix bz 1298327
+                log.exception(e)
+                pass
+        else:
+            self.uep = None
 
         self.written_overrides = WrittenOverrideCache()
 


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1621275
* Added several hooks to minimize communication with candlepin
  server.
* Do not try to communicate with candlepin server, when "local
  yum commands are executed (e.g. yum --help, list, check,
  history, etc.).
* The presence of identity and entitlements certificates on
  the disk of host is checked in postconfig hook
* Updating of redhat.repo is done in prereposetup_hook
* When rhsm.full_refresh_on_yum == 0, then the plugin doesn't
  communicate with candlepin server at all, because it wasn't
  necessary at all.
* Small refactoring of code