### PR TITLE
1838012: prevent redundant remote syspurpose sync

### DIFF
--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -293,9 +293,10 @@ class SyncedStore(object):
 
         sync_result = SyncResult(
             result,
-            self.update_remote(result),
-            self.update_local(local_result),
-            self.update_cache(result), self.report
+            (remote_contents == result) or self.update_remote(result),
+            (local_contents == result) or self.update_local(local_result),
+            (cached_contents == result) or self.update_cache(result),
+            self.report
         )
 
         log.debug('Successfully synced system purpose.')


### PR DESCRIPTION
When populating SyncResult, update [remote|local|cache] only when either
has changed. That prevents namely redundant update of syspurpose to the
RHSM server when no change has been detected.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>