### PR TITLE
1741364: Make existing ent. cert/keys readable by others; ENT-1593 

### DIFF
--- a/src/rhsm/certificate.py
+++ b/src/rhsm/certificate.py
@@ -122,6 +122,7 @@ class Certificate(object):
         :type content: str
         """
         self._update(content)
+        self.path = None
 
     def _update(self, content):
         if content:
@@ -523,7 +524,7 @@ class Key(object):
         Read the key.
 
         :param pem_path: The path to the .pem file.
-        :type path: str
+        :type pem_path: str
         """
         f = open(pem_path)
         content = f.read()
@@ -538,6 +539,7 @@ class Key(object):
         :type content: str
         """
         self.content = content
+        self.path = None
 
     def bogus(self):
         bogus = []
@@ -555,8 +557,8 @@ class Key(object):
         """
         Write the key.
 
-        :param path: The path to the .pem file.
-        :type path: str
+        :param pem_path: The path to the .pem file.
+        :type pem_path: str
         :return: self
         """
         f = open(pem_path, 'w')

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1331,6 +1331,9 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
     %endif
 %endif
 
+# Make all entitlement certificates and keys files readable by group and other
+chmod go+r /etc/pki/entitlement/*.pem || true
+
 if [ -x /bin/dbus-send ] ; then
     dbus-send --system --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig > /dev/null 2>&1 || :
 fi


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1741364
* New entitlement certs/keys are readable by others. This changes
  was introduced in this PR:
  #2084
  but existing entitlement keys still have 0600 permissions.
* Permissions are changed during post installation script
* Small refactoring of code