### PR TITLE
List user's organization during registration process on CLI

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1542,6 +1542,11 @@ class RegisterCommand(UserPassCommand):
         if len(owners) == 1:
             return owners[0]['key']
 
+        if len(owners) > 1:
+            org_keys = [owner['key'] for owner in owners]
+            print(_('Hint: User "%s" is member of following organizations: %s') %
+                  (self.username, ', '.join(org_keys)))
+
         owner_key = None
         while not owner_key:
             owner_key = six.moves.input(_("Organization: "))


### PR DESCRIPTION
* I figured out that it would be useful to list user's
  organizations during registration, when subscription-manager
  CLI tool is used. It is not necessary to do another REST API
  call, because GET /candlepin/users/{username}/owners is called
  anyway. All we do now is listing results of this call before
  user has to enter the organization name.