### PR TITLE
spec: Don't supplement initial-setup-gui on Fedora

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -418,7 +418,7 @@ Group: System Environment/Base
 Requires: rhsm-gtk = %{version}-%{release}
 Requires: initial-setup-gui >= 0.3.9.24-1
 Obsoletes: subscription-manager-firstboot < 1.15.3-1
-%if (0%{?fedora} >= 24 || 0%{?rhel} >= 8)
+%if (0%{?rhel} >= 8)
 Supplements: initial-setup-gui
 %endif
 


### PR DESCRIPTION
I don't think we want this addon installed by default on Fedora.
AIUI it does not and cannot really do anything useful on Fedora,
it will only confuse people.

Signed-off-by: Adam Williamson <awilliam@redhat.com>