### PR TITLE
Refactoring of save_sla_to_syspurpose_metadata; ENT-2228

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1478,7 +1478,15 @@ class RegisterCommand(UserPassCommand):
                 raise
             else:
                 if self.options.service_level is not None:
-                    save_sla_to_syspurpose_metadata(self.options.service_level)
+                    # uep and consumer_uuid are None, because the service_level was sent to candlepin server
+                    # during registration and it is not necessary to send it twice. It is only necessary to
+                    # save it to syspurpose.json file
+                    save_sla_to_syspurpose_metadata(
+                        uep=None,
+                        consumer_uuid=None,
+                        service_level=self.options.service_level
+                    )
+                    log.debug('>>>>> syspurpose SLA value saved')
                     print(_("Service level set to: %s") % self.options.service_level)
 
         if self.options.consumerid or \
@@ -1933,8 +1941,13 @@ class AttachCommand(CliCommand):
                     attach_service.attach_auto(self.options.service_level)
                     if self.options.service_level is not None:
                         #  RHBZ 1632797 we should only save the sla if the sla was actually
-                        #  specified
-                        save_sla_to_syspurpose_metadata(self.options.service_level)
+                        #  specified. The uep and consumer_uuid are None, because service_level was sent
+                        # to candlepin server using attach_service.attach_auto()
+                        save_sla_to_syspurpose_metadata(
+                            uep=None,
+                            consumer_uuid=None,
+                            service_level=self.options.service_level
+                        )
                         print(_("Service level set to: %s") % self.options.service_level)
 
             if cert_update:

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -49,24 +49,27 @@ store = None
 syspurpose = None
 
 
-def save_sla_to_syspurpose_metadata(service_level):
+def save_sla_to_syspurpose_metadata(uep, consumer_uuid, service_level):
     """
     Saves the provided service-level value to the local Syspurpose Metadata (syspurpose.json) file.
     If the service level provided is null or empty, the sla value to the local syspurpose file is set to null.
+    when uep and consumer_uuid is not None, then service_level is also synced with candlepin server
 
+    :param uep: The object with uep connection (connection to candlepin server)
+    :param consumer_uuid: Consumer UUID
     :param service_level: The service-level value to be saved in the syspurpose file.
     :type service_level: str
     """
 
     if 'SyncedStore' in globals() and SyncedStore is not None:
-        store = SyncedStore(None)
+        synced_store = SyncedStore(uep=uep, consumer_uuid=consumer_uuid)
 
         # if empty, set it to null
         if service_level is None or service_level == "":
             service_level = None
 
-        store.set("service_level_agreement", service_level)
-        store.finish()
+        synced_store.set("service_level_agreement", service_level)
+        synced_store.finish()
         log.debug("Syspurpose SLA value successfully saved locally.")
     else:
         log.error("SyspurposeStore could not be imported. Syspurpose SLA value not saved locally.")

--- a/test/test_syspurposestore_interface.py
+++ b/test/test_syspurposestore_interface.py
@@ -92,7 +92,7 @@ class SyspurposeStoreInterfaceTests(unittest.TestCase):
         Tests that the syspurpose sla is set through the syspurposestore interface
         when the syspurpose module is available for import.
         """
-        self.syspurposelib.save_sla_to_syspurpose_metadata("Freemium")
+        self.syspurposelib.save_sla_to_syspurpose_metadata(None, None, "Freemium")
 
         contents = self.syspurposelib.read_syspurpose()
         self.assertEqual(contents.get("service_level_agreement"), "Freemium")
@@ -102,7 +102,7 @@ class SyspurposeStoreInterfaceTests(unittest.TestCase):
         Tests that the syspurpose sla is not set through the syspurposestore interface
         when None is passed to save_sla_to_syspurpose_metadata method.
         """
-        self.syspurposelib.save_sla_to_syspurpose_metadata(None)
+        self.syspurposelib.save_sla_to_syspurpose_metadata(None, None, None)
 
         contents = self.syspurposelib.read_syspurpose()
         self.assertEqual(contents.get("service_level_agreement"), None)
@@ -112,7 +112,7 @@ class SyspurposeStoreInterfaceTests(unittest.TestCase):
         Tests that the syspurpose sla is not set through the syspurposestore interface
         when an empty string is passed to save_sla_to_syspurpose_metadata method.
         """
-        self.syspurposelib.save_sla_to_syspurpose_metadata("")
+        self.syspurposelib.save_sla_to_syspurpose_metadata(None, None, "")
 
         contents = self.syspurposelib.read_syspurpose()
         self.assertEqual(contents.get("service_level_agreement"), None)
@@ -129,7 +129,7 @@ class SyspurposeStoreInterfaceTests(unittest.TestCase):
         del self.syspurposelib.SyncedStore
         del self.syspurposelib.USER_SYSPURPOSE
 
-        self.syspurposelib.save_sla_to_syspurpose_metadata("Freemium")
+        self.syspurposelib.save_sla_to_syspurpose_metadata(None, None, "Freemium")
 
         # Add SyspurposeStore and USER_SYSPURPOSE back to syspurposestore_interface's scope
         self.syspurposelib.SyncedStore = tmp_syspurpose_store


### PR DESCRIPTION
* It wasn't possible to sync SLA with candlepin server.
* It is possible to do it now, but current usage of this function doesn't require this functionality ATM
* Make the code more explicit about syncing SLA with server