### PR TITLE
Reduced REST API calls during register, when SLA is set; ENT-2229

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1467,9 +1467,11 @@ class RegisterCommand(UserPassCommand):
                 system_exit(os.EX_UNAVAILABLE, _("Error: The --servicelevel option is not supported "
                                  "by the server. Did not complete your request."))
             try:
-                attach.AttachService(self.cp).attach_auto(self.options.service_level)
-            except connection.RestlibException as re:
-                print_error(re.msg)
+                # We don't call auto_attach with self.option.service_level, because it has been already
+                # set during service.register() call
+                attach.AttachService(self.cp).attach_auto(service_level=None)
+            except connection.RestlibException as rest_lib_err:
+                print_error(rest_lib_err.msg)
             except Exception:
                 log.exception("Auto-attach failed")
                 raise


### PR DESCRIPTION
* When CLI option --servicelevel is set for register command, then
  two REST API calls were removed. Service level is set only
  in POST /candlepin/consumers
* You can also test changes using this:
```
[root@localhost syspurpose]# PYTHONPATH=./src:./syspurpose/src \
	python -m syspurpose.main set-sla "Super"

[root@localhost syspurpose]# PYTHONPATH=./src:./syspurpose/src \
	python -m syspurpose.main show

[root@localhost syspurpose]# dbus-send --system --print-reply \
	--dest='com.redhat.RHSM1' '/com/redhat/RHSM1/RegisterServer' \
	com.redhat.RHSM1.RegisterServer.Start string:""
method return time=1587110291.947024 sender=:1.4529 -> destination=:1.4575 serial=45 reply_serial=2
   string "unix:abstract=/var/run/dbus-BZsXJp8NJf,guid=5aff4cdf83827f689069534f5e996193"

[root@localhost syspurpose]# export sock_addr="unix:abstract=/var/run/dbus-BZsXJp8NJf,guid=5aff4cdf83827f689069534f5e996193"

[root@localhost syspurpose]# dbus-send --address="${sock_addr}" --print-reply \
	--dest='com.redhat.RHSM1.Register' '/com/redhat/RHSM1/Register' \
	com.redhat.RHSM1.Register.Register string:"admin" string:"admin" \
	string:"admin" dict:string:string:"service_level","Premium" \
	dict:string:string:"","" string:""

[root@localhost syspurpose]# dbus-send --system --print-reply \
	--dest='com.redhat.RHSM1' '/com/redhat/RHSM1/RegisterServer' \
	com.redhat.RHSM1.RegisterServer.Stop string:""

[root@localhost syspurpose]# cat /etc/rhsm/syspurpose/syspurpose.json
{
  "service_level_agreement": "Premium"
}
```

* The SLA should be "Premium" at the end in the syspurpose.json
* Added one unit test for this case
* I also added debug prints that could be used for further
  testing and optimization. You can print content of requests and
  response, when you set following environment variables:
  SUBMAN_DEBUG_PRINT_REQUEST, SUBMAN_DEBUG_PRINT_RESPONSE.
  You can also display more content, when you set following
  env. vars: SUBMAN_DEBUG_PRINT_REQUEST_HEADER, SUBMAN_DEBUG_PRINT_REQUEST_BODY