### PR TITLE
1688702: Generate redhat.repo in off-line mode; ENT-2302

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2457,6 +2457,10 @@ class ReposCommand(CliCommand):
 
                 repo_action_invoker.update()
             else:
+                # When subscription-manager is in offline mode, then we have to generate redhat.repo from
+                # entitlement certificates
+                rl = RepoActionInvoker()
+                rl.update()
                 # In the disconnected case we must modify the repo file directly.
                 changed_repos = [repo for repo in matches if repo['enabled'] != status]
                 for repo in changed_repos:


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1688702
* When entitlement certs and keys are imported in off-line mode
  using: "subscription-manager import" command, then it is
  possible to print repositories provided in entitlement certs,
  but it wasn't possible to enable any repository, because
  redhat.repo wasn't created yet.