### PR TITLE
1708494: Proper messaging of syspurpose add-addons; ENT-1332

### DIFF
--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -42,14 +42,18 @@ def add_command(args, syspurposestore):
     :param syspurposestore: An SyspurposeStore object to manipulate
     :return: None
     """
+    any_addon_added = False
     for value in args.values:
         if syspurposestore.add(args.prop_name, value):
+            any_addon_added = True
             print(_("Added {value} to {prop_name}.").format(
                 value=make_utf8(value), prop_name=make_utf8(args.prop_name)))
         else:
             print(_("Not adding value {value} to {prop_name}; it already exists.").format(
                 value=make_utf8(value), prop_name=make_utf8(args.prop_name)))
-            return
+
+    if any_addon_added is False:
+        return
 
     success_msg = _("{attr} updated.").format(attr=make_utf8(args.prop_name))
     to_add = "".join(args.values)

--- a/syspurpose/test/syspurpose/test_cli.py
+++ b/syspurpose/test/syspurpose/test_cli.py
@@ -81,7 +81,7 @@ class SyspurposeCliTests(SyspurposeTestBase):
 
     def test_add_command_more_values(self):
         """
-        A smoke test to ensure nothing bizarre happens when we try to add value to addons attribute
+        A smoke test to ensure nothing bizarre happens when we try to add more addons attribute
         """
         args = MagicMock()
         args.prop_name = "addons"
@@ -90,6 +90,51 @@ class SyspurposeCliTests(SyspurposeTestBase):
             cli.add_command(args, self.syspurposestore)
             self.assertTrue('Added ADDON1 to addons' in captured.out)
             self.assertTrue('Added ADDON2 to addons' in captured.out)
+            self.assertTrue('addons updated.' in captured.out)
+
+    def test_add_command_existing_values(self):
+        """
+        A smoke test to ensure nothing bizarre happens when we try to add existing addons attribute
+        """
+        args = MagicMock()
+        args.prop_name = "addons"
+        args.values = ["ADDON1", "ADDON2"]
+        with Capture() as captured:
+            cli.add_command(args, self.syspurposestore)
+            self.assertTrue('Added ADDON1 to addons' in captured.out)
+            self.assertTrue('Added ADDON2 to addons' in captured.out)
+            self.assertTrue('addons updated.' in captured.out)
+        # Try to add same addons once again
+        args.prop_name = "addons"
+        args.values = ["ADDON1", "ADDON2"]
+        with Capture() as captured:
+            cli.add_command(args, self.syspurposestore)
+            self.assertTrue('Not adding value ADDON1 to addons; it already exists.' in captured.out)
+            self.assertTrue('Not adding value ADDON2 to addons; it already exists.' in captured.out)
+            self.assertFalse('addons updated.' in captured.out)
+
+    def test_add_command_existing_values_and_one_new(self):
+        """
+        A smoke test to ensure nothing bizarre happens when we try to add existing addons attribute
+        and also try to add one new value
+        """
+        args = MagicMock()
+        args.prop_name = "addons"
+        args.values = ["ADDON1", "ADDON2"]
+        with Capture() as captured:
+            cli.add_command(args, self.syspurposestore)
+            self.assertTrue('Added ADDON1 to addons' in captured.out)
+            self.assertTrue('Added ADDON2 to addons' in captured.out)
+            self.assertTrue('addons updated.' in captured.out)
+        # Try to add same addons once again
+        args.prop_name = "addons"
+        args.values = ["ADDON1", "ADDON2", "ADDON3"]
+        with Capture() as captured:
+            cli.add_command(args, self.syspurposestore)
+            self.assertTrue('Not adding value ADDON1 to addons; it already exists.' in captured.out)
+            self.assertTrue('Not adding value ADDON2 to addons; it already exists.' in captured.out)
+            self.assertTrue('Added ADDON3 to addons' in captured.out)
+            self.assertTrue('addons updated.' in captured.out)
 
     def test_remove_command(self):
         """


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1708494
* When user tries to add more existing addon values, then the
  function is not exited immediately, when existing addon value
  is detected, but it tries to add all new addons
* Added two unit tests for this case