### PR TITLE
1667792: added --disable-auto-attach option to register command; ENT-1684

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -230,6 +230,9 @@ subscription-manager register --org="IT Dept" --activationkey=1234abcd
 .B --auto-attach
 Automatically attaches compatible subscriptions to this system.
 
+.TP
+.B --disable-auto-attach
+Do not automatically attach compatible subscriptions, when activation key is used.
 
 .TP
 .B --servicelevel=LEVEL

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -978,7 +978,7 @@ class UEPConnection(object):
     def registerConsumer(self, name="unknown", type="system", facts={},
             owner=None, environment=None, keys=None,
             installed_products=None, uuid=None, hypervisor_id=None,
-            content_tags=None, role=None, addons=None, service_level=None, usage=None):
+            content_tags=None, role=None, addons=None, service_level=None, usage=None, autoheal=None):
         """
         Creates a consumer on candlepin server
         """
@@ -1004,6 +1004,8 @@ class UEPConnection(object):
             params['usage'] = usage
         if service_level is not None:
             params['serviceLevel'] = service_level
+        if autoheal is not None:
+            params['autoheal'] = autoheal
 
         url = "/consumers"
         if environment:

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -34,7 +34,7 @@ class RegisterService(object):
         self.cp = cp
 
     def register(self, org, activation_keys=None, environment=None, force=None, name=None, consumerid=None,
-            type=None, role=None, addons=None, service_level=None, usage=None, **kwargs):
+            type=None, role=None, addons=None, service_level=None, usage=None, autoheal=None, **kwargs):
         # We accept a kwargs argument so that the DBus object can pass the options dictionary it
         # receives transparently to the service via dictionary unpacking.  This strategy allows the
         # DBus object to be more independent of the service implementation.
@@ -88,7 +88,8 @@ class RegisterService(object):
                 role=role,
                 addons=addons,
                 service_level=service_level,
-                usage=usage
+                usage=usage,
+                autoheal=autoheal
             )
         self.installed_mgr.write_cache()
         self.plugin_manager.run("post_register_consumer", consumer=consumer, facts=facts_dict)

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -472,6 +472,12 @@ class TestRegisterCommand(TestCliProxyCommand):
     def test_key_and_org(self):
         self._test_no_exception(["--activationkey", "key", "--org", "org"])
 
+    def test_key_and_disable_auto_attach(self):
+        self._test_no_exception(["--activationkey", "key", "--org", "org", "--disable-auto-attach"])
+
+    def test_auto_attach_and_disable_auto_attach(self):
+        self._test_exception(["--auto-attach", "--disable-auto-attach"])
+
     def test_key_and_no_org(self):
         self._test_exception(["--activationkey", "key"])
 


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1667792
* When system is registered using CLI tool and activation key is
  used, then --disable-auto-attach option can be used and
  auto-attach process is disabled during registration process
* New option --disable-auto-attach cannot be used with --auto-attach
  option
* Added two unit tests for this case
* Modified man pages
* Modified register service to support auto-attach
* Added unit test for auto-attach option in register service
* TODO: fix issue in candlepin server, because candlepin server
  ignores autoheal option during registration