### PR TITLE
1681171: Install only one prod cert, when RPM is available in more repos.

### DIFF
--- a/src/dnf-plugins/product-id/product-id.h
+++ b/src/dnf-plugins/product-id/product-id.h
@@ -78,7 +78,7 @@ GPtrArray *getInstalledPackages(DnfSack *rpmDbSack);
 int getInstalledProductCerts(gchar *certDir, GPtrArray *repos, GPtrArray *enabledRepoProductId, ProductDb *productDb);
 void getActiveReposFromInstalledPkgs(DnfContext *dnfContext, const GPtrArray *enabledRepoAndProductIds,
                                      GPtrArray *activeRepoAndProductIds, GPtrArray *installedPackages);
-void getActive(DnfContext *dnfContext, DnfPluginHookData *hookData, const GPtrArray *enabledRepoAndProductIds,
+void getActive(DnfContext *dnfContext, const GPtrArray *enabledRepoAndProductIds,
         GPtrArray *activeRepoAndProductIds);
 int decompress(gzFile input, GString *output);
 int findProductId(GString *certContent, GString *result);

--- a/src/dnf-plugins/product-id/test-product-id.c
+++ b/src/dnf-plugins/product-id/test-product-id.c
@@ -308,7 +308,6 @@ void testGetEnabledRepos(enabledReposFixture *fixture, gconstpointer testData) {
 }
 
 typedef struct {
-    DnfPluginHookData *hookData;
     DnfContext *dnfContext;
     GPtrArray *repoAndProductIds;
     GPtrArray *activeRepoAndProductIds;
@@ -319,7 +318,6 @@ typedef struct {
 
 void setupActiveRepos(activeReposFixture *fixture, gconstpointer testData) {
     (void)testData;
-    fixture->hookData = NULL;
     fixture->dnfContext = dnf_context_new();
     int max_size = 3;
     fixture->repoAndProductIds = g_ptr_array_sized_new(max_size);
@@ -349,7 +347,7 @@ void teardownActiveRepos(activeReposFixture *fixture, gconstpointer testData) {
 
 void testGetActiveRepos(activeReposFixture *fixture, gconstpointer testData) {
     (void)testData;
-    getActive(fixture->dnfContext, fixture->hookData, fixture->repoAndProductIds, fixture->activeRepoAndProductIds);
+    getActive(fixture->dnfContext, fixture->repoAndProductIds, fixture->activeRepoAndProductIds);
     // TODO: improve this unit test to get at least one active repository
     g_assert_cmpint(fixture->activeRepoAndProductIds->len, ==, 0);
 }


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1681171
* This bug fix prevents installing two product certificates,
  when two repositories provide same RPM, but RPM is downloaded
  only from one of them. The product-id certificate installs
  only one certificate from the certificate that is actually
  used.
* NOTE: Behavior of yum product-id is different. It installs
  both certificates, but installing only one certificate is
  IMHO correct behavior.