### PR TITLE
1703054: Blacklist some locales for Python2.x; ENT-1288

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -427,7 +427,7 @@ def _get_locale():
     l = None
     try:
         l = locale.getlocale()
-    except locale.Error:
+    except (locale.Error, ValueError):
         try:
             l = locale.getdefaultlocale()
         except locale.Error:

--- a/src/subscription_manager/scripts/subscription_manager.py
+++ b/src/subscription_manager/scripts/subscription_manager.py
@@ -46,6 +46,7 @@ def system_exit(code, msgs=None):
             sys.stderr.write(str(msg) + '\n')
     sys.exit(code)
 
+
 # quick check to see if you are a super-user.
 if os.getuid() != 0:
     sys.stderr.write('Error: this command requires root access to execute\n')


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1703054#c10
* When some locales are used (e.g. Turkish), then behavior of
  lower() and upper() methods is influenced by locale and
  e.g. parsing of ini file doesn't work as expected. We can
  also expect unexpexted behavior of other parts of sub-man.
* When unsupported locale is specified, then sub-man is not
  terminated.
* When you add some custom section and custom attributes to
  rhsm.conf. Something like this:
```
[foo]
bar = 0
```
  then subscription-manager config --help will not contain
  option --foo.bar=FOO.BAR, but it will contain only options
  with default values (supported by subscription-manager).