### PR TITLE
Add --no-insights option; ENT-2471

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -176,7 +176,7 @@ _subscription_manager_register()
 {
   local opts="--activationkey --auto-attach --autosubscribe --baseurl --consumerid
               --environment --force --name --org --password --release
-              --servicelevel --username --token
+              --servicelevel --username --token --no-insights
               ${_subscription_manager_common_url_opts}
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -259,6 +259,10 @@ Registers the system to an environment within an organization.
 .B --release=VERSION
 Shortcut for "release --set=VERSION"
 
+.TP
+.B --no-insights
+Stop insights from automatically registering using the subscription-manager identity.
+
 .SS UNREGISTER OPTIONS
 The
 .B unregister

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -14,6 +14,7 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 import logging
 import socket
+import subprocess
 
 from rhsmlib.services import exceptions
 
@@ -34,7 +35,7 @@ class RegisterService(object):
         self.cp = cp
 
     def register(self, org, activation_keys=None, environment=None, force=None, name=None, consumerid=None,
-            type=None, role=None, addons=None, service_level=None, usage=None, **kwargs):
+            type=None, role=None, addons=None, service_level=None, usage=None, no_insights=None, **kwargs):
         # We accept a kwargs argument so that the DBus object can pass the options dictionary it
         # receives transparently to the service via dictionary unpacking.  This strategy allows the
         # DBus object to be more independent of the service implementation.
@@ -43,6 +44,16 @@ class RegisterService(object):
         # signature we want to consider that an error.
         if kwargs:
             raise exceptions.ValidationError(_("Unknown arguments: %s") % kwargs.keys())
+
+        if no_insights is True:
+            try:
+                with open('/dev/null', 'w') as devnull:
+                    subprocess.call(['/usr/bin/systemctl', 'mask', '--now', 'insights-register.path'], stdout=devnull,
+                                    stderr=devnull)
+            except:
+                # ignore failures here in case we're running in a container, or some other issue prevents disabling
+                # insights auto-register
+                log.warn("Failed to disable automatic insights registration")
 
         syspurpose = syspurposelib.read_syspurpose()
 

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -47,13 +47,17 @@ class RegisterService(object):
 
         if no_insights is True:
             try:
+                # insights-client implements a systemd path unit to trigger insights registration whenever the consumer
+                # certificate changes. By masking this unit, we disable this automatic insights registration mechanism.
+                # See: https://www.freedesktop.org/software/systemd/man/systemd.path.html
+                log.debug("Disabling automatic insights registration by masking insights-register.path")
                 with open('/dev/null', 'w') as devnull:
                     subprocess.call(['/usr/bin/systemctl', 'mask', '--now', 'insights-register.path'], stdout=devnull,
                                     stderr=devnull)
-            except:
+            except Exception as e:
                 # ignore failures here in case we're running in a container, or some other issue prevents disabling
                 # insights auto-register
-                log.warn("Failed to disable automatic insights registration")
+                log.warning("Failed to disable automatic insights registration: %s", e, exc_info=True)
 
         syspurpose = syspurposelib.read_syspurpose()
 

