### PR TITLE
1738764: Fix issue with syspurpose three-way merge; ENT-1564

### DIFF
--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -42,17 +42,17 @@ def add_command(args, syspurposestore):
     :param syspurposestore: An SyspurposeStore object to manipulate
     :return: None
     """
-    any_addon_added = False
+    any_prop_added = False
     for value in args.values:
         if syspurposestore.add(args.prop_name, value):
-            any_addon_added = True
+            any_prop_added = True
             print(_("Added {value} to {prop_name}.").format(
                 value=make_utf8(value), prop_name=make_utf8(args.prop_name)))
         else:
             print(_("Not adding value {value} to {prop_name}; it already exists.").format(
                 value=make_utf8(value), prop_name=make_utf8(args.prop_name)))
 
-    if any_addon_added is False:
+    if any_prop_added is False:
         return
 
     success_msg = _("{attr} updated.").format(attr=make_utf8(args.prop_name))
@@ -60,7 +60,7 @@ def add_command(args, syspurposestore):
     command = "syspurpose add-{name} ".format(name=args.prop_name) + to_add
     check_result(
         syspurposestore,
-        expectation=lambda res: all(x in res.get('addons', []) for x in args.values),
+        expectation=lambda res: all(x in res.get(args.prop_name, []) for x in args.values),
         success_msg=success_msg,
         command=command,
         attr=args.prop_name
@@ -178,117 +178,159 @@ def setup_arg_parser():
 
     # Generic assignments
     # Set ################
-    generic_set_parser = subparsers.add_parser("set",
-        help=_("Sets the value for the given property"))
+    generic_set_parser = subparsers.add_parser(
+        "set",
+        help=_("Sets the value for the given property")
+    )
 
-    generic_set_parser.add_argument("prop_name",
+    generic_set_parser.add_argument(
+        "prop_name",
         metavar="property",
         help=_("The name of the property to set/update"),
-        action="store")
+        action="store"
+    )
 
-    generic_set_parser.add_argument("value",
+    generic_set_parser.add_argument(
+        "value",
         help=_("The value to set"),
-        action="store")
+        action="store"
+    )
 
     generic_set_parser.set_defaults(func=set_command, requires_sync=True)
 
     # Unset ##############
-    generic_unset_parser = subparsers.add_parser("unset",
+    generic_unset_parser = subparsers.add_parser(
+        "unset",
         help=_("Unsets (clears) the value for the given property"),
-        parents=[unset_options])
+        parents=[unset_options]
+    )
 
-    generic_unset_parser.add_argument("prop_name",
+    generic_unset_parser.add_argument(
+        "prop_name",
         metavar="property",
         help=_("The name of the property to set/update"),
-        action="store")
+        action="store"
+    )
 
     # Add ################
-    generic_add_parser = subparsers.add_parser("add",
-        help=_("Adds the value(s) to the given property"))
+    generic_add_parser = subparsers.add_parser(
+        "add",
+        help=_("Adds the value(s) to the given property")
+    )
 
-    generic_add_parser.add_argument("prop_name",
+    generic_add_parser.add_argument(
+        "prop_name",
         metavar="property",
         help=_("The name of the property to update"),
-        action="store")
+        action="store"
+    )
 
-    generic_add_parser.add_argument("values",
+    generic_add_parser.add_argument(
+        "values",
         help=_("The value(s) to add"),
         action="store",
-        nargs="+")
+        nargs="+"
+    )
 
     generic_add_parser.set_defaults(func=add_command, requires_sync=True)
 
     # Remove #############
-    generic_remove_parser = subparsers.add_parser("remove",
-        help=_("Removes the value(s) from the given property"))
+    generic_remove_parser = subparsers.add_parser(
+        "remove",
+        help=_("Removes the value(s) from the given property")
+    )
 
-    generic_remove_parser.add_argument("prop_name",
+    generic_remove_parser.add_argument(
+        "prop_name",
         metavar="property",
         help=_("The name of the property to update"),
-        action="store")
+        action="store"
+    )
 
-    generic_remove_parser.add_argument("values",
+    generic_remove_parser.add_argument(
+        "values",
         help=_("The value(s) to remove"),
         action="store",
-        nargs="+")
+        nargs="+"
+    )
 
     generic_remove_parser.set_defaults(func=remove_command, requires_sync=True)
     # Targeted commands
     # Roles ##########
-    set_role_parser = subparsers.add_parser("set-role",
+    set_role_parser = subparsers.add_parser(
+        "set-role",
         help=_("Set the system role to the system syspurpose"),
-        parents=[set_options])
+        parents=[set_options]
+    )
     # TODO: Set prop_name from schema file
     set_role_parser.set_defaults(prop_name="role")
 
-    unset_role_parser = subparsers.add_parser("unset-role",
+    unset_role_parser = subparsers.add_parser(
+        "unset-role",
         help=_("Clear set role"),
-        parents=[unset_options])
+        parents=[unset_options]
+    )
     unset_role_parser.set_defaults(prop_name="role")
 
     # ADDONS #############
-    add_addons_parser = subparsers.add_parser("add-addons",
+    add_addons_parser = subparsers.add_parser(
+        "add-addons",
         help=_("Add addons to the system syspurpose"),
-        parents=[add_options])
+        parents=[add_options]
+    )
     # TODO: Set prop_name from schema file
     add_addons_parser.set_defaults(prop_name="addons")
 
-    remove_addons_parser = subparsers.add_parser("remove-addons",
+    remove_addons_parser = subparsers.add_parser(
+        "remove-addons",
         help=_("Remove addons from the system syspurpose"),
-        parents=[remove_options])
+        parents=[remove_options]
+    )
     remove_addons_parser.set_defaults(prop_name="addons")
 
-    unset_role_parser = subparsers.add_parser("unset-addons",
+    unset_role_parser = subparsers.add_parser(
+        "unset-addons",
         help=_("Clear set addons"),
-        parents=[unset_options])
+        parents=[unset_options]
+    )
     unset_role_parser.set_defaults(prop_name="addons")
 
     # SLA ################
-    set_sla_parser = subparsers.add_parser("set-sla",
+    set_sla_parser = subparsers.add_parser(
+        "set-sla",
         help=_("Set the system sla"),
-        parents=[set_options])
+        parents=[set_options]
+    )
     set_sla_parser.set_defaults(prop_name="service_level_agreement")
 
-    unset_sla_parser = subparsers.add_parser("unset-sla",
+    unset_sla_parser = subparsers.add_parser(
+        "unset-sla",
         help=_("Clear set sla"),
-        parents=[unset_options])
+        parents=[unset_options]
+    )
     unset_sla_parser.set_defaults(prop_name="service_level_agreement")
 
     # USAGE ##############
-    set_usage_parser = subparsers.add_parser("set-usage",
-       help=_("Set the system usage"),
-       parents=[set_options])
+    set_usage_parser = subparsers.add_parser(
+        "set-usage",
+        help=_("Set the system usage"),
+        parents=[set_options]
+    )
 
     set_usage_parser.set_defaults(prop_name="usage")
 
-    unset_usage_parser = subparsers.add_parser("unset-usage",
+    unset_usage_parser = subparsers.add_parser(
+        "unset-usage",
         help=_("Clear set usage"),
-        parents=[unset_options])
+        parents=[unset_options]
+    )
     unset_usage_parser.set_defaults(prop_name="usage")
 
     # Pretty Print Json contents of default syspurpose file
-    show_parser = subparsers.add_parser("show",
-        help=_("Show the current system syspurpose"))
+    show_parser = subparsers.add_parser(
+        "show",
+        help=_("Show the current system syspurpose")
+    )
     show_parser.set_defaults(func=show_contents, requires_sync=False)
 
     return parser

--- a/syspurpose/test/syspurpose/test_cli.py
+++ b/syspurpose/test/syspurpose/test_cli.py
@@ -79,6 +79,17 @@ class SyspurposeCliTests(SyspurposeTestBase):
             cli.add_command(args, self.syspurposestore)
             self.assertTrue('Added ADDON1 to addons' in captured.out)
 
+    def test_add_generic_command_one_value(self):
+        """
+        A smoke test to ensure nothing bizarre happens when we try to add some attribute (not addons)
+        """
+        args = MagicMock()
+        args.prop_name = "foo"
+        args.values = ["BAR1"]
+        with Capture() as captured:
+            cli.add_command(args, self.syspurposestore)
+            self.assertTrue('Added BAR1 to foo' in captured.out)
+
     def test_add_command_more_values(self):
         """
         A smoke test to ensure nothing bizarre happens when we try to add more addons attribute
