### PR TITLE
1708438: Don't print traceback during list --available; ENT-1331

### DIFF
--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -75,7 +75,11 @@ class ModulesProfile(object):
         if dnf is not None and libdnf is not None:
             base = dnf.Base()
             base.read_all_repos()
-            base.fill_sack()
+            try:
+                base.fill_sack()
+            except dnf.exceptions.RepoError as err:
+                log.error("Unable to create sack object: %s" % str(err))
+                return []
             # FIXME: DNF doesn't provide public API for modulemd
             try:
                 modules = base._moduleContainer


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1708438
* When two product certificates are installed (Beta and GA), then
  dnf isn't able to synchronize cache for one of them.