### PR TITLE
1713626: Option disable_system_repos didn't work with DNF; ENT-1350

### DIFF
--- a/etc-conf/plugin/subscription-manager.conf
+++ b/etc-conf/plugin/subscription-manager.conf
@@ -1,6 +1,6 @@
 [main]
 enabled=1
 
-# Setting disable_system_repos to 1, disables all system repositories
-# (= repositories which are not mangaged by subscription-manager will NOT be used)
+# When following option is set to 1, then all repositories defined outside redhat.repo will be disabled
+# every time subscription-manager plugin is triggered by dnf or yum
 disable_system_repos=0


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1713626
* The original functionality was provided by community only for yum plugin, but the template of dubsription-manager plugin is the same for dnf and yum plugin
* It was easier to implement this functionality for dnf plugin then create special template of conf file for dnf plugin
* Updated comment in template of plugin configuration file