### PR TITLE
1830994: Fix warning messages in dnf/yum

### DIFF
--- a/src/dnf-plugins/subscription-manager.py
+++ b/src/dnf-plugins/subscription-manager.py
@@ -41,19 +41,19 @@ expired_warning = _("""
 *** WARNING ***
 The subscription for following product(s) has expired:
 %s
-You no longer have access to the repositories that provide these products.  It is important that you apply an active "
-"subscription in order to resume access to security and other critical updates. If you don't have other active "
-"subscriptions, you can renew the expired subscription.  """
+You no longer have access to the repositories that provide these products.  It is important that you apply an active \
+subscription in order to resume access to security and other critical updates. If you don't have other active \
+subscriptions, you can renew the expired subscription.  """
 )
 
-not_registered_warning = _(
-    "This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register."
-)
+not_registered_warning = _("""
+This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
+""")
 
-no_subs_warning = _(
-    "This system is registered to Red Hat Subscription Management, but is not receiving updates. You can use "
-    "subscription-manager to assign subscriptions."
-)
+no_subs_warning = _("""
+This system is registered to Red Hat Subscription Management, but is not receiving updates. You can use \
+subscription-manager to assign subscriptions.
+""")
 
 log = logging.getLogger('rhsm-app.' + __name__)
 

--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -39,9 +39,9 @@ expired_warning = """
 *** WARNING ***
 The subscription for following product(s) has expired:
 %s
-You no longer have access to the repositories that provide these products.  It is important that you apply an active "
-"subscription in order to resume access to security and other critical updates. If you don't have other active "
-"subscriptions, you can renew the expired subscription.
+You no longer have access to the repositories that provide these products.  It is important that you apply an active \
+subscription in order to resume access to security and other critical updates. If you don't have other active \
+subscriptions, you can renew the expired subscription.
 """
 
 not_registered_warning = """
@@ -49,8 +49,8 @@ This system is not registered with an entitlement server. You can use subscripti
 """
 
 no_subs_warning = """
-This system is registered with an entitlement server, but is not receiving updates. You can use subscription-manager "
-"to assign subscriptions.
+This system is registered with an entitlement server, but is not receiving updates. You can use subscription-manager \
+to assign subscriptions.
 """
 
 no_subs_container_warning = """


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1830994
* We added line breaks as part of one refactoring effort and side-effect
  is wrong printing of warning messages in DNF/YUM subscription-manager
  plugin.
* Warning message looks the same generated by DNF and YUM plugin now.