### PR TITLE
1764340: Handle RestlibException in zypper plugin

### DIFF
--- a/src/zypper/services/rhsm
+++ b/src/zypper/services/rhsm
@@ -82,7 +82,11 @@ class ZypperService(object):
         self.ca_cert_dir = cfg.get('rhsm', 'ca_cert_dir')
 
     def main(self):
-        self.update()
+        try:
+            self.update()
+        except connection.RestlibException as e:
+            sys.stderr.write('Error while syncing: %s; repos will not be updated.' % e.msg)
+            sys.stderr.write('\n')
         self.warn_or_give_usage_message()
         self.warn_expired()
         self.print_zypper_repos()


### PR DESCRIPTION
With this change, if subman cannot reach Candlepin, then the repo file
should be written properly anyways (using last known state).