### PR TITLE
1821747: Automatically create /etc/rhsm/syspurpose

### DIFF
--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -29,9 +29,11 @@ from syspurpose.utils import system_exit, create_dir, create_file, make_utf8, wr
 from syspurpose.i18n import ugettext as _
 
 # Constants for locations of the two system syspurpose files
-USER_SYSPURPOSE = "/etc/rhsm/syspurpose/syspurpose.json"
-VALID_FIELDS = "/etc/rhsm/syspurpose/valid_fields.json"  # Will be used for future validation
-CACHED_SYSPURPOSE = "/var/lib/rhsm/cache/syspurpose.json"  # Stores cached values
+USER_SYSPURPOSE_DIR = "/etc/rhsm/syspurpose"
+USER_SYSPURPOSE = os.path.join(USER_SYSPURPOSE_DIR, "syspurpose.json")
+VALID_FIELDS = os.path.join(USER_SYSPURPOSE_DIR, "valid_fields.json")  # Will be used for future validation
+CACHE_DIR = "/var/lib/rhsm/cache"
+CACHED_SYSPURPOSE = os.path.join(CACHE_DIR, "syspurpose.json")  # Stores cached values
 
 # All names that represent syspurpose values locally
 ROLE = 'role'
@@ -499,6 +501,19 @@ class SyncedStore(object):
         :param data: The data to write to the file
         :return: None
         """
+
+        # Check if /etc/rhsm/syspurpose directory exists
+        if not os.path.isdir(USER_SYSPURPOSE_DIR):
+            # If not create the file
+            log.debug('Creating directory: %s' % USER_SYSPURPOSE_DIR)
+            os.mkdir(USER_SYSPURPOSE_DIR)
+
+        # Check if /var/lib/rhsm/cache/ directory exists
+        if not os.path.isdir(CACHE_DIR):
+            log.debug('Creating directory: %s' % CACHE_DIR)
+            os.mkdir(CACHE_DIR)
+
+        # Then we can try to create syspurpose.json file
         modes = ['w+']
         for mode in modes:
             try:

--- a/syspurpose/test/syspurpose/test_cli.py
+++ b/syspurpose/test/syspurpose/test_cli.py
@@ -34,11 +34,20 @@ class SyspurposeCliTests(SyspurposeTestBase):
         self.OLD_PATH = files.SyncedStore.PATH
         self.OLD_CACHE_PATH = files.SyncedStore.CACHE_PATH
         self.tmp_dir = self._mktmp()
-        os.makedirs(self.tmp_dir + '/cache')
-        files.SyncedStore.PATH = self.tmp_dir + '/syspurpose.json'
+        self.tmp_cache_dir = self._mktmp()
+
+        user_syspurpose_dir_patch = patch('syspurpose.files.USER_SYSPURPOSE_DIR', self.tmp_dir)
+        user_syspurpose_dir_patch.start()
+        self.addCleanup(user_syspurpose_dir_patch.stop)
+
+        cache_dir_patch = patch('syspurpose.files.CACHE_DIR', self.tmp_cache_dir)
+        cache_dir_patch.start()
+        self.addCleanup(cache_dir_patch.stop)
+
+        files.SyncedStore.PATH = os.path.join(self.tmp_dir, 'syspurpose.json')
         with open(files.SyncedStore.PATH, "w") as fp:
             fp.write("{}")
-        files.SyncedStore.CACHE_PATH = self.tmp_dir + '/cache/syspurpose.json'
+        files.SyncedStore.CACHE_PATH = os.path.join(self.tmp_cache_dir, 'syspurpose.json')
         with open(files.SyncedStore.CACHE_PATH, "w") as fp:
             fp.write("{}")
         self.syspurposestore = files.SyncedStore(uep=None, consumer_uuid=None)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1821747
* When /etc/rhsm/syspurpose does not exist, then it is
  automatically created
* When /var/lib/rhsm/cache does not exist, then it is also
  automaticlly created
* Added two unit tests and fixed several unit tests