### PR TITLE
Updated man pages (redeem command does not have --org option)

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -416,10 +416,6 @@ Gives the email account to send the redemption notification message to.
 .B --locale=LOCALE
 Sets the locale to use for the message. If none is given, then it defaults to the local system's locale.
 
-.TP
-.B --org=ORG
-Identifies the organization which issued the subscription being redeemed.
-
 
 .SS LIST OPTIONS
 The


### PR DESCRIPTION
* Removed --org option (command redeem) from man pages
* subscription-manager redeem --help doesn't print anything about
  --org option and in fact this option is not supported due
  to e.g. back compatibility too