### PR TITLE
1665167: list --consumed print syspurpose attributes from ent. cert; ENT-1315

### DIFF
--- a/src/rct/printing.py
+++ b/src/rct/printing.py
@@ -32,6 +32,8 @@ from subscription_manager.i18n import ugettext as _
 def xstr(value):
     if value is None:
         return ''
+    elif isinstance(value, list):
+        return ", ".join([xstr(val) for val in value])
     elif isinstance(value, six.text_type) and six.PY2:
         return value.encode('utf-8')
     else:

--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -344,7 +344,10 @@ class _CertFactory(object):
                 stacking_id=sub.get('stacking_id', None),
                 virt_only=sub.get('virt_only', False),
                 ram_limit=sub.get('ram', None),
-                core_limit=sub.get('cores', None)
+                core_limit=sub.get('cores', None),
+                roles=sub.get('roles', None),
+                usage=sub.get('usage', None),
+                addons=sub.get('addons', None)
             )
 
     def _parse_v3_products(self, payload):

--- a/src/rhsmlib/services/entitlement.py
+++ b/src/rhsmlib/services/entitlement.py
@@ -214,10 +214,15 @@ class EntitlementService(object):
 
             if order:
                 service_type = order.service_type or ""
-                roles = order.roles
                 service_level = order.service_level or ""
-                usage = order.usage
-                addons = order.addons
+                if cert.version.major >= 3 and cert.version.minor >= 4:
+                    roles = order.roles or ""
+                    usage = order.usage or ""
+                    addons = order.addons or ""
+                else:
+                    roles = None
+                    usage = None
+                    addons = None
                 name = order.name
                 sku = order.sku
                 contract = order.contract or ""

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2566,6 +2566,18 @@ class ListCommand(CliCommand):
             system_exit(os.EX_DATAERR,
                         msg.format(dateexample=dateexample))
 
+    def _split_mulit_value_field(self, values):
+        """
+        REST API returns multi-value fields in string, where values are separated with comma, but
+        each value of multi-value field should be printed on new line. It is done automatically, when
+        values are in list
+        :param values: String containing multi-value string, where values are separated with comma
+        :return: list of values
+        """
+        if values is None:
+            return ""
+        return [item.strip() for item in values.split(",")]
+
     def _do_command(self):
         """
         Executes the command.
@@ -2643,10 +2655,10 @@ class ListCommand(CliCommand):
                                 data['quantity'],
                                 data['suggested'],
                                 data['service_type'] or "",
-                                data['roles'] or "",
+                                self._split_mulit_value_field(data['roles']),
                                 data['service_level'] or "",
                                 data['usage'] or "",
-                                data['addons'] or "",
+                                self._split_mulit_value_field(data['addons']),
                                 data['pool_type'],
                                 data['startDate'],
                                 data['endDate'],

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -270,6 +270,8 @@ class StubEntitlementCertificate(EntitlementCertificate):
         path = "/tmp/fake_ent_cert.pem"
         self.is_deleted = False
 
+        version = Version("3.0")
+
         # might as well make this a big num since live serials #'s are already > maxint
         self.serial = random.randint(1000000000000000000, 10000000000000000000000)
         # write these to tmp, could we abuse PATH thing in certs for tests?
@@ -277,7 +279,7 @@ class StubEntitlementCertificate(EntitlementCertificate):
         path = "/tmp/fake_ent_cert-%s.pem" % self.serial
         super(StubEntitlementCertificate, self).__init__(path=path, products=products, order=order,
                                                          content=content, pool=pool, start=start_date,
-                                                         end=end_date, serial=self.serial)
+                                                         end=end_date, serial=self.serial, version=version)
         if ent_id:
             self.subject = {'CN': ent_id}
 


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1717903
* When version of entitlement certificate is higher than 3.3,
  then list --consumed prints syspurpose attributes, when
  the version smaller than 3.4, then syspurpose attributes are
  no printed, because there cannot be any.
* Modified output of "rct cc" command
* Fixed few unit tests
* Added two unit tests
* Note: the output of list --available and list --consumed is
  little bit different, when e.g. roles/addons contains multiple
  values (e.g. ADDON1, ADDON2).