### PR TITLE
Fix RHSM addon spoke header background

### DIFF
--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.ui
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.ui
@@ -15,7 +15,6 @@
         <property name="spacing">6</property>
         <child internal-child="nav_box">
           <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
-            <property name="app_paintable">True</property>
             <property name="can_focus">False</property>
             <child internal-child="nav_area">
               <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">


### PR DESCRIPTION
Drop the app_paintable option preventing the RHSM addon spoke
header from having the correct background color.

I hope this is the correct branch. :)

I've only tested this on RHEL7 - originally it looks like this:
![is_rhsm_addon_original_state](https://user-images.githubusercontent.com/829558/64427895-98556480-d0b2-11e9-8046-dd541989784b.png)

This is how it looks like with the fix:
![is_rhsm_addon_fixed](https://user-images.githubusercontent.com/829558/64427915-a86d4400-d0b2-11e9-8db5-72f516b55e0e.png)
