### PR TITLE
1637090: Do not send Host header twice, when m2crypto is used; ENT-1100

### DIFF
--- a/src/rhsm/m2cryptohttp.py
+++ b/src/rhsm/m2cryptohttp.py
@@ -16,6 +16,12 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 #
 
+"""
+This is wrapper providing https connection on RHEL6. It is not used on higher versions
+of RHEL. It also is not used on Fedora (since version 23).
+NOTE: using environment variable RHSM_USE_M2CRYPTO does not work with Python3.
+"""
+
 import six.moves.http_client
 from M2Crypto import httpslib, SSL
 from M2Crypto.SSL import timeout
@@ -128,7 +134,6 @@ class _RhsmProxyHTTPSConnection(httpslib.ProxyHTTPSConnection):
         except Exception:
             port = None
         msg = "CONNECT %s:%d HTTP/1.1\r\n" % (self._real_host, port)
-        msg += "Host: %s:%d\r\n" % (self._real_host, port)
         if self.proxy_headers:
             for key, value in list(self.proxy_headers.items()):
                 msg += "%s: %s\r\n" % (key, value)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1637090
* RHEL6 still uses m2crypto wrapper, but we decided to not use
  m2crypto wrapper in RHEL7 and Fedora23. Thus we had to fix
  abscence of "Host" header in connection.py. See e.g. this
  BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1507158
* Previous bug fixes caused this issue.
* It is still possible to use m2crypto wrapper on RHEL7, when
  environment variable RHSM_USE_M2CRYPTO=1 is set, but this
  approach is not supported with Python3 (different API).