@@ -91,6 +102,19 @@ class SyspurposeCliTests(SyspurposeTestBase):
             self.assertTrue('Added ADDON1 to addons' in captured.out)
             self.assertTrue('Added ADDON2 to addons' in captured.out)
             self.assertTrue('addons updated.' in captured.out)
+
+    def test_add_generic_command_more_value(self):
+        """
+        A smoke test to ensure nothing bizarre happens when we try to add more generic list attribute
+        """
+        args = MagicMock()
+        args.prop_name = "foo"
+        args.values = ["BAR1", "BAR2"]
+        with Capture() as captured:
+            cli.add_command(args, self.syspurposestore)
+            self.assertTrue('Added BAR1 to foo' in captured.out)
+            self.assertTrue('Added BAR2 to foo' in captured.out)
+            self.assertTrue('foo updated.' in captured.out)
 
     def test_add_command_existing_values(self):
         """
@@ -151,6 +175,22 @@ class SyspurposeCliTests(SyspurposeTestBase):
         with Capture() as captured:
             cli.remove_command(args, self.syspurposestore)
             self.assertTrue('Removed "ADDON1" from addons' in captured.out)
+
+    def test_generic_remove_command(self):
+        """
+        A smoke test to ensure nothing bizarre happens when we try to remove one value from generic list
+        """
+        args = MagicMock()
+
+        # Add value first
+        args.prop_name = "foo"
+        args.values = ["BAR1"]
+        cli.add_command(args, self.syspurposestore)
+
+        # Now we can try to remove value
+        with Capture() as captured:
+            cli.remove_command(args, self.syspurposestore)
+            self.assertTrue('Removed "BAR1" from foo' in captured.out)
 
     def test_show_command(self):
         """

--- a/syspurpose/test/syspurpose/test_syspurposefiles.py
+++ b/syspurpose/test/syspurpose/test_syspurposefiles.py
@@ -944,7 +944,6 @@ class TestThreeWayMerge(SyspurposeTestBase):
     def test_merge(self):
         """
         Shows that a change in only one place does not consitute a conflict.
-        :return:
         """
         base = {"C": "base"}
         remote = {"A": "remote", "C": "remote"}
@@ -963,7 +962,6 @@ class TestThreeWayMerge(SyspurposeTestBase):
         """
         This test shows that remote wins by default in the case of concurrent modification of
         a shared key. It also shows that the on_conflict kwarg can override this.
-        :return:
         """
         shared_key = "C"
         base = {shared_key: "base"}
@@ -986,7 +984,6 @@ class TestThreeWayMerge(SyspurposeTestBase):
         This test shows that remote wins by default in the case of concurrent modification of
         a shared key even when the shared key is not in the base.
         It also shows that the on_conflict kwarg can override this.
-        :return:
         """
         shared_key = "C"
         base = {}
@@ -1007,7 +1004,6 @@ class TestThreeWayMerge(SyspurposeTestBase):
     def test_merge_conflicting_lists(self):
         """
         This test shows that lists are treated atomically (as in we do not merge differing lists).
-        :return:
         """
         shared_key = "C"
         base = {shared_key: ["base"]}
@@ -1031,13 +1027,38 @@ class TestThreeWayMerge(SyspurposeTestBase):
     def test_merge_remote_missing_field(self):
         """
         Shows that if the server does not support a field, local gets to modify it.
-        :return:
         """
         base = {"B": None}
         remote = {}
         local = {"B": "local"}
 
         expected = {"B": "local"}
+
+        result = three_way_merge(local=local, base=base, remote=remote)
+        self.assert_equal_dict(expected, result)
+
+    def test_merge_remote_empty_field(self):
+        """
+        Shows that if the server has field with empty string, local gets to modify it.
+        """
+        base = {"B": None}
+        remote = {"B": ""}
+        local = {"B": "local"}
+
+        expected = {"B": "local"}
+
+        result = three_way_merge(local=local, base=base, remote=remote)
+        self.assert_equal_dict(expected, result)
+
+    def test_merge_missing_remote_list(self):
+        """
+        Shows that if the server does not have list, local can add it.
+        """
+        base = {"B": None}
+        remote = {}
+        local = {"B": ["local"]}
+
+        expected = {"B": ["local"]}
 
         result = three_way_merge(local=local, base=base, remote=remote)
         self.assert_equal_dict(expected, result)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1738764
* The BZ bug report contained actually two issues.
  - It wasn't possible to add other list than addons (minor issue)
  - When some attribute was removed and user tried to add new
    one again, then confusing warning was printed to stdout.
    It happened, because server set removed attribute to empty
    string, but removed attribute is completely removed from
    syspurpose.json. Maybe we should be consisten on client and
    server side too, because current implementatin is not
    clean. Topic for discussion.
* Fixed some style issues
* Added several unit tests for these two cases