### PR TITLE
1763271: Golden ticket: do not print list of products; ENT-2017

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -608,7 +608,9 @@ class BaseRestLib(object):
         if cert_key_pairs is None or len(cert_key_pairs) == 0:
             cert_key_pairs = self._get_cert_key_list()
 
-        if headers is not None and headers['Content-type'] == 'application/x-www-form-urlencoded':
+        if headers is not None and \
+                'Content-type' in headers and \
+                headers['Content-type'] == 'application/x-www-form-urlencoded':
             body = six.moves.urllib.parse.urlencode(info).encode('utf-8')
         elif info is not None:
             body = json.dumps(info, default=json.encode)

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -227,6 +227,16 @@ def handle_exception(msg, ex):
 
 
 def show_autosubscribe_output(uep, identity):
+    """
+    Try to show auto-attach output
+    :param uep: object with connection to candlepin
+    :param identity: object with identity
+    :return: return 1, when all installed products are subscribed, otherwise return 0
+    """
+
+    if is_owner_using_golden_ticket(uep=uep, identity=identity):
+        return 0
+
     installed_products = products.InstalledProducts(uep).list()
 
     if not installed_products:
@@ -247,10 +257,7 @@ def show_autosubscribe_output(uep, identity):
             all_subscribed = False
         print(columnize(PRODUCT_STATUS, echo_columnize_callback, product[0], status) + "\n")
     if not all_subscribed:
-        if is_owner_using_golden_ticket(uep=uep, identity=identity):
-            subscribed = 0
-        else:
-            print(_("Unable to find available subscriptions for all your installed products."))
+        print(_("Unable to find available subscriptions for all your installed products."))
     return subscribed
 
 

--- a/test/rhsm/unit/connection_tests.py
+++ b/test/rhsm/unit/connection_tests.py
@@ -391,7 +391,7 @@ class ConnectionTests(unittest.TestCase):
             Options = namedtuple('Options', 'reporter_id')
             options = Options('tester')
             self.cp.hypervisorHeartbeat("owner", options=options)
-            self.cp.conn.request_put.assert_not_called
+            self.cp.conn.request_put.assert_not_called()
 
     def test_hypervisor_check_in_no_reporter(self):
             self.cp.conn = Mock()
@@ -399,7 +399,7 @@ class ConnectionTests(unittest.TestCase):
             Options = namedtuple('Options', 'reporter_id')
             options = Options('')
             self.cp.hypervisorHeartbeat("owner", options=options)
-            self.cp.conn.request_put.assert_not_called
+            self.cp.conn.request_put.assert_not_called()
 
 
 class RestlibValidateResponseTests(unittest.TestCase):


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1763271
* When you register and content access mode for specified
  origanization is org_environment and CLI option --auto-attach
  is used, then do not print list of installed products,
  because it does not make sense to print status of installed
  product in this case
* Fixed bug in connection.py
* Fixed two unit tests