### PR TITLE
1761566: include kpatch in facts; ENT-1700

### DIFF
--- a/src/rhsm/utils.py
+++ b/src/rhsm/utils.py
@@ -67,6 +67,29 @@ class UnsupportedOperationException(Exception):
     pass
 
 
+def which(program):
+    """
+    Function returning path of program (it could be path to executable file or command)
+    :param program: string with command
+    :return: Path to command, when some executable exists in system. Otherwise it returns None.
+    """
+
+    def is_exe(_fpath):
+        return os.path.isfile(_fpath) and os.access(_fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None
+
+
 def has_bad_scheme(url):
     """Check a url for an invalid or unuseful schema.
 

--- a/src/rhsmlib/facts/all.py
+++ b/src/rhsmlib/facts/all.py
@@ -17,6 +17,7 @@ from rhsmlib.facts import custom
 from rhsmlib.facts import host_collector
 from rhsmlib.facts import hwprobe
 from rhsmlib.facts import insights
+from rhsmlib.facts import kpatch
 
 
 class AllFactsCollector(collector.FactsCollector):
@@ -26,7 +27,8 @@ class AllFactsCollector(collector.FactsCollector):
             host_collector.HostCollector(),
             hwprobe.HardwareCollector(),
             custom.CustomFactsCollector(),
-            insights.InsightsCollector()
+            insights.InsightsCollector(),
+            kpatch.KPatchCollector()
         ]
 
     def get_all(self):

--- a/src/rhsmlib/facts/kpatch.py
+++ b/src/rhsmlib/facts/kpatch.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import
+
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+import logging
+import os
+
+from rhsmlib.facts import collector
+from rhsm.utils import which
+
+log = logging.getLogger(__name__)
+
+
+class KPatchCollector(collector.FactsCollector):
+    """
+    Class used for collecting facts related to installed and loaded liver kernel patches (kpatch)
+    """
+
+    DIR_WITH_INSTALLED_KPATCH_MODULES = "/var/lib/kpatch"
+
+    # Current kpatch module can be in several directories according version of kpatch
+    DIRS_WITH_LOADED_MODULE = [
+        "/sys/kernel/livepatch",
+        "/sys/kernel/kpatch/patches",
+        "/sys/kernel/kpatch"
+    ]
+
+    def get_all(self):
+        return self.get_kpatch_info()
+
+    def get_kpatch_info(self):
+        """
+        Get all information about kpatch on current system
+        :return: dictionary with kpatch information
+        """
+        kpatch_info = {}
+
+        if self._is_kpatch_installed():
+            kpatch_info['kpatch.installed'] = self._get_installed_live_kernel_patches()
+            kpatch_info['kpatch.loaded'] = self._get_loaded_live_kernel_patch()
+
+        return kpatch_info
+
+    @staticmethod
+    def _is_kpatch_installed():
+        """
+        Check if kpatch is installed
+        :return: Return true, when kpatch CLI tool is installed. Otherwise return False
+        """
+        return which('kpatch') is not None
+
+    def _get_installed_live_kernel_patches(self):
+        """
+        Return list of installed live kernel patches
+        :return: list of strings with live kernel patches
+        """
+        installed_kpatches = []
+
+        # Directory with installed kpatches contains several directories
+        # Each directory should contain installed kpatch
+        if os.path.isdir(self.DIR_WITH_INSTALLED_KPATCH_MODULES):
+            files = os.listdir(self.DIR_WITH_INSTALLED_KPATCH_MODULES)
+            for kpatch in files:
+                if os.path.isdir(os.path.join(self.DIR_WITH_INSTALLED_KPATCH_MODULES, kpatch)):
+                    installed_kpatches.append(kpatch)
+
+        return " ".join(installed_kpatches)
+
+    def _get_loaded_live_kernel_patch(self):
+        """
+        Get currently used kpatch
+        :return: String with current kpach
+        """
+        current_kpatch = ""
+
+        # Installed kpatches can be installed in several directories.
+        # Use first existing directory from the list
+        for kpatch_dir in self.DIRS_WITH_LOADED_MODULE:
+            if os.path.isdir(kpatch_dir):
+                files = os.listdir(kpatch_dir)
+                for kpatch in files:
+                    if os.path.isdir(os.path.join(kpatch_dir, kpatch)):
+                        current_kpatch = kpatch
+                break
+
+        return current_kpatch

--- a/test/rhsm/unit/util_tests.py
+++ b/test/rhsm/unit/util_tests.py
@@ -7,7 +7,7 @@ from rhsm.utils import remove_scheme, get_env_proxy_info, \
     ServerUrlParseErrorEmpty, ServerUrlParseErrorNone, \
     ServerUrlParseErrorPort, ServerUrlParseErrorScheme, \
     ServerUrlParseErrorJustScheme, has_bad_scheme, has_good_scheme, \
-    parse_url, cmd_name
+    parse_url, cmd_name, which
 from rhsm.config import DEFAULT_PORT, DEFAULT_PREFIX, DEFAULT_HOSTNAME
 
 
@@ -421,3 +421,23 @@ class TestCmdName(unittest.TestCase):
     def test_rhsmd(self):
         argv = ['/usr/libexec/rhsmd', '-i', '-f', 'valid']
         self.assertEqual("rhsmd", cmd_name(argv))
+
+
+class TestWhich(unittest.TestCase):
+    def test_which_python(self):
+        """Some python command just has to exist :-)"""
+        cmd_path = which('python')
+        self.assertIsNotNone(cmd_path)
+
+    def test_which_bin_sh(self):
+        """Assumed that Linux is used and some /bin/sh exist"""
+        cmd_path = which('/bin/sh')
+        self.assertIsNotNone(cmd_path)
+
+    def test_which_not_existing_command(self):
+        cmd_path = which('not-existing-command')
+        self.assertIsNone(cmd_path)
+
+    def test_which_not_existing_command_path(self):
+        cmd_path = which('/not/existing/command/path/not-existing-command')
+        self.assertIsNone(cmd_path)

--- a/test/rhsmlib_test/test_kpatch.py
+++ b/test/rhsmlib_test/test_kpatch.py
@@ -1,0 +1,68 @@
+from __future__ import print_function, division, absolute_import
+
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from mock import patch
+import tempfile
+import shutil
+import os
+
+from rhsmlib.facts import kpatch
+
+
+class TestKPatchCollector(unittest.TestCase):
+    def setUp(self):
+        self.DIR_WITH_INSTALLED_KPATCH_MODULES = tempfile.mkdtemp()
+        os.mkdir(os.path.join(self.DIR_WITH_INSTALLED_KPATCH_MODULES, "3.10.0-1062.el7.x86_64"))
+        os.mkdir(os.path.join(self.DIR_WITH_INSTALLED_KPATCH_MODULES, "3.10.0-1062.1.1.el7.x86_64"))
+        os.mkdir(os.path.join(self.DIR_WITH_INSTALLED_KPATCH_MODULES, "3.10.0-1062.1.2.el7.x86_64"))
+        self.DIRS_WITH_LOADED_MODULE = [
+            "/path/to/not-existing-directory",
+            tempfile.mkdtemp()
+        ]
+        os.mkdir(os.path.join(self.DIRS_WITH_LOADED_MODULE[1], "3.10.0-1062.el7.x86_64"))
+
+    def tearDown(self):
+        shutil.rmtree(self.DIRS_WITH_LOADED_MODULE[1])
+        shutil.rmtree(self.DIR_WITH_INSTALLED_KPATCH_MODULES)
+
+    @patch('rhsmlib.facts.kpatch.which')
+    def test_kpatch_is_not_installed(self, which):
+        which.return_value = None
+        collector = kpatch.KPatchCollector()
+        kpatch_facts = collector.get_all()
+        self.assertEqual(kpatch_facts, {})
+
+    @patch('rhsmlib.facts.kpatch.which')
+    def test_get_kpatch_facts(self, which):
+        which.return_value = '/usr/sbin/kpatch'
+        collector = kpatch.KPatchCollector()
+        collector.DIR_WITH_INSTALLED_KPATCH_MODULES = self.DIR_WITH_INSTALLED_KPATCH_MODULES
+        collector.DIRS_WITH_LOADED_MODULE = self.DIRS_WITH_LOADED_MODULE
+        kpatch_facts = collector.get_all()
+        self.assertIn('kpatch.loaded', kpatch_facts)
+        self.assertEqual(kpatch_facts['kpatch.loaded'], '3.10.0-1062.el7.x86_64')
+        self.assertIn('kpatch.installed', kpatch_facts)
+        installed_kpatches = sorted(kpatch_facts['kpatch.installed'].split())
+        self.assertEqual(len(installed_kpatches), 3)
+        self.assertEqual(
+            installed_kpatches,
+            ['3.10.0-1062.1.1.el7.x86_64', '3.10.0-1062.1.2.el7.x86_64', '3.10.0-1062.el7.x86_64']
+        )


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1761566
* Information about live kernel patches are included in reported
  facts. There are new keys: "kpatch.installed" and
  "kpatch.loaded". These keys are reported only in case that
  kpatch binary is installed.
* Added two unit tests for new facts
* Added which method to rhsm.utils. Functionality of this method
  is similar to which linux command.
* Added unit tests for which method