### PR TITLE
Remove yum for suse

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -93,7 +93,7 @@
 %endif
 
 %global use_dnf (%{with python3} && (0%{?fedora} || (0%{?rhel}))) || (0%{?rhel} >= 7)
-%global use_yum (0%{?rhel} && 0%{?rhel} <= 7) || (0%{?suse_version})
+%global use_yum (0%{?rhel} && 0%{?rhel} <= 7)
 %global use_cockpit 0%{?fedora} || 0%{?rhel} >= 7
 
 %if %{with python3}


### PR DESCRIPTION
The dependency of yum isn't required anymore as the katello-host-tools and the subscription-manager zypper plugin can be used pretty good without yum.