### PR TITLE
1719725: rhsm - Write config file atomically

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -22,6 +22,7 @@ import os
 from iniparse import SafeConfigParser
 from iniparse.compat import NoOptionError, InterpolationMissingOptionError, NoSectionError
 import re
+import tempfile
 
 CONFIG_ENV_VAR = "RHSM_CONFIG"
 
@@ -120,8 +121,10 @@ class RhsmConfigParser(SafeConfigParser):
 
     def save(self, config_file=None):
         """Writes config file to storage."""
-        fo = open(self.config_file, "w")
-        self.write(fo)
+        with tempfile.NamedTemporaryFile(mode="w", dir=os.path.dirname(self.config_file), delete=False) as fo:
+            self.write(fo)
+            fo.flush()
+            os.rename(fo.name, self.config_file)
 
     def get(self, section, prop):
         """Get a value from rhsm config.


### PR DESCRIPTION
The config file is read asynchronously by at least the file watches of
dbus/server.py, and if it is just overwritten in place the file watch
handler might read it when it has only been partially written.