### PR TITLE
1848636, 1849074: Update insights machine-id path

### DIFF
--- a/test/rhsmlib_test/test_insights.py
+++ b/test/rhsmlib_test/test_insights.py
@@ -19,13 +19,15 @@ try:
 except ImportError:
     import unittest
 
+from ..fixture import open_mock_many
 from rhsmlib.facts import insights
 from mock import patch
 import tempfile
 import six
 
-
+INSIGHT_FUTURE_UUID = "250878c1-a8a2-4c44-8a29-5736dc4094c7"
 INSIGHT_TEST_UUID = "2d05f031-d20c-40c9-9cee-2a1d7e823ab6"
+INSIGHT_OLD_UUID = "0d1ff8fb-0279-4575-9f89-9617cfaf9db2"
 
 
 class TestInsightsCollector(unittest.TestCase):
@@ -61,3 +63,40 @@ class TestInsightsCollector(unittest.TestCase):
         self.assertFalse(hasattr(consts, 'machine_id_file'))
         fact = self.collector.get_all()
         self.assertEqual(fact, {})
+
+    @patch('rhsmlib.facts.insights.insights_constants')
+    def test_get_machine_id_old_location(self, consts):
+        # When the file pointed to by consts doesn't exist, at least try to read the old one for
+        # backwards compatibility
+        consts.machine_id_file = "/not/existing/file/machine_id"
+        with open_mock_many({
+            "/etc/redhat-access-insights/machine-id": INSIGHT_OLD_UUID
+        }):
+            fact = self.collector.get_all()
+        self.assertIn("insights_id", fact)
+        self.assertEqual(fact["insights_id"], INSIGHT_OLD_UUID)
+
+    @patch('rhsmlib.facts.insights.insights_constants', spec=['InsightsConstants'])
+    def test_get_machine_id_old_and_new_location(self, consts):
+        # Prefer the new location over the old when we can't get the current location from consts
+        with open_mock_many({
+            "/etc/insights-client/machine-id": INSIGHT_TEST_UUID,
+            "/etc/redhat-access-insights/machine-id": INSIGHT_OLD_UUID
+        }):
+            fact = self.collector.get_all()
+        self.assertIn("insights_id", fact)
+        self.assertEqual(fact["insights_id"], INSIGHT_TEST_UUID)
+
+    @patch('rhsmlib.facts.insights.insights_constants', spec=['InsightsConstants'])
+    def test_get_machine_id_future_location(self, consts):
+        # Show that so long as the "consts.machine_id_file" is updated when the path for
+        # machine id is updated by insights, that we will read from the right location
+        consts.machine_id_file = "/new/future/location"
+        with open_mock_many({
+            consts.machine_id_file: INSIGHT_FUTURE_UUID,
+            "/etc/insights-client/machine-id": INSIGHT_TEST_UUID,
+            "/etc/redhat-access-insights/machine-id": INSIGHT_OLD_UUID
+        }):
+            fact = self.collector.get_all()
+        self.assertIn("insights_id", fact)
+        self.assertEqual(fact["insights_id"], INSIGHT_FUTURE_UUID)


### PR DESCRIPTION
Prior the insights-client machine-id (the id used to uniquely
identify a system for Red Hat Insights) was located in the filesystem
at '/etc/redhat-access-insights/machine-id'.
It is (as of 3.0.13+ of insights-client) moved to
'/etc/insights-client/machine-id'.

Subscription-manager needs to report this in order to ensure we
do not end up with two records for the same system (one created
during registration using insights-client and another created
in hosted based on the new consumer registration to RHSM)

Now subscription-manager will first try to read the machine id:
    1) from the file specified in insights_client.constants.machine_id_file
    2) from "/etc/insights-client/machine-id"
    3) from "/etc/redhat-access-insights/machine-id"
    
Also added a new test function to allow mocking of an arbitrary number
of files on the file system called open_mock_many.