### PR TITLE
1794653: 1803794: 1823780: Make rhsmd cron read 'processTimeout' case…

### DIFF
--- a/etc-conf/rhsmd.cron
+++ b/etc-conf/rhsmd.cron
@@ -2,7 +2,7 @@
 # nightly run of rhsmd to log entitlement expiration/validity errors to syslog
 # this is a cron job because it doesn't need to 'phone home'. should that
 # change, look into calling the dbus interface from rhsmcertd instead.
-config=$(grep -E "^processTimeout" /etc/rhsm/rhsm.conf | grep -Po "[0-9]+")
+config=$(grep -iE "^processTimeout" /etc/rhsm/rhsm.conf | grep -Po "[0-9]+")
 if [ -n "$config" ]; then
   rhsmd_timeout=$config
 else


### PR DESCRIPTION
…-insensitive

We forgot this in the initial implementation. We should match "processTimeout" case-insensitively.