### PR TITLE
1742208: Send package profile on yum transactions

### DIFF
--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -21,6 +21,7 @@ import os
 from yum.plugins import TYPE_CORE
 
 from subscription_manager import injection as inj
+from subscription_manager.action_client import ProfileActionClient
 from subscription_manager.repolib import RepoActionInvoker
 from subscription_manager.entcertlib import EntCertActionInvoker
 from rhsmlib.facts.hwprobe import ClassicCheck
@@ -219,3 +220,14 @@ def postconfig_hook(conduit):
         warnExpired(conduit)
     except Exception as e:
         conduit.error(2, str(e))
+
+
+def posttrans_hook(conduit):
+    # BZ#1742208 - Upload package profile after transactions if run as a yum plugin
+    cfg = config.initConfig()
+    if '1' == cfg.get('rhsm', 'package_profile_on_trans'):
+        package_profile_client = ProfileActionClient()
+        package_profile_client.update()
+    else:
+        # do nothing
+        return


### PR DESCRIPTION
When we started producing combined package profile reports (which encompassed the enabled_repos report and module reports for newer versions of fedora / RHEL), we started sending those updates on dnf transactions based on the value of the setting package_profile_on_trans.

A similar update was not made to our yum plugins. This can cause neither subman nor katello-host-tools to report the package profile (when used with newer versions of katello-host-tools which check the value of package_profile_on_trans in rhsm.conf to determine whether or not to upload the package profile).

The solution is for our subscription-manager yum plugin to also check the package_profile_on_trans setting in rhsm.conf and to report the package profile post transaction based on that.