### PR TITLE
No need for inotify on suse

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -83,6 +83,7 @@
 %global use_firstboot 0
 %global use_subman_gui 0
 %global use_container_plugin 0
+%global use_inotify 0
 %endif
 
 %if (%{use_subman_gui} || %{use_initial_setup} || %{use_firstboot})


### PR DESCRIPTION
As an artefact of #2167 we started requiring python-inotify on suse. This really is a weak dependency at best and not something we have historically supported. As such this PR removes it. 