### PR TITLE
cockpit: Call run-tests from common to run cockpit integration tests

### DIFF
--- a/integration-tests/run
+++ b/integration-tests/run
@@ -28,7 +28,7 @@ SMBEXT_TAR=$(CURDIR)/dist/subscription-manager-build-extra.tar.gz
 TEST_NODE_MODULES = node_modules/chrome-remote-interface node_modules/sizzle
 
 check: prepare
-	integration-tests/check-subscriptions
+	integration-tests/common/run-tests --test-dir integration-tests
 
 reset:
 	rm -f $(COCKPIT_TAR) $(SUBMAN_TAR) $(SMBEXT_TAR) $(VM_IMAGE)
@@ -70,7 +70,7 @@ bots:
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time
 integration-test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 210
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 220
 	git archive FETCH_HEAD -- test/common | tar -x -C integration-tests --strip-components=1 -f -
 
 node_modules:


### PR DESCRIPTION
We moved some stuff over to test/common/run-tests, tests need to be run via run-tests in order to have correct tap output and to have bots/tests-policy run on the output.