### PR TITLE
1823523: Read from proc instead of using psutil

### DIFF
--- a/src/subscription_manager/scripts/rhsm_d.py
+++ b/src/subscription_manager/scripts/rhsm_d.py
@@ -52,7 +52,6 @@ import dbus.glib
 import decorator
 import logging
 import traceback
-import psutil
 
 from subscription_manager import ga_loader
 ga_loader.init_ga()
@@ -90,7 +89,7 @@ from subscription_manager.i18n_optparse import OptionParser, \
 from subscription_manager.cert_sorter import RHSM_VALID, \
         RHSM_EXPIRED, RHSM_WARNING, RHSM_PARTIALLY_VALID, \
         RHN_CLASSIC, RHSM_REGISTRATION_REQUIRED
-from subscription_manager.utils import print_error
+from subscription_manager.utils import print_error, is_process_running
 
 from rhsm.config import get_config_parser
 from rhsmlib.services import config
@@ -182,16 +181,8 @@ def is_rhsm_icon_running():
     :return: It returns True, when rhsm-icon is running. Otherwise return False.
     """
     debug('Checking if rhsm-icon process is running')
-    process_names = []
-    for proc in psutil.process_iter():
-        try:
-            name = proc.name()
-        except psutil.AccessDenied as err:
-            debug('Unable to get process name: %s' % str(err))
-        else:
-            process_names.append(name)
-    ret = 'rhsm-icon' in process_names
-    if ret is True:
+    ret = is_process_running('rhsm-icon')
+    if ret:
         debug('Process rhsm-icon is running')
     else:
         debug('Process rhsm-icon is not running')

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -617,3 +617,30 @@ def unique_list_items(l, hash_function=lambda x: x):
 
 def generate_correlation_id():
     return str(uuid.uuid4()).replace('-', '')  # FIXME cp should accept -
+
+
+def get_process_names():
+    """
+    Returns a list of "Name" values for all processes running on the system.
+    This assumes an accessible and standard procfs at "/proc/".
+    It will only work on unix-like systems.
+    """
+    proc_name_expr = "[Nn][Aa][Mm][Ee]:?[\s]*(?P<proc_name>.*)"
+    for subdir in os.listdir('/proc'):
+        if re.match('[0-9]+', subdir):
+            process_status_file_path = os.path.join(os.path.sep, 'proc', subdir, 'status')
+            with open(process_status_file_path) as status:
+                lines = "".join(status.readlines())
+                # Find first value of something that looks like "Name: THING"
+                match = re.search(proc_name_expr, lines)
+                if match:
+                    proc_name = match.groupdict().get('proc_name')
+                    if proc_name:
+                        yield proc_name
+
+
+def is_process_running(process_to_find):
+    for process_name in get_process_names():
+        if process_to_find == process_name:
+            return True
+    return False


### PR DESCRIPTION
This let's us determine if a particular named process is running without the use of psutil or any additional external dependency (apparently ps isn't installed by default in RHEL 8 ubi containers...).

There is one outstanding issue which I have yet to figure out, for some reason the mocking of os.listdir and open works for one test but then fails for the second test despite using the same code paths.
Any feedback or insights would be much appreciated. (There might also be some small change required for stylish).