### PR TITLE
1722238: Fix reporting insights id in facts on RHEL7

### DIFF
--- a/src/rhsmlib/facts/insights.py
+++ b/src/rhsmlib/facts/insights.py
@@ -56,7 +56,7 @@ class InsightsCollector(collector.FactsCollector):
         """
         insights_id = {}
 
-        if insights_constants is not None:
+        if insights_constants is not None and hasattr(insights_constants, 'machine_id_file'):
             machine_id_filepath = insights_constants.machine_id_file
         else:
             machine_id_filepath = self.DEFAULT_INSIGHTS_MACHINE_ID

--- a/test/rhsmlib_test/test_insights.py
+++ b/test/rhsmlib_test/test_insights.py
@@ -54,3 +54,10 @@ class TestInsightsCollector(unittest.TestCase):
         consts.machine_id_file = "/not/existing/file/machine_id"
         fact = self.collector.get_all()
         self.assertEqual(fact, {})
+
+    @patch('rhsmlib.facts.insights.insights_constants', spec=['InsightsConstants'])
+    def test_old_insights_api(self, consts):
+        # Try to mimic old version of insights client without consts.machine_id_file
+        self.assertFalse(hasattr(consts, 'machine_id_file'))
+        fact = self.collector.get_all()
+        self.assertEqual(fact, {})


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1722238
* The old version of insights client didn't have attribute
  `machine_id_path`. Thus it couldn't work on RHEL7.
* Added one unit test for this case