### PR TITLE
1728054: Obsolete sm-plugin-container on RHEL 8

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -367,6 +367,10 @@ BuildRequires: systemd-rpm-macros
 BuildRequires: systemd
 %endif
 
+%if !%{use_container_plugin}
+Obsoletes: subscription-manager-plugin-container
+%endif
+
 %description
 The Subscription Manager package provides programs and libraries to allow users
 to manage subscriptions and yum repositories from the Red Hat entitlement


### PR DESCRIPTION
In the prior iteration of this bug fix we were missing an obsoletes to let dnf/rpm know that the subscription-manager-plugin-container package could be uninstalled. Without this, upgrades from systems with the subscription-manager-plugin-container of the subscription-manager package fail with conflicting requirements.