### PR TITLE
1840364: Kill rhsmd during post-install on rhel8; ENT-2449

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1333,6 +1333,15 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
     %endif
 %endif
 
+# When subscription-manager is upgraded on RHEL 8 (from RHEL 8.2 to RHEL 8.3), then kill
+# instance of rhsmd, because it is not necessary anymore and it can cause issues.
+# See: https://bugzilla.redhat.com/show_bug.cgi?id=1840364
+%if ( 0%{?rhel} >= 8 || 0%{?fedora} )
+if [ "$1" = "2" ] ; then
+    killall rhsmd 2> /dev/null || true
+fi
+%endif
+
 # Make all entitlement certificates and keys files readable by group and other
 chmod go+r /etc/pki/entitlement/*.pem || true
 


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1840364
* The rhsmd is not part of RHEL8 anymore. Thus it is good to
  kill this service at the end of installation process, when
  the RPM package of subscription-manager is upgraded.
* The rhsmd is also killed, when the package is installed
  on Fedora.