### PR TITLE
Implementation of getting organization using D-Bus API; ENT-1760

### DIFF
--- a/src/rhsmlib/dbus/base_object.py
+++ b/src/rhsmlib/dbus/base_object.py
@@ -66,7 +66,7 @@ class BaseObject(dbus.service.Object):
                 "This object requires the consumer to be registered before it can be used."
             )
 
-    def build_uep(self, options, proxy_only=False):
+    def build_uep(self, options, proxy_only=False, basic_auth_method=False):
         conf = config.Config(rhsm.config.initConfig())
         # Some commands/services only allow manipulation of the proxy information for a connection
         cp_provider = inj.require(inj.CP_PROVIDER)
@@ -89,7 +89,7 @@ class BaseObject(dbus.service.Object):
         cp_provider.set_connection_info(**connection_info)
         cp_provider.set_correlation_id(utils.generate_correlation_id())
 
-        if self.is_registered():
+        if self.is_registered() and basic_auth_method is False:
             return cp_provider.get_consumer_auth_cp()
         elif 'username' in options and 'password' in options:
             cp_provider.set_user_pass(options['username'], options['password'])

--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -91,6 +91,35 @@ class DomainSocketRegisterDBusObject(base_object.BaseObject):
 
     @dbus.service.method(
         dbus_interface=constants.PRIVATE_REGISTER_INTERFACE,
+        in_signature='ssa{sv}s',
+        out_signature='s'
+    )
+    @util.dbus_handle_exceptions
+    def GetOrgs(self, username, password, connection_options, locale):
+        """
+        This method tries to return list of organization user belongs to. This method also uses
+        basic authentication method (using username and password).
+
+        :param username: string with username used for connection to candlepin server
+        :param password: string with password
+        :param connection_options: dictionary with connection options
+        :param locale: string with locale
+        :return: string with json returned by candlepin server
+        """
+        connection_options = dbus_utils.dbus_to_python(connection_options, expected_type=dict)
+        connection_options['username'] = dbus_utils.dbus_to_python(username, expected_type=str)
+        connection_options['password'] = dbus_utils.dbus_to_python(password, expected_type=str)
+        locale = dbus_utils.dbus_to_python(locale, expected_type=str)
+
+        Locale.set(locale)
+        cp = self.build_uep(connection_options, basic_auth_method=True)
+
+        owners = cp.getOwnerList(connection_options['username'])
+
+        return json.dumps(owners)
+
+    @dbus.service.method(
+        dbus_interface=constants.PRIVATE_REGISTER_INTERFACE,
         in_signature='sssa{sv}a{sv}s',
         out_signature='s'
     )


### PR DESCRIPTION
* Implemented GetOrgs() D-Bus method for Register service
  - It has 4 arguments. The first argument is username,
    the second argument is password, the third argument
    is dictionary with connection options and the last
    argument is string with locale
* Add one unit test for new method
* It can be tested using:

```
[root@localhost ~]# dbus-send --system --print-reply \
--dest='com.redhat.RHSM1' '/com/redhat/RHSM1/RegisterServer' \
com.redhat.RHSM1.RegisterServer.Start string:""
...
   string "unix:abstract=/var/run/dbus-LDibqhpU9H,guid=660..."

[root@localhost ~]# export \
my_addr="unix:abstract=/var/run/dbus-LDibqhpU9H,guid=660..."

[root@localhost ~]# busctl introspect --address="${my_addr}" \
com.redhat.RHSM1 /com/redhat/RHSM1/Register
NAME                                TYPE      SIGNATURE      RESULT/VALUE FLAGS
com.redhat.RHSM1.Register           interface -              -            -
.GetOrgs                            method    ssa{sv}s       s            -
.Register                           method    sssa{sv}a{sv}s s            -
.RegisterWithActivationKeys         method    sasa{sv}a{sv}s s            -
org.freedesktop.DBus.Introspectable interface -              -            -
.Introspect                         method    -              s            -
org.freedesktop.DBus.Properties     interface -              -            -
.GetAll                             method    s              a{sv}        -

[root@localhost ~]# dbus-send --address=${my_addr} --print-reply \
--dest='com.redhat.RHSM1.Register' '/com/redhat/RHSM1/Register' \
com.redhat.RHSM1.Register.GetOrgs string:"admin" string:"admin" \
dict:string:string:"","" string:""
```