### PR TITLE
1657269: Do not use /var/run, but use /run; ENT-1086

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ DESTDIR ?= /
 PREFIX ?= /usr/local
 SYSCONF ?= etc
 INSTALL_DIR = $(PREFIX)/share
+RUN_DIR ?= /run
 
 OS = $(shell test -f /etc/os-release && source /etc/os-release; echo $$ID)
 OS_DIST ?= $(shell rpm --eval='%dist')
@@ -381,7 +382,7 @@ install: install-via-setup install-files
 install-files: dbus-install install-conf install-plugins install-post-boot install-ga
 	install -d $(DESTDIR)/var/log/rhsm
 	install -d $(DESTDIR)/var/spool/rhsm/debug
-	install -d $(DESTDIR)/var/run/rhsm
+	install -d $(DESTDIR)${RUN_DIR}/rhsm
 	install -d -m 750 $(DESTDIR)/var/lib/rhsm/{cache,facts,packages,repo_server_val}
 
 	# Set up rhsmcertd daemon. Installation location depends on distro...

--- a/etc-conf/subscription-manager.conf.tmpfiles
+++ b/etc-conf/subscription-manager.conf.tmpfiles
@@ -1,1 +1,1 @@
-d /var/run/rhsm 0755 root root -
+d /run/rhsm 0755 root root -

--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -35,9 +35,9 @@
 
 #define LOGFILE "/var/log/rhsm/rhsmcertd.log"
 #define LOCKFILE "/var/lock/subsys/rhsmcertd"
-#define UPDATEFILE "/var/run/rhsm/update"
-#define NEXT_CERT_UPDATE_FILE "/var/run/rhsm/next_cert_check_update"
-#define NEXT_AUTO_ATTACH_UPDATE_FILE "/var/run/rhsm/next_auto_attach_update"
+#define UPDATEFILE "/run/rhsm/update"
+#define NEXT_CERT_UPDATE_FILE "/run/rhsm/next_cert_check_update"
+#define NEXT_AUTO_ATTACH_UPDATE_FILE "/run/rhsm/next_auto_attach_update"
 #define WORKER LIBEXECDIR"/rhsmcertd-worker"
 #define WORKER_NAME WORKER
 #define INITIAL_DELAY_SECONDS 120

--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -266,7 +266,7 @@ class DomainSocketServer(object):
 
     def run(self):
         try:
-            self._server = dbus.server.Server("unix:tmpdir=/var/run")
+            self._server = dbus.server.Server("unix:tmpdir=/run")
 
             for clazz in self.object_classes:
                 self._server.on_connection_added.append(

--- a/src/subscription_manager/gui/about.py
+++ b/src/subscription_manager/gui/about.py
@@ -35,8 +35,8 @@ LICENSE = _("\nThis software is licensed to you under the GNU General Public Lic
             "granted to use or replicate Red Hat trademarks that are incorporated "
             "in this software or its documentation.\n")
 
-AUTO_ATTACH_UPDATE_FILE = '/var/run/rhsm/next_auto_attach_update'
-CERT_CHECK_UPDATE_FILE = '/var/run/rhsm/next_cert_check_update'
+AUTO_ATTACH_UPDATE_FILE = '/run/rhsm/next_auto_attach_update'
+CERT_CHECK_UPDATE_FILE = '/run/rhsm/next_cert_check_update'
 
 prefix = os.path.dirname(__file__)
 

--- a/src/subscription_manager/lock.py
+++ b/src/subscription_manager/lock.py
@@ -215,7 +215,7 @@ class Lock(object):
 
 class ActionLock(Lock):
 
-    PATH = '/var/run/rhsm/cert.pid'
+    PATH = '/run/rhsm/cert.pid'
 
     def __init__(self):
         super(ActionLock, self).__init__(self.PATH)

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -64,7 +64,7 @@
 %global completion_dir %{_datadir}/bash-completion/completions
 %endif
 
-%if 0%{?suse_version} > 1110
+%if 0%{?suse_version} > 1110 || 0%{?rhel} >= 7 || 0%{?fedora}
 %global run_dir /run
 %else
 %global run_dir /var/run

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -478,7 +478,7 @@ class DomainSocketRegisterDBusObjectTest(DBusObjectTest, InjectionMockingTest):
 
         def assertions(*args):
             result = args[0]
-            six.assertRegex(self, result, r'/var/run/dbus.*')
+            six.assertRegex(self, result, r'/run/dbus.*')
 
         self.dbus_request(assertions, self.interface.Start, dbus_method_args)
 
@@ -489,7 +489,7 @@ class DomainSocketRegisterDBusObjectTest(DBusObjectTest, InjectionMockingTest):
             # Assign the result as an attribute to this function.
             # See http://stackoverflow.com/a/27910553/6124862
             assertions.result = args[0]
-            six.assertRegex(self, assertions.result, r'/var/run/dbus.*')
+            six.assertRegex(self, assertions.result, r'/run/dbus.*')
 
         self.dbus_request(assertions, self.interface.Start, dbus_method_args)
 


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1657269
* The directory `/var/run` is marked as obsoleted and it is
  also hard link to `/run`
* Chnaged all occurance of `/var/run` to `/run`
* Prepared the code for similar change in virt-who