### PR TITLE
1643189: Updated defaults to include rhsmd.processtimeout

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -86,6 +86,10 @@ RHSMCERTD_DEFAULTS = {
         'disable': '0'
         }
 
+RHSMD_DEFAULTS = {
+        'processtimeout': '300'
+        }
+
 LOGGING_DEFAULTS = {
         'default_log_level': 'INFO'
         }
@@ -95,6 +99,7 @@ DEFAULTS = {
         'server': SERVER_DEFAULTS,
         'rhsm': RHSM_DEFAULTS,
         'rhsmcertd': RHSMCERTD_DEFAULTS,
+        'rhsmd': RHSMD_DEFAULTS,
         'logging': LOGGING_DEFAULTS
         }
 

--- a/test/rhsmlib_test/test_config.py
+++ b/test/rhsmlib_test/test_config.py
@@ -61,13 +61,16 @@ manage_repos =
 [rhsmcertd]
 certCheckInterval = 245
 
+[rhsmd]
+processTimeout = 300
+
 [logging]
 default_log_level = DEBUG
 """
 
 
 class BaseConfigTest(unittest.TestCase, TestUtilsMixin):
-    expected_sections = ['foo', 'server', 'rhsm', 'rhsmcertd', 'logging']
+    expected_sections = ['foo', 'server', 'rhsm', 'rhsmcertd', 'rhsmd', 'logging']
 
     def setUp(self):
         super(BaseConfigTest, self).setUp()


### PR DESCRIPTION
Left this out of the first PR, will give us the default visualization from `subscription-manager config` output, etc.