### PR TITLE
Mark node_modules as part of rpm package.

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1309,6 +1309,7 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %files -n subscription-manager-cockpit
 %defattr(-,root,root,-)
 %dir %{_datadir}/cockpit/subscription-manager
+%dir %{_datadir}/cockpit/subscription-manager/node_modules
 %{_datadir}/cockpit/subscription-manager/index.html
 %{_datadir}/cockpit/subscription-manager/index.min.js.gz
 %{_datadir}/cockpit/subscription-manager/subscriptions.css


### PR DESCRIPTION
* When subman-cocpit rpm package was removed then node_modules
  was not removed and /usr/share/cockpit/subscription-manager
  was not removed too.