### PR TITLE
Added basic support for Pipenv for subscription-manager; ENT-1755

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+decorator = "*"
+six = "*"
+python-dateutil = ">=2.0"
+
+[requires]
+python_version = "*"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,84 @@ url | proxy-server.subman.example.com:3128
 username | proxyuser
 password | password
 
+Pipenv
+------
+
+There is experimental support for installation of subscription-manager using
+Pipenv. We tested installing subscription-manager using Pipenv only on following
+operating systems:
+
+* Fedora 30
+* RHEL/CentOS 7
+* RHEL/CentOS 8
+
+We tested pipenv with Python 2 and Python 3. It is necessary to install following
+packages to your system, because binary module have to be compiled in virtual
+environment:
+
+### Python 2
+
+```bash
+dnf install -y pipenv gcc make python2-devel \
+    openssl-devel intltool libnl3-devel
+```
+
+### Python 3
+
+```bash
+dnf install -y pipenv gcc make python3-devel \
+    openssl-devel intltool libnl3-devel
+```
+
+You can create virtual environment using following steps:
+
+1. Create virtual environment using Python 2 or Python 3 and it is necessary to
+   use `--site-packages` argument, because virtual environment has to
+   use `rpm` Python package installed in your system. It is not possible
+   to install `rpm` Python package to virtual environment using pip/pipenv.
+
+   Python 2:
+
+   ```bash
+   pipenv --site-packages --two
+   ```
+
+   Python 3:
+
+   ```bash
+   pipenv --site-packages --three
+   ```
+
+2. Install required Python packages defined in `Pipfile` into virtual environment:
+
+   ```bash
+   pipevn install
+   ```
+
+3. Start virtual environment:
+
+   ```bash
+   pipenv shell
+   ```
+
+4. Build binary modules in virtual environment:
+
+   ```bash
+   python ./setup.py build
+   ```
+
+5. Install subscription-manager into virtual environment:
+
+   ```bash
+   python ./setup.py install
+   ```
+
+6. It should be possible to run subscription-manager in virtual environment
+
+   ```bash
+   sudo subscription-manager version
+   ```
+
 Development of the Subscription-Manager Deployment Ansible role
 ---------------------------------------------------------------
 The Ansible role that is used for deploying subscription-manager can be found at 

--- a/setup.py
+++ b/setup.py
@@ -388,6 +388,12 @@ setup(
             'versioned_packages': ('setup.py', ['subscription_manager', 'rct']),
         },
     },
+    classifiers=[
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GPL License",
+        "Operating System :: Linux",
+    ],
     include_package_data=True,
     setup_requires=setup_requires,
     install_requires=install_requires,

--- a/src/subscription_manager/branding/__init__.py
+++ b/src/subscription_manager/branding/__init__.py
@@ -90,6 +90,8 @@ class DefaultBranding(object):
                 _("Please enter your account information:")
         self.GUI_FORGOT_LOGIN_TIP = \
                 _("Contact your system administrator if you have forgotten your login or password")
+        self.REGISTERED_TO_SUBSCRIPTION_MANAGEMENT_SUMMARY = \
+                _("Red Hat Subscription Management")
 
 
 class EmptyBranding(object):


### PR DESCRIPTION
* Only Fedora30 or RHEL/CentOS 8 are supported
* Installation is still quite complicated using Pipenv
* More details are in REDME.md