### PR TITLE
Hint about environments is printed by subscription-manager during registration.

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1507,6 +1507,10 @@ class RegisterCommand(UserPassCommand):
                     log.debug('Using the only available environment: "%s"' % env_list[0]['name'])
                     return env_list[0]['id']
 
+                env_name_list = [env['name'] for env in env_list]
+                print(_('Hint: Organization "%s" contains following environments: %s') %
+                      (owner_key, ", ".join(env_name_list)))
+
                 environment_name = self._prompt_for_environment()
 
                 # Should only ever be len 0 or 1


### PR DESCRIPTION
* When organization contains more than one environment and
  environment is not specified using command line option,
  then subscription-manager prints hint with list of
  available entitlements now. So user can easily choose
  one of them.