### PR TITLE
cockpit: Add support for Red Hat Insights

### DIFF
--- a/cockpit/lib/service.js
+++ b/cockpit/lib/service.js
@@ -1,0 +1,332 @@
+import cockpit from "cockpit";
+
+/* SERVICE MANAGEMENT API
+ *
+ * The "service" module lets you monitor and manage a
+ * system service on localhost in a simple way.
+ *
+ * It mainly exists because talking to the systemd D-Bus API is
+ * not trivial enough to do it directly.
+ *
+ * - proxy = service.proxy(name)
+ *
+ * Create a proxy that represents the service named NAME.
+ *
+ * The proxy has properties and methods (described below) that
+ * allow you to monitor the state of the service, and perform
+ * simple actions on it.
+ *
+ * Initially, any of the properties can be "null" until their
+ * actual values have been retrieved in the background.
+ *
+ * - $(proxy).on('changed', function (event) { ... })
+ *
+ * The 'changed' event is emitted whenever one of the properties
+ * of the proxy changes.
+ *
+ * - proxy.exists
+ *
+ * A boolean that tells whether the service is known or not.  A
+ * proxy with 'exists == false' will have 'state == undefined' and
+ * 'enabled == undefined'.
+ *
+ * - proxy.state
+ *
+ * Either 'undefined' when the state can't be retrieved, or a
+ * string that has one of the values "starting", "running",
+ * "stopping", "stopped", or "failed".
+ *
+ * - proxy.enabled
+ *
+ * Either 'undefined' when the value can't be retrieved, or a
+ * boolean that tells whether the service is started 'enabled'.
+ * What it means exactly for a service to be enabled depends on
+ * the service, but a enabled service is usually started on boot,
+ * no matter wether other services need it or not.  A disabled
+ * service is usually only started when it is needed by some other
+ * service.
+ *
+ * - proxy.unit
+ * - proxy.details
+ *
+ * The raw org.freedesktop.systemd1.Unit and type-specific D-Bus
+ * interface proxies for the service.
+ *
+ * - promise = proxy.start()
+ *
+ * Start the service.  The return value is a standard jQuery
+ * promise as returned from DBusClient.call.
+ *
+ * - promise =  proxy.restart()
+ *
+ * Restart the service.
+ *
+ * - promise = proxy.tryRestart()
+ *
+ * Try to restart the service if it's running or starting
+ *
+ * - promise = proxy.stop()
+ *
+ * Stop the service.
+ *
+ * - promise = proxy.enable()
+ *
+ * Enable the service.
+ *
+ * - promise = proxy.disable()
+ *
+ * Disable the service.
+ */
+
+var systemd_client;
+var systemd_manager;
+
+function wait_valid(proxy, callback) {
+    proxy.wait(function() {
+        if (proxy.valid)
+            callback();
+    });
+}
+
+function with_systemd_manager(done) {
+    if (!systemd_manager) {
+        systemd_client = cockpit.dbus("org.freedesktop.systemd1", { superuser: "try" });
+        systemd_manager = systemd_client.proxy("org.freedesktop.systemd1.Manager",
+                                               "/org/freedesktop/systemd1");
+        wait_valid(systemd_manager, function() {
+            systemd_manager.Subscribe()
+                    .fail(function (error) {
+                        if (error.name != "org.freedesktop.systemd1.AlreadySubscribed" &&
+                        error.name != "org.freedesktop.DBus.Error.FileExists")
+                            console.warn("Subscribing to systemd signals failed", error);
+                    });
+        });
+    }
+    wait_valid(systemd_manager, done);
+}
+
+export function proxy(name, kind) {
+    var self = {
+        exists: null,
+        state: null,
+        enabled: null,
+
+        wait: wait,
+
+        start: start,
+        stop: stop,
+        restart: restart,
+        tryRestart: tryRestart,
+
+        enable: enable,
+        disable: disable
+    };
+
+    cockpit.event_target(self);
+
+    var unit, details;
+    var wait_callbacks = cockpit.defer();
+
+    if (name.indexOf(".") == -1)
+        name = name + ".service";
+    if (kind === undefined)
+        kind = "Service";
+
+    function update_from_unit() {
+        self.exists = (unit.LoadState != "not-found" || unit.ActiveState != "inactive");
+
+        if (unit.ActiveState == "activating")
+            self.state = "starting";
+        else if (unit.ActiveState == "deactivating")
+            self.state = "stopping";
+        else if (unit.ActiveState == "active" || unit.ActiveState == "reloading")
+            self.state = "running";
+        else if (unit.ActiveState == "failed")
+            self.state = "failed";
+        else if (unit.ActiveState == "inactive" && self.exists)
+            self.state = "stopped";
+        else
+            self.state = undefined;
+
+        if (unit.UnitFileState == "enabled" || unit.UnitFileState == "linked")
+            self.enabled = true;
+        else if (unit.UnitFileState == "disabled" || unit.UnitFileState == "masked")
+            self.enabled = false;
+        else
+            self.enabled = undefined;
+
+        self.unit = unit;
+
+        self.dispatchEvent("changed");
+        wait_callbacks.resolve();
+    }
+
+    function update_from_details() {
+        self.details = details;
+        self.dispatchEvent("changed");
+    }
+
+    with_systemd_manager(function () {
+        systemd_manager.LoadUnit(name)
+                .done(function (path) {
+                    unit = systemd_client.proxy('org.freedesktop.systemd1.Unit', path);
+                    unit.addEventListener('changed', update_from_unit);
+                    wait_valid(unit, update_from_unit);
+
+                    details = systemd_client.proxy('org.freedesktop.systemd1.' + kind, path);
+                    details.addEventListener('changed', update_from_details);
+                    wait_valid(details, update_from_details);
+                })
+                .fail(function () {
+                    self.exists = false;
+                    self.dispatchEvent('changed');
+                });
+    });
+
+    function refresh() {
+        if (!unit || !details)
+            return;
+
+        function refresh_interface(path, iface) {
+            systemd_client.call(path,
+                                "org.freedesktop.DBus.Properties", "GetAll", [ iface ])
+                    .fail(function (error) {
+                        console.log(error);
+                    })
+                    .done(function (result) {
+                        var props = { };
+                        for (var p in result[0])
+                            props[p] = result[0][p].v;
+                        var ifaces = { };
+                        ifaces[iface] = props;
+                        var data = { };
+                        data[unit.path] = ifaces;
+                        systemd_client.notify(data);
+                    });
+        }
+
+        refresh_interface(unit.path, "org.freedesktop.systemd1.Unit");
+        refresh_interface(details.path, "org.freedesktop.systemd1." + kind);
+    }
+
+    function on_job_new_removed_refresh(event, number, path, unit_id, result) {
+        if (unit_id == name)
+            refresh();
+    }
+
+    /* HACK - https://bugs.freedesktop.org/show_bug.cgi?id=69575
+     *
+     * We need to explicitly get new property values when getting
+     * a UnitNew signal since UnitNew doesn't carry them.
+     * However, reacting to UnitNew with GetAll could lead to an
+     * infinite loop since systemd emits a UnitNew in reaction to
+     * GetAll for units that it doesn't want to keep loaded, such
+     * as units without unit files.
+     *
+     * So we ignore UnitNew and instead assume that the unit state
+     * only changes in interesting ways when there is a job for it
+     * or when the daemon is reloaded (or when we get a property
+     * change notification, of course).
+     */
+
+    // This is what we want to do:
+    // systemd_manager.addEventListener("UnitNew", function (event, unit_id, path) {
+    //     if (unit_id == name)
+    //         refresh();
+    // });
+
+    // This is what we have to do:
+    systemd_manager.addEventListener("Reloading", function (event, reloading) {
+        if (!reloading)
+            refresh();
+    });
+
+    systemd_manager.addEventListener("JobNew", on_job_new_removed_refresh);
+    systemd_manager.addEventListener("JobRemoved", on_job_new_removed_refresh);
+
+    function wait(callback) {
+        wait_callbacks.promise.then(callback);
+    }
+
+    /* Actions
+     *
+     * We don't call methods on the D-Bus proxies here since they
+     * might not be ready when these functions are called.
+     */
+
+    var pending_jobs = { };
+
+    systemd_manager.addEventListener("JobRemoved", function (event, number, path, unit_id, result) {
+        if (pending_jobs[path]) {
+            if (result == "done")
+                pending_jobs[path].resolve();
+            else
+                pending_jobs[path].reject(result);
+            delete pending_jobs[path];
+        }
+    });
+
+    function call_manager(method, args) {
+        return systemd_client.call("/org/freedesktop/systemd1",
+                                   "org.freedesktop.systemd1.Manager",
+                                   method, args);
+    }
+
+    function call_manager_with_job(method, args) {
+        var dfd = cockpit.defer();
+        call_manager(method, args)
+                .done(function (results) {
+                    var path = results[0];
+                    pending_jobs[path] = dfd;
+                })
+                .fail(function (error) {
+                    dfd.reject(error);
+                });
+        return dfd.promise();
+    }
+
+    function call_manager_with_reload(method, args) {
+        return call_manager(method, args).then(function () {
+            var dfd = cockpit.defer();
+            call_manager("Reload", [ ])
+                    .done(function () { dfd.resolve(); })
+                    .fail(function (error) {
+                    // HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1560549
+                    // some systemd versions disconnect too fast from the bus
+                        if (error.name === "org.freedesktop.DBus.Error.NoReply") {
+                            refresh();
+                            dfd.resolve();
+                        } else {
+                            dfd.reject(error);
+                        }
+                    });
+            return dfd.promise();
+        });
+    }
+
+    function start() {
+        return call_manager_with_job("StartUnit", [ name, "replace" ]);
+    }
+
+    function stop() {
+        return call_manager_with_job("StopUnit", [ name, "replace" ]);
+    }
+
+    function restart() {
+        return call_manager_with_job("RestartUnit", [ name, "replace" ]);
+    }
+
+    function tryRestart() {
+        return call_manager_with_job("TryRestartUnit", [ name, "replace" ]);
+    }
+
+    function enable() {
+        return call_manager_with_reload("EnableUnitFiles", [ [ name ], false, false ]);
+    }
+
+    function disable() {
+        return call_manager_with_reload("DisableUnitFiles", [ [ name ], false ]);
+    }
+
+    return self;
+}

