### PR TITLE
1797386: Allow service plugin for zypper (SLES 11 only) to set autorefresh

### DIFF
--- a/etc-conf/zypper.conf
+++ b/etc-conf/zypper.conf
@@ -4,3 +4,6 @@ enabled = 1
 
 # When gpgcheck is set to 0, then 'gpgcheck' will be set to 0 in generated repo file too.
 gpgcheck = 0
+
+# Enable/Disable autorefresh on all repositories
+autorefresh = 0

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -500,6 +500,12 @@ class RepoUpdateActionCommand(object):
         if zypper_repo_file.gpgcheck is False:
             zypper_cont['gpgcheck'] = '0'
 
+        # See BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1797386
+        if zypper_repo_file.autorefresh is True:
+            zypper_cont['autorefresh'] = '1'
+        else:
+            zypper_cont['autorefresh'] = '0'
+
         baseurl = zypper_cont['baseurl']
         parsed = urlparse(baseurl)
         zypper_query_args = parse_qs(parsed.query)
@@ -1067,6 +1073,7 @@ class ZypperRepoFile(YumRepoFile):
     def __init__(self, path=None, name=None):
         super(ZypperRepoFile, self).__init__(path, name)
         self.gpgcheck = False
+        self.autorefresh = False
 
     def read_zypp_conf(self):
         """
@@ -1077,3 +1084,5 @@ class ZypperRepoFile(YumRepoFile):
         zypp_cfg.read(self.ZYPP_RHSM_PLUGIN_CONFIG_FILE)
         if zypp_cfg.has_option('rhsm-plugin', 'gpgcheck'):
             self.gpgcheck = zypp_cfg.getboolean('rhsm-plugin', 'gpgcheck')
+        if zypp_cfg.has_option('rhsm-plugin', 'autorefresh'):
+            self.autorefresh = zypp_cfg.getboolean('rhsm-plugin', 'autorefresh')

--- a/src/zypper/services/rhsm
+++ b/src/zypper/services/rhsm
@@ -84,6 +84,7 @@ class ZypperService(object):
         self.full_refresh_on_yum = None
         self.ca_cert_dir = None
         self.gpgcheck = False
+        self.autorefresh = False
         self.plugin_enabled = True
 
     def read_rhsm_conf(self):


### PR DESCRIPTION
This is the same functional change as https://github.com/candlepin/subscription-manager/pull/2211, but specifically for the 1.20 back-revved subscription-manager for SLES 11sp4.

There is a bug in zypper in SLES 11 that does not honor changes to the autorefresh value after the repo file has been created, but that bug is being addressed by SUSE separately.  Once that bugfix is released, the updates in this PR will be functional