### PR TITLE
D-BUS API: Better listing of provided products

### DIFF
--- a/src/rhsmlib/services/entitlement.py
+++ b/src/rhsmlib/services/entitlement.py
@@ -242,7 +242,7 @@ class EntitlementService(object):
             if hasattr(cert.pool, "id"):
                 pool_id = cert.pool.id
 
-            product_names = [p.name for p in cert.products]
+            provided_products = {p.id: p.name for p in cert.products}
 
             reasons = []
             pool_type = ''
@@ -268,7 +268,7 @@ class EntitlementService(object):
             if roles is None and usage is None and addons is None:
                 consumed_statuses.append(OldConsumedStatus(
                     name,
-                    product_names,
+                    provided_products,
                     sku,
                     contract,
                     account,
@@ -287,7 +287,7 @@ class EntitlementService(object):
             else:
                 consumed_statuses.append(ConsumedStatus(
                     name,
-                    product_names,
+                    provided_products,
                     sku,
                     contract,
                     account,

--- a/src/subscription_manager/jsonwrapper.py
+++ b/src/subscription_manager/jsonwrapper.py
@@ -91,4 +91,4 @@ class PoolWrapper(object):
 
     def get_provided_products(self):
         products = self.data.get('providedProducts', [])
-        return [prod.get('productName') for prod in products]
+        return {prod.get('productId'): prod.get('productName') for prod in products}

--- a/src/subscription_manager/printing_utils.py
+++ b/src/subscription_manager/printing_utils.py
@@ -64,6 +64,8 @@ def columnize(caption_list, callback, *args, **kwargs):
     output = []
     for (caption, value) in lines:
         kwargs['caption'] = caption
+        if isinstance(value, dict):
+            value = [val for val in value.values()]
         if isinstance(value, list):
             if value:
                 # Put the first value on the same line as the caption


### PR DESCRIPTION
* When list of available or consumed list is returned, then the
  list of provided products was changed to dictionary. Key is
  id of provided product and value is name of provided product.
  It will be easier to reference provided product in cockpit
  plugin. This change was introduced in PR #2176.
* Listing of consumed and available subscriptions is not affected
  in subscription-manager CLI or GUI