### PR TITLE
1713626: Only disable system repos if the disable_system_repos is "1"

### DIFF
--- a/src/dnf-plugins/subscription-manager.py
+++ b/src/dnf-plugins/subscription-manager.py
@@ -95,7 +95,7 @@ class SubscriptionManager(dnf.Plugin):
 
             if plugin_config.has_option('main', 'disable_system_repos'):
                 disable_system_repos = plugin_config.get('main', 'disable_system_repos')
-                if disable_system_repos:
+                if disable_system_repos == '1':
                     disable_count = 0
                     for repo in self.base.repos.iter_enabled():
                         if os.path.basename(repo.repofile) != 'redhat.repo':


### PR DESCRIPTION
We need to disable system repos only when the value of the "disable_system_repos" is "1" (as per the comment in the subscription-manager.conf file). Prior to this setting any value (including "0") would trigger the disabling of system repos.