--- a/cockpit/src/cockpit-components-dialog.jsx
+++ b/cockpit/src/cockpit-components-dialog.jsx
@@ -42,6 +42,7 @@ let _ = cockpit.gettext;
  *      - disabled optional, defaults to false
  *      - style defaults to 'default', other options: 'primary', 'danger'
  *  - static_error optional, always show this error
+ *  - idle_message optional, always show this message on the last row when idle
  *  - dialog_done optional, callback when dialog is finished (param true if success, false on cancel)
  */
 class DialogFooter extends React.Component {
@@ -143,6 +144,10 @@ class DialogFooter extends React.Component {
             wait_element = <div className="dialog-wait-ct pull-left">
                 <div className="spinner spinner-sm"/>
                 <span>{ this.state.action_progress_message }</span>
+            </div>;
+        } else if (this.props.idle_message) {
+            wait_element = <div className="dialog-wait-ct pull-left">
+                { this.props.idle_message }
             </div>;
         }
 

--- a/cockpit/src/index.js
+++ b/cockpit/src/index.js
@@ -24,6 +24,7 @@ import ReactDOM from 'react-dom';
 import subscriptionsClient from './subscriptions-client';
 import subscriptionsRegister from './subscriptions-register.jsx';
 import subscriptionsView from './subscriptions-view.jsx';
+import * as Insights from './insights.jsx';
 import Dialog from './cockpit-components-dialog.jsx';
 
 let _ = cockpit.gettext;
@@ -38,6 +39,7 @@ let registerDialogDetails = {
     proxy_server: '',
     proxy_user: '',
     proxy_password: '',
+    insights: false
 };
 
 function dismissStatusError() {
@@ -46,7 +48,10 @@ function dismissStatusError() {
 }
 
 function registerSystem () {
-    return subscriptionsClient.registerSystem(registerDialogDetails);
+    return subscriptionsClient.registerSystem(registerDialogDetails).then(() => {
+        if (registerDialogDetails.insights)
+            return Insights.register();
+    });
 }
 
 let footerProps = {
@@ -65,6 +70,8 @@ function openRegisterDialog() {
         password: '',
         activation_keys: '',
         org: '',
+        insights: false,
+        insights_available: subscriptionsClient.insightsAvailable
     });
     // show dialog to register
     let renderDialog;
@@ -98,7 +105,7 @@ function openRegisterDialog() {
 }
 
 function unregisterSystem() {
-    subscriptionsClient.unregisterSystem();
+    Insights.unregister().catch(error => true).then(subscriptionsClient.unregisterSystem);
 }
 
 function initStore(rootElement) {
@@ -117,6 +124,7 @@ function initStore(rootElement) {
                 error: subscriptionsClient.subscriptionStatus.error,
                 syspurpose: subscriptionsClient.syspurposeStatus.info,
                 syspurpose_status: subscriptionsClient.syspurposeStatus.status,
+                insights_available: subscriptionsClient.insightsAvailable,
                 dismissError: dismissStatusError,
                 register: openRegisterDialog,
                 unregister: unregisterSystem,

--- a/cockpit/src/insights.jsx
+++ b/cockpit/src/insights.jsx
@@ -1,0 +1,330 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+import moment from "moment";
+
+import { show_modal_dialog } from "./cockpit-components-dialog.jsx";
+import * as service from "../lib/service.js";
+
+import subscriptionsClient from './subscriptions-client';
+
+let _ = cockpit.gettext;
+
+moment.locale(cockpit.language);
+
+const insights_timer = service.proxy("insights-client.timer", "Timer");
+const insights_service = service.proxy("insights-client.service", "Service");
+
+export function detect() {
+    return cockpit.spawn([ "which", "insights-client" ], { err: "ignore" }).then(() => true, () => false);
+}
+
+function catch_error(err) {
+    let msg = err.toString();
+    // The insights-client frequently dumps
+    // Python backtraces on us. Make them more
+    // readable by wrapping the text in <pre>.
+    if (msg.indexOf("\n") > 0)
+        msg = <pre>{msg}</pre>;
+    subscriptionsClient.setError("error", msg);
+}
+
+export function register() {
+    return cockpit.spawn([ "insights-client", "--register" ], { superuser: true, err: "message" })
+        .catch(catch_error);
+}
+
+export function unregister() {
+    if (insights_timer.enabled) {
+        return cockpit.spawn([ "insights-client", "--unregister" ], { superuser: true, err: "message" })
+            .catch(catch_error);
+    } else {
+        return cockpit.resolve();
+    }
+}
+
+// TODO - generalize this to arbitrary number of arguments (when needed)
+export function arrfmt(fmt, arg) {
+    var index = fmt.indexOf("$0");
+    if (index >= 0)
+        return [ fmt.slice(0, index), arg, fmt.slice(index + 2) ];
+    else
+        return [ fmt ];
+}
+
+function left(func) {
+    return function (event) {
+        if (!event || event.button !== 0)
+            return;
+        func();
+        event.stopPropagation();
+    };
+}
+
+export const blurb =
+    _("Proactively identify and remediate threats to security, performance, availability, and stability with Red Hat Insights \u2014 with predictive analytics, avoid problems and unplanned downtime in your Red Hat environment.");
+
+export const link =
+    <a href="https://www.redhat.com/en/technologies/management/insights" target="_blank" rel="noopener">Red Hat Insights <i className="fa fa-external-link"/></a>;
+
+function show_connect_dialog() {
+    show_modal_dialog(
+        {
+            title: _("Connect to Red Hat Insights"),
+            body: (
+                <div className="modal-body">
+                    <strong>{ arrfmt(_("This system is not connected to $0."), link) }</strong>
+                    <p>{blurb}</p>
+                </div>
+            )
+        },
+        {
+            actions: [
+                {
+                    caption: _("Connect"),
+                    style: "primary",
+                    clicked: () => register().catch(catch_error)
+                }
+            ]
+        }
+    );
+}
+
+class Revealer extends React.Component {
+    constructor() {
+        super();
+        this.state = { revealed: false };
+    }
+
+    render() {
+        return (
+            <div>
+                <a onClick={event => { if (event.button == 0) this.setState({ revealed: !this.state.revealed }); }}>
+                   {this.props.summary}
+                </a> <i className={this.state.revealed ? "fa fa-angle-down" : "fa fa-angle-right"}/>
+                <br/>
+                {this.state.revealed && this.props.children}
+            </div>
+        );
+    }
+}
+
+const get_monotonic_start = cockpit.spawn(
+    [ "/usr/libexec/platform-python", "-c",
+      "import time; print(time.clock_gettime(time.CLOCK_REALTIME) - time.clock_gettime(time.CLOCK_MONOTONIC))"
+    ]).then(data => {
+        return parseFloat(data);
+    });
+
+function calc_next_elapse(monotonic_start, timer) {
+    let next_mono = Infinity, next_real = Infinity;
+    if (monotonic_start) {
+        if (timer.NextElapseUSecMonotonic)
+            next_mono = timer.NextElapseUSecMonotonic / 1e6 + monotonic_start;
+        if (timer.NextElapseUSecRealtime)
+            next_real = timer.NextElapseUSecRealtime / 1e6;
+    }
+    let next = Math.min(next_mono, next_real);
+    if (next !== Infinity)
+        return moment(next * 1000).calendar();
+    else
+        return _("unknown");
+}
+
+function jump_to_service() {
+    cockpit.jump("/system/services#/insights-client.service", cockpit.transport.host);
+}
+
+function jump_to_timer() {
+    cockpit.jump("/system/services#/insights-client.timer", cockpit.transport.host);
+}
+
+function monitor_last_upload() {
+    let self = {
+        timestamp: 0,
+        results: null,
+
+        close: close
+    };
+
+    cockpit.event_target(self);
+
+    let results_file = cockpit.file("/etc/insights-client/.last-upload.results", { syntax: JSON });
+    results_file.watch(data => {
+        self.results = data;
+        cockpit.spawn([ "stat", "-c", "%Y", "/etc/insights-client/.last-upload.results" ], { err: "message" })
+            .then(ts => {
+                self.timestamp = parseInt(ts);
+                self.dispatchEvent("changed");
+            })
+            .catch(() => {
+                self.timestamp = 0;
+                self.dispatchEvent("changed");
+            });
+    });
+
+    function close() {
+        results_file.close();
+    }
+
+    return self;
+}
+
+const last_upload_monitor = monitor_last_upload();
+
+function show_status_dialog() {
+    function show(monotonic_start) {
+        let lastupload = last_upload_monitor.timestamp;
+        let next_elapse = calc_next_elapse(monotonic_start, insights_timer.details);
+
+        let failed_text = null;
+        if (insights_service.unit.ActiveExitTimestamp &&
+            insights_service.unit.ActiveExitTimestamp / 1e6 > lastupload) {
+            lastupload = insights_service.unit.ActiveExitTimestamp / 1e6;
+            failed_text = _("The last Insights data upload has failed.");
+        }
+
+        let dlg = show_modal_dialog(
+            {
+                title: _("Connected to Red Hat Insights"),
+                body: (
+                        <div className="modal-body">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <th style={{ textAlign: "right", paddingRight: "1em" }}>Next Insights data upload</th>
+                                <td>{next_elapse}</td>
+                              </tr>
+                              { lastupload ?
+                              <tr>
+                                <th style={{ textAlign: "right", paddingRight: "1em" }}>Last Insights data upload</th>
+                                <td>{moment(lastupload * 1000).calendar()}</td>
+                               </tr> : null
+                              }
+                            </tbody>
+                          </table>
+                          <br/>
+                          { insights_timer.state == "failed" &&
+                          <div className="alert alert-warning">
+                            <span className="pficon pficon-warning-triangle-o"/>
+                              {_("Next Insights data upload could not be scheduled.")}{" "}
+                              <a onClick={left(jump_to_timer)}>{_("Details")}</a>
+                          </div>
+                          }
+                          { insights_service.state == "failed" && failed_text &&
+                          <div className="alert alert-warning">
+                            <span className="pficon pficon-warning-triangle-o"/>
+                              {failed_text}{" "}
+                              <a onClick={left(jump_to_service)}>{_("Details")}</a>
+                          </div>
+                          }
+                          <Revealer summary={_("Disconnect from Insights")}>
+                            <div className="alert alert-warning"
+                                 style={{ "padding": "14px", "marginTop": "1ex", "marginBottom": "0px" }}>
+                              <p>{_("If you disconnect this system from Insights, it will no longer report it's Insights status in Red Hat Cloud or Satellite.")}</p>
+                              <br/>
+                              <button className="btn btn-danger" onClick={left(disconnect)}>
+                                {_("Disconnect from Insights")}
+                              </button>
+                            </div>
+                          </Revealer>
+                        </div>
+                )
+            },
+            {
+                cancel_caption: _("Close"),
+                actions: [ ]
+            }
+        );
+
+        function disconnect() {
+            dlg.setFooterProps(
+                {
+                    cancel_caption: _("Cancel"),
+                    actions: [ ],
+                    idle_message: <div className="spinner spinner-sm"/>
+                });
+            unregister().then(
+                () => {
+                    dlg.footerProps.dialog_done();
+                },
+                error => {
+                    dlg.setFooterProps(
+                        {
+                            cancel_caption: _("Close"),
+                            actions: [ ],
+                            static_error: error.toString()
+                        });
+                })
+        }
+    }
+
+    get_monotonic_start.then(show).catch(err => { console.warn(err); show(null) });
+}
+
+
+export class InsightsStatus extends React.Component {
+    constructor() {
+        super();
+        this.state = { };
+        this.on_changed = () => { this.setState({ }) };
+    }
+
+    componentDidMount() {
+        insights_timer.addEventListener("changed", this.on_changed);
+        insights_service.addEventListener("changed", this.on_changed);
+        last_upload_monitor.addEventListener("changed", this.on_changed);
+    }
+
+    componentWillUnmount() {
+        insights_timer.removeEventListener("changed", this.on_changed);
+        insights_service.removeEventListener("changed", this.on_changed);
+        last_upload_monitor.removeEventListener("changed", this.on_changed);
+    }
+
+    render() {
+        let status;
+
+        if (!insights_timer.exists || !insights_service.exists)
+            return null;
+
+        if (insights_timer.enabled) {
+            let warn = (insights_service.state == "failed" &&
+                        insights_service.unit.ActiveExitTimestamp &&
+                        insights_service.unit.ActiveExitTimestamp / 1e6 > last_upload_monitor.timestamp);
+
+            status = (
+                    <div style={{display: "inline-block", verticalAlign: "top" }}>
+                    <a onClick={left(show_status_dialog)}>{_("Connected to Insights")}</a>
+                    { warn && [ " ", <i className="pficon pficon-warning-triangle-o"/> ] }
+                    <br/>
+                    <a href="http://cloud.redhat.com/insights" target="_blank" rel="noopener">
+                    View your Insights results <i className="fa fa-external-link"/>
+                    </a>
+                </div>
+            );
+        } else {
+            status = <a onClick={left(show_connect_dialog)}>{_("Not connected")}</a>;
+        }
+
+        return <div><label>Insights: {status}</label></div>;
+    }
+}

--- a/cockpit/src/manifest.json
+++ b/cockpit/src/manifest.json
@@ -9,5 +9,8 @@
         "index": {
             "label": "Subscriptions"
         }
+    },
+    "features": {
+        "insights": true
     }
 }

--- a/cockpit/src/subscriptions-client.js
+++ b/cockpit/src/subscriptions-client.js
@@ -61,6 +61,8 @@ client.syspurposeStatus = {
     status : null,
 };
 
+client.insightsAvailable = false;
+
 const RHSM_DEFAULTS = { // TODO get these from a d-bus service instead
     hostname: 'subscription.rhsm.redhat.com',
     port: '443',
@@ -609,9 +611,23 @@ client.toArray = obj => {
         }
     };
 
+const detectInsights = () => {
+    return cockpit.spawn([ "which", "insights-client" ], { err: "ignore" }).then(
+        () => client.insightsAvailable = true,
+        () => client.insightsAvailable = false);
+};
+
 const updateConfig = () => {
-        return client.readConfig().then(needRender);
+    return client.readConfig().then(detectInsights).then(needRender);
+};
+
+client.setError = (severity, message) => {
+    client.subscriptionStatus.error = {
+        severity: severity,
+        msg: message
     };
+    needRender();
+};
 
 client.init = () => {
     /* we want to get notified if subscription status of the system changes */

--- a/cockpit/src/subscriptions-register.jsx
+++ b/cockpit/src/subscriptions-register.jsx
@@ -24,6 +24,8 @@ var React = require("react");
 import Select from "./Select/Select.jsx";
 import '../lib/form-layout.less';
 
+import * as Insights from './insights.jsx';
+
 /* Subscriptions: registration dialog body
  * Expected props:
  *   - onChange  callback to signal when the data has changed
@@ -65,6 +67,22 @@ class PatternDialogBody extends React.Component {
                 </form>
             );
         }
+        let insights;
+        if (this.props.insights_available) {
+            insights = [
+                <label key="0" className="control-label" htmlFor="subscription-insights">
+                    {_("Insights")}
+                </label>,
+                <label key="1" className="checkbox-inline">
+                    <input id="subscription-insights" type="checkbox" checked={this.props.insights}
+                           onChange={value => this.props.onChange('insights', value)}/>
+                    <span>
+                    { Insights.arrfmt(_("Connect this system to $0."), Insights.link) }
+                    </span>
+                </label>
+            ];
+        }
+
         const urlEntries = {
             'default': _("Default"),
             'custom': _("Custom URL"),
@@ -115,6 +133,7 @@ class PatternDialogBody extends React.Component {
                     <input id="subscription-register-org" className="form-control" type="text"
                            value={this.props.org}
                            onChange={value => this.props.onChange('org', value)}/>
+                    {insights}
                 </form>
             </div>
         );

--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -23,6 +23,7 @@ import createFragment from 'react-addons-create-fragment';
 import subscriptionsClient from './subscriptions-client';
 import { ListView, ListViewItem, ListViewIcon } from 'patternfly-react';
 import { Row, Col } from 'react-bootstrap';
+import { InsightsStatus } from './insights.jsx';
 
 let _ = cockpit.gettext;
 
@@ -175,6 +176,7 @@ class SubscriptionStatus extends React.Component {
 
         let label;
         let action;
+        let insights;
         let note;
         let syspurpose;
         let sla;
@@ -265,6 +267,8 @@ class SubscriptionStatus extends React.Component {
                     </div>
                 );
             }
+            if (this.props.insights_available)
+                insights = <InsightsStatus />;
         }
         return (
             <div className="subscription-status-ct">
@@ -272,6 +276,7 @@ class SubscriptionStatus extends React.Component {
                 {errorMessage}
                 {label}
                 {action}
+                {insights}
                 {syspurpose}
                 {note}
             </div>

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -139,6 +139,20 @@ class TestSubscriptions(MachineCase):
         # Wait for the web service to be accessible
         machine_python(self.machine, WAIT_SCRIPT, CANDLEPIN_URL)
 
+        m.write("/etc/insights-client/insights-client.conf",
+"""
+[insights-client]
+gpg=False
+auto_config=False
+base_url=127.0.0.1:8888/r/insights
+username=admin
+password=foobar
+insecure_connection=True
+""")
+
+        m.upload([ "files/mock-insights" ], "/var/tmp")
+        m.spawn("/var/tmp/mock-insights", "mock-insights")
+
     def wait_subscription(self, product, is_subscribed):
         b = self.browser
         product_selector = ".list-group-item-heading:contains('%s')" % product["name"]
@@ -158,8 +172,10 @@ class TestSubscriptions(MachineCase):
 
         self.login_and_go("/subscriptions")
 
+        register_button_sel = "label:contains('Status') + button:contains('Register')"
+        unregister_button_sel = "label:contains('Status') + button:contains('Unregister')"
+
         # wait until we can open the registration dialog
-        register_button_sel = "button.btn-primary:contains('Register')"
         b.click(register_button_sel)
 
         b.wait_visible("#subscription-register-url")
@@ -203,7 +219,6 @@ class TestSubscriptions(MachineCase):
         self.wait_subscription(PRODUCT_SNOWY, True)
 
         # unregister
-        unregister_button_sel = "button.btn-primary:contains('Unregister')"
         b.click(unregister_button_sel)
 
     def testRegisterWithKey(self):
@@ -243,6 +258,85 @@ class TestSubscriptions(MachineCase):
         self.browser.wait_in_text(".curtains-ct h1", "current user isn't allowed to access system subscription")
         self.allow_authorize_journal_messages()
 
+    def testInsights(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/subscriptions")
+
+        b.click("label:contains('Status') + button:contains('Register')")
+        b.wait_visible("#subscription-register-url")
+
+        b.set_val("#subscription-register-url", "custom")
+        b.set_input_text("#subscription-register-url-custom", "10.111.113.5:8443/candlepin")
+        b.set_input_text("#subscription-register-username", "admin")
+        b.set_input_text("#subscription-register-password", "admin")
+        b.set_input_text("#subscription-register-org", "admin")
+        dialog_register_button_sel = "div.modal-footer .btn-primary"
+        b.click(dialog_register_button_sel)
+        b.wait_not_present(dialog_register_button_sel)
+
+        b.click("label:contains('Insights') a:contains('Not connected')")
+        b.wait_present('.modal-body:contains("This system is not connected")')
+        b.click('.modal-footer button.apply')
+        with b.wait_timeout(360):
+            b.wait_not_present('.modal-dialog')
+
+        b.click("label:contains('Insights') a:contains('Connected to Insights')")
+        b.wait_present('.modal-body:contains("Next Insights data upload")')
+        b.wait_present('.modal-body:contains("Last Insights data upload")')
+        b.click("a:contains('Disconnect from Insights')")
+        b.click("button:contains('Disconnect from Insights')")
+        b.wait_not_present('.modal-dialog')
+
+        b.wait_present("label:contains('Insights') a:contains('Not connected')")
+
+    def testSubAndInAndFail(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/subscriptions")
+
+        b.click("label:contains('Status') + button:contains('Register')")
+        b.wait_visible("#subscription-register-url")
+
+        b.set_val("#subscription-register-url", "custom")
+        b.set_input_text("#subscription-register-url-custom", "10.111.113.5:8443/candlepin")
+        b.set_input_text("#subscription-register-username", "admin")
+        b.set_input_text("#subscription-register-password", "admin")
+        b.set_input_text("#subscription-register-org", "admin")
+        b.set_checked("#subscription-insights", True)
+        dialog_register_button_sel = "div.modal-footer .btn-primary"
+        b.click(dialog_register_button_sel)
+        with b.wait_timeout(360):
+            b.wait_not_present(dialog_register_button_sel)
+
+        b.wait_present("label:contains('Insights') a:contains('Connected to Insights')")
+
+        # Break the next upload and expect the warning triangle to tell us about it
+        m.execute("mv /etc/insights-client/machine-id /etc/insights-client/machine-id.lost")
+        m.execute("systemctl start insights-client")
+
+        b.wait_present("label:contains('Insights') i.pficon-warning-triangle-o")
+
+        b.click("label:contains('Insights') a:contains('Connected to Insights')")
+        b.wait_present('.modal-body:contains("The last Insights data upload has failed")')
+        b.click("button.cancel")
+
+        # Unbreak it and retry.
+        m.execute("mv /etc/insights-client/machine-id.lost /etc/insights-client/machine-id")
+        m.execute("systemctl start insights-client; while systemctl --quiet is-active insights-client; do sleep 1; done",
+                  timeout=360)
+
+        # We can't rely on the insights-client actually succeeding.
+        # It seems to randomly run out of its TasksMax=20 limit, for
+        # example.
+        if m.execute("systemctl is-failed insights-client || true").strip() != "failed":
+            b.wait_not_present("label:contains('Insights') i.pficon-warning-triangle-o")
+
+        b.click("label:contains('Status') + button:contains('Unregister')")
+        b.wait_not_present("label:contains('Insights')")
+        m.execute("test -f /etc/insights-client/.unregistered")
 
 if __name__ == '__main__':
     test_main()

--- a/test/files/mock-insights
+++ b/test/files/mock-insights
@@ -1,0 +1,86 @@
+#! /usr/bin/python3
+
+# This is just enough of the Insights REST API to make the following
+# work:
+#
+#   insights-client --register
+#   insights-client --status
+#   insights-client --unregister
+#
+# You need these in your insights-client.conf:
+#
+# gpg=False
+# auto_config=False
+# base_url=127.0.0.1:8888/r/insights
+# insecure_connection=True
+
+from http.server import *
+import json
+
+systems = { }
+
+class handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/r/insights/":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"lub-dup")
+        elif self.path.endswith("/static/core/insights-core.egg"):
+            self.send_response(304)
+            self.end_headers()
+        elif self.path.endswith("/static/uploader.v2.json"):
+            # This is not a valid response and will cause the client
+            # to fall back to the builtin rules.
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"{ }\n")
+        elif "/systems/" in self.path:
+            machine_id = self.path.split("/")[-1]
+            self.send_response(200)
+            self.end_headers()
+            if machine_id in systems:
+                self.wfile.write(json.dumps(systems[machine_id]).encode('utf-8') + b"\n")
+            else:
+                self.wfile.write(b"{ }\n")
+        elif self.path.endswith("/branch_info"):
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{ "remote_branch": -1, "remote_leaf": -1 }\n')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        len = int(self.headers.get('content-length', 0))
+        data = self.rfile.read(len)
+        if self.path.endswith("/systems"):
+            s = json.loads(data)
+            s["unregistered_at"] = None
+            s["account_number"] = "123456"
+            print(s)
+            systems[s["machine_id"]] = s
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(data)
+        elif "/uploads/" in self.path:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{ "reports": [ "foo", "bar" ] }\n')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_DELETE(self):
+        if "/systems/" in self.path:
+            machine_id = self.path.split("/")[-1]
+            self.send_response(200)
+            self.end_headers()
+            if machine_id in systems:
+                del systems[machine_id]
+        self.send_response(200)
+        self.end_headers()
+
+def insights_server(port):
+    HTTPServer(('', port), handler).serve_forever()
+
+insights_server(8888)


### PR DESCRIPTION
This implements part of [this mockup](https://github.com/cockpit-project/cockpit-design/blob/master/subscriptions/insights.png).

It uses a brittle method for retrieving the local client status.  See https://github.com/RedHatInsights/insights-core/issues/1939 for some plans to improve that.

Still to do:

- [x] Link to cloud.redhat.com as in the mockup
- [x] Get local status from insights-client.timer and insights-client.service and don't talk about "Register" anymore.
- [x] Add more blurbs to the dialogs
- [x] Error reporting via banners, like with subscriptions.
- [x] Integration tests
