### PR TITLE
1698645: Ensure we use local syspurpose when there are network issues

### DIFF
--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -271,8 +271,12 @@ class SyncedStore(object):
 
     def sync(self):
         log.debug('Attempting to sync syspurpose content...')
-        if self.uep and not self.uep.has_capability('syspurpose'):
-            log.debug('Server does not support syspurpose, syncing only locally.')
+        try:
+            if self.uep and not self.uep.has_capability('syspurpose'):
+                log.debug('Server does not support syspurpose, syncing only locally.')
+                return self._sync_local_only()
+        except:
+            log.debug('Failed to detect whether the server has syspurpose capability')
             return self._sync_local_only()
 
         remote_contents = self.get_remote_contents()


### PR DESCRIPTION
When installing a new RHEL 8 system with anaconda, if you do not configure any network at all (but still set some syspurpose info), on reboot the syspurpose info is lost.

In addition, when the network is unreachable, all related syspurpose commands fail with a traceback (in both subman and syspurpose). This PR should fix these cases.