### PR TITLE
Cockpit CI updates

### DIFF
--- a/integration-tests/run
+++ b/integration-tests/run
@@ -57,11 +57,7 @@ $(VM_IMAGE): $(COCKPIT_TAR) $(SUBMAN_TAR) $(SMBEXT_TAR) bots
 # checkout Cockpit's bots for standard test VM images and API to launch them
 # must be from master, as only that has current and existing images; but testvm.py API is stable
 bots:
-	if [ ! -d bots ]; then \
-		git clone --depth=1 https://github.com/cockpit-project/bots.git; \
-	else \
-		cd bots && git fetch && git reset --hard origin/master; \
-        fi
+	git clone --depth=1 https://github.com/cockpit-project/bots.git
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time
@@ -79,4 +75,4 @@ cockpit/node_modules:
 	mkdir cockpit/node_modules
 	cd cockpit/ && npm install
 
-.PHONY: check prepare reset bots
+.PHONY: check prepare reset

--- a/integration-tests/run
+++ b/integration-tests/run
@@ -17,7 +17,7 @@
 # for more information about the Cockpit integration test machinery.
 
 ifeq ($(TEST_OS),)
-TEST_OS = rhel-8-0
+TEST_OS = rhel-8-1
 endif
 export TEST_OS
 VM_IMAGE=$(CURDIR)/integration-tests/images/$(TEST_OS).qcow2

--- a/integration-tests/run
+++ b/integration-tests/run
@@ -56,8 +56,16 @@ $(VM_IMAGE): $(COCKPIT_TAR) $(SUBMAN_TAR) $(SMBEXT_TAR) bots
 
 # checkout Cockpit's bots for standard test VM images and API to launch them
 # must be from master, as only that has current and existing images; but testvm.py API is stable
+# support CI testing against a bots change
 bots:
-	git clone --depth=1 https://github.com/cockpit-project/bots.git
+	git clone --quiet \
+		--reference-if-able $${XDG_CACHE_HOME:-$$HOME/.cache}/cockpit-project/bots \
+		https://github.com/cockpit-project/bots.git
+	if [ -n "$$COCKPIT_BOTS_REF" ]; then \
+	    git -C bots fetch --quiet --depth=1 origin "$$COCKPIT_BOTS_REF"; \
+	    git -C bots checkout --quiet FETCH_HEAD; \
+	fi
+	@echo "checked out bots/ ref $$(git -C bots rev-parse HEAD)"
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time

--- a/integration-tests/run
+++ b/integration-tests/run
@@ -70,7 +70,7 @@ bots:
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time
 integration-test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 191
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 204
 	git archive FETCH_HEAD -- test/common | tar -x -C integration-tests --strip-components=1 -f -
 
 node_modules:


### PR DESCRIPTION
Ported from recent changes to starter-kit. The first one is crucial to ensure that our CI and image updates changes don't break subscription-manager.