### PR TITLE
Add fedora30 vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
     "centos7" => "candlepin/subscription-manager-centos7",
     "centos6" => "centos/6",
     "debian9" => "debian/stretch64",
-    "fedora25" => "fedora/25-cloud-base",
+    "fedora30" => "fedora/30-cloud-base",
     "opensuse42.2" => "opensuse/openSUSE-42.2-x86_64",
   }
 
@@ -25,6 +25,9 @@ Vagrant.configure("2") do |config|
     "centos7" => {
       "needs_provision" => false,
     },
+    "fedora30" => {
+        "ansible_python_interpreter" => "/usr/bin/python3",
+    }
   }
 
   # allows us to share base boxes with Katello/forklift

--- a/vagrant/vagrant.yml
+++ b/vagrant/vagrant.yml
@@ -3,7 +3,7 @@
   gather_facts: no
   tasks:
     - name: install libs so we can use ansible (fedora only)
-      raw: sudo yum install -y python python2-dnf
+      raw: sudo dnf install -y python3 python3-dnf
 
 - hosts: "subman-devel"
   roles:


### PR DESCRIPTION
A small PR to update our existing fedora vagrant box to a more recent version.
This should work just as the other boxes do, it is not pre-provisioned like the centos7 one though so it will take a little bit of time to run the ansible playbook against it.