### PR TITLE
Make sure to set the mtime of the py files before creating pyc

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -813,13 +813,13 @@ install -m 644 %{_builddir}/%{buildsubdir}/etc-conf/redhat-uep.pem %{buildroot}/
     tar --strip-components=1 -xzf %{SOURCE1} -C %{buildroot}
 %endif
 
+# fix timestamps on our byte compiled files so they match across arches
+find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
+
 %if %{with python3}
 %py_byte_compile %{__python3} %{buildroot}%{rhsm_plugins_dir}/
 %py_byte_compile %{__python3} %{buildroot}%{_datadir}/anaconda/addons/com_redhat_subscription_manager/
 %endif
-
-# fix timestamps on our byte compiled files so they match across arches
-find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 
 # symlink services to /usr/sbin/ when building for SUSE distributions
 %if 0%{?suse_version}


### PR DESCRIPTION
So this is a fairly long story but one worth capturing.
Python compiles py source files to pyc python bytecode files.
There is a really good intro to python bytecode here [0].

The result of python compiling it's source is a pyc file.
This file has a specific format dependent on the version of
python used to compile. Regardless of which python version
was used, the first chunk of the pyc file is a header with
metadata about the actual bytecode (which appears later in
the file).

As mentioned before, the exact format of this pyc file (header and
even the bytecode) is dependent on the version of python used but
there is a general format to it (as follows, afaict the bytes are
always little-endian):

unsigned short magic_number;
unsigned short magic_number_micro;
long mtime_of_source_file;
long size_of_actual_compiled_bytes;
bytes[] actual_compiled_bytecode (length above);

The magic_number is used by the python virtual machine to
determine if it can run it. You can see what this value
(including the micro version which never changes) is for
a version of python by running (should work on all released versions of python
though note the use of the now deprecated "imp" library):

python -c "import imp, binascii; print(binascii.hexlify(imp.get_magic()))"

This magic_number should map to a particular format for reading the pyc
file.

The mtime_of_source_file is used by python to determine whether or not
the pyc file can be used. To do this it checks the embedded mtime against
the mtime of the source file (py). If the source file has been modified more
recently than the pyc file, the pyc file is deleted and the py file recompiled.

So why does this matter to this project?

It matters because as a part of our release process (and due to the fact
that we have C extensions, see src/certificate.c) our packages are
rebuilt for multiple architectures. There is an expectation that
files be compatible between 32bit and 64bit architectures
(those that share a common base instruction set like, i686 and x86_64).
In addition there is an expectation that subsequent builds of a source
rpm on the same architecture produce the same output.

Thanks to the embedded mtime in the pyc files, this means we need
the source py files to have a reliable/stable mtime, which will
ensure that byte-for-byte comparisons between resulting pyc files
across compatible architectures will pass.

The way this is ensured is setting the mtime of all py files to
the same as the SOURCE0 (normally the tar.gz included in the srpm).

For future reference there is an accepted PEP that could help
us not run into this situation in the future[1] (for python 3.7+ builds).

[0]: https://opensource.com/article/18/4/introduction-python-bytecode
[1]: https://www.python.org/dev/peps/pep-0552/