--- a/src/rhsmlib/services/unregister.py
+++ b/src/rhsmlib/services/unregister.py
@@ -21,11 +21,15 @@ server.
 """
 
 import logging
+import os
+import subprocess
 
 from subscription_manager import injection as inj
 from subscription_manager import managerlib
 from rhsm import connection
 
+
+INSIGHTS_REGISTER_UNIT_PATH = '/etc/systemd/system/insights-register.path'
 
 log = logging.getLogger(__name__)
 
@@ -65,3 +69,12 @@ class UnregisterService(object):
                 managerlib.clean_all_data(backup=False)
             else:
                 raise ge
+        finally:
+            try:
+                if os.path.exists(INSIGHTS_REGISTER_UNIT_PATH) and os.path.islink(INSIGHTS_REGISTER_UNIT_PATH) and \
+                        os.readlink(INSIGHTS_REGISTER_UNIT_PATH) == '/dev/null':
+                    with open('/dev/null', 'w') as devnull:
+                        subprocess.call(['/usr/bin/systemctl', 'unmask', 'insights-register.path'], stdout=devnull,
+                                        stderr=devnull)
+            except:
+                log.warn("Failed to ensure insights automatic registration enabled")

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -28,6 +28,7 @@ import re
 import readline
 import socket
 import six.moves
+import subprocess
 import sys
 from time import localtime, strftime, strptime
 
@@ -1486,6 +1487,21 @@ class RegisterCommand(UserPassCommand):
             subscribed = show_autosubscribe_output(self.cp, self.identity)
 
         self._request_validity_check()
+
+        if self.options.no_insights:
+            print(_('Red Hat Insights registration disabled.'))
+            if self._is_insights_installed():
+                print(_('To opt into Red Hat Insights, run "insights-client --register".'))
+            else:
+                print(_('To opt into Red Hat Insights, install the insights-client package '
+                        'and run "insights-client --register".'))
+        else:
+            print(_('Red Hat Insights registration enabled.'))
+            if not self._is_insights_installed():
+                print(_('To use Red Hat Insights, install the insights-client package.'))
+            print(_('To opt out of Red Hat Insights, run "insights-client --unregister" '
+                    'or reregister with "--no-insights".'))
+
         return subscribed
 
     def _prompt_for_environment(self):
@@ -1568,6 +1584,11 @@ class RegisterCommand(UserPassCommand):
             owner_key = six.moves.input(_("Organization: "))
             readline.clear_history()
         return owner_key
+
+    def _is_insights_installed(self):
+        with open('/dev/null', 'w') as devnull:
+            returncode = subprocess.call('which insights-client', stdout=devnull, stderr=devnull, shell=True)
+        return returncode == 0
 
 
 class UnRegisterCommand(CliCommand):

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1283,6 +1283,8 @@ class RegisterCommand(UserPassCommand):
                                help=_("activation key to use for registration (can be specified more than once)"))
         self.parser.add_option("--servicelevel", dest="service_level",
                                help=_("system preference used when subscribing automatically, requires --auto-attach"))
+        self.parser.add_option("--no-insights", action='store_true',
+                               help=_("stop insights from automatically registering using the system identity"))
 
     def _validate_options(self):
         self.autoattach = self.options.autosubscribe or self.options.autoattach
@@ -1403,6 +1405,7 @@ class RegisterCommand(UserPassCommand):
                     name=self.options.consumername,
                     type=self.options.consumertype,
                     service_level=self.options.service_level,
+                    no_insights=self.options.no_insights
                 )
         except (connection.RestlibException, exceptions.ServiceError) as re:
             log.exception(re)

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -211,6 +211,79 @@ class RegisterServiceTest(InjectionMockingTest):
         ]
         self.assertEqual(expected_plugin_calls, self.mock_pm.run.call_args_list)
 
+    @mock.patch("subprocess.call")
+    @mock.patch("rhsmlib.services.register.managerlib.persist_consumer_cert")
+    def test_register_with_no_insights(self, mock_persist_consumer, mock_subprocess_call):
+        self.mock_identity.is_valid.return_value = False
+        self.mock_installed_products.format_for_server.return_value = []
+        self.mock_installed_products.tags = []
+        expected_consumer = json.loads(CONSUMER_CONTENT_JSON)
+        self.mock_cp.registerConsumer.return_value = expected_consumer
+
+        register_service = register.RegisterService(self.mock_cp)
+        mock_open = mock.mock_open()
+        with mock.patch('rhsmlib.services.register.open', mock_open, create=True):
+            register_service.register("org", name="name", environment="environment", no_insights=True)
+
+        self.mock_cp.registerConsumer.assert_called_once_with(
+            name="name",
+            facts={},
+            owner="org",
+            environment="environment",
+            keys=None,
+            installed_products=[],
+            content_tags=[],
+            type="system",
+            role="",
+            addons=[],
+            service_level="",
+            usage="")
+        self.mock_installed_products.write_cache.assert_called()
+
+        mock_persist_consumer.assert_called_once_with(expected_consumer)
+        mock_subprocess_call.assert_called_once_with(['/usr/bin/systemctl', 'mask', '--now', 'insights-register.path'],
+                                                     stdout=mock_open(), stderr=mock_open())
+        expected_plugin_calls = [
+            mock.call('pre_register_consumer', name='name', facts={}),
+            mock.call('post_register_consumer', consumer=expected_consumer, facts={})
+        ]
+        self.assertEqual(expected_plugin_calls, self.mock_pm.run.call_args_list)
+
+    @mock.patch("subprocess.call")
+    @mock.patch("rhsmlib.services.register.managerlib.persist_consumer_cert")
+    def test_register_with_no_insights_with_systemctl_failure(self, mock_persist_consumer, mock_subprocess_call):
+        self.mock_identity.is_valid.return_value = False
+        self.mock_installed_products.format_for_server.return_value = []
+        self.mock_installed_products.tags = []
+        expected_consumer = json.loads(CONSUMER_CONTENT_JSON)
+        self.mock_cp.registerConsumer.return_value = expected_consumer
+        mock_subprocess_call.side_effect = Exception
+
+        register_service = register.RegisterService(self.mock_cp)
+        register_service.register("org", name="name", environment="environment", no_insights=True)
+
+        self.mock_cp.registerConsumer.assert_called_once_with(
+            name="name",
+            facts={},
+            owner="org",
+            environment="environment",
+            keys=None,
+            installed_products=[],
+            content_tags=[],
+            type="system",
+            role="",
+            addons=[],
+            service_level="",
+            usage="")
+        self.mock_installed_products.write_cache.assert_called()
+
+        mock_persist_consumer.assert_called_once_with(expected_consumer)
+        expected_plugin_calls = [
+            mock.call('pre_register_consumer', name='name', facts={}),
+            mock.call('post_register_consumer', consumer=expected_consumer, facts={})
+        ]
+        self.assertEqual(expected_plugin_calls, self.mock_pm.run.call_args_list)
+
     @mock.patch("rhsmlib.services.register.managerlib.persist_consumer_cert")
     def test_register_with_activation_keys(self, mock_persist_consumer):
         self.mock_cp.username = None

--- a/test/rhsmlib_test/test_unregister.py
+++ b/test/rhsmlib_test/test_unregister.py
@@ -49,13 +49,38 @@ class TestUnregisterService(InjectionMockingTest):
         else:
             return None
 
+    @mock.patch('os.path.exists')
     @mock.patch('subscription_manager.managerlib.clean_all_data')
-    def test_unregister(self, clean_all_data):
+    def test_unregister(self, clean_all_data, mock_path_exists):
         """
         Testing normal unregistration process
         """
+        mock_path_exists.return_value = False  # this short-circuits --no-insights path mask check
         result = unregister.UnregisterService(self.mock_cp).unregister()
         self.assertIsNone(result)
+
+    @mock.patch('subprocess.call')
+    @mock.patch('os.path.islink')
+    @mock.patch('os.readlink')
+    @mock.patch('os.path.exists')
+    @mock.patch('subscription_manager.managerlib.clean_all_data')
+    def test_unregister_insights_register_unmask(self, clean_all_data, mock_path_exists, mock_readlink, mock_islink,
+                                                 mock_subprocess_call):
+        """
+        Testing normal unregistration process
+        """
+        mock_path_exists.return_value = True
+        mock_readlink.return_value = '/dev/null'
+        mock_islink.return_value = True
+
+        mock_open = mock.mock_open()
+        with mock.patch('rhsmlib.services.unregister.open', mock_open, create=True):
+            result = unregister.UnregisterService(self.mock_cp).unregister()
+        self.assertIsNone(result)
+        mock_subprocess_call.assert_called_once_with(
+            ['/usr/bin/systemctl', 'unmask', 'insights-register.path'],
+            stdout=mock_open(), stderr=mock_open()
+        )
 
 
 class TestUnregisterDBusObject(DBusObjectTest, InjectionMockingTest):

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -499,6 +499,9 @@ class TestRegisterCommand(TestCliProxyCommand):
     def test_env_and_org(self):
         self._test_no_exception(["--env", "env", "--org", "org"])
 
+    def test_no_insights(self):
+        self._test_no_exception(['--activationkey', 'key', '--org', 'org', '--no-insights'])
+
     def test_no_commands(self):
         self._test_no_exception([])
 


### PR DESCRIPTION
Insights client plans to implement a process to watch the consumer cert
directory and perform registration automatically when we land a consumer
cert in this directory.

In order to disable this functionality during registration, this change
adds the `--no-insights` option, which disables the planned systemd
unit.

If the systemctl command fails to disable the unit, we proceed with
registration. There may be some use cases (e.g. container where systemd
does not run) where failure to mask may be a non-issue.

This PR also adds messaging to the registration output.
    
There are four scenarios:
1. `--no-insights` passed, insights-client not present
2. `--no-insights` passed, insights-client present
3. `--no-insights` not passed, insights-client not present
4. `--no-insights` not passed, insights-client present

There are 6 new strings involved, see the code for details.
    
The messaging indicates how to opt-in/opt-out, instructing the user to
install the insights-client package if needed.

This change also looks for a disabled unit and removes it on
unregistration if present.

To test
-------
Try any given register command, appending `--no-insights` option.
Observe that after registration
`systemctl status insights-register.path` explains that the unit is
masked. Note you don't actually have to have a pre-existing
`insights-register.path`, so no need to install insights-client or mock
up the unit.

To test the messaging, it is possible to mock insights-client installation by stubbing
out insights-client. For example:
    
```
sudo cp /usr/bin/echo /usr/bin/insights-client
```

Afterwards, try `subscription-manager unregister` and observe that the
unit is no longer masked via `systemctl status insights-register.path`.