### PR TITLE
1743729: Update dnf-plugin dependencies for RHEL 7

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -374,7 +374,7 @@ Requires: libdnf >= 0.22.5
 %endif
 # See BZ 1581410 - avoid a circular dependency
 %if (0%{?rhel} < 8)
-Requires: %{name} = %{version}-%{release}
+Requires: %{name} >= %{version}-%{release}
 %endif
 %if %{with python3}
 Requires: python3-dnf-plugins-core


### PR DESCRIPTION
To allow users to install newer versions of subman where changes are not necessary for the dnf-plugin-subscription-manager on RHEL 7, update the spec file.

Please note that this means we'll need to be conscious of any changes in the subman codebase which would cause an incompatibility between the two packages.