### PR TITLE
Install /run/rhsm on suse instead of /var/run/rhsm

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -733,7 +733,11 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 
 %attr(755,root,root) %dir %{_var}/log/rhsm
 %attr(755,root,root) %dir %{_var}/spool/rhsm/debug
+%if 0%{?suse_version}
+%attr(755,root,root) %dir /run/rhsm
+%else
 %attr(755,root,root) %dir %{_var}/run/rhsm
+%endif
 %attr(750,root,root) %dir %{_var}/lib/rhsm
 %attr(750,root,root) %dir %{_var}/lib/rhsm/facts
 %attr(750,root,root) %dir %{_var}/lib/rhsm/packages
@@ -1090,6 +1094,7 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 %if %use_systemd
     %if 0%{?suse_version}
         %service_add_post rhsmcertd.service
+        %tmpfiles_create %_tmpfilesdir/subscription-manager.conf
     %else
         %systemd_post rhsmcertd.service
     %endif


### PR DESCRIPTION
This also runs the systemd-tmpfiles --create in the %post to
create the necessary directories for our daemons operations.

I believe this PR will solve the primary issue presented in this build of subscription-manager on SLES 15: https://build.opensuse.org/package/live_build_log/home:cnsnyder/subscription-manager/SLE_15/x86_64

We were already installing a tmpfiles.d configuration but we included the wrong path in the spec file to refer to that file this was failing rpmlint.