### PR TITLE
1704662: Do not create corrupted redhat.repo (wrong scheme); ENT-1306

### DIFF
--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -162,6 +162,11 @@ class Repo(dict):
         if proxy_scheme.endswith("://"):
             proxy_scheme = proxy_scheme[:-3]
 
+        # Proxy scheme can be empty: 1704662
+        if proxy_scheme == "":
+            defaults = conf.defaults()
+            proxy_scheme = defaults.get('proxy_scheme', 'http')
+
         # Worth passing in proxy config info to from_ent_cert_content()?
         # That would decouple Repo some
         proxy_host = conf['server']['proxy_hostname']

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -130,6 +130,13 @@ proxy_hostname = fake.server.com
 proxy_port = 3129
 """
 
+PROXY_EMPTY_PROTOCOL = """
+[server]
+proxy_hostname = fake.server.com
+proxy_port = 3129
+proxy_scheme =
+"""
+
 PROXY_HTTP_PROTOCOL = """
 [server]
 proxy_hostname = fake.server.com
@@ -195,6 +202,12 @@ class RepoTests(unittest.TestCase):
 
     @patch.object(repofile, 'conf', ConfigFromString(config_string=PROXY_NO_PROTOCOL))
     def test_http_by_default(self):
+        repo = Repo('testrepo')
+        r = Repo._set_proxy_info(repo)
+        self.assertEqual(r['proxy'], "http://fake.server.com:3129")
+
+    @patch.object(repofile, 'conf', ConfigFromString(config_string=PROXY_EMPTY_PROTOCOL))
+    def test_http_by_empty(self):
         repo = Repo('testrepo')
         r = Repo._set_proxy_info(repo)
         self.assertEqual(r['proxy'], "http://fake.server.com:3129")


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1704662
* When proxy_scheme is empty, then create redhat.repo with default
  scheme. It should be http in this case.
* Added one unit test for this case.