### PR TITLE
1781887: Do not terminate zypper, when rhsm plugin is disabled; ENT-1818

### DIFF
--- a/src/zypper/services/rhsm
+++ b/src/zypper/services/rhsm
@@ -205,8 +205,12 @@ class ZypperService(object):
 
 if __name__ == '__main__':
     if 'ZYPP_RHSM_PLUGIN_DISABLE' in os.environ:
-        sys.stderr.write('ZYPP_RHSM_PLUGIN_DISABLE environment variable is set - plugin disabled')
-        sys.stderr.write('\n')
+        # See: https://bugzilla.redhat.com/show_bug.cgi?id=1781887
+        # it seems that sles 12 consider printing to stderr as the same as printing to stdout
+        # and following message is not .INI file format
+        #
+        # sys.stderr.write('ZYPP_RHSM_PLUGIN_DISABLE environment variable is set - plugin disabled')
+        # sys.stderr.write('\n')
         sys.exit(0)
 
     service = ZypperService()


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1781887
* TODO: testing on sles 12 required