### PR TITLE
1775714: Do not install rhsmd and rhsm-icon on rhel8; ENT-1959

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -268,15 +268,26 @@ class install_data(_install_data):
         self.data_files = [(item, value) for item, value in data_files.items()]
 
     def add_dbus_service_files(self):
+        """
+        Add D-Bus service files to the list of files installed to the system
+        """
         dbus_service_directory = self.join('share', 'dbus-1', 'system-services')
         if self.with_systemd:
             source_dir = self.join('build', 'dbus', 'system-services-systemd')
         else:
             source_dir = self.join('build', 'dbus', 'system-services')
-        for file in os.listdir(source_dir):
-            self.data_files.append((dbus_service_directory, [self.join(source_dir, file)]))
+        for template_file in os.listdir(source_dir):
+            if template_file == 'com.redhat.SubscriptionManager.service' and not self.with_subman_gui:
+                # com.redhat.SubscriptionManager.service contains definition of the service to be started
+                # for D-Bus service: com.redhat.SubscriptionManager. It is necessary only for sub-man-gui.
+                print('Skipping %s, because subscription-manager-gui will not be installed' % template_file)
+            else:
+                self.data_files.append((dbus_service_directory, [self.join(source_dir, template_file)]))
 
     def add_systemd_services(self):
+        """
+        Add .service files for systemd
+        """
         if not self.with_systemd:
             return  # if we're not installing for systemd, stop!
         systemd_install_directory = self.join('lib', 'systemd', 'system')

--- a/src/subscription_manager/dbus_interface.py
+++ b/src/subscription_manager/dbus_interface.py
@@ -20,8 +20,6 @@ import dbus.mainloop
 import dbus.mainloop.glib
 
 import inspect
-import traceback
-import sys
 import logging
 import subscription_manager.injection as inj
 
@@ -52,9 +50,9 @@ class DbusIface(object):
         except dbus.DBusException:
             # we can't connect to dbus. it's not running, likely from a minimal
             # install. we can't do anything here, so just ignore it.
-            log.debug("Unable to connect to dbus")
-            # BZ 1600694 We should print the dbus traceback at the debug level
-            log.debug(''.join(traceback.format_tb(sys.exc_info()[2])))
+            # When subscription-manager-gui is not installed, then rhsmd is not installed too.
+            # Then com.redhat.SubscriptionManager is not available.
+            log.debug("Unable to connect to D-Bus service: %s" % self.service_name)
 
     def update(self):
         pass

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -772,14 +772,18 @@ cp %{buildroot}%{python_sitearch}/rhsm/*.py %{buildroot}%{python2_sitearch}/rhsm
 desktop-file-validate %{buildroot}/etc/xdg/autostart/rhsm-icon.desktop
 desktop-file-validate %{buildroot}/usr/share/applications/subscription-manager-gui.desktop
 %else
+
 %if %use_cockpit
 desktop-file-validate %{buildroot}/usr/share/applications/subscription-manager-cockpit.desktop
 %endif
+
 %endif
 
 # libexec directory does not exist on sles based distros
 %if 0%{?suse_version}
-sed -i 's/libexec/lib/g' %{buildroot}/%{_sysconfdir}/cron.daily/rhsmd
+%if %use_subman_gui
+    sed -i 's/libexec/lib/g' %{buildroot}/%{_sysconfdir}/cron.daily/rhsmd
+%endif
 %endif
 
 %find_lang rhsm
@@ -885,7 +889,10 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %attr(755,root,root) %{_bindir}/rhsmcertd
 
 %attr(755,root,root) %{_libexecdir}/rhsmcertd-worker
-%attr(755,root,root) %{_libexecdir}/rhsmd
+
+%if %{use_subman_gui}
+    %attr(755,root,root) %{_libexecdir}/rhsmd
+%endif
 
 
 # our config dirs and files
@@ -931,7 +938,9 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 
 # misc system config
 %config(noreplace) %attr(644,root,root) %{_sysconfdir}/logrotate.d/subscription-manager
-%attr(700,root,root) %{_sysconfdir}/cron.daily/rhsmd
+%if %{use_subman_gui}
+    %attr(700,root,root) %{_sysconfdir}/cron.daily/rhsmd
+%endif
 
 %attr(755,root,root) %dir %{_var}/log/rhsm
 %attr(755,root,root) %dir %{_var}/spool/rhsm/debug
@@ -1105,6 +1114,7 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 # symlink to console-helper
 %{_bindir}/subscription-manager-gui
 %endif
+
 %{_bindir}/rhsm-icon
 
 %doc %{_datadir}/gnome/help/subscription-manager/C/figures/*.png


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1775714
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1780028
* Stop rhsmd, when rhsm-icon is not running, because only
  rhsm-icon can be listening for D-Bus service on
  `com.redhat.SubscriptionManager`
* Do not install rhsmd on RHEL8
* Do not install configuration file related with D-Bus service
  com.redhat.SubscriptionManager
* Do not try to build rhsm-icon, when WITH_SUBMAN_GUI is false