### PR TITLE
Set LANG to run subscription-manager and get proper output

### DIFF
--- a/debian-stuff/deb_package_profile_upload
+++ b/debian-stuff/deb_package_profile_upload
@@ -13,7 +13,7 @@ KATELLO_SERVER=$(sed -n -e 's/^hostname\s*=\s*\(.*\)$/\1/p' /etc/rhsm/rhsm.conf)
 
 [ "${KATELLO_SERVER}" ] || exit_msg "No Katello server is configured. Skipping."
 
-IDENTITY=$(subscription-manager identity 2> /dev/null | sed -n 's/system identity: //p')
+IDENTITY=$(LANG=C subscription-manager identity 2> /dev/null | sed -n 's/system identity: //p')
 
 [ "${IDENTITY}" ] || exit_msg "Host is not registered with Katello. Skipping."
 


### PR DESCRIPTION
When a Debian host uses a language that is not English (for example German), the `deb_package_profile_upload` will not parse the output of `subscription-manager identity` correctly.

This PR fixes this by setting `LANG=C` for the relevant command.