### PR TITLE
1700445: Do not disabled repos in redhat.repo; ENT-1261

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -951,6 +951,14 @@ class UEPConnection(object):
 
         return resource_name in self.resources
 
+    def get_supported_resources(self):
+        """
+        Get the list (dictionary) of supported resources
+        :return: dictionary of supported resources
+        """
+        self._load_supported_resources()
+        return self.resources
+
     def _load_manager_capabilities(self):
         """
         Loads manager capabilities by doing a GET on the status

--- a/src/subscription_manager/capabilities.py
+++ b/src/subscription_manager/capabilities.py
@@ -1,0 +1,168 @@
+from __future__ import print_function, division, absolute_import
+
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+Some REST API calls returns still the same result (usually some server capabilities).
+Thus it is wise to cache such result to some file. This modules is used for caching
+such REST API calls.
+"""
+
+import json
+import socket
+import logging
+
+import rhsm.connection as connection
+import subscription_manager.injection as inj
+import subscription_manager.version as version
+
+log = logging.getLogger(__name__)
+
+
+class ServerCache(object):
+    """
+    Class providing cached information about resources and capabilities of candlepin server
+    """
+
+    CACHE_FILE = "/var/lib/rhsm/server_capabilities.json"
+
+    @classmethod
+    def _load_cache_file(cls):
+        """
+        Try to load data from cache file
+        :return:
+        """
+        data = None
+
+        try:
+            with open(cls.CACHE_FILE, 'r') as fp:
+                json_str = fp.read()
+                data = json.loads(json_str)
+        except IOError:
+            pass
+
+        return data
+
+    @classmethod
+    def _write_cache_file(cls, data):
+        """
+        Try to write data to cache file
+        :param data: fresh data
+        :return: None
+        """
+        log.debug("Writing cached server capabilities: %s" % data)
+
+        # Write fresh data to cache file
+        with open(cls.CACHE_FILE, 'w') as fp:
+            json.dump(data, fp)
+
+    @staticmethod
+    def _get_supported_resources_from_server(uep=None):
+        """
+        Try to load supported resources from the server
+        :param uep: connection to candlepin server
+        :return: dictionary of supported resources
+        """
+        resources = {}
+
+        if uep is None:
+            cp_provider = inj.require(inj.CP_PROVIDER)
+            uep = cp_provider.get_consumer_auth_cp()
+        try:
+            resources = uep.get_supported_resources()
+        except (socket.error, connection.ConnectionException) as e:
+            log.exception(e)
+
+        return resources
+
+    @staticmethod
+    def _loaded_data_obsoleted(data, consumer_uuid):
+        """
+        Try to validate loaded data from cache file to not be obsoleted by re-register or new version
+        of subscription-manager
+        :param data: loaded data
+        :return: True, when data are valid. False otherwise.
+        """
+        if data is None:
+            return True
+
+        # Data has to be valid for current consumer (system could be registered to different candlepin server
+        # with different set of features)
+        if consumer_uuid not in data:
+            log.debug("Server capabilites cache file is obsoleted (old consumer UUID)")
+            return True
+
+        # Data has to be valid for current version of subscription-manager (some new features could be added
+        # to subscription-manager). Thus resources are reloaded from candlepin server for every new version
+        # of subscription-manager
+        if "version" not in data:
+            log.warning("Server capabilites cache file has wrong structure (missing version)")
+            return True
+        elif data["version"] != version.rpm_version:
+            log.debug("Server capabilites cache file is obsoleted (old version)")
+            return True
+
+        return False
+
+    @staticmethod
+    def _assembly_capabilities(consumer_uuid, old_data, resources=None):
+        """
+        Assembly capabilities to structure to be saved in JSON file. Note: this method could be extended
+        in the future. We will want to cache other REST API calls.
+        :param resources: supported resources
+        :return: data
+        """
+        if resources is None:
+            try:
+                resources = old_data[consumer_uuid]["supported_resources"]
+            except (TypeError, KeyError):
+                resources = {}
+        data = {
+            consumer_uuid: {
+                "supported_resources": resources
+            },
+            "version": version.rpm_version
+        }
+        return data
+
+    @classmethod
+    def get_supported_resources(cls, consumer_uuid, uep=None):
+        """
+        Try to get supported resources for given consumer UUID from cache file. When cache file
+        does not exist or the cache file is obsolete, then load supported resources from server
+        and save fresh data to cache file.
+        :param consumer_uuid: UUID of consumer
+        :param uep: connection to candlepin server
+        :return: array of supported resources
+        """
+        resources = {}
+
+        data = cls._load_cache_file()
+
+        if data is not None:
+            data_obsoleted = cls._loaded_data_obsoleted(data, consumer_uuid)
+            if data_obsoleted is False and "supported_resources" in data[consumer_uuid]:
+                resources = data[consumer_uuid]["supported_resources"]
+
+        # If it wasn't able to load supported resources from cache for some reason, then
+        # try to load supported resources from candlepin server
+        if not resources:
+            resources = cls._get_supported_resources_from_server(uep)
+
+            data = cls._assembly_capabilities(consumer_uuid, data, resources)
+
+            cls._write_cache_file(data)
+
+        return resources

