### PR TITLE
1696428: use enabled_metadata = 0 for disabled repositories

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2327,7 +2327,7 @@ class ReposCommand(CliCommand):
 
             if self.is_registered() and self.use_overrides:
                 overrides = [{'contentLabel': repo.id, 'name': 'enabled', 'value': repos_to_modify[repo]} for repo in repos_to_modify]
-                metadata_overrides = [{'contentLabel': repo.id, 'name': 'enable_metadata', 'value': repos_to_modify[repo]} for repo in repos_to_modify]
+                metadata_overrides = [{'contentLabel': repo.id, 'name': 'enabled_metadata', 'value': repos_to_modify[repo]} for repo in repos_to_modify]
                 overrides.extend(metadata_overrides)
                 results = self.cp.setContentOverrides(self.identity.uuid, overrides)
 
@@ -2343,7 +2343,7 @@ class ReposCommand(CliCommand):
                 changed_repos = [repo for repo in matches if repo['enabled'] != status]
                 for repo in changed_repos:
                     repo['enabled'] = status
-                    repo['enable_metadata'] = status
+                    repo['enabled_metadata'] = status
                 if changed_repos:
                     repo_file = YumRepoFile()
                     repo_file.read()

--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -62,7 +62,7 @@ class Repo(dict):
             'sslclientkey': (0, None),
             'sslclientcert': (0, None),
             'metadata_expire': (1, None),
-            'enable_metadata': (1, '0'),
+            'enabled_metadata': (1, '0'),
             'proxy': (0, None),
             'proxy_username': (0, None),
             'proxy_password': (0, None),
@@ -113,10 +113,10 @@ class Repo(dict):
 
         if content.enabled:
             repo['enabled'] = "1"
-            repo['enable_metadata'] = "1"
+            repo['enabled_metadata'] = "1"
         else:
             repo['enabled'] = "0"
-            repo['enable_metadata'] = "0"
+            repo['enabled_metadata'] = "0"
 
         expanded_url_path = Repo._expand_releasever(release_source, content.url)
         repo['baseurl'] = utils.url_base_join(baseurl, expanded_url_path)

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1018,7 +1018,7 @@ class TestReposCommand(TestCliCommand):
         self.cc._set_repo_status(repos, repolib_instance, items)
 
         expected_overrides = [{'contentLabel': i, 'name': 'enabled', 'value': '0'} for (_action, i) in items]
-        metadata_overrides = [{'contentLabel': i, 'name': 'enable_metadata', 'value': '0'} for (_action, i) in items]
+        metadata_overrides = [{'contentLabel': i, 'name': 'enabled_metadata', 'value': '0'} for (_action, i) in items]
         expected_overrides.extend(metadata_overrides)
 
         # The list of overrides sent to setContentOverrides is really a set of
@@ -1042,7 +1042,7 @@ class TestReposCommand(TestCliCommand):
         self.cc._set_repo_status(repos, repolib_instance, items)
 
         expected_overrides = [{'contentLabel': i.id, 'name': 'enabled', 'value': '0'} for i in repos]
-        metadata_overrides = [{'contentLabel': i.id, 'name': 'enable_metadata', 'value': '0'} for i in repos]
+        metadata_overrides = [{'contentLabel': i.id, 'name': 'enabled_metadata', 'value': '0'} for i in repos]
         expected_overrides.extend(metadata_overrides)
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
         self.cc.cp.setContentOverrides.assert_called_once_with('fake_id', match_dict_list)
@@ -1061,11 +1061,11 @@ class TestReposCommand(TestCliCommand):
 
         expected_overrides = [
             {'contentLabel': 'zebra', 'name': 'enabled', 'value': '0'},
-            {'contentLabel': 'zebra', 'name': 'enable_metadata', 'value': '0'},
+            {'contentLabel': 'zebra', 'name': 'enabled_metadata', 'value': '0'},
             {'contentLabel': 'zoo', 'name': 'enabled', 'value': '1'},
-            {'contentLabel': 'zoo', 'name': 'enable_metadata', 'value': '1'},
+            {'contentLabel': 'zoo', 'name': 'enabled_metadata', 'value': '1'},
             {'contentLabel': 'zip', 'name': 'enabled', 'value': '1'},
-            {'contentLabel': 'zip', 'name': 'enable_metadata', 'value': '1'}
+            {'contentLabel': 'zip', 'name': 'enabled_metadata', 'value': '1'}
         ]
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
         self.cc.cp.setContentOverrides.assert_called_once_with('fake_id',
@@ -1085,11 +1085,11 @@ class TestReposCommand(TestCliCommand):
 
         expected_overrides = [
             {'contentLabel': 'zebra', 'name': 'enabled', 'value': '1'},
-            {'contentLabel': 'zebra', 'name': 'enable_metadata', 'value': '1'},
+            {'contentLabel': 'zebra', 'name': 'enabled_metadata', 'value': '1'},
             {'contentLabel': 'zoo', 'name': 'enabled', 'value': '0'},
-            {'contentLabel': 'zoo', 'name': 'enable_metadata', 'value': '0'},
+            {'contentLabel': 'zoo', 'name': 'enabled_metadata', 'value': '0'},
             {'contentLabel': 'zip', 'name': 'enabled', 'value': '0'},
-            {'contentLabel': 'zip', 'name': 'enable_metadata', 'value': '0'}
+            {'contentLabel': 'zip', 'name': 'enabled_metadata', 'value': '0'}
         ]
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
         self.cc.cp.setContentOverrides.assert_called_once_with('fake_id',
@@ -1108,11 +1108,11 @@ class TestReposCommand(TestCliCommand):
 
         expected_overrides = [
             {'contentLabel': 'zebra', 'name': 'enabled', 'value': '0'},
-            {'contentLabel': 'zebra', 'name': 'enable_metadata', 'value': '0'},
+            {'contentLabel': 'zebra', 'name': 'enabled_metadata', 'value': '0'},
             {'contentLabel': 'zoo', 'name': 'enabled', 'value': '0'},
-            {'contentLabel': 'zoo', 'name': 'enable_metadata', 'value': '0'},
+            {'contentLabel': 'zoo', 'name': 'enabled_metadata', 'value': '0'},
             {'contentLabel': 'zip', 'name': 'enabled', 'value': '0'},
-            {'contentLabel': 'zip', 'name': 'enable_metadata', 'value': '0'}
+            {'contentLabel': 'zip', 'name': 'enabled_metadata', 'value': '0'}
         ]
         match_dict_list = Matcher(self.assert_items_equals, expected_overrides)
         self.cc.cp.setContentOverrides.assert_called_once_with('fake_id',


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1696428
* This bug fix use right option "enabled_metadata" and not
  "enable_metadata".
* You can check that PackageKit does not download metadata for
  disabled repositories by observing content of directory:
  /var/cache/PackageKit/<release_version>/metadata/