### PR TITLE
1798909: renamed auto-attach command to auto-heal command

### DIFF
--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -473,10 +473,10 @@ class TestRegisterCommand(TestCliProxyCommand):
         self._test_no_exception(["--activationkey", "key", "--org", "org"])
 
     def test_key_and_disable_auto_attach(self):
-        self._test_no_exception(["--activationkey", "key", "--org", "org", "--disable-auto-attach"])
+        self._test_no_exception(["--activationkey", "key", "--org", "org", "--disable-auto-heal"])
 
     def test_auto_attach_and_disable_auto_attach(self):
-        self._test_exception(["--auto-attach", "--disable-auto-attach"])
+        self._test_no_exception(["--auto-attach", "--disable-auto-heal"])
 
     def test_key_and_no_org(self):
         self._test_exception(["--activationkey", "key"])


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1798909
* Renamed auto-attach command to auto-heal
  - auto-attach still works, but it is marked as deprecated
* Option of register command --disable-auto-attach was removed
  to --disable-auto-heal
  - This option is possible to use with --auto-attach option
  - This option is possible to use for registration using
    username and password
* Fixed two unit tests
* TODO: wait for approvement from PMs