### PR TITLE
1643189: Added timeout for rhsmd cron job

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -95,6 +95,10 @@ splay = 1
 # If set to 1, rhsmcertd will not execute.
 disable = 0
 
+[rhsmd]
+# The time in seconds we will allow the rhsmd cron job to run before terminating the process.
+processTimeout = 300
+
 [logging]
 default_log_level = INFO
 # subscription_manager = DEBUG

--- a/etc-conf/rhsmd.cron
+++ b/etc-conf/rhsmd.cron
@@ -2,4 +2,17 @@
 # nightly run of rhsmd to log entitlement expiration/validity errors to syslog
 # this is a cron job because it doesn't need to 'phone home'. should that
 # change, look into calling the dbus interface from rhsmcertd instead.
-/usr/libexec/rhsmd -s
+config=$(grep -E "^processTimeout" /etc/rhsm/rhsm.conf | grep -Po "[0-9]+")
+if [ -n $config ]; then
+  rhsmd_timeout=$config
+else
+  rhsmd_timeout=300
+fi
+
+/usr/libexec/rhsmd -s &
+sleep $rhsmd_timeout;
+
+if ps h -C rhsmd; then
+  pkill rhsmd
+  logger -t rhsmd -p user.warn "rhsmd process exceeded runtime and was killed."
+fi

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -248,6 +248,11 @@ were set to 3 minutes, the initial cert check would begin somewhere between 2 mi
 disable
 .RS 4
 set to 1 to disable rhsmcertd operation entirely.
+.SH "[RHSMD] OPTIONS"
+.PP
+processTimeout
+.RS 4
+The time in seconds we will allow the rhsmd cron job to run before terminating the process.
 .SH "[LOGGING] OPTIONS"
 .PP
 default_log_level


### PR DESCRIPTION
Added a configuration option for a timeout on the rhsmd cron job run, as well as documented it in man for rhsm.conf and reconfigured the cron.daily script to utilize the timeout and verify the process has ended - otherwise we terminate it.

Since this runs daily, it will also clean up other rhsmd runs that hang for any reason hopefully, and prevent some of the issues we have seen around migrations to Satellite environments.