### PR TITLE
1794826: Added option --force for command refresh; ENT-2033

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -166,7 +166,8 @@ _subscription_manager_redeem()
 
 _subscription_manager_refresh()
 {
-  local opts="${_subscription_manager_common_opts}"
+  local opts="--force
+              ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }
 

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -485,8 +485,9 @@ command pulls the latest subscription data from the server. Normally, the system
 .B refresh
 command checks with the subscription management service right then, outside the normal interval.
 
-.PP
-This command has no options.
+.TP
+.B --force
+Force regeneration of entitlement certificates on the server before these certificates are pulled from the server.
 
 
 .SS ENVIRONMENTS OPTIONS

--- a/src/rhsmlib/services/entitlement.py
+++ b/src/rhsmlib/services/entitlement.py
@@ -439,4 +439,7 @@ class EntitlementService(object):
 
     def reload(self):
         sorter = inj.require(inj.CERT_SORTER, on_date=None)
+        status_cache = inj.require(inj.ENTITLEMENT_STATUS_CACHE)
+        log.debug('Clearing in-memory cache of file %s' % status_cache.CACHE_FILE)
+        status_cache.server_status = None
         sorter.load()

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -181,7 +181,7 @@ class CacheManager(object):
                 log.error("Error updating system data on the server")
                 log.exception(e)
                 raise Exception(_("Error updating system data on the server, see /var/log/rhsm/rhsm.log "
-                        "for more details."))
+                                  "for more details."))
         else:
             log.debug("No changes.")
             return 0  # No updates performed.
@@ -260,7 +260,10 @@ class StatusCache(CacheManager):
         the disk cache to the in-memory cache to avoid reading again.
         """
         if self.server_status is None:
+            log.debug('Trying to read status from %s file' % self.CACHE_FILE)
             self.server_status = super(StatusCache, self)._read_cache()
+        else:
+            log.debug('Reading status from in-memory cache of %s file' % self.CACHE_FILE)
         return self.server_status
 
     def _cache_exists(self):
@@ -268,11 +271,11 @@ class StatusCache(CacheManager):
         If a cache exists in memory, we have written it to the disk
         No need for unnecessary disk io here.
         """
-        if not self.server_status is None:
+        if self.server_status is not None:
             return True
         return super(StatusCache, self)._cache_exists()
 
-    def read_status(self, uep, uuid):
+    def read_status(self, uep, uuid, on_date=None):
         """
         Return status, from cache if it exists, otherwise load_status
         and write cache and return it.
@@ -287,7 +290,9 @@ class StatusCache(CacheManager):
         """
 
         if self.server_status is None:
-            self.server_status = self.load_status(uep, uuid)
+            self.server_status = self.load_status(uep, uuid, on_date)
+        else:
+            log.debug('Reading status from in-memory cache of %s file' % self.CACHE_FILE)
         return self.server_status
 
     def write_cache(self):

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -324,7 +324,8 @@ class CliCommand(AbstractCLICommand):
         self.parser.add_option("--serverurl", dest="server_url",
                                default=None, help=_("server URL in the form of https://hostname:port/prefix"))
         self.parser.add_option("--insecure", action="store_true",
-                                default=False, help=_("do not check the entitlement server SSL certificate against available certificate authorities"))
+                                default=False, help=_("do not check the entitlement server SSL certificate against "
+                                                      "available certificate authorities"))
 
     def _add_proxy_options(self):
         """ Add proxy options that apply to sub-commands that require network connections. """
@@ -843,22 +844,22 @@ class RefreshCommand(CliCommand):
 
         super(RefreshCommand, self).__init__("refresh", shortdesc, True)
 
+        self.parser.add_option("--force", action='store_true', help=_("force certificate regeneration"))
+
     def _do_command(self):
         self.assert_should_be_registered()
         try:
-            # get current consumer identity
-            identity = inj.require(inj.IDENTITY)
-
             # remove content_access cache, ensuring we get it fresh
             content_access = inj.require(inj.CONTENT_ACCESS_CACHE)
             if content_access.exists():
                 content_access.remove()
 
-            # Force a regen of the entitlement certs for this consumer
-            # TODO: Eventually migrate this to capability recognition. Currently it will silently return
-            #   false if an error occurs
-            if not self.cp.regenEntitlementCertificates(identity.uuid, True):
-                log.debug("Warning: Unable to refresh entitlement certificates; service likely unavailable")
+            if self.options.force is True:
+                # get current consumer identity
+                consumer_identity = inj.require(inj.IDENTITY)
+                # Force a regen of the entitlement certs for this consumer
+                if not self.cp.regenEntitlementCertificates(consumer_identity.uuid, True):
+                    log.debug("Warning: Unable to refresh entitlement certificates; service likely unavailable")
 
             self.entcertlib.update()
 
@@ -883,7 +884,8 @@ class IdentityCommand(UserPassCommand):
         self.parser.add_option("--regenerate", action='store_true',
                                help=_("request a new certificate be generated"))
         self.parser.add_option("--force", action='store_true',
-                               help=_("force certificate regeneration (requires username and password); Only used with --regenerate"))
+                               help=_("force certificate regeneration (requires username and password); "
+                                      "Only used with --regenerate"))
 
     def _validate_options(self):
         self.assert_should_be_registered()

--- a/test/test_cert_sorter.py
+++ b/test/test_cert_sorter.py
@@ -107,6 +107,7 @@ class CertSorterTests(SubManFixture):
     def test_no_usable_status(self, mock_update):
         self.status_mgr.load_status = Mock(
                 return_value=None)
+        self.status_mgr.server_status = None
         sorter = CertSorter()
         sorter.is_registered = Mock(return_value=True)
         self.assertEqual(UNKNOWN, sorter.get_status(INST_PID_1))
@@ -116,6 +117,7 @@ class CertSorterTests(SubManFixture):
     def test_deleted_consumer_status(self, mock_update):
         self.status_mgr.load_status = Mock(
                 return_value=None)
+        self.status_mgr.server_status = None
         sorter = CertSorter()
         sorter.is_registered = Mock(return_value=True)
         expected = subscription_manager.cert_sorter.STATUS_MAP['unknown']
@@ -125,6 +127,7 @@ class CertSorterTests(SubManFixture):
     def test_unregistered_system_status(self, mock_update):
         self.status_mgr.load_status = Mock(
                 return_value=None)
+        self.status_mgr.server_status = None
         sorter = CertSorter()
         sorter.is_registered = Mock(return_value=False)
         expected = subscription_manager.cert_sorter.STATUS_MAP['unknown']

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -405,6 +405,9 @@ class TestCleanCommand(TestCliCommand):
 class TestRefreshCommand(TestCliProxyCommand):
     command_class = managercli.RefreshCommand
 
+    def test_force_option(self):
+        self.cc.main(["--force"])
+
 
 class TestIdentityCommand(TestCliProxyCommand):
 


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1794826
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1796088
  - Cloned BZ for RHEL 7
* Added option --force for command refresh. When this option is
  used, then entitlement certificates are regenerated on
  candlepin server.
* Also REST API calls were optimized and following call:

    GET /candlepin/consumers/{uuid}/compliance

  is called only once (not 4 times). This optimization should
  influence other commands (e.g. register). It is optimized,
  because status is cached in memory. It is attribute of
  class ComplianceManager
* TODO:
  - Do more testing due to caching of status. It will be
    probably necessary to obsolete this in memory cache
    in some cases.
  - Write some unit tests for new functionality