### PR TITLE
Report insights id as fact, when insights is installed.

### DIFF
--- a/src/rhsmlib/facts/all.py
+++ b/src/rhsmlib/facts/all.py
@@ -16,6 +16,7 @@ from rhsmlib.facts import collector
 from rhsmlib.facts import custom
 from rhsmlib.facts import host_collector
 from rhsmlib.facts import hwprobe
+from rhsmlib.facts import insights
 
 
 class AllFactsCollector(collector.FactsCollector):
@@ -25,6 +26,7 @@ class AllFactsCollector(collector.FactsCollector):
             host_collector.HostCollector(),
             hwprobe.HardwareCollector(),
             custom.CustomFactsCollector(),
+            insights.InsightsCollector()
         ]
 
     def get_all(self):

--- a/src/rhsmlib/facts/insights.py
+++ b/src/rhsmlib/facts/insights.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+import logging
+
+from rhsmlib.facts import collector
+
+try:
+    from insights_client import constants as insights_constants
+except ImportError:
+    insights_constants = None
+
+log = logging.getLogger(__name__)
+
+
+class InsightsCollector(collector.FactsCollector):
+    """
+    Class used for collecting facts related to Red Hat Access Insights
+    """
+
+    DEFAULT_INSIGHTS_MACHINE_ID = "/etc/redhat-access-insights/machine-id"
+
+    def __init__(self, arch=None, prefix=None, testing=None, collected_hw_info=None):
+        super(InsightsCollector, self).__init__(
+            arch=arch,
+            prefix=prefix,
+            testing=testing,
+            collected_hw_info=collected_hw_info
+        )
+
+        self.hardware_methods = [
+            self.get_insights_machine_id
+        ]
+
+    def get_insights_machine_id(self):
+        """
+        Try to return content of insights machine_id (UUID)
+        :return: dictionary containing insights_id, when machine_id file exist.
+        Otherwise empty dictionary is returned.
+        """
+        insights_id = {}
+
+        if insights_constants is not None:
+            machine_id_filepath = insights_constants.machine_id_file
+        else:
+            machine_id_filepath = self.DEFAULT_INSIGHTS_MACHINE_ID
+
+        try:
+            with open(machine_id_filepath, "r") as fd:
+                machine_id = fd.read()
+        except IOError as err:
+            log.debug("Unable to read insights machine_id file: %s, error: %s" % (machine_id_filepath, err))
+        else:
+            insights_id = {
+                "insights_id": machine_id
+            }
+
+        return insights_id

--- a/test/rhsmlib_test/test_insights.py
+++ b/test/rhsmlib_test/test_insights.py
@@ -1,0 +1,56 @@
+from __future__ import print_function, division, absolute_import
+
+#
+# Copyright (c) 2010 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from rhsmlib.facts import insights
+from mock import patch
+import tempfile
+import six
+
+
+INSIGHT_TEST_UUID = "2d05f031-d20c-40c9-9cee-2a1d7e823ab6"
+
+
+class TestInsightsCollector(unittest.TestCase):
+
+    def setUp(self):
+        self.collector = insights.InsightsCollector()
+        self.machine_id_fp = tempfile.NamedTemporaryFile()
+        if six.PY3:
+            self.machine_id_fp.write(bytes(INSIGHT_TEST_UUID, 'UTF-8'))
+        else:
+            self.machine_id_fp.write(INSIGHT_TEST_UUID)
+        self.machine_id_fp.flush()
+
+    def tearDown(self):
+        self.machine_id_fp.close()
+
+    @patch('rhsmlib.facts.insights.insights_constants')
+    def test_get_machine_id(self, consts):
+        consts.machine_id_file = self.machine_id_fp.name
+        fact = self.collector.get_all()
+        self.assertIn("insights_id", fact)
+        self.assertEqual(fact["insights_id"], INSIGHT_TEST_UUID)
+
+    @patch('rhsmlib.facts.insights.insights_constants')
+    def test_not_get_machine_id(self, consts):
+        consts.machine_id_file = "/not/existing/file/machine_id"
+        fact = self.collector.get_all()
+        self.assertEqual(fact, {})


### PR DESCRIPTION
* Insights generates unique id (uuid) to file
  /etc/redhat-access-insights/machine-id or
  /etc/insights-client/machine-id
* The path is read from insights configuration, when insights is
  installed.
* The fact is reported as insights_id: <UUID>
* Added two unit tests