--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -593,12 +593,12 @@ def init_repo_file_classes():
     repo_file_classes = [YumRepoFile, ZypperRepoFile]
     if HAS_DEB822:
         repo_file_classes.append(AptRepoFile)
-    repo_files = [
+    _repo_files = [
         (RepoFile, RepoFile.server_value_repo_file)
         for RepoFile in repo_file_classes
         if RepoFile.installed()
     ]
-    return repo_files
+    return _repo_files
 
 
 def get_repo_file_classes():

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -21,16 +21,15 @@ from __future__ import print_function, division, absolute_import
 from iniparse import RawConfigParser as ConfigParser
 import logging
 import os
-import socket
 import subscription_manager.injection as inj
 from subscription_manager.cache import OverrideStatusCache, WrittenOverrideCache
 from subscription_manager import model
 from subscription_manager.model import ent_cert
 from subscription_manager.repofile import Repo, manage_repos_enabled, get_repo_file_classes
 from subscription_manager.repofile import YumRepoFile
+from subscription_manager.capabilities import ServerCache
 
 from rhsm.config import initConfig, in_container
-from rhsm import connection
 import six
 from six.moves import configparser
 
@@ -333,6 +332,10 @@ class RepoUpdateActionCommand(object):
     Returns an RepoActionReport.
     """
     def __init__(self, cache_only=False, apply_overrides=True):
+
+        log.debug("Updating repo triggered with following attributes: cache_only=%s, apply_overrides=%s" %
+                  (str(cache_only), str(apply_overrides)))
+
         self.identity = inj.require(inj.IDENTITY)
 
         # These should probably move closer their use
@@ -350,16 +353,15 @@ class RepoUpdateActionCommand(object):
         self.release = None
         self.overrides = {}
         self.override_supported = False
+
         if not cache_only:
             self.uep = self.cp_provider.get_consumer_auth_cp()
-            try:
-                self.override_supported = bool(self.identity.is_valid() and self.uep and self.uep.supports_resource('content_overrides'))
-            except (socket.error, connection.ConnectionException) as e:
-                # swallow the error to fix bz 1298327
-                log.exception(e)
-                pass
         else:
             self.uep = None
+
+        if self.identity.is_valid():
+            supported_resources = ServerCache.get_supported_resources(self.identity.uuid, self.uep)
+            self.override_supported = 'content_overrides' in supported_resources
 
         self.written_overrides = WrittenOverrideCache()
 
@@ -370,6 +372,7 @@ class RepoUpdateActionCommand(object):
         # If we are not registered, skip trying to refresh the
         # data from the server
         if not self.identity.is_valid():
+            log.debug("The system is not registered. Skipping refreshing data from server.")
             return
 
         # NOTE: if anything in the RepoActionInvoker init blocks, and it
@@ -585,7 +588,7 @@ class RepoUpdateActionCommand(object):
                 old_repo[key] = new_val
                 changes_made += 1
 
-            if (mutable and new_val is not None):
+            if mutable and new_val is not None:
                 server_value_repo[key] = new_val
 
         return changes_made

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -421,6 +421,7 @@ class StubUEP(object):
         self.called_unbind_pool_id = []
         self.username = username
         self.password = password
+        self._resources = []
         self._capabilities = []
 
     def reset(self):
@@ -433,7 +434,10 @@ class StubUEP(object):
         return capability in self._capabilities
 
     def supports_resource(self, resource):
-        return False
+        return resource in self._resources
+
+    def get_supported_resources(self):
+        return self._resources
 
     def registerConsumer(self, name, type, facts, owner, environment, keys,
                          installed_products, content_tags):

--- a/test/test_capabilities.py
+++ b/test/test_capabilities.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import tempfile
+import os
+import mock
+
+from . import stubs
+
+from subscription_manager.capabilities import ServerCache
+
+SUBMAN_VERSION = "1.25.1-1.el7"
+CONSUMER_UUID = "84cf4ee1-9b72-4ebd-8647-056d2fc36898"
+SUPPORTED_RESOURCES_SERVER = {
+    "": "/",
+    "guestids": "/consumers/{consumer_uuid}/guestids",
+    "cdn": "/cdn",
+    "content_overrides": "/consumers/{consumer_uuid}/content_overrides",
+    "hypervisors": "/hypervisors",
+    "serials": "/serials",
+    "deleted_consumers": "/deleted_consumers",
+    "consumers": "/consumers",
+    "content": "/content",
+    "entitlements": "/entitlements",
+    "events": "/events",
+    "status": "/status",
+    "jobs": "/jobs",
+    "users": "/users",
+    "subscriptions": "/subscriptions",
+    "rules": "/rules",
+    "distributor_versions": "/distributor_versions",
+    "consumertypes": "/consumertypes",
+    "pools": "/pools",
+    "atom": "/atom",
+    "owners": "/owners",
+    "roles": "/roles",
+    "admin": "/admin",
+    "products": "/products",
+    "activation_keys": "/activation_keys",
+    "crl": "/crl",
+    "foo": "/foo"
+}
+
+CACHE_FILE = """
+{
+    "version": "%s",
+    "%s": {
+        "supported_resources": {
+            "": "/",
+            "guestids": "/consumers/{consumer_uuid}/guestids",
+            "cdn": "/cdn",
+            "content_overrides": "/consumers/{consumer_uuid}/content_overrides",
+            "hypervisors": "/hypervisors",
+            "serials": "/serials",
+            "deleted_consumers": "/deleted_consumers",
+            "consumers": "/consumers",
+            "content": "/content",
+            "entitlements": "/entitlements",
+            "events": "/events",
+            "status": "/status",
+            "jobs": "/jobs",
+            "users": "/users",
+            "subscriptions": "/subscriptions",
+            "rules": "/rules",
+            "distributor_versions": "/distributor_versions",
+            "consumertypes": "/consumertypes",
+            "pools": "/pools",
+            "atom": "/atom",
+            "owners": "/owners",
+            "roles": "/roles",
+            "admin": "/admin",
+            "products": "/products",
+            "activation_keys": "/activation_keys",
+            "crl": "/crl",
+            "bar": "/bar"
+        }
+    }
+}""" % (SUBMAN_VERSION, CONSUMER_UUID)
+
+
+class TestServerCache(unittest.TestCase):
+    """
+    Class for testing ServerChache
+    """
+
+    def setUp(self):
+        """
+        Set up testing environment before each test
+        """
+        temp_repo_dir = tempfile.mkdtemp()
+        cache_file = os.path.join(temp_repo_dir, 'server_capabilities.json')
+        with open(cache_file, 'w') as repo_file:
+            repo_file.write(CACHE_FILE)
+        self.ServerCache = ServerCache
+        self.ServerCache.CACHE_FILE = cache_file
+        self.consumer_uuid = "84cf4ee1-9b72-4ebd-8647-056d2fc36898"
+        self.version_patcher = mock.patch('subscription_manager.capabilities.version')
+        self.version_mock = self.version_patcher.start()
+        self.version_mock.rpm_version = SUBMAN_VERSION
+        self.uep = stubs.StubUEP()
+        self.uep._resources = SUPPORTED_RESOURCES_SERVER
+
+    def tearDown(self):
+        """
+        Tear down test environment
+        """
+        self.version_patcher.stop()
+
+    def test_loading_cached_data(self):
+        """
+        Test loading cached data form file
+        """
+        resources = self.ServerCache.get_supported_resources(self.consumer_uuid, self.uep)
+        self.assertTrue("bar" in resources)
+
+    def test_changed_consumer_uuid(self):
+        """
+        Test that resources are loaded from server, when consumer UUID was changed
+        """
+        consumer_uuid = "84cf4ee1-9b72-4ebd-8647-aaaaaaaaaaaa"
+        resources = self.ServerCache.get_supported_resources(consumer_uuid, self.uep)
+        self.assertTrue("foo" in resources)
+
+    def test_changed_subman_version(self):
+        """
+        Test that resources are loaded from server, when version of subscription-manager was changed
+        """
+        self.version_mock.rpm_version = "1.36.1-1.el9"
+        resources = self.ServerCache.get_supported_resources(self.consumer_uuid, self.uep)
+        self.assertTrue("foo" in resources)

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -870,6 +870,10 @@ class TestReposCommand(TestCliCommand):
         self.mock_sp_store = syspurpose_patch.start()
         self.mock_sp_store, self.mock_sp_store_contents = set_up_mock_sp_store(self.mock_sp_store)
         self.addCleanup(syspurpose_patch.stop)
+        server_cache_patcher = patch('subscription_manager.repolib.ServerCache')
+        self.mock_server_cache = server_cache_patcher.start()
+        self.mock_server_cache._write_cache_file = MagicMock()
+        self.addCleanup(server_cache_patcher.stop)
 
     def check_output_for_repos(self, output, repos):
         """

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -85,7 +85,9 @@ class TestRepoActionInvoker(fixture.SubManFixture):
         inj.provide(inj.ENT_DIR, stub_ent_dir)
         inj.provide(inj.PROD_DIR, stub_prod_dir)
 
-    def test_is_managed(self):
+    @patch('subscription_manager.repolib.ServerCache')
+    def test_is_managed(self, mock_server_cache):
+        mock_server_cache._write_cache_file = MagicMock()
         self._stub_content()
         repo_action_invoker = RepoActionInvoker()
         repo_label = 'a_test_repo'
@@ -100,13 +102,17 @@ class TestRepoActionInvoker(fixture.SubManFixture):
         repo_file = repo_action_invoker.get_repo_file()
         self.assertFalse(repo_file is None)
 
-    def test_get_repos_empty_dirs(self):
+    @patch('subscription_manager.repolib.ServerCache')
+    def test_get_repos_empty_dirs(self, mock_server_cache):
+        mock_server_cache._write_cache_file = MagicMock()
         repo_action_invoker = RepoActionInvoker()
         repos = repo_action_invoker.get_repos()
         if repos:
             self.fail("get_repos() should have returned an empty set but did not.")
 
-    def test_get_repos(self):
+    @patch('subscription_manager.repolib.ServerCache')
+    def test_get_repos(self, mock_server_cache):
+        mock_server_cache._write_cache_file = MagicMock()
         self._stub_content(include_content_access=True)
         repo_action_invoker = RepoActionInvoker()
         repos = repo_action_invoker.get_repos()
@@ -278,6 +284,13 @@ class RepoUpdateActionTests(fixture.SubManFixture):
         inj.provide(inj.ENT_DIR, ent_dir)
 
         repolib.ConsumerIdentity = StubConsumerIdentity
+        self.patcher = patch('subscription_manager.repolib.ServerCache')
+        self.mock_server_cache = self.patcher.start()
+        self.mock_server_cache._write_cache_file = MagicMock()
+
+    def tearDown(self):
+        super(RepoUpdateActionTests, self).tearDown()
+        self.patcher.stop()
 
     def _find_content(self, content_list, name):
         """


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1700445
* This issue was cauded by #2051
* To avoid REST API calls with same results, results are saved to
  cache file. Example of such REST API call is "/".
* New file: capabilities.py
* TODO: use it on more places