### PR TITLE
1710564: Make entitlement certs and keys world-readable

### DIFF
--- a/src/rhsm/certificate.py
+++ b/src/rhsm/certificate.py
@@ -563,7 +563,7 @@ class Key(object):
         f.write(self.content)
         self.path = pem_path
         f.close()
-        os.chmod(pem_path, 0o600)
+        os.chmod(pem_path, 0o644)
         return self
 
     def delete(self):


### PR DESCRIPTION
To better enable users running rootless containers which require
access to content provided by subscription-manager/RHSM, the
entitlement certificates (and their keys) are now readable by
"other".