### PR TITLE
Do not use importlib unless available

### DIFF
--- a/src/rhsmlib/__init__.py
+++ b/src/rhsmlib/__init__.py
@@ -13,11 +13,30 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
-import importlib
+try:
+    # Prefer using importlib where available
+    import importlib
 
+    def import_class(name):
+        """Load a class from the string"""
+        comps = name.split('.')
+        module = importlib.import_module(".".join(comps[0:-1]))
+        return getattr(module, comps[-1])
 
-def import_class(name):
-    """Load a class from the string"""
-    comps = name.split('.')
-    module = importlib.import_module(".".join(comps[0:-1]))
-    return getattr(module, comps[-1])
+except ImportError:
+    # in cases where importlib is not available (I'm looking at you python 2.6.9)
+    # use the older "imp"
+    import imp
+
+    def import_class(name):
+        """Load a class from a string.  Thanks http://stackoverflow.com/a/547867/61248 """
+        components = name.split('.')
+        current_level = components[0]
+        module_tuple = imp.find_module(current_level)
+        module = imp.load_module(current_level, *module_tuple)
+        for comp in components[1:-1]:
+            # import all the way down to the class
+            module_tuple = imp.find_module(comp, module.__path__)
+            module = imp.load_module(comp, *module_tuple)
+        # the class will be an attribute on the lowest level module
+        return getattr(module, components[-1])


### PR DESCRIPTION
On some slightly older versions of python (namely python 2.6.9), the importlib module has not been backported (from python 3+).

This PR let's us switch between using imp and importlib based on availability. 