### PR TITLE
Fix broken AptRepoFile section function

### DIFF
--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -411,9 +411,9 @@ if HAS_DEB822:
             self.repos822[:] = [repo822 if repo822['id'] != repo.id else Deb822(repo_dict) for repo822 in self.repos822]
 
         def section(self, repo_id):
-            result = [Repo(repo822) for repo822 in self.repos822 if repo822['id'] == repo_id]
+            result = [repo822 for repo822 in self.repos822 if repo822['id'] == repo_id]
             if len(result) > 0:
-                return result[0]
+                return Repo(result[0]['id'], result[0].items())
             else:
                 return None
 


### PR DESCRIPTION
The `section` function from the `AptRepoFile` class is broken.

This causes problems for the Debian version of the subscription-manager.

For example `subscription-manager refresh` won't update `/etc/apt/sources.list.d/rhsm.sources` at all.
This breaks all `apt` actions since the repos are associated with the wrong certificates.