### PR TITLE
Create rpm of cockpit plugin correctly; ENT-1620

### DIFF
--- a/.tito/cockpit-build.sh
+++ b/.tito/cockpit-build.sh
@@ -12,9 +12,10 @@ if [ ! $(which yarn) ] ; then
   echo "Unable to build cockpit, yarn not installed (see README)"
   exit 1
 fi
+
 pushd cockpit
 yarn cache clean
 yarn install --frozen-lockfile
 make dist-gzip
 popd
-echo "$(find -name *.tar.gz)"
+echo "$(find -name *.tar)"

--- a/.tito/lib/rhsmtagger.py
+++ b/.tito/lib/rhsmtagger.py
@@ -1,7 +1,7 @@
 import os
 import six
 from tito.tagger.main import VersionTagger
-from tito.common import info_out, debug, replace_version, run_command
+from tito.common import debug, replace_version, run_command
 
 
 class MultiPythonPackageVersionTagger(VersionTagger):
@@ -12,7 +12,6 @@ class MultiPythonPackageVersionTagger(VersionTagger):
             self.subpackages = config.get('tagconfig', 'python_subpackages').split(',')
         else:
             self.subpackages = []
-
 
     def _update_setup_py_in_dir(self, new_version, package_dir=None):
         """

--- a/cockpit/Makefile
+++ b/cockpit/Makefile
@@ -17,8 +17,6 @@ dist-gzip: clean all
 	mkdir -p _install/usr/share/metainfo/
 	cp *.metainfo.xml _install/usr/share/metainfo/
 	(cd _install; find -type f) | tar -C _install/ --mtime "$(stat -c '%Y' package.json)" --owner root --group root -cf subscription-manager-cockpit.tar -T -
-	gzip -n subscription-manager-cockpit.tar
-	rm -rf _install
 
 srpm: dist-gzip
 	rpmbuild -bs \

--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -189,7 +189,7 @@ class SubscriptionStatus extends React.Component {
             sla = (
                 <div>
                     <label>
-                        { _("Service Level:  ") }
+                        { _("Service Level: ") }
                         <span className="value">{ _(String(this.props.syspurpose["service_level_agreement"])) }</span>
                     </label>
                 </div>
@@ -199,7 +199,7 @@ class SubscriptionStatus extends React.Component {
             usage = (
                 <div>
                     <label>
-                        { _("Usage:  ") }
+                        { _("Usage: ") }
                         <span className="value">{ _(String(this.props.syspurpose["usage"])) }</span>
                     </label>
                 </div>
@@ -209,7 +209,7 @@ class SubscriptionStatus extends React.Component {
             role = (
                 <div>
                     <label>
-                        { _("Role:  ") }
+                        { _("Role: ") }
                         <span className="value">{ _(String(this.props.syspurpose["role"])) }</span>
                     </label>
                 </div>
@@ -219,7 +219,7 @@ class SubscriptionStatus extends React.Component {
             add_ons = (
                 <div>
                     <label>
-                        { _("Addons:  ") }
+                        { _("Addons: ") }
                         <span className="value">
                             { _(String(subscriptionsClient.toArray(this.props.syspurpose["addons"]).join(", "))) }
                         </span>

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -182,7 +182,7 @@ Source0: %{name}-%{version}.tar.gz
 # this is a little different from the Source0, because of limitations in tito,
 # namely that tito expects only one source tarball
 %if %{use_cockpit}
-Source1: %{name}-cockpit-%{version}.tar.gz
+Source1: %{name}-cockpit-%{version}.tar
 %endif
 %if 0%{?suse_version}
 Source2: subscription-manager-rpmlintrc
@@ -711,7 +711,7 @@ install -m 644 %{_builddir}/%{buildsubdir}/etc-conf/redhat-uep.pem %{buildroot}/
 
 %if %use_cockpit
     # install cockpit dist targz
-    tar --strip-components=1 -xzf %{SOURCE1} -C %{buildroot}
+    tar --strip-components=1 -xf %{SOURCE1} -C %{buildroot}
 %endif
 
 %if %{with python3}


### PR DESCRIPTION
* It wasn't possible to create rpmdiff rpm with our cockpit plugin
  (subscription-manager-cockpit) due to binary files in RPM.
  This commit tries to fix this issue. Content is not compressed
  tarball, but content is simple tarball (rpm is compressed using cpio).
* Testing of cockpit CI