### PR TITLE
Also handle anaconda removal of install classes in rhsm_gui.py

### DIFF
--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
@@ -80,8 +80,14 @@ class RHSMSpoke(NormalSpoke):
         """Run this spoke for Anaconda and InitialSetup"""
         return True
 
-    def __init__(self, data, storage, payload, instclass):
-        NormalSpoke.__init__(self, data, storage, payload, instclass)
+    def __init__(self, data, storage, payload, instclass=None):
+        # Before 78fd1e82 , anaconda passes us instclass, and
+        # NormalSpoke accepts it. After 78fd1e82, it doesn't. So we
+        # handle both cases.
+        if instclass:
+            NormalSpoke.__init__(self, data, storage, payload, instclass)
+        else:
+            NormalSpoke.__init__(self, data, storage, payload)
         self._done = False
         self._addon_data = self.data.addons.com_redhat_subscription_manager
 


### PR DESCRIPTION
Fix one more remaining place where we were affected by anaconda
removing install classes. As with the earlier fixes to rhsm_ks,
handle both old and new anaconda so we can work with either.

Signed-off-by: Adam Williamson <awilliam@redhat.com>