### PR TITLE
1643189: Stop rhsmd process before installing a new rpm

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1119,6 +1119,9 @@ scrollkeeper-update -q -o %{_datadir}/omf/%{name} || :
 %endif
 %endif
 
+%pre
+killall rhsmd > /dev/null 2>&1
+
 %post -n subscription-manager-plugin-container
 %{__python} %{rhsm_plugins_dir}/container_content.py || :
 


### PR DESCRIPTION
to test:
 /usr/libexec/rhsmd &
tito build -i --rpm --test

the stopping of the process will be shown at the end of the execution
[1]+  Terminated              sudo /usr/libexec/rhsmd

