### PR TITLE
Refactoring of DNF subscription-manager plugin; ENT-1906

### DIFF
--- a/src/dnf-plugins/product-id.py
+++ b/src/dnf-plugins/product-id.py
@@ -33,6 +33,8 @@ import librepo
 import os
 from rhsm import ourjson as json
 
+log = logging.getLogger('rhsm-app.' + __name__)
+
 
 class ProductId(dnf.Plugin):
     name = 'product-id'
@@ -64,7 +66,7 @@ class ProductId(dnf.Plugin):
         try:
             init_dep_injection()
         except ImportError as e:
-            logger.error(str(e))
+            log.error(str(e))
             return
 
         logutil.init_logger_for_yum()
@@ -74,10 +76,7 @@ class ProductId(dnf.Plugin):
             pm.update_all(self._enabled_repos)
             logger.info(_('Installed products updated.'))
         except Exception as e:
-            logger.error(str(e))
-
-
-log = logging.getLogger('rhsm-app.' + __name__)
+            log.error(str(e))
 
 
 class DnfProductManager(ProductManager):

--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -40,7 +40,9 @@ expired_warning = """
 *** WARNING ***
 The subscription for following product(s) has expired:
 %s
-You no longer have access to the repositories that provide these products.  It is important that you apply an active subscription in order to resume access to security and other critical updates. If you don't have other active subscriptions, you can renew the expired subscription.
+You no longer have access to the repositories that provide these products.  It is important that you apply an active "
+"subscription in order to resume access to security and other critical updates. If you don't have other active "
+"subscriptions, you can renew the expired subscription.
 """
 
 not_registered_warning = """
@@ -48,7 +50,8 @@ This system is not registered with an entitlement server. You can use subscripti
 """
 
 no_subs_warning = """
-This system is registered with an entitlement server, but is not receiving updates. You can use subscription-manager to assign subscriptions.
+This system is registered with an entitlement server, but is not receiving updates. You can use subscription-manager "
+"to assign subscriptions.
 """
 
 no_subs_container_warning = """
@@ -106,8 +109,9 @@ def update(conduit, cache_only):
         cert_action_invoker = EntCertActionInvoker(locker=YumRepoLocker(conduit=conduit))
         cert_action_invoker.update()
 
-    repo_action_invoker = RepoActionInvoker(cache_only=cache_only, locker=YumRepoLocker(conduit=conduit))
-    repo_action_invoker.update()
+    if cache_only or config.in_container():
+        repo_action_invoker = RepoActionInvoker(cache_only=cache_only, locker=YumRepoLocker(conduit=conduit))
+        repo_action_invoker.update()
 
 
 def warn_expired_entitlements(conduit):
@@ -156,7 +160,7 @@ def warn_or_usage_message(conduit):
 def init_hook(conduit):
     """
     Hook for disabling system repositories (repositories which are
-    not mangaged by subscription-manager will NOT be used)
+    not managed by subscription-manager will NOT be used)
     """
 
     disable_system_repos = conduit.confBool('main', 'disable_system_repos', default=False)
@@ -169,7 +173,11 @@ def init_hook(conduit):
                 conduit.info(2, 'Disabling system repository "%s" in file "%s"' % (repo.id, repo.repofile))
                 repo_storage.disableRepo(repo.id)
                 disable_count += 1
-        conduit.info(2, 'subscription-manager plugin disabled "%d" system repositories with respect of configuration in /etc/yum/pluginconf.d/subscription-manager.conf' % (disable_count))
+        conduit.info(
+            2,
+            'subscription-manager plugin disabled "%d" system repositories with respect of configuration in '
+            '/etc/yum/pluginconf.d/subscription-manager.conf' % disable_count
+        )
 
 
 def config_hook(conduit):

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -184,7 +184,7 @@ class YumPluginManager(object):
 
 
 class RepoActionInvoker(BaseActionInvoker):
-    """Invoker for yum repo updating related actions."""
+    """Invoker for yum/dnf repo updating related actions."""
     def __init__(self, cache_only=False, locker=None):
         super(RepoActionInvoker, self).__init__(locker=locker)
         self.cache_only = cache_only
@@ -200,8 +200,7 @@ class RepoActionInvoker(BaseActionInvoker):
         return repo in [c.label for c in action.matching_content()]
 
     def get_repos(self, apply_overrides=True):
-        action = RepoUpdateActionCommand(cache_only=self.cache_only,
-                                  apply_overrides=apply_overrides)
+        action = RepoUpdateActionCommand(cache_only=self.cache_only, apply_overrides=apply_overrides)
         repos = action.get_unique_content()
 
         current = set()
@@ -377,8 +376,6 @@ class RepoUpdateActionCommand(object):
         # Only attempt to update the overrides if they are supported
         # by the server.
         if self.override_supported:
-            self.written_overrides.read_cache_only()
-
             try:
                 override_cache = inj.require(inj.OVERRIDE_STATUS_CACHE)
             except KeyError:


### PR DESCRIPTION
* Changed names of methods to be more pythonic
* Do not try to get content overrides twice, when configuration
  option rhsm.full_refresh_on_yum is set to 1. Same optimization
  was implemented for YUM plugin
* Fixed small bug in repolib.py
* Added support for debug print to DNF subscription-manager plugin
* Do not try to connect to candlepin server, when
  rhsm.full_refresh_on_yum is set to 0, because it is useless.
* Changed one debug print in product-id plugin
* Some long strings were split into more lines