### PR TITLE
1708105: Fixed unsetting syspurpose attributes; ENT-1330

### DIFF
--- a/syspurpose/README.md
+++ b/syspurpose/README.md
@@ -12,3 +12,13 @@ The recommended workflow is as follows:
 
 From inside this virtual env you can freely install the syspurpose tool and test it as you like.
 Just run `python ./setup.py install` to install and `python ./setup.py test` to run the tests.
+
+## Testing of code
+
+When you want to debug code, then pipenv can be too complicated. When your system contains all required
+modules. then you can run syspurpose using following command from root directory of subscription-manager
+source code:
+
+```bash
+sudo PYTHONPATH=./src:./syspurpose/src python -m syspurpose.main show
+```

--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -44,9 +44,11 @@ def add_command(args, syspurposestore):
     """
     for value in args.values:
         if syspurposestore.add(args.prop_name, value):
-            print(_("Added {} to {}.").format(make_utf8(value), make_utf8(args.prop_name)))
+            print(_("Added {value} to {prop_name}.").format(
+                value=make_utf8(value), prop_name=make_utf8(args.prop_name)))
         else:
-            print(_("Not adding value {} to {}; it already exists.").format(make_utf8(value), make_utf8(args.prop_name)))
+            print(_("Not adding value {value} to {prop_name}; it already exists.").format(
+                value=make_utf8(value), prop_name=make_utf8(args.prop_name)))
             return
 
     success_msg = _("{attr} updated.").format(attr=make_utf8(args.prop_name))
@@ -126,7 +128,7 @@ def unset_command(args, syspurposestore):
         syspurposestore,
         expectation=lambda res: res.get(args.prop_name) in ["", None, []],
         success_msg=success_msg,
-        command="syspurpose unset {name}".format(args.prop_name),
+        command="syspurpose unset {name}".format(name=args.prop_name),
         attr=args.prop_name
 )
 
@@ -317,7 +319,7 @@ def main():
 
     syspurposestore = SyncedStore(uep=uep, consumer_uuid=uuid)
     if getattr(args, 'func', None) is not None:
-        result = args.func(args, syspurposestore)
+        args.func(args, syspurposestore)
     else:
         parser.print_help()
         return 0

--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -55,7 +55,6 @@ ATTRIBUTES = [ROLE, ADDONS, SERVICE_LEVEL, USAGE]
 UNSUPPORTED = "unsupported"
 
 
-
 log = logging.getLogger(__name__)
 
 
@@ -324,7 +323,7 @@ class SyncedStore(object):
                         'Cannot read local syspurpose, trying to update from server only'
                 )
             log.debug('Unable to read local system purpose at  \'%s\'\nUsing the server values.'
-                      % USER_SYSPURPOSE)
+                      % self.path)
             self.update_local({})
             self.local_contents = {}
             return self.local_contents
@@ -355,7 +354,7 @@ class SyncedStore(object):
                 self.cache_contents = json.load(io.open(self.cache_path, 'r', encoding='utf-8'))
                 log.debug('Successfully read cached syspurpose contents.')
             except (ValueError, os.error, IOError):
-                log.debug('Unable to read cached syspurpose contents at \'%s\'.' % USER_SYSPURPOSE)
+                log.debug('Unable to read cached syspurpose contents at \'%s\'.' % self.path)
                 self.cache_contents = {}
                 self.update_cache({})
         return self.cache_contents

--- a/syspurpose/test/syspurpose/base.py
+++ b/syspurpose/test/syspurpose/base.py
@@ -104,6 +104,50 @@ class SyspurposeTestBase(unittest.TestCase):
             self.fail(message)
 
 
+class Capture(object):
+    class Tee(object):
+        def __init__(self, stream, silent):
+            self.buf = six.StringIO()
+            self.stream = stream
+            self.silent = silent
+
+        def write(self, data):
+            self.buf.write(data)
+            if not self.silent:
+                self.stream.write(data)
+
+        def flush(self):
+            pass
+
+        def getvalue(self):
+            return self.buf.getvalue()
+
+        def isatty(self):
+            return False
+
+    def __init__(self, silent=False):
+        self.silent = silent
+
+    def __enter__(self):
+        self.buffs = (self.Tee(sys.stdout, self.silent), self.Tee(sys.stderr, self.silent))
+        self.stdout = sys.stdout
+        self.stderr = sys.stderr
+        sys.stdout, sys.stderr = self.buffs
+        return self
+
+    @property
+    def out(self):
+        return self.buffs[0].getvalue()
+
+    @property
+    def err(self):
+        return self.buffs[1].getvalue()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+
+
 # utility functions from syspurpose.utils to help ensure data written to files is utf-8
 def make_utf8(obj):
     """

--- a/syspurpose/test/syspurpose/test_cli.py
+++ b/syspurpose/test/syspurpose/test_cli.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+from mock import MagicMock, patch
+
+# Mock importing subscription_manager modules, because we do not want to print
+# anything to log or exit the testing application in tests
+import sys
+sys.modules['subscription_manager'] = MagicMock()
+sys.modules['subscription_manager.cli'] = MagicMock()
+
+from syspurpose import cli, files
+from .base import SyspurposeTestBase, Capture
+import os
+
+
+class SyspurposeCliTests(SyspurposeTestBase):
+
+    def setUp(self):
+        self.OLD_PATH = files.SyncedStore.PATH
+        self.OLD_CACHE_PATH = files.SyncedStore.CACHE_PATH
+        self.tmp_dir = self._mktmp()
+        os.makedirs(self.tmp_dir + '/cache')
+        files.SyncedStore.PATH = self.tmp_dir + '/syspurpose.json'
+        with open(files.SyncedStore.PATH, "w") as fp:
+            fp.write("{}")
+        files.SyncedStore.CACHE_PATH = self.tmp_dir + '/cache/syspurpose.json'
+        with open(files.SyncedStore.CACHE_PATH, "w") as fp:
+            fp.write("{}")
+        self.syspurposestore = files.SyncedStore(uep=None, consumer_uuid=None)
+
+    def tearDown(self):
+        files.SyncedStore.PATH = self.OLD_PATH
+        files.SyncedStore.CACHE_PATH = self.OLD_CACHE_PATH
+
+    def test_unset_command(self):
+        """
+        A smoke test to ensure nothing bizarre happens when we try to unset some attribute
+        """
+        args = MagicMock()
+        args.prop_name = "foo"
+        with Capture() as captured:
+            cli.unset_command(args, self.syspurposestore)
+            self.assertTrue('foo unset' in captured.out)
+
+    def test_set_command(self):
+        """
+        A smoke test to ensure nothing bizarre happens when we try to set some attribute
+        """
+        args = MagicMock()
+        args.prop_name = "foo"
+        args.value = "bar"
+        with Capture() as captured:
+            cli.set_command(args, self.syspurposestore)
+            self.assertTrue('foo set to "bar"' in captured.out)
+
+    def test_add_command_one_value(self):
+        """
+        A smoke test to ensure nothing bizarre happens when we try to add some attribute
+        """
+        args = MagicMock()
+        args.prop_name = "addons"
+        args.values = ["ADDON1"]
+        with Capture() as captured:
+            cli.add_command(args, self.syspurposestore)
+            self.assertTrue('Added ADDON1 to addons' in captured.out)
+
+    def test_add_command_more_values(self):
+        """
+        A smoke test to ensure nothing bizarre happens when we try to add value to addons attribute
+        """
+        args = MagicMock()
+        args.prop_name = "addons"
+        args.values = ["ADDON1", "ADDON2"]
+        with Capture() as captured:
+            cli.add_command(args, self.syspurposestore)
+            self.assertTrue('Added ADDON1 to addons' in captured.out)
+            self.assertTrue('Added ADDON2 to addons' in captured.out)
+
+    def test_remove_command(self):
+        """
+        A smoke test to ensure nothing bizarre happens when we try to remove one value from addons attribute
+        """
+        args = MagicMock()
+
+        # Add value first
+        args.prop_name = "addons"
+        args.values = ["ADDON1"]
+        cli.add_command(args, self.syspurposestore)
+
+        # Now we can try to remove value
+        with Capture() as captured:
+            cli.remove_command(args, self.syspurposestore)
+            self.assertTrue('Removed ADDON1 from addons' in captured.out)
+
+    def test_show_command(self):
+        """
+        A smoke test to ensure nothing bizarre happens when we try to show content fo syspurpose.json file
+        """
+        args = MagicMock()
+
+        # Add value first
+        with Capture() as captured:
+            cli.show_contents(args, self.syspurposestore)
+            self.assertTrue('{}' in captured.out)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1708105
* This bug was mostly caused by absence of any unit tests for
  modul cli
* I added serveral unit tests for the cli module
* Fixed few minor issues (code style, confusing debug prints)
* Updated documentation in README.md and added there tip how to test syspurpose code. It can be handy, when you try to do e.g. remote debuging in PyCharm