### PR TITLE
1804114: New D-Bus method SetAll; ENT-2124

### DIFF
--- a/cockpit/src/index.js
+++ b/cockpit/src/index.js
@@ -64,51 +64,54 @@ let footerProps = {
 };
 
 function openRegisterDialog() {
-    // set config to what was loaded and clean previous credential information
-    Object.assign(registerDialogDetails, subscriptionsClient.config, {
-        user: '',
-        password: '',
-        activation_keys: '',
-        org: '',
-        insights: false,
-        insights_available: subscriptionsClient.insightsAvailable,
-        insights_detected: false,
-        register_method: 'account',
-        auto_attach: true
-    });
+    // Read configuration file before opening register dialog
+    subscriptionsClient.readConfig().then(() => {
+        // set config to what was loaded and clean previous credential information
+        Object.assign(registerDialogDetails, subscriptionsClient.config, {
+            user: '',
+            password: '',
+            activation_keys: '',
+            org: '',
+            insights: false,
+            insights_available: subscriptionsClient.insightsAvailable,
+            insights_detected: false,
+            register_method: 'account',
+            auto_attach: true
+        });
 
-    Insights.detect().then(installed => {
-        registerDialogDetails.insights_detected = installed;
+        Insights.detect().then(installed => {
+            registerDialogDetails.insights_detected = installed;
 
-        // show dialog to register
-        let renderDialog;
-        let updatedData = function(prop, data) {
-            if (prop) {
-                if (data.target) {
-                    if (data.target.type === "checkbox") {
-                        registerDialogDetails[prop] = data.target.checked;
+            // show dialog to register
+            let renderDialog;
+            let updatedData = function(prop, data) {
+                if (prop) {
+                    if (data.target) {
+                        if (data.target.type === "checkbox") {
+                            registerDialogDetails[prop] = data.target.checked;
+                        } else {
+                            registerDialogDetails[prop] = data.target.value;
+                        }
                     } else {
-                        registerDialogDetails[prop] = data.target.value;
+                        registerDialogDetails[prop] = data;
                     }
-                } else {
-                    registerDialogDetails[prop] = data;
                 }
-            }
 
-            registerDialogDetails.onChange = updatedData;
+                registerDialogDetails.onChange = updatedData;
 
-            let dialogProps = {
-                'id': 'register_dialog',
-                'title': _("Register System"),
-                'body': React.createElement(subscriptionsRegister.dialogBody, registerDialogDetails),
+                let dialogProps = {
+                    'id': 'register_dialog',
+                    'title': _("Register System"),
+                    'body': React.createElement(subscriptionsRegister.dialogBody, registerDialogDetails),
+                };
+
+                if (renderDialog)
+                    renderDialog.setProps(dialogProps);
+                else
+                    renderDialog = Dialog.show_modal_dialog(dialogProps, footerProps);
             };
-
-            if (renderDialog)
-                renderDialog.setProps(dialogProps);
-            else
-                renderDialog = Dialog.show_modal_dialog(dialogProps, footerProps);
-        };
-        updatedData();
+            updatedData();
+        });
     });
 }
 

--- a/cockpit/src/subscriptions-client.js
+++ b/cockpit/src/subscriptions-client.js
@@ -598,8 +598,11 @@ client.getSyspurpose = function() {
     return dfd.promise();
 };
 
-client.readConfig = () => {
-    return safeDBusCall(configService, () => {
+client.readConfig = function() {
+    let dfd = cockpit.defer();
+
+    safeDBusCall(configService, () => {
+        console.debug('Reading configuration file');
         configService.GetAll(userLang).then(config => {
             const hostname = config.server.v.hostname;
             const port = config.server.v.port;
@@ -641,8 +644,13 @@ client.readConfig = () => {
                 loaded: true,
             });
             console.debug('loaded client config', client.config);
+            dfd.resolve();
+        }).catch(ex => {
+            console.debug(ex);
         });
     });
+
+    return dfd.promise();
 };
 
 client.toArray = obj => {

--- a/src/dnf-plugins/product-id.py
+++ b/src/dnf-plugins/product-id.py
@@ -17,7 +17,6 @@ from __future__ import print_function, division, absolute_import
 
 import logging
 
-from subscription_manager import logutil
 from subscription_manager.productid import ProductManager
 from subscription_manager.utils import chroot
 from subscription_manager.injectioninit import init_dep_injection
@@ -31,7 +30,9 @@ import dnf.exceptions
 import errno
 import librepo
 import os
-from rhsm import ourjson as json
+from rhsm import ourjson as json, logutil
+
+log = logging.getLogger('rhsm-app.' + __name__)
 
 log = logging.getLogger('rhsm-app.' + __name__)
 

--- a/src/dnf-plugins/subscription-manager.py
+++ b/src/dnf-plugins/subscription-manager.py
@@ -26,7 +26,7 @@ from subscription_manager.entcertlib import EntCertActionInvoker
 from rhsmlib.facts.hwprobe import ClassicCheck
 from subscription_manager.utils import chroot
 from subscription_manager.injectioninit import init_dep_injection
-from subscription_manager import logutil
+from rhsm import logutil
 from rhsm import config
 
 from dnfpluginscore import _, logger

--- a/src/dnf-plugins/subscription-manager.py
+++ b/src/dnf-plugins/subscription-manager.py
@@ -75,7 +75,7 @@ class SubscriptionManager(dnf.Plugin):
 
         chroot(self.base.conf.installroot)
 
-        cfg = config.initConfig()
+        cfg = config.get_config_parser()
         cache_only = not bool(cfg.get_int('rhsm', 'full_refresh_on_yum'))
 
         try:
@@ -188,7 +188,7 @@ class SubscriptionManager(dnf.Plugin):
         """
         Call Package Profile
         """
-        cfg = config.initConfig()
+        cfg = config.get_config_parser()
         if '1' == cfg.get('rhsm', 'package_profile_on_trans'):
             log.debug('Uploading package profile')
             package_profile_client = ProfileActionClient()

--- a/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
+++ b/src/initial-setup/com_redhat_subscription_manager/gui/spokes/rhsm_gui.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     from pyanaconda.core.constants import ANACONDA_ENVIRON
 
-from subscription_manager import logutil
+from rhsm import logutil
 
 logutil.init_logger()
 log = logging.getLogger(__name__)

--- a/src/plugins/product-id.py
+++ b/src/plugins/product-id.py
@@ -21,7 +21,7 @@ import logging
 import yum
 from yum.plugins import TYPE_CORE
 
-from subscription_manager import logutil
+from rhsm import logutil
 from subscription_manager.productid import ProductManager, RpmVersion
 from subscription_manager.utils import chroot
 from subscription_manager.injectioninit import init_dep_injection

--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -28,8 +28,7 @@ from rhsmlib.facts.hwprobe import ClassicCheck
 from subscription_manager.certlib import Locker
 from subscription_manager.utils import chroot
 from subscription_manager.injectioninit import init_dep_injection
-from subscription_manager import logutil
-from rhsm import config
+from rhsm import config, logutil
 
 requires_api_version = '2.5'
 plugin_type = (TYPE_CORE,)

--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -221,7 +221,7 @@ def prereposetup_hook(conduit):
     :return: None
     """
 
-    cfg = config.initConfig()
+    cfg = config.get_config_parser()
     cache_only = not bool(cfg.get_int('rhsm', 'full_refresh_on_yum'))
 
     try:
@@ -236,7 +236,7 @@ def posttrans_hook(conduit):
     :param conduit:
     :return: None
     """
-    cfg = config.initConfig()
+    cfg = config.get_config_parser()
     if '1' == cfg.get('rhsm', 'package_profile_on_trans'):
         conduit.info(3, "Updating package profile")
         package_profile_client = ProfileActionClient()

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -124,6 +124,17 @@ class RhsmConfigParser(SafeConfigParser):
         SafeConfigParser.__init__(self)
         self.read(self.config_file)
 
+    def read(self, file_names=None):
+        """
+        Read configuration files. When configuration files are not specified, then read self.config_file
+        :param file_names: list of configuration files
+        :return: number of configuration files read
+        """
+        if file_names is None:
+            return super(RhsmConfigParser, self).read(self.config_file)
+        else:
+            return super(RhsmConfigParser, self).read(file_names)
+
     def save(self, config_file=None):
         """Writes config file to storage."""
         with tempfile.NamedTemporaryFile(mode="w", dir=os.path.dirname(self.config_file), delete=False) as fo:
@@ -304,29 +315,22 @@ class RhsmHostConfigParser(RhsmConfigParser):
             self.set('rhsm', 'entitlementcertdir', ent_cert_dir)
 
 
-def initConfig(config_file=None):
+def get_config_parser():
     """
     Get an :class:`RhsmConfig` instance
 
     Will use the first config file defined in the following list:
-
-    - argument to this method if provided (only for tests)
     - /etc/rhsm-host/rhsm.conf if it exists (only in containers)
     - /etc/rhsm/rhsm.conf
     """
     global CFG
-    # If a config file was specified, assume we should overwrite the global config
-    # to use it. This should only be used in testing. Could be switch to env var?
-    if config_file:
-        CFG = RhsmConfigParser(config_file=config_file)
-        return CFG
 
     try:
         CFG = CFG
     except NameError:
         CFG = None
-    if CFG is None:
 
+    if CFG is None:
         # Load alternate config file implementation if we detect that we're
         # running in a container.
         if in_container():

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -34,7 +34,7 @@ from rhsm.https import httplib, ssl
 from six.moves.urllib.request import proxy_bypass
 from six.moves.urllib.parse import urlencode, quote, quote_plus
 
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 from rhsm import ourjson as json
 from rhsm import utils
 
@@ -44,7 +44,7 @@ try:
 except ImportError:
     subman_version = "unknown"
 
-config = initConfig()
+config = get_config_parser()
 
 
 def safe_int(value, safe_value=None):

--- a/src/rhsm/logutil.py
+++ b/src/rhsm/logutil.py
@@ -154,7 +154,7 @@ def init_logger(config=None):
         log.warning("logging already initialized")
 
     if config is None:
-        config = rhsm.config.initConfig()
+        config = rhsm.config.get_config_parser()
 
     default_log_level = config.get('logging', 'default_log_level')
     pending_error_messages = []

--- a/src/rhsm/logutil.py
+++ b/src/rhsm/logutil.py
@@ -144,7 +144,7 @@ def _get_default_subman_debug_handler():
     return _subman_debug_handler
 
 
-def init_logger():
+def init_logger(config=None):
     """Load logging config file and setup logging.
 
     Only needs to be called once per process."""
@@ -153,7 +153,8 @@ def init_logger():
     if log:
         log.warning("logging already initialized")
 
-    config = rhsm.config.initConfig()
+    if config is None:
+        config = rhsm.config.initConfig()
 
     default_log_level = config.get('logging', 'default_log_level')
     pending_error_messages = []

--- a/src/rhsm_debug/debug_commands.py
+++ b/src/rhsm_debug/debug_commands.py
@@ -30,14 +30,14 @@ from subscription_manager.managercli import CliCommand
 from subscription_manager.cli import InvalidCLIOptionError, system_exit
 from subscription_manager.certdirectory import DEFAULT_PRODUCT_CERT_DIR
 from rhsm import ourjson as json
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 from rhsmlib.services import config
 
 from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger('rhsm-app.' + __name__)
 
-conf = config.Config(initConfig())
+conf = config.Config(get_config_parser())
 
 ERR_NOT_REGISTERED_MSG = _("This system is not yet registered. Try 'subscription-manager register --help' for more information.")
 ERR_NOT_REGISTERED_CODE = 1

--- a/src/rhsmlib/dbus/base_object.py
+++ b/src/rhsmlib/dbus/base_object.py
@@ -67,7 +67,7 @@ class BaseObject(dbus.service.Object):
             )
 
     def build_uep(self, options, proxy_only=False, basic_auth_method=False):
-        conf = config.Config(rhsm.config.initConfig())
+        conf = config.Config(rhsm.config.get_config_parser())
         # Some commands/services only allow manipulation of the proxy information for a connection
         cp_provider = inj.require(inj.CP_PROVIDER)
         if proxy_only:

--- a/src/rhsmlib/dbus/objects/config.py
+++ b/src/rhsmlib/dbus/objects/config.py
@@ -16,6 +16,8 @@ from __future__ import print_function, division, absolute_import
 import dbus
 import logging
 import six
+from iniparse import ini
+
 import rhsm
 import rhsm.config
 import rhsm.logutil
@@ -175,12 +177,17 @@ class ConfigDBusObject(base_object.BaseObject):
         """
         parser = rhsm.config.get_config_parser()
 
+        # We are going to read configuration file again, but we have to clean all data in parser object
+        # this way, because iniparse module doesn't provide better method to do that.
+        parser.data = ini.INIConfig(None, optionxformsource=parser)
+
         # We have to read parser again to get fresh data from the file
         files_read = parser.read()
 
-        self.config = Config(parser)
-        rhsm.logutil.init_logger(parser)
-        if files_read > 0:
+        if len(files_read) > 0:
+            log.debug('files read: %s' % str(files_read))
+            self.config = Config(parser)
+            rhsm.logutil.init_logger(parser)
             log.debug("Configuration file: %s reloaded: %s" % (parser.config_file, str(self.config)))
         else:
             log.warning("Unable to read configuration file: %s" % parser.config_file)

--- a/src/rhsmlib/dbus/objects/config.py
+++ b/src/rhsmlib/dbus/objects/config.py
@@ -173,10 +173,17 @@ class ConfigDBusObject(base_object.BaseObject):
         This callback method is called, when i-notify or periodical directory polling detects
         any change of rhsm.conf file. Thus configuration file is reloaded and new values are used.
         """
-        parser = rhsm.config.initConfig()
+        parser = rhsm.config.get_config_parser()
+
+        # We have to read parser again to get fresh data from the file
+        files_read = parser.read()
+
         self.config = Config(parser)
         rhsm.logutil.init_logger(parser)
-        log.debug("configuration file reloaded: %s" % str(self.config))
+        if files_read > 0:
+            log.debug("Configuration file: %s reloaded: %s" % (parser.config_file, str(self.config)))
+        else:
+            log.warning("Unable to read configuration file: %s" % parser.config_file)
 
 
 def temporary_disable_dir_watcher():

--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -26,7 +26,7 @@ ga_loader.init_ga()
 from subscription_manager.ga import GLib
 from functools import partial
 from rhsmlib.services import config
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 from rhsmlib.file_monitor import create_filesystem_watcher, DirectoryWatch
 from rhsmlib.file_monitor import CONSUMER_WATCHER, ENTITLEMENT_WATCHER, CONFIG_WATCHER, PRODUCT_WATCHER, \
     SYSPURPOSE_WATCHER
@@ -36,7 +36,7 @@ from rhsm.logutil import init_logger
 
 log = logging.getLogger(__name__)
 
-parser = initConfig()
+parser = get_config_parser()
 conf = config.Config(parser)
 
 init_logger(parser)

--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -822,7 +822,8 @@ if __name__ == '__main__':
     if _LIBPATH not in sys.path:
         sys.path.append(_LIBPATH)
 
-    from subscription_manager import logutil
+    from rhsm import logutil
+
     logutil.init_logger()
 
     hw = HardwareCollector(prefix=sys.argv[1], testing=True)

--- a/src/rhsmlib/file_monitor.py
+++ b/src/rhsmlib/file_monitor.py
@@ -13,7 +13,7 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 from rhsmlib.services import config
 from six.moves import configparser
 import logging
@@ -28,7 +28,7 @@ except ImportError:
 
 
 log = logging.getLogger(__name__)
-conf = config.Config(initConfig())
+conf = config.Config(get_config_parser())
 
 
 CONSUMER_WATCHER = "CONSUMER_WATCHER"

--- a/src/rhsmlib/file_monitor.py
+++ b/src/rhsmlib/file_monitor.py
@@ -31,6 +31,13 @@ log = logging.getLogger(__name__)
 conf = config.Config(initConfig())
 
 
+CONSUMER_WATCHER = "CONSUMER_WATCHER"
+ENTITLEMENT_WATCHER = "ENTITLEMENT_WATCHER"
+CONFIG_WATCHER = "CONFIG_WATCHER"
+PRODUCT_WATCHER = "PRODUCT_WATCHER"
+SYSPURPOSE_WATCHER = "SYSPURPOSE_WATCHER"
+
+
 class FilesystemWatcher(object):
     """
     Watches a set of directories and notifies when there are changes
@@ -40,14 +47,21 @@ class FilesystemWatcher(object):
     Uses a loop running in its own thread
     ** Use create_filesystem_watcher to create an instance of a filesystem_watcher
     """
+
+    # Timeout of loop in milliseconds
+    TIMEOUT = 2000
+
     def __init__(self, dir_watches):
         """
-        :param dir_watches: list of directories to watch (see DirectoryWatch class below)
+        :param dir_watches: dictionary of directories to watch (see DirectoryWatch class below)
         """
-        self.dir_watches = set(dir_watches)
+        self.dir_watches = dir_watches
         self.should_stop = False
 
     def stop(self):
+        """
+        Calling this method stops infinity loop of FileSystemWatcher
+        """
         self.should_stop = True
 
     def update(self):
@@ -78,7 +92,7 @@ class FilesystemWatcher(object):
         :return: set of changed dir watches
         """
         changed_dws = set()
-        for dir_watch in self.dir_watches:
+        for dir_watch in self.dir_watches.values():
             timestamp = self.get_mtime(dir_watch)
             if dir_watch.timestamp != timestamp:
                 changed_dws.add(dir_watch)
@@ -92,13 +106,18 @@ class FilesystemWatcher(object):
         Initializes timestamps for each dir watch in dir watch list, sets callback,
         notifies dir watch if it has changed
         :param user_end_loop_cb: callback function to be called at end of each iteration of the loop
-        :return:
         """
-        for dw in self.dir_watches:
+        for dw in self.dir_watches.values():
             dw.timestamp = self.get_mtime(dw)
+
+        # Never ending loop of watcher
         while not end_loop_cb(self, user_callback=user_end_loop_cb):
             self.update()
-            time.sleep(2.0)
+            # Try to update state of temporary disabled watchers
+            for dir_watch in self.dir_watches.values():
+                if dir_watch.temporary_disabled is True:
+                    dir_watch.update_temporary_disabled_watcher()
+            time.sleep(self.TIMEOUT / 1000.0)
         self.stop()
 
 
@@ -111,6 +130,10 @@ class InotifyFilesystemWatcher(FilesystemWatcher):
     Uses a loop running in its own thread
     ** Use create_filesystem_watcher to create instance of filesystem watcher
     """
+
+    # Timeout of i-notify notifier in milliseconds
+    TIMEOUT = 500
+
     def __init__(self, dir_watches):
         """
         Filesystem watcher if pyinotify is configured and available
@@ -125,43 +148,74 @@ class InotifyFilesystemWatcher(FilesystemWatcher):
         """
         sets up watch manager, notifier, adds watches to watch manager, and starts loop
         :param callback: callback method to be called at the end of each iteration of the loop
-        :return:
         """
         self.watch_manager = pyinotify.WatchManager()
-        self.notifier = pyinotify.Notifier(self.watch_manager, self.handle_event)
+        self.notifier = pyinotify.Notifier(
+            watch_manager=self.watch_manager,
+            default_proc_fun=self.handle_event
+        )
         self.add_watches()
 
         def inotify_callback():
+            """
+            This function checks if main loop should be ended or not
+            :return: True, when main loop should be ended. Otherwise return False.
+            """
             return end_loop_cb(self, user_callback=callback)
 
         while not inotify_callback():
             self.notifier.process_events()
-            if self.notifier.check_events(500):  # keeps tests reasonably fast while still timing out
+            # We use timeout to keep checks reasonably fast while still timing out
+            if self.notifier.check_events(self.TIMEOUT):
+                log.debug('Some i-notify event occured')
                 self.notifier.read_events()
+
+            for dir_watch in self.dir_watches.values():
+                if dir_watch.temporary_disabled is True:
+                    dir_watch.update_temporary_disabled_watcher()
 
     def handle_event(self, event):
         """
         default process function for pyinotify notifier
         :param event: pyinotify Event object, has path and mask of flags representing file modification
-        :return:
         """
-        for dir_watch in self.dir_watches:
-            if dir_watch.paths_match(event.path, event.pathname) and dir_watch.file_modified(event.mask):
+        log.debug('Some event occured: %s (%s)' % (event.path, event.pathname))
+
+        for dir_watch in self.dir_watches.values():
+            # When watcher is temporary disabled, ten
+            if dir_watch.temporary_disabled is True:
+                log.debug('Directory watcher: %s temporary disabled. Ignoring event.' % dir_watch.path)
+                continue
+            # The event has to happen on file/directory we are interested in and the type of event
+            # has to match the set of events we are interested in too
+            if dir_watch.paths_match(event.path, event.pathname) and dir_watch.is_file_modified(event.mask):
+                # Call all callbacks associated with dir_watch
                 dir_watch.notify()
 
     def add_watches(self):
         """
         adds watches to the watch manager
-        :return:
         """
-        for dir_watch in self.dir_watches:
+        for dir_watch in self.dir_watches.values():
+            log.debug('Added i-notifier watcher for: %s with mask: %s' %
+                      (dir_watch.path, dir_watch.mask))
             if dir_watch.is_file:
                 # watch for any changes in the directory, but only be notified of the specific path
                 dir_name = os.path.abspath(os.path.dirname(dir_watch.path))
-                self.watch_manager.add_watch(dir_name, dir_watch.mask, self.handle_event, do_glob=dir_watch.is_glob)
+                self.watch_manager.add_watch(
+                    path=dir_name,
+                    mask=dir_watch.mask,
+                    proc_fun=self.handle_event,
+                    do_glob=dir_watch.is_glob
+                )
             else:
                 # is already directory
-                self.watch_manager.add_watch(dir_watch.path, dir_watch.mask, self.handle_event, do_glob=dir_watch.is_glob)
+                self.watch_manager.add_watch(
+                    path=dir_watch.path,
+                    mask=dir_watch.mask,
+                    proc_fun=self.handle_event,
+                    do_glob=dir_watch.is_glob
+                )
 
 
 class DirectoryWatch(object):
@@ -172,6 +226,10 @@ class DirectoryWatch(object):
     Example usage:
         directory_watch = DirectoryWatch("~/home/", [my_function1, my_function2])
     """
+
+    # Time of temporary disablement of watcher in seconds
+    DISABLEMENT_TIMEOUT = 5.0
+
     def __init__(self, path, callbacks, is_glob=False):
         """
         :param path: path associated with directory to be watched
@@ -188,11 +246,12 @@ class DirectoryWatch(object):
         self.is_glob = is_glob
         self.callbacks = callbacks
         self.mask = self.IN_DELETE | self.IN_MODIFY | self.IN_MOVED_TO
+        self.temporary_disabled = False
+        self._time_tmp_dis = 0.0
 
     def notify(self):
         """
-        calls all callbacks associated with dir watch
-        :return:
+        Calls all callbacks associated with dir watch
         """
         for cb in self.callbacks:
             if cb is not None:
@@ -203,29 +262,61 @@ class DirectoryWatch(object):
 
     def paths_match(self, event_path, event_pathname):
         """
-        checks if event path matches any of the dir watch paths associated to it
-        :param event_path: path of the inotify event object
-        :param event_pathname: pathname of the inotify event object
-        see pyinotify event class for more info
+        Checks if event path matches any of the dir watch paths associated to it
+        :param event_path: path of the i-notify event object (directory)
+        :param event_pathname: pathname of the i-notify event object
+            see pyinotify event class for more info (directory/filename)
         :return: bool - if paths match or not
         """
-        event_pathname = os.path.realpath(event_pathname)
-        event_path = os.path.realpath(event_path)
-        if self.is_file:
-            # we do not care about events on other paths, like .swp files
-            return fnmatch.fnmatchcase(event_pathname, self.path)
-        return fnmatch.fnmatchcase(event_path, self.path)
 
-    def file_modified(self, event_mask):
+        # If we are looking for changes of file, then event_pathname has to be the
+        # same as self.path. We do not care about events on other paths, e.g. .swp
+        # files in this case.
+        if self.is_file:
+            event_pathname = os.path.realpath(event_pathname)
+            return fnmatch.fnmatchcase(event_pathname, self.path)
+        else:
+            event_path = os.path.realpath(event_path)
+            return fnmatch.fnmatchcase(event_path, self.path)
+
+    def is_file_modified(self, event_mask):
         """
-        checks if any flag has been set by event corresponding to modification
+        Checks if any flag has been set by event corresponding to modification
         :param event_mask: mask of the inotify event object, signifies what happened
         :return: bool - if any of the modification flags have been set
         """
         return bool(self.mask & event_mask)
 
+    def temporary_disable(self):
+        """
+        Temporary disable watcher
+        """
+        log.debug('Temporary disabled watcher: %s for %d seconds' % (self.path, self.DISABLEMENT_TIMEOUT))
+        self.temporary_disabled = True
+        self._time_tmp_dis = time.time()
+
+    def update_temporary_disabled_watcher(self):
+        """
+        Check if it is right to enable watcher again
+        """
+        cur_time = time.time()
+        time_diff = cur_time - self._time_tmp_dis
+        if time_diff > self.DISABLEMENT_TIMEOUT:
+            log.debug('Enabling watcher: %s again' % self.path)
+            self.temporary_disabled = False
+            self._time_tmp_dis = 0.0
+
 
 def end_loop_cb(fsw, user_callback=None):
+    """
+    Callback method called to check if infinity loop should be finished.
+    The check of the loop could be implemented in user_callback or setting
+    fsw.should_stop to true
+
+    :param fsw: instance of FilesystemWatcher of subclass
+    :param user_callback: user defined callback (optional)
+    :return: result of user_callback or fsw.should_stop
+    """
     if user_callback is not None:
         try:
             return user_callback() or fsw.should_stop
@@ -239,7 +330,7 @@ def create_filesystem_watcher(dir_watches):
     determines if inotify is available and configured in rhsm.conf
     If yes, uses pyinotify. Else, uses polling methods.
     Uses inotify by default
-    :param dir_watches: list of directories to watch to create
+    :param dir_watches: dictionary of directories to watch to create
     correct filesystem watcher object
     :return: correct filesystem watcher object
 
@@ -249,14 +340,18 @@ def create_filesystem_watcher(dir_watches):
         thread.start()
     """
     available = is_inotify_available()
-    configed = is_inotify_config()
-    if not (available and configed):
+    configured = is_inotify_config()
+    if not (available and configured):
         return FilesystemWatcher(dir_watches)
     else:
         return InotifyFilesystemWatcher(dir_watches)
 
 
 def is_inotify_available():
+    """
+    Checks if i-notify module is available on the system
+    :return:
+    """
     return pyinotify is not None
 
 

--- a/src/rhsmlib/services/config.py
+++ b/src/rhsmlib/services/config.py
@@ -23,7 +23,7 @@ class Config(collections.MutableMapping):
         if parser:
             self._parser = parser
         else:
-            self._parser = rhsm.config.initConfig()
+            self._parser = rhsm.config.get_config_parser()
 
         self.auto_persist = auto_persist
 

--- a/src/rhsmlib/services/entitlement.py
+++ b/src/rhsmlib/services/entitlement.py
@@ -515,6 +515,11 @@ class EntitlementService(object):
         return removed_serials, unremoved_serials
 
     def reload(self):
+        """
+        This callback function is called, when there is detected any change in directory with entitlement
+        certificates (e.g. certificate is installed or removed)
+        :return:
+        """
         sorter = inj.require(inj.CERT_SORTER, on_date=None)
         status_cache = inj.require(inj.ENTITLEMENT_STATUS_CACHE)
         log.debug('Clearing in-memory cache of file %s' % status_cache.CACHE_FILE)

--- a/src/subscription_manager/api/__init__.py
+++ b/src/subscription_manager/api/__init__.py
@@ -19,7 +19,7 @@ external applications.
 All reasonable efforts will be made to maintain compatibility.
 """
 from functools import wraps
-from subscription_manager import logutil
+from rhsm import logutil
 
 injected = False
 

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -27,7 +27,7 @@ import threading
 import time
 from rhsm.https import ssl
 
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 import rhsm.connection as connection
 from rhsm.profile import get_profile
 import subscription_manager.injection as inj
@@ -43,7 +43,7 @@ log = logging.getLogger(__name__)
 
 PACKAGES_RESOURCE = "packages"
 
-conf = config.Config(initConfig())
+conf = config.Config(get_config_parser())
 
 
 class CacheManager(object):

--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -340,20 +340,20 @@ class CertSorter(ComplianceManager):
         super(CertSorter, self).__init__(on_date)
         self.callbacks = set()
 
-        cert_dir_monitors = [
-            file_monitor.DirectoryWatch(
+        cert_dir_monitors = {
+            file_monitor.PRODUCT_WATCHER: file_monitor.DirectoryWatch(
                 inj.require(inj.PROD_DIR).path,
                 [self.on_prod_dir_changed, self.load]
             ),
-            file_monitor.DirectoryWatch(
+            file_monitor.ENTITLEMENT_WATCHER: file_monitor.DirectoryWatch(
                 inj.require(inj.ENT_DIR).path,
                 [self.on_ent_dir_changed, self.load]
             ),
-            file_monitor.DirectoryWatch(
+            file_monitor.CONSUMER_WATCHER: file_monitor.DirectoryWatch(
                 inj.require(inj.IDENTITY).cert_dir_path,
                 [self.on_identity_changed, self.load]
             )
-        ]
+        }
 
         # Note: no timer is setup to poll file_monitor by cert_sorter itself,
         # the gui can add one.

--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -20,7 +20,7 @@ import logging
 import os
 
 from rhsm.certificate import Key, create_from_file
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 from subscription_manager.injection import require, ENT_DIR
 
 from rhsmlib.services import config
@@ -28,7 +28,7 @@ from rhsm.certificate2 import CONTENT_ACCESS_CERT_TYPE
 
 log = logging.getLogger(__name__)
 
-conf = config.Config(initConfig())
+conf = config.Config(get_config_parser())
 
 DEFAULT_PRODUCT_CERT_DIR = "/etc/pki/product-default"
 

--- a/src/subscription_manager/gui/firstboot/rhsm_login.py
+++ b/src/subscription_manager/gui/firstboot/rhsm_login.py
@@ -15,7 +15,8 @@ gtk_compat.threads_init()
 import rhsm
 
 # enable logging for firstboot
-from subscription_manager import logutil
+from rhsm import logutil
+
 logutil.init_logger()
 
 log = logging.getLogger(__name__)

--- a/src/subscription_manager/gui/firstboot/rhsm_login.py
+++ b/src/subscription_manager/gui/firstboot/rhsm_login.py
@@ -290,7 +290,7 @@ class moduleClass(module.Module, object):
         # Read and store rhn-setup's proxy settings, as they have been set
         # on the prior screen (which is owned by rhn-setup)
         up2date_cfg = rhn_config.initUp2dateConfig()
-        cfg = rhsm.config.initConfig()
+        cfg = rhsm.config.get_config_parser()
 
         # Track if we have changed this in the gui proxy dialog, if
         # we have changed it to disabled, then we apply "null", otherwise

--- a/src/subscription_manager/gui/managergui.py
+++ b/src/subscription_manager/gui/managergui.py
@@ -70,7 +70,7 @@ from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 
-cfg = config.initConfig()
+cfg = config.get_config_parser()
 
 ONLINE_DOC_URL_TEMPLATE = "https://access.redhat.com/documentation/%s/red_hat_subscription_management/"
 ONLINE_DOC_FALLBACK_URL = "https://access.redhat.com/documentation/en-us/red_hat_subscription_management/"
@@ -178,7 +178,7 @@ class MainWindow(widgets.SubmanBaseWidget):
                  auto_launch_registration=False):
         super(MainWindow, self).__init__()
 
-        rhsm_cfg = config.initConfig()
+        rhsm_cfg = config.get_config_parser()
         proxy_server = rhsm_cfg.get("server", "proxy_hostname")
         proxy_port = int(rhsm_cfg.get("server", "proxy_port") or config.DEFAULT_PROXY_PORT)
 

--- a/src/subscription_manager/gui/networkConfig.py
+++ b/src/subscription_manager/gui/networkConfig.py
@@ -88,7 +88,7 @@ class NetworkConfigDialog(widgets.SubmanBaseWidget):
         self.org_timeout = socket.getdefaulttimeout()
         self.progress_bar = None
 
-        self.cfg = rhsm.config.initConfig()
+        self.cfg = rhsm.config.get_config_parser()
         self.cp_provider = inj.require(inj.CP_PROVIDER)
 
         # Need to load values before connecting signals because when the dialog

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -62,7 +62,7 @@ logutil.init_logger()
 log = logging.getLogger(__name__)
 
 from rhsmlib.services import config, attach
-conf = config.Config(base_config.initConfig())
+conf = config.Config(base_config.get_config_parser())
 
 
 class RegisterState(object):

--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -56,7 +56,7 @@ from subscription_manager import syspurposelib
 
 from subscription_manager.i18n import ugettext as _
 
-from subscription_manager import logutil
+from rhsm import logutil
 
 logutil.init_logger()
 log = logging.getLogger(__name__)

--- a/src/subscription_manager/gui/reposgui.py
+++ b/src/subscription_manager/gui/reposgui.py
@@ -38,7 +38,7 @@ from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 
-cfg = rhsm.config.initConfig()
+cfg = rhsm.config.get_config_parser()
 
 
 class RepositoriesDialog(widgets.SubmanBaseWidget, HasSortableWidget):

--- a/src/subscription_manager/identity.py
+++ b/src/subscription_manager/identity.py
@@ -22,13 +22,13 @@ import threading
 import six
 
 from rhsm.certificate import create_from_pem
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 from subscription_manager.certdirectory import Path
 
 from rhsmlib.services import config
 from rhsm.certificate import CertificateException
 
-conf = config.Config(initConfig())
+conf = config.Config(get_config_parser())
 log = logging.getLogger(__name__)
 
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -75,7 +75,7 @@ from rhsmlib.services import config, attach, products, unregister, entitlement, 
 from rhsmlib.services import exceptions
 from subscription_manager import syspurposelib
 
-conf = config.Config(rhsm.config.initConfig())
+conf = config.Config(rhsm.config.get_config_parser())
 
 SM = "subscription-manager"
 ERR_NOT_REGISTERED_MSG = _("This system is not yet registered. Try 'subscription-manager register --help' for more information.")

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -24,7 +24,7 @@ import shutil
 import stat
 import syslog
 
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 from rhsm.certificate import Key, CertificateException, create_from_pem
 
 import subscription_manager.cache as cache
@@ -48,7 +48,7 @@ from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 
-cfg = initConfig()
+cfg = get_config_parser()
 ENT_CONFIG_DIR = cfg.get('rhsm', 'entitlementCertDir')
 
 # Expected permissions for identity certificates:

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -44,7 +44,7 @@ from subscription_manager import repolib
 from rhsm.utils import parse_url
 from rhsm import ourjson as json
 
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 from rhsmlib.services import config
 
 _RHNLIBPATH = "/usr/share/rhn"
@@ -158,7 +158,7 @@ class UserCredentials(object):
 class MigrationEngine(object):
     def __init__(self, options):
         self.rhncfg = initUp2dateConfig()
-        self.rhsmcfg = config.Config(initConfig())
+        self.rhsmcfg = config.Config(get_config_parser())
 
         # Sometimes we need to send up the entire contents of the system id file
         # which is referred to in Satellite 5 nomenclature as a "certificate"
@@ -969,7 +969,7 @@ def validate_options(options):
 
 
 def is_hosted():
-    rhsmcfg = config.Config(initConfig())
+    rhsmcfg = config.Config(get_config_parser())
     hostname = rhsmcfg['server']['hostname']
     return bool(re.search('subscription\.rhn\.(.*\.)*redhat\.com', hostname) or
                 re.search('subscription\.rhsm\.(.*\.)*redhat\.com', hostname))

--- a/src/subscription_manager/plugin/ostree/config.py
+++ b/src/subscription_manager/plugin/ostree/config.py
@@ -18,7 +18,7 @@ from __future__ import print_function, division, absolute_import
 import logging
 import os
 
-from rhsm.config import initConfig, RhsmConfigParser
+from rhsm.config import get_config_parser, RhsmConfigParser
 from rhsm.config import NoSectionError  # noqa: F401 Imported so we can catch elsewhere
 from subscription_manager import utils
 from rhsmlib.services import config
@@ -33,7 +33,7 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
-conf = config.Config(initConfig())
+conf = config.Config(get_config_parser())
 
 """Ostree has two config files, both based on the freedesktop.org
 Desktop Entry spec. This defines a file format based on "ini" style

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -27,7 +27,7 @@ else:
 from iniparse import SafeConfigParser
 from iniparse.compat import NoSectionError, NoOptionError
 
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 from subscription_manager.base_plugin import SubManPlugin
 
 # The API_VERSION constant defines the current plugin API version. It is used
@@ -49,7 +49,7 @@ API_VERSION = "1.1"
 DEFAULT_SEARCH_PATH = "/usr/share/rhsm-plugins/"
 DEFAULT_CONF_PATH = "/etc/rhsm/pluginconf.d/"
 
-cfg = initConfig()
+cfg = get_config_parser()
 
 log = logging.getLogger(__name__)
 

--- a/src/subscription_manager/release.py
+++ b/src/subscription_manager/release.py
@@ -35,7 +35,7 @@ from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 
-cfg = rhsm.config.initConfig()
+cfg = rhsm.config.get_config_parser()
 
 
 class MultipleReleaseProductsError(ValueError):

--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -38,13 +38,13 @@ from subscription_manager.certdirectory import Path
 from six.moves import configparser
 from six.moves.urllib.parse import parse_qs, urlparse, urlunparse, urlencode
 
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 
 from rhsmlib.services import config
 
 log = logging.getLogger(__name__)
 
-conf = config.Config(initConfig())
+conf = config.Config(get_config_parser())
 
 repo_files = []
 

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -30,7 +30,7 @@ from subscription_manager.repofile import Repo, manage_repos_enabled, get_repo_f
 from subscription_manager.repofile import YumRepoFile
 from subscription_manager.utils import get_supported_resources
 
-from rhsm.config import initConfig, in_container
+from rhsm.config import get_config_parser, in_container
 from rhsm import connection
 import six
 from six.moves import configparser
@@ -44,7 +44,7 @@ from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 
-conf = config.Config(initConfig())
+conf = config.Config(get_config_parser())
 
 ALLOWED_CONTENT_TYPES = ["yum", "deb"]
 

--- a/src/subscription_manager/scripts/package_profile_upload.py
+++ b/src/subscription_manager/scripts/package_profile_upload.py
@@ -27,7 +27,8 @@ init_dep_injection()
 from subscription_manager.i18n import configure_i18n, ugettext as _
 configure_i18n()
 
-from subscription_manager import logutil
+from rhsm import logutil
+
 logutil.init_logger()
 
 from subscription_manager import packageprofilelib

--- a/src/subscription_manager/scripts/rct.py
+++ b/src/subscription_manager/scripts/rct.py
@@ -29,7 +29,8 @@ if six.PY2:
 from subscription_manager.i18n import configure_i18n, ugettext as _
 configure_i18n()
 
-from subscription_manager import logutil
+from rhsm import logutil
+
 logutil.init_logger()
 
 from rct.cli import RctCLI

--- a/src/subscription_manager/scripts/rhn_migrate_classic_to_rhsm.py
+++ b/src/subscription_manager/scripts/rhn_migrate_classic_to_rhsm.py
@@ -53,7 +53,8 @@ try:
     from subscription_manager.i18n import configure_i18n
     configure_i18n()
 
-    from subscription_manager import logutil
+    from rhsm import logutil
+
     logutil.init_logger()
 
     from subscription_manager.injectioninit import init_dep_injection

--- a/src/subscription_manager/scripts/rhsm_d.py
+++ b/src/subscription_manager/scripts/rhsm_d.py
@@ -59,7 +59,8 @@ ga_loader.init_ga()
 # from gi.repository import GObject
 log = logging.getLogger("rhsm-app.rhsmd")
 
-from subscription_manager import logutil
+from rhsm import logutil
+
 logutil.init_logger()
 
 

--- a/src/subscription_manager/scripts/rhsm_d.py
+++ b/src/subscription_manager/scripts/rhsm_d.py
@@ -91,10 +91,10 @@ from subscription_manager.cert_sorter import RHSM_VALID, \
         RHN_CLASSIC, RHSM_REGISTRATION_REQUIRED
 from subscription_manager.utils import print_error
 
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 from rhsmlib.services import config
 
-conf = config.Config(initConfig())
+conf = config.Config(get_config_parser())
 
 enable_debug = False
 

--- a/src/subscription_manager/scripts/rhsm_debug.py
+++ b/src/subscription_manager/scripts/rhsm_debug.py
@@ -30,7 +30,8 @@ import os
 from subscription_manager.i18n import configure_i18n, ugettext as _
 configure_i18n()
 
-from subscription_manager import logutil
+from rhsm import logutil
+
 logutil.init_logger()
 
 from rhsm_debug.cli import RhsmDebugCLI

--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -31,10 +31,9 @@ import signal
 import logging
 import dbus.mainloop.glib
 
-from subscription_manager import logutil
 import subscription_manager.injection as inj
 
-from rhsm import connection, config
+from rhsm import connection, config, logutil
 
 from subscription_manager import ga_loader
 ga_loader.init_ga()

--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -69,7 +69,7 @@ def _main(options, log):
     correlation_id = generate_correlation_id()
     log.debug('X-Correlation-ID: %s', correlation_id)
     cp_provider.set_correlation_id(correlation_id)
-    cfg = config.initConfig()
+    cfg = config.get_config_parser()
 
     log.debug('check for rhsmcertd disable')
     if '1' == cfg.get('rhsmcertd', 'disable') and not options.force:

--- a/src/subscription_manager/scripts/sat5to6.py
+++ b/src/subscription_manager/scripts/sat5to6.py
@@ -48,7 +48,8 @@ try:
     from subscription_manager.i18n import configure_i18n
     configure_i18n()
 
-    from subscription_manager import logutil
+    from rhsm import logutil
+
     logutil.init_logger()
 
     from subscription_manager.injectioninit import init_dep_injection

--- a/src/subscription_manager/scripts/subscription_manager.py
+++ b/src/subscription_manager/scripts/subscription_manager.py
@@ -57,7 +57,8 @@ try:
     from subscription_manager.i18n import configure_i18n
     configure_i18n()
 
-    from subscription_manager import logutil
+    from rhsm import logutil
+
     logutil.init_logger()
 
     from subscription_manager.injectioninit import init_dep_injection

--- a/src/subscription_manager/scripts/subscription_manager_gui.py
+++ b/src/subscription_manager/scripts/subscription_manager_gui.py
@@ -133,7 +133,8 @@ try:
     from subscription_manager.i18n import configure_i18n
     configure_i18n()
 
-    from subscription_manager import logutil
+    from rhsm import logutil
+
     logutil.init_logger()
 
     from subscription_manager.injectioninit import init_dep_injection

--- a/src/zypper/commit/product-id
+++ b/src/zypper/commit/product-id
@@ -19,14 +19,13 @@ from xml.etree import ElementTree
 import logging
 import os
 import os.path
-import sys
 import time
 
 from zypp import RepoType
 from zypp_plugin import Plugin
 import zypp
 
-from subscription_manager import logutil
+from rhsm import logutil
 from subscription_manager.productid import ProductManager
 from subscription_manager.injectioninit import init_dep_injection
 

--- a/src/zypper/services/rhsm
+++ b/src/zypper/services/rhsm
@@ -92,7 +92,7 @@ class ZypperService(object):
         Read rhsm configuration file
         :return: None
         """
-        cfg = config.initConfig()
+        cfg = config.get_config_parser()
         self.full_refresh_on_yum = bool(cfg.get_int('rhsm', 'full_refresh_on_yum'))
         self.ca_cert_dir = cfg.get('rhsm', 'ca_cert_dir')
 

--- a/src/zypper/services/rhsm
+++ b/src/zypper/services/rhsm
@@ -24,8 +24,7 @@ from subscription_manager.repolib import RepoActionInvoker
 from subscription_manager.entcertlib import EntCertActionInvoker
 from subscription_manager.certlib import Locker
 from subscription_manager.injectioninit import init_dep_injection
-from subscription_manager import logutil
-from rhsm import connection
+from rhsm import connection, logutil
 from rhsm import config
 
 from six.moves.configparser import ConfigParser

--- a/test/rhsmlib_test/test_file_monitor.py
+++ b/test/rhsmlib_test/test_file_monitor.py
@@ -33,7 +33,7 @@ class TestFilesystemWatcher(fixture.SubManFixture):
         self.dw1 = file_monitor.DirectoryWatch(self.testpath1, [], is_glob=True)
         self.dw2 = file_monitor.DirectoryWatch(self.testpath2, [], is_glob=False)
         self.dw3 = file_monitor.DirectoryWatch(self.testpath2, [self.mock_cb1, self.mock_cb2], is_glob=False)
-        self.dir_list = [self.dw1, self.dw2, self.dw3]
+        self.dir_list = {"DW1": self.dw1, "DW2": self.dw2, "DW3": self.dw3}
         self.fsw1 = file_monitor.FilesystemWatcher(self.dir_list)
         self.fsw2 = file_monitor.InotifyFilesystemWatcher(self.dir_list)
 
@@ -237,13 +237,13 @@ class TestDirectoryWatch(fixture.SubManFixture):
     @patch("pyinotify.Event")
     def test_file_modified(self, mock_event):
         mock_event.mask = 1
-        self.assertFalse(self.dw3.file_modified(mock_event.mask))
+        self.assertFalse(self.dw3.is_file_modified(mock_event.mask))
         mock_event.mask = self.dw3.IN_MODIFY
-        self.assertTrue(self.dw3.file_modified(mock_event.mask))
+        self.assertTrue(self.dw3.is_file_modified(mock_event.mask))
         mock_event.mask = self.dw3.IN_DELETE
-        self.assertTrue(self.dw3.file_modified(mock_event.mask))
+        self.assertTrue(self.dw3.is_file_modified(mock_event.mask))
         mock_event.mask = self.dw3.IN_MOVED_TO
-        self.assertTrue(self.dw3.file_modified(mock_event.mask))
+        self.assertTrue(self.dw3.is_file_modified(mock_event.mask))
 
 
 class TestLoop:

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -128,7 +128,7 @@ def stubInitConfig():
 
 # create a global CFG object,then replace it with our own that candlepin
 # read from a stringio
-config.initConfig(config_file="test/rhsm.conf")
+#config.get_config_parser(config_file="test/rhsm.conf")
 config.CFG = StubConfig()
 
 # we are not actually reading test/rhsm.conf, it's just a placeholder

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -122,6 +122,16 @@ class TestProfileManager(unittest.TestCase):
         repo_file_name = os.path.join(temp_repo_dir, 'awesome.repo')
         with open(repo_file_name, 'w') as repo_file:
             repo_file.write(CONTENT_REPO_FILE)
+
+        patcher = patch('rhsm.profile.dnf')
+        self.addCleanup(patcher.stop)
+        dnf_mock = patcher.start()
+        dnf_mock.dnf = Mock()
+        mock_db = Mock()
+        mock_db.conf = Mock()
+        mock_db.conf.substitutions = {'releasever': '1', 'basearch': 'x86_64'}
+        dnf_mock.dnf.Base = Mock(return_value=mock_db)
+
         self.current_profile = self._mock_pkg_profile(current_pkgs, repo_file_name, ENABLED_MODULES)
         self.profile_mgr = ProfileManager()
         self.profile_mgr.current_profile = self.current_profile

--- a/test/test_logutil.py
+++ b/test/test_logutil.py
@@ -10,7 +10,7 @@ from . import fixture
 
 from . import stubs
 
-from subscription_manager import logutil
+from rhsm import logutil
 
 
 # no NullHandler in 2.6, include our own

--- a/test/test_logutil.py
+++ b/test/test_logutil.py
@@ -25,7 +25,7 @@ class TestLogutil(fixture.SubManFixture):
         self.rhsm_config = stubs.StubConfig()
         rhsm_patcher = mock.patch('rhsm.config')
         self.rhsm_config_mock = rhsm_patcher.start()
-        self.rhsm_config_mock.initConfig.return_value = self.rhsm_config
+        self.rhsm_config_mock.get_config_parser.return_value = self.rhsm_config
         self.addCleanup(rhsm_patcher.stop)
 
     def tearDown(self):

--- a/test/test_managerlib.py
+++ b/test/test_managerlib.py
@@ -36,7 +36,7 @@ import rhsm
 from rhsm.certificate import create_from_pem, DateRange, GMT
 from mock import Mock, patch
 
-cfg = rhsm.config.initConfig()
+cfg = rhsm.config.get_config_parser()
 ENT_CONFIG_DIR = cfg.get('rhsm', 'entitlementCertDir')
 
 #[-]*BEGIN [\w\ ]*[-]* - Find all begin lines

--- a/test/test_rhsm_debug_command.py
+++ b/test/test_rhsm_debug_command.py
@@ -27,11 +27,11 @@ import six
 
 from rhsm_debug import debug_commands
 from rhsm_debug import cli
-from rhsm.config import initConfig
+from rhsm.config import get_config_parser
 from subscription_manager.cli import InvalidCLIOptionError
 
 
-cfg = initConfig()
+cfg = get_config_parser()
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1804114
* Implemented method SetAll()
  - It is possible to set all configuration option or
    several configuration options
  - This method is prefered, because it minimize number of
    writing to configuration file rhsm.conf
* Implemented temporary disablement of directory watcher of
  file system monitor.
  - When rhsm.service write something to rhsm.conf and temporary
    disablement would not be implemented, then configuration
    options would be read back from rhsm.conf, because i-notify
    detected some changes in rhsm.conf. When mulitple values
    are set using D-Bus method Set() or SetAll(), then there
    is danger that some WIP values would be read back to
    rhsm.service and it would not be possible to e.g. register
    system to candlepin server.
* Moved logutil from subscription_manager to rhsm
* Refactored usage of i-notify a little bit. Added many comments
  and renamed some methods to be more descriptive
* Fixed few unit tests