### PR TITLE
Support Insights registration by default in cockpit

### DIFF
--- a/cockpit/src/index.js
+++ b/cockpit/src/index.js
@@ -39,7 +39,7 @@ let registerDialogDetails = {
     proxy_server: '',
     proxy_user: '',
     proxy_password: '',
-    insights: false
+    insights: true,
 };
 
 function dismissStatusError() {
@@ -50,7 +50,7 @@ function dismissStatusError() {
 function registerSystem (update_progress) {
     return subscriptionsClient.registerSystem(registerDialogDetails, update_progress).then(() => {
         if (registerDialogDetails.insights)
-            return Insights.register(update_progress).catch(Insights.catch_error);
+            Insights.register(update_progress).catch(Insights.catch_error);
     });
 }
 
@@ -72,7 +72,7 @@ function openRegisterDialog() {
             password: '',
             activation_keys: '',
             org: '',
-            insights: false,
+            insights: true,
             insights_available: subscriptionsClient.insightsAvailable,
             insights_detected: false,
             register_method: 'account',

--- a/cockpit/src/insights.jsx
+++ b/cockpit/src/insights.jsx
@@ -35,7 +35,9 @@ const insights_timer = service.proxy("insights-client.timer", "Timer");
 const insights_service = service.proxy("insights-client.service", "Service");
 
 export function detect() {
-    return cockpit.spawn([ "which", "insights-client" ], { err: "ignore" }).then(() => true, () => false);
+    return new Promise(resolve => {
+        cockpit.spawn([ "which", "insights-client" ], { err: "ignore" }).then(() => resolve(true), () => resolve(false));
+    });
 }
 
 export function catch_error(err) {
@@ -45,7 +47,7 @@ export function catch_error(err) {
     // readable by wrapping the text in <pre>.
     if (msg.indexOf("\n") > 0)
         msg = <pre>{msg}</pre>;
-    subscriptionsClient.setError("error", msg);
+    subscriptionsClient.setError("warning", msg);
 }
 
 function ensure_installed(update_progress) {
@@ -60,6 +62,9 @@ function ensure_installed(update_progress) {
                             return Promise.reject(cockpit.format(_("The system could not be connected to Insights because installing the $0 package requires the unexpected removal of other packages."),
                                                                  subscriptionsClient.insightsPackage));
                         return PK.install_missing_packages(data, update_install_progress(update_progress));
+                    }, error => {
+                        console.error('Error while trying to install insights-client', error);
+                        return Promise.reject(cockpit.format(_("The $0 package could not be installed."), subscriptionsClient.insightsPackage));
                     });
         else
             return Promise.resolve();

--- a/cockpit/src/subscriptions-client.js
+++ b/cockpit/src/subscriptions-client.js
@@ -313,6 +313,12 @@ client.registerSystem = (subscriptionDetails, update_progress) => {
                     'com.redhat.RHSM1.Register',
                     '/com/redhat/RHSM1/Register'
                 );
+                const options = {
+                    'no_insights': {
+                        't': 'b',
+                        'v': !subscriptionDetails.insights,
+                    }
+                };
                 if (subscriptionDetails.activation_keys) {
                     if (update_progress)
                         update_progress(_("Registering using activation key ..."), null);
@@ -322,7 +328,7 @@ client.registerSystem = (subscriptionDetails, update_progress) => {
                         [
                             subscriptionDetails.org,
                             subscriptionDetails.activation_keys.split(','),
-                            {},
+                            options,
                             connection_options,
                             userLang
                         ]
@@ -340,7 +346,7 @@ client.registerSystem = (subscriptionDetails, update_progress) => {
                             subscriptionDetails.org,
                             subscriptionDetails.user,
                             subscriptionDetails.password,
-                            {},
+                            options,
                             connection_options,
                             userLang
                         ]

--- a/cockpit/src/subscriptions-register.jsx
+++ b/cockpit/src/subscriptions-register.jsx
@@ -70,22 +70,13 @@ class PatternDialogBody extends React.Component {
                 </div>
             );
         }
-        let insights;
-        let insights_checkbox_disabled = true;
-        if (this.props.insights_available === true) {
-            insights_checkbox_disabled = false;
-        } else {
-            if (this.props.auto_attach === true) {
-                insights_checkbox_disabled = false;
-            }
-        }
-        insights = [
+        let insights = [
             <label key="0" className="control-label" htmlFor="subscription-insights">
                 {_("Insights")}
             </label>,
             <label key="1" className="checkbox-inline">
                 <input id="subscription-insights" type="checkbox" checked={this.props.insights}
-                       disabled={ insights_checkbox_disabled } onChange={value => this.props.onChange('insights', value)}/>
+                       onChange={value => this.props.onChange('insights', value)}/>
                 <span>
                 { Insights.arrfmt(_("Connect this system to $0."), Insights.link) }
                 </span>


### PR DESCRIPTION
This makes the following changes:
- checks the "Connect this system to Red Hat Insights" option by default
- passes the no_insights option through when the option is unchecked
- reduces any errors encountered during Insights registration to
  warnings

Note I wrapped the use of `cockpit.spawn` in one place to adapt
cockpit promises to standard Promises, this was necessary to get error
logic working properly.

To test
-------
Try a centos 7 machine without insights-client packages available. Not
that by default, you'll see a warning about not being able to install
the insights-client package.

Try unchecking the box and observe the masking introduced in ENT-2471
happens.

Try unregistering via cockpit and observe the registration is unmasked.

Note that there may be some additional cleanup to do here (e.g. may not
be necessary to have cockpit code call `insights --register` in the
future.