### PR TITLE
Require the python2 version of Sphinx when necessary

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,6 +14,7 @@ polib
 pyinotify
 simplejson
 mock
-Sphinx
+Sphinx==1.8.5;python_version<="2.7"
+Sphinx>=1.8.5;python_version>="3.0"
 git+https://github.com/alikins/pyqver.git#egg=pyqver
 git+https://github.com/awood/nose-xvfb.git#egg=nose-xvfb


### PR DESCRIPTION
This is necessary for building vm images which do not support python3 (Centos7, RHEL7.x, and similar).