### PR TITLE
1719709: cockpit - Improve behavior when connection to D-Bus fails

### DIFF
--- a/cockpit/src/subscriptions-client.js
+++ b/cockpit/src/subscriptions-client.js
@@ -126,7 +126,6 @@ function safeDBusCall(serviceProxy, delegateMethod) {
         .then(delegateMethod)
         .fail(ex => {
             console.debug(ex);
-            delegateMethod();
         });
 }
 
@@ -423,7 +422,7 @@ client.unregisterSystem = () => {
 
 function statusUpdateFailed(reason) {
     console.warn("Subscription status update failed:", reason);
-    client.subscriptionStatus.status = "not-found";
+    client.subscriptionStatus.status = (reason && reason.problem) || "not-found";
     needRender();
 }
 

--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -269,7 +269,7 @@ class SubscriptionsPage extends React.Component {
                 "and try reloading the page. Additionally, make sure that you have checked the " +
                 "'Reuse my password for privileged tasks' checkbox on the login page.");
             description = _("Unable to the reach the rhsm service.");
-        } else if (this.props.status === undefined || !subscriptionsClient.config.loaded) {
+        } else if (this.props.status === undefined && !subscriptionsClient.config.loaded) {
             icon = <div className="spinner spinner-lg" />;
             message = _("Updating");
             description = _("Retrieving subscription status...");


### PR DESCRIPTION
Don't call methods on a proxy that has failed, that is pointless and
will likely just crash since the proxy doesn't have the expected
methods defined on it.

Propagate the failure reason as the client subscription status when a
status update fails.

Don't unconditionally show the spinner until the config has loaded,
only while there is no other failure status yet.