### PR TITLE
Ensure serial existence before comparison

### DIFF
--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -500,10 +500,10 @@ class Certificate(object):
         return self.end > other.end
 
     def __eq__(self, other):
-        return self.serial == other.serial
+        return hasattr(other, 'serial') and self.serial == other.serial
 
     def __ne__(self, other):
-        return self.serial != other.serial
+        return not hasattr(other, 'serial') or self.serial != other.serial
 
     def __hash__(self):
         return self.serial


### PR DESCRIPTION
When comparing for equality (or not equality) with certificates
try to use the 'serial' attribute of the other object.
Check for the 'serial' attribute first and require their values
to be equal for the certificates to be equal (likewise for ne).
This allows us to ensure we are comparing something equitable.