### PR TITLE
cockpit: Be more robust when showing the time for next Insights upload

### DIFF
--- a/cockpit/src/insights.jsx
+++ b/cockpit/src/insights.jsx
@@ -302,12 +302,10 @@ const get_monotonic_start = cockpit.spawn(
 
 function calc_next_elapse(monotonic_start, timer) {
     let next_mono = Infinity, next_real = Infinity;
-    if (monotonic_start) {
-        if (timer.NextElapseUSecMonotonic)
-            next_mono = timer.NextElapseUSecMonotonic / 1e6 + monotonic_start;
-        if (timer.NextElapseUSecRealtime)
-            next_real = timer.NextElapseUSecRealtime / 1e6;
-    }
+    if (timer.NextElapseUSecMonotonic && monotonic_start)
+        next_mono = timer.NextElapseUSecMonotonic / 1e6 + monotonic_start;
+    if (timer.NextElapseUSecRealtime)
+        next_real = timer.NextElapseUSecRealtime / 1e6;
     let next = Math.min(next_mono, next_real);
     if (next !== Infinity)
         return moment(next * 1000).calendar();


### PR DESCRIPTION
If we can't get the start of the monotonic clock, we only have to
ignore timers that use the monotonic clock.  We can still use the real
time clock.