### PR TITLE
Use /run/rhsm instead of /var/run/rhsm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,7 @@ install: install-via-setup install-files
 install-files: dbus-install install-conf install-plugins install-post-boot install-ga
 	install -d $(DESTDIR)/var/log/rhsm
 	install -d $(DESTDIR)/var/spool/rhsm/debug
-	install -d $(DESTDIR)/var/run/rhsm
+	install -d $(DESTDIR)/run/rhsm
 	install -d -m 750 $(DESTDIR)/var/lib/rhsm/{cache,facts,packages,repo_server_val}
 
 	# Set up rhsmcertd daemon. Installation location depends on distro...

--- a/etc-conf/subscription-manager.conf.tmpfiles
+++ b/etc-conf/subscription-manager.conf.tmpfiles
@@ -1,1 +1,1 @@
-d /var/run/rhsm 0755 root root -
+d /run/rhsm 0755 root root -

--- a/scripts/suse_build.sh
+++ b/scripts/suse_build.sh
@@ -11,4 +11,4 @@ fi
 prepare_obs "$project_name"
 cd "$OBS_DIR/$project_name/$package_name"
 
-osc build "$@"
+osc build --clean "$@"

--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -35,9 +35,9 @@
 
 #define LOGFILE "/var/log/rhsm/rhsmcertd.log"
 #define LOCKFILE "/var/lock/subsys/rhsmcertd"
-#define UPDATEFILE "/var/run/rhsm/update"
-#define NEXT_CERT_UPDATE_FILE "/var/run/rhsm/next_cert_check_update"
-#define NEXT_AUTO_ATTACH_UPDATE_FILE "/var/run/rhsm/next_auto_attach_update"
+#define UPDATEFILE "/run/rhsm/update"
+#define NEXT_CERT_UPDATE_FILE "/run/rhsm/next_cert_check_update"
+#define NEXT_AUTO_ATTACH_UPDATE_FILE "/run/rhsm/next_auto_attach_update"
 #define WORKER LIBEXECDIR"/rhsmcertd-worker"
 #define WORKER_NAME WORKER
 #define INITIAL_DELAY_SECONDS 120

--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -230,7 +230,7 @@ class DomainSocketServer(object):
 
     def run(self):
         try:
-            self._server = dbus.server.Server("unix:tmpdir=/var/run")
+            self._server = dbus.server.Server("unix:tmpdir=/run/rhsm")
 
             for clazz in self.object_classes:
                 self._server.on_connection_added.append(

--- a/src/subscription_manager/gui/about.py
+++ b/src/subscription_manager/gui/about.py
@@ -35,8 +35,8 @@ LICENSE = _("\nThis software is licensed to you under the GNU General Public Lic
             "granted to use or replicate Red Hat trademarks that are incorporated "
             "in this software or its documentation.\n")
 
-AUTO_ATTACH_UPDATE_FILE = '/var/run/rhsm/next_auto_attach_update'
-CERT_CHECK_UPDATE_FILE = '/var/run/rhsm/next_cert_check_update'
+AUTO_ATTACH_UPDATE_FILE = '/run/rhsm/next_auto_attach_update'
+CERT_CHECK_UPDATE_FILE = '/run/rhsm/next_cert_check_update'
 
 prefix = os.path.dirname(__file__)
 

--- a/src/subscription_manager/lock.py
+++ b/src/subscription_manager/lock.py
@@ -215,7 +215,7 @@ class Lock(object):
 
 class ActionLock(Lock):
 
-    PATH = '/var/run/rhsm/cert.pid'
+    PATH = '/run/rhsm/cert.pid'
 
     def __init__(self):
         super(ActionLock, self).__init__(self.PATH)

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -338,7 +338,7 @@ def restart_virt_who():
     Send a SIGHUP signal to virt-who if it running on the same machine.
     """
     try:
-        pidfile = open('/var/run/virt-who.pid', 'r')
+        pidfile = open('/run/virt-who.pid', 'r')
         pid = int(pidfile.read())
         os.kill(pid, signal.SIGHUP)
         log.debug("Restarted virt-who")

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -733,7 +733,7 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 
 %attr(755,root,root) %dir %{_var}/log/rhsm
 %attr(755,root,root) %dir %{_var}/spool/rhsm/debug
-%attr(755,root,root) %dir %{_var}/run/rhsm
+%attr(755,root,root) %dir /run/rhsm
 %attr(750,root,root) %dir %{_var}/lib/rhsm
 %attr(750,root,root) %dir %{_var}/lib/rhsm/facts
 %attr(750,root,root) %dir %{_var}/lib/rhsm/packages
@@ -1089,8 +1089,11 @@ find %{buildroot} -name \*.py -exec touch -r %{SOURCE0} '{}' \;
 %post
 %if %use_systemd
     %if 0%{?suse_version}
+#        %%tmpfiles_create %_tmpfilesdir/subscription-manager.conf
+        [ -x /usr/bin/systemd-tmpfiles ] && /usr/bin/systemd-tmpfiles --create %{_tmpfilesdir}/subscription-manager.conf > /dev/null 2>&1 || :
         %service_add_post rhsmcertd.service
     %else
+        systemd-tmpfiles --create %{_tmpfilesdir}/subscription-manager.conf
         %systemd_post rhsmcertd.service
     %endif
 %else

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -335,7 +335,7 @@ class DomainSocketRegisterDBusObjectTest(DBusObjectTest, InjectionMockingTest):
 
         def assertions(*args):
             result = args[0]
-            six.assertRegex(self, result, r'/var/run/dbus.*')
+            six.assertRegex(self, result, r'/run/rhsm/dbus.*')
 
         self.dbus_request(assertions, self.interface.Start, dbus_method_args)
 
@@ -346,7 +346,7 @@ class DomainSocketRegisterDBusObjectTest(DBusObjectTest, InjectionMockingTest):
             # Assign the result as an attribute to this function.
             # See http://stackoverflow.com/a/27910553/6124862
             assertions.result = args[0]
-            six.assertRegex(self, assertions.result, r'/var/run/dbus.*')
+            six.assertRegex(self, assertions.result, r'/run/rhsm/dbus.*')
 
         self.dbus_request(assertions, self.interface.Start, dbus_method_args)
 


### PR DESCRIPTION
This also runs the systemd-tmpfiles --create in the %post to
create the necessary directories for our daemons operations.