### PR TITLE
1698606: Better advice message for syspurpose conflict; ENT-1341

### DIFF
--- a/syspurpose/test/syspurpose/test_cli.py
+++ b/syspurpose/test/syspurpose/test_cli.py
@@ -105,7 +105,7 @@ class SyspurposeCliTests(SyspurposeTestBase):
         # Now we can try to remove value
         with Capture() as captured:
             cli.remove_command(args, self.syspurposestore)
-            self.assertTrue('Removed ADDON1 from addons' in captured.out)
+            self.assertTrue('Removed "ADDON1" from addons' in captured.out)
 
     def test_show_command(self):
         """


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1698606
* The advice message is little bit different, when there is conflict
  between value on server, chached value and new value
* It is possible to test conflict using:
  - Set syspurpose attribute role using subscription-manager:

    $ subscription-manager role --set 'Bar'

  - Create testing syspurpose json file `new_syspurpose.json` with
    following content:

    ```yaml
    {
       'role': 'Foo'
    }
    ```

  - Set syspurpose attribute role on the server using:

    curl -ik -u admin:admin --request PUT \
      "https://localhost:8443/candlepin/consumers/58ed1af1-6213-4314-b08b-f586b73f32f7" \
      -d @./new_syspurpose.json --header "Content-Type: application/json"

  - Try to set role once again using subsription-manager:

    $ subscription-manager role --set 'Bar'

* Added one unit test for this case