### PR TITLE
1673662: Print reasons, why syspurpose status is mismatch; ENT-1247

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -340,6 +340,18 @@ class SyspurposeComplianceStatusCache(StatusCache):
         else:
             return self.syspurpose_service.get_overall_status('unknown')
 
+    def get_overall_status_code(self):
+        if self.server_status is not None:
+            return self.server_status
+        else:
+            return 'unknown'
+
+    def get_status_reasons(self):
+        if self.server_status is not None and 'reasons' in self.server_status:
+            return self.server_status['reasons']
+        else:
+            return None
+
 
 class ProductStatusCache(StatusCache):
     """

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2907,7 +2907,15 @@ class StatusCommand(CliCommand):
 
         syspurpose_cache = inj.require(inj.SYSTEMPURPOSE_COMPLIANCE_STATUS_CACHE)
         syspurpose_cache.load_status(self.cp, self.identity.uuid, on_date)
-        print(_("System Purpose Status: %s\n") % syspurpose_cache.get_overall_status())
+        print(_("System Purpose Status: %s") % syspurpose_cache.get_overall_status())
+
+        syspurpose_status_code = syspurpose_cache.get_overall_status_code()
+        if syspurpose_status_code != 'matched':
+            reasons = syspurpose_cache.get_status_reasons()
+            if reasons is not None:
+                for reason in reasons:
+                    print("- %s" % reason)
+        print('')
 
         return result
 

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -362,6 +362,18 @@ class TestStatusCommand(SubManFixture):
             self.cc._do_command()
         self.assertTrue('System Purpose Status: Unknown' in cap.out)
 
+    def test_purpose_status_mismatch(self):
+        self.cc.consumerIdentity = StubConsumerIdentity
+        self.cc.cp = StubUEP()
+        self.cc.cp.setSyspurposeCompliance({'status': 'mismatched', 'reasons': ['unsatisfied usage: Production']})
+        self.cc.cp._capabilities = ["syspurpose"]
+        self.cc.options = Mock()
+        self.cc.options.on_date = None
+        with Capture() as cap:
+            self.cc._do_command()
+        self.assertTrue('System Purpose Status: Mismatched' in cap.out)
+        self.assertTrue('unsatisfied usage: Production' in cap.out)
+
 
 # for command classes that expect proxy related cli args
 class TestCliProxyCommand(TestCliCommand):


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1673662
* When syspurpose status is not valid, then try to print list of
  reason, why system is not valid
* Added one unit test.