### PR TITLE
1702239: Fix traceback for syspurpose on rhel7; ENT-1286

### DIFF
--- a/src/subscription_manager/identity.py
+++ b/src/subscription_manager/identity.py
@@ -19,6 +19,7 @@ import logging
 import os
 import errno
 import threading
+import six
 
 from rhsm.certificate import create_from_pem
 from rhsm.config import initConfig
@@ -143,8 +144,12 @@ class Identity(object):
             # existsAndValid did, so this is better.
             except (CertificateException, IOError) as err:
                 self.consumer = None
+                if six.PY2:
+                    err_msg = str(err).decode('utf-8')
+                else:
+                    err_msg = err
                 msg = "Reload of consumer identity cert %s raised an exception with msg: %s" \
-                    % (ConsumerIdentity.certpath(), err)
+                    % (ConsumerIdentity.certpath(), err_msg)
                 if isinstance(err, IOError) and err.errno == errno.ENOENT:
                     log.debug(msg)
                 else:


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1702239
* The traceback is displayed, when the LANG is not en_EN,
  (it is e.g. cs_CZ.utf8), system is not registered and
  default_log_level is set to DEBUG.