### PR TITLE
1764265: Set gpgcheck to 0, when zypper is used; ENT-1758

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,9 @@ install-conf:
 		install -m 644 etc-conf/subscription-manager-gui.completion.sh $(DESTDIR)/$(COMPLETION_DIR)/subscription-manager-gui; \
 		install -m 644 etc-conf/rhsm-icon.completion.sh $(DESTDIR)/$(COMPLETION_DIR)/rhsm-icon; \
 	fi;
+	if [[ -f /etc/SuSE-release ]]; then \
+	    install -m 644 etc-conf/zypper.conf $(DESTDIR)/etc/rhsm/; \
+	fi;
 
 .PHONY: install-plugins
 install-plugins:

--- a/etc-conf/zypper.conf
+++ b/etc-conf/zypper.conf
@@ -1,0 +1,6 @@
+[rhsm-plugin]
+# It is possible to disable rhsm zypper plugin
+enabled = 1
+
+# When gpgcheck is set to 0, then 'gpgcheck' will be set to 0 in generated repo file too.
+gpgcheck = 0

--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -42,7 +42,6 @@ from rhsm.config import initConfig
 
 from rhsmlib.services import config
 
-
 log = logging.getLogger(__name__)
 
 conf = config.Config(initConfig())
@@ -527,7 +526,11 @@ class YumRepoFile(RepoFileBase, ConfigParser):
 
 
 class ZypperRepoFile(YumRepoFile):
+    """
+    Class for manipulation of repo file on systems using Zypper (SuSE, OpenSuse).
+    """
 
+    ZYPP_RHSM_PLUGIN_CONFIG_FILE = '/etc/rhsm/zypper.conf'
     PATH = 'etc/rhsm/zypper.repos.d'
     NAME = 'redhat.repo'
     REPOFILE_HEADER = """#
@@ -544,8 +547,20 @@ class ZypperRepoFile(YumRepoFile):
 
     def __init__(self, path=None, name=None):
         super(ZypperRepoFile, self).__init__(path, name)
+        self.gpgcheck = False
+
+    def read_zypp_conf(self):
+        """
+        Read configuration file for zypper plugin
+        :return: None
+        """
+        zypp_cfg = configparser.ConfigParser()
+        zypp_cfg.read(self.ZYPP_RHSM_PLUGIN_CONFIG_FILE)
+        if zypp_cfg.has_option('rhsm-plugin', 'gpgcheck'):
+            self.gpgcheck = zypp_cfg.getboolean('rhsm-plugin', 'gpgcheck')
 
     def fix_content(self, content):
+        self.read_zypp_conf()
         zypper_cont = content.copy()
         sslverify = zypper_cont['sslverify']
         sslcacert = zypper_cont['sslcacert']
@@ -567,6 +582,10 @@ class ZypperRepoFile(YumRepoFile):
         # clean up data for zypper
         if zypper_cont['gpgkey'] in ['https://', 'http://']:
             del zypper_cont['gpgkey']
+
+        # See BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1764265
+        if self.gpgcheck is False:
+            zypper_cont['gpgcheck'] = '0'
 
         baseurl = zypper_cont['baseurl']
         parsed = urlparse(baseurl)
@@ -602,12 +621,12 @@ def init_repo_file_classes():
     repo_file_classes = [YumRepoFile, ZypperRepoFile]
     if HAS_DEB822:
         repo_file_classes.append(AptRepoFile)
-    repo_files = [
+    _repo_files = [
         (RepoFile, RepoFile.server_value_repo_file)
         for RepoFile in repo_file_classes
         if RepoFile.installed()
     ]
-    return repo_files
+    return _repo_files
 
 
 def get_repo_file_classes():

--- a/src/zypper/services/rhsm
+++ b/src/zypper/services/rhsm
@@ -28,6 +28,9 @@ from subscription_manager import logutil
 from rhsm import connection
 from rhsm import config
 
+from six.moves.configparser import ConfigParser
+
+
 c_rehash = '/usr/bin/c_rehash'
 
 expired_warning = \
@@ -72,16 +75,42 @@ class RepoLocker(Locker):
 
 
 class ZypperService(object):
+
+    ZYPP_RHSM_PLUGIN_CONFIG_FILE = '/etc/rhsm/zypper.conf'
+
     def __init__(self):
         logutil.init_logger()
         init_dep_injection()
         self.is_root = os.getuid() == 0
-        # Read subscription-manager config
+        self.full_refresh_on_yum = None
+        self.ca_cert_dir = None
+        self.gpgcheck = False
+        self.plugin_enabled = True
+
+    def read_rhsm_conf(self):
+        """
+        Read rhsm configuration file
+        :return: None
+        """
         cfg = config.initConfig()
         self.full_refresh_on_yum = bool(cfg.get_int('rhsm', 'full_refresh_on_yum'))
         self.ca_cert_dir = cfg.get('rhsm', 'ca_cert_dir')
 
+    def read_zypp_conf(self):
+        """
+        Read configuration file specific for zypper
+        :return: None
+        """
+        zypp_cfg = ConfigParser()
+        zypp_cfg.read(self.ZYPP_RHSM_PLUGIN_CONFIG_FILE)
+        if zypp_cfg.has_option('rhsm-plugin', 'enabled'):
+            self.plugin_enabled = zypp_cfg.getboolean('rhsm-plugin', 'enabled')
+
     def main(self):
+        """
+        Main plugin method
+        :return:
+        """
         try:
             self.update()
         except connection.RestlibException as e:
@@ -92,7 +121,9 @@ class ZypperService(object):
         self.print_zypper_repos()
 
     def update(self):
-        """ update entitlement certificates """
+        """
+        Update entitlement certificates
+        """
         if not self.is_root:
             sys.stderr.write('Not root, Subscription Management repositories not updated')
             sys.stderr.write("\n")
@@ -123,8 +154,11 @@ class ZypperService(object):
         else:
             sys.stderr.write("WARNING: c_rehash could not be found!\n")
 
-    def warn_expired(self):
-        """ display warning for expired entitlements """
+    @staticmethod
+    def warn_expired():
+        """
+        Display warning for expired entitlements
+        """
         ent_dir = inj.require(inj.ENT_DIR)
         products = set()
         for cert in ent_dir.list_expired():
@@ -137,7 +171,9 @@ class ZypperService(object):
             sys.stderr.write("\n")
 
     def warn_or_give_usage_message(self):
-        """ either output a warning, or a usage message """
+        """
+        Either output a warning, or a usage message
+        """
         msg = ""
         if not self.is_root:
             return
@@ -157,7 +193,8 @@ class ZypperService(object):
                 sys.stderr.write(msg)
                 sys.stderr.write("\n")
 
-    def print_zypper_repos(self):
+    @staticmethod
+    def print_zypper_repos():
         try:
             repo_file = ZypperRepoFile()
             with open(repo_file.path) as repo:
@@ -173,6 +210,17 @@ if __name__ == '__main__':
         sys.exit(0)
 
     service = ZypperService()
+    service.read_rhsm_conf()
+    service.read_zypp_conf()
+
+    if service.plugin_enabled is False:
+        sys.stderr.write('plugin disabled in configuration file: %s' % service.ZYPP_RHSM_PLUGIN_CONFIG_FILE)
+        sys.stderr.write('\n')
+        sys.exit(0)
+    else:
+        sys.stderr.write('plugin enabled in configuration file: %s' % service.ZYPP_RHSM_PLUGIN_CONFIG_FILE)
+        sys.stderr.write('\n')
+
     service.main()
 
     # suppress python-dmidecode warnings

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -868,6 +868,10 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %attr(644,root,root) %config(noreplace) %{_sysconfdir}/rhsm/rhsm.conf
 %config %attr(644,root,root) %{_sysconfdir}/rhsm/logging.conf
 
+%if 0%{?suse_version}
+    %attr(644,root,root) %config(noreplace) %{_sysconfdir}/rhsm/zypper.conf
+%endif
+
 # PAM config
 %if !0%{?suse_version}
 %{_sysconfdir}/pam.d/subscription-manager


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1764265
* This is workaround for Zypper. Repo file is generated with
  option gpgcheck equal to 0.