### PR TITLE
1701406: Do not build subman-rhsm with python2 on later versions of rhel

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -19,7 +19,7 @@
 %bcond_without python3
 %endif
 
-%if !(0%{?fedora} < 30 && %{with python3})
+%if !(0%{?fedora} < 30 && %{with python3}) || 0%{?rhel} >= 8
 %bcond_with python2_rhsm
 %else
 %bcond_without python2_rhsm


### PR DESCRIPTION
It is no longer necessary to default to building the python2 version of subscription-manager-rhsm on later versions of RHEL.