### PR TITLE
Align RHSM spoke to center

### DIFF
--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.ui
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.ui
@@ -35,6 +35,11 @@
           <object class="GtkAlignment" id="RHSMSpokeWindow-alignment1">
             <property name="can_focus">False</property>
             <property name="yalign">0</property>
+            <property name="xscale">0</property>
+            <property name="yscale">0.5</property>
+            <property name="bottom_padding">48</property>
+            <property name="left_padding">24</property>
+            <property name="right_padding">24</property>
             <child internal-child="action_area">
               <object class="GtkBox" id="RHSMSpokeWindow-action_area1">
                 <property name="can_focus">False</property>


### PR DESCRIPTION
* The RHSM spoke was aligned to left in past.
* This commit changes horizontal alignment to center. Other spokes are
  aligned to center too (e.g. Users) .

![rhsm_spoke_aligment](https://user-images.githubusercontent.com/2057012/64529828-0d6fa680-d30c-11e9-8558-4d0c96c12c85.png)
