### PR TITLE
Revert "1667792: added --disable-auto-attach option to register comma…

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -234,9 +234,6 @@ subscription-manager register --org="IT Dept" --activationkey=1234abcd
 .B --auto-attach
 Automatically attaches compatible subscriptions to this system.
 
-.TP
-.B --disable-auto-attach
-Do not automatically attach compatible subscriptions, when activation key is used.
 
 .TP
 .B --servicelevel=LEVEL

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -995,7 +995,7 @@ class UEPConnection(BaseConnection):
     def registerConsumer(self, name="unknown", type="system", facts={},
             owner=None, environment=None, keys=None,
             installed_products=None, uuid=None, hypervisor_id=None,
-            content_tags=None, role=None, addons=None, service_level=None, usage=None, autoheal=None):
+            content_tags=None, role=None, addons=None, service_level=None, usage=None):
         """
         Creates a consumer on candlepin server
         """
@@ -1021,8 +1021,6 @@ class UEPConnection(BaseConnection):
             params['usage'] = usage
         if service_level is not None:
             params['serviceLevel'] = service_level
-        if autoheal is not None:
-            params['autoheal'] = autoheal
 
         url = "/consumers"
         if environment:

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -34,7 +34,7 @@ class RegisterService(object):
         self.cp = cp
 
     def register(self, org, activation_keys=None, environment=None, force=None, name=None, consumerid=None,
-            type=None, role=None, addons=None, service_level=None, usage=None, autoheal=None, **kwargs):
+            type=None, role=None, addons=None, service_level=None, usage=None, **kwargs):
         # We accept a kwargs argument so that the DBus object can pass the options dictionary it
         # receives transparently to the service via dictionary unpacking.  This strategy allows the
         # DBus object to be more independent of the service implementation.
@@ -106,8 +106,7 @@ class RegisterService(object):
                 role=role,
                 addons=addons,
                 service_level=service_level,
-                usage=usage,
-                autoheal=autoheal
+                usage=usage
             )
         self.installed_mgr.write_cache()
         self.plugin_manager.run("post_register_consumer", consumer=consumer, facts=facts_dict)

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -201,9 +201,7 @@ class RegisterServiceTest(InjectionMockingTest):
             role="",
             addons=[],
             service_level="",
-            usage="",
-            autoheal=None
-        )
+            usage="")
         self.mock_installed_products.write_cache.assert_called()
 
         mock_persist_consumer.assert_called_once_with(expected_consumer)
@@ -239,46 +237,7 @@ class RegisterServiceTest(InjectionMockingTest):
             role="",
             addons=[],
             service_level="",
-            usage="",
-            autoheal=None
-        )
-        self.mock_installed_products.write_cache.assert_called()
-
-        mock_persist_consumer.assert_called_once_with(expected_consumer)
-        expected_plugin_calls = [
-            mock.call('pre_register_consumer', name='name', facts={}),
-            mock.call('post_register_consumer', consumer=expected_consumer, facts={})
-        ]
-        self.assertEqual(expected_plugin_calls, self.mock_pm.run.call_args_list)
-
-    @mock.patch("rhsmlib.services.register.managerlib.persist_consumer_cert")
-    def test_register_with_activation_keys_autoattach_disabled(self, mock_persist_consumer):
-        self.mock_cp.username = None
-        self.mock_cp.password = None
-        self.mock_identity.is_valid.return_value = False
-        self.mock_installed_products.format_for_server.return_value = []
-        self.mock_installed_products.tags = []
-
-        expected_consumer = json.loads(CONSUMER_CONTENT_JSON)
-        self.mock_cp.registerConsumer.return_value = expected_consumer
-
-        register_service = register.RegisterService(self.mock_cp)
-        register_service.register("org", name="name", activation_keys=[1], autoheal=False)
-
-        self.mock_cp.registerConsumer.assert_called_once_with(
-            name="name",
-            facts={},
-            owner="org",
-            environment=None,
-            keys=[1],
-            installed_products=[],
-            content_tags=[],
-            type="system",
-            role="",
-            addons=[],
-            service_level="",
-            usage="",
-            autoheal=False
+            usage=""
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -359,51 +318,7 @@ class RegisterServiceTest(InjectionMockingTest):
             role="test_role",
             service_level="test_sla",
             type="system",
-            usage="test_usage",
-            autoheal=None
-        )
-
-    @mock.patch('subscription_manager.syspurposelib.write_syspurpose')
-    @mock.patch("rhsmlib.services.register.managerlib.persist_consumer_cert")
-    def test_writes_syspurpose(self, mock_persist_consumer, mock_write_syspurpose):
-        self.mock_installed_products.format_for_server.return_value = []
-        self.mock_installed_products.tags = []
-        self.mock_identity.is_valid.return_value = False
-        self.mock_sp_store_contents["role"] = "test_role"
-        self.mock_sp_store_contents["service_level_agreement"] = "test_sla"
-        self.mock_sp_store_contents["addons"] = ["addon1"]
-        self.mock_sp_store_contents["usage"] = "test_usage"
-
-        expected_consumer = json.loads(CONSUMER_CONTENT_JSON)
-        self.mock_cp.registerConsumer.return_value = expected_consumer
-
-        register_service = register.RegisterService(self.mock_cp)
-        register_service.register("org", name="name", service_level="another_sla")
-
-        self.mock_cp.registerConsumer.assert_called_once_with(
-            addons=["addon1"],
-            content_tags=[],
-            environment=None,
-            facts={},
-            installed_products=[],
-            keys=None,
-            name="name",
-            owner="org",
-            role="test_role",
-            service_level="another_sla",
-            type="system",
-            usage="test_usage",
-            autoheal=None
-        )
-
-        mock_write_syspurpose.assert_called_once_with(
-            {
-                'usage': 'test_usage',
-                'service_level_agreement': 'another_sla',
-                'addons': ['addon1'],
-                'role': 'test_role'
-            }
-        )
+            usage="test_usage")
 
     def test_does_not_require_basic_auth_with_activation_keys(self):
         self.mock_cp.username = None

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -484,12 +484,6 @@ class TestRegisterCommand(TestCliProxyCommand):
     def test_key_and_org(self):
         self._test_no_exception(["--activationkey", "key", "--org", "org"])
 
-    def test_key_and_disable_auto_attach(self):
-        self._test_no_exception(["--activationkey", "key", "--org", "org", "--disable-auto-attach"])
-
-    def test_auto_attach_and_disable_auto_attach(self):
-        self._test_exception(["--auto-attach", "--disable-auto-attach"])
-
     def test_key_and_no_org(self):
         self._test_exception(["--activationkey", "key"])
 


### PR DESCRIPTION
…nd; ENT-1684"

This reverts commit a736b0824b4883cd49843bd0db7a2df91eb41497.

As we hadn't quite finished deciding to go with the disable-auto-attach option, this pulls it out of master for the time being.

We can reconsider in the future.