### PR TITLE
1841600: D-Bus - update ent. cert., when act. key is used; ENT-2453

### DIFF
--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -22,6 +22,7 @@ from rhsmlib.dbus import constants, exceptions, dbus_utils, base_object, server,
 from rhsmlib.services.register import RegisterService
 
 from subscription_manager.i18n import Locale
+from subscription_manager.entcertlib import EntCertActionInvoker
 
 log = logging.getLogger(__name__)
 
@@ -172,4 +173,9 @@ class DomainSocketRegisterDBusObject(base_object.BaseObject):
 
         register_service = RegisterService(cp)
         consumer = register_service.register(org, **options)
+
+        log.debug("System registered, updating entitlements if needed")
+        entcertlib = EntCertActionInvoker()
+        entcertlib.update()
+
         return json.dumps(consumer)

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -465,6 +465,10 @@ class DomainSocketRegisterDBusObjectTest(DBusObjectTest, InjectionMockingTest):
         self.mock_register = register_patcher.start().return_value
         self.addCleanup(register_patcher.stop)
 
+        cert_invoker_patcher = mock.patch('rhsmlib.dbus.objects.register.EntCertActionInvoker', autospec=True)
+        self.mock_cert_invoker = cert_invoker_patcher.start().return_value
+        self.addCleanup(cert_invoker_patcher.stop)
+
     def injection_definitions(self, *args, **kwargs):
         if args[0] == inj.IDENTITY:
             return self.mock_identity


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1841600
* When activation key is used for registration over D-Bus API
  and auto-attach was enabled on activation key, then entitlement
  certificates were not installed to the system.
* It is possible to reproduce this issue using following script.
  Note: this script doesn't work on Fedora32, because there is
  some bug in busctl and busctl doesn't work as expected, when
  unix socket is used. I used this script on CentOS 7:

```bash
#!/bin/bash

echo "starting RegisterServer..."
dbus-send --system --print-reply --dest='com.redhat.RHSM1' \
    '/com/redhat/RHSM1/RegisterServer' \
    com.redhat.RHSM1.RegisterServer.Start string:"" \
    > /root/register_server_output.txt

if [[ $? -eq 0 ]]
then
    export my_addr=`cat /root/register_server_output.txt \
        | gawk '/string/{ print $2 }' | sed 's/\"//g'`
fi

echo "Using address: ${my_addr}"

echo "Registering using activation key and org..."
busctl --address=${my_addr} call 'com.redhat.RHSM1' \
    '/com/redhat/RHSM1/Register' 'com.redhat.RHSM1.Register' \
    'RegisterWithActivationKeys' 'sasa{sv}a{sv}s' \
    "organization_key" 1 "activation-key" \
    0 0 "" > /root/register_output.txt

if [[ $? -eq 0 ]]
then
    echo "Registration sucess"
else
    echo "Registration FAILED"
fi

echo "stoping RegisterServer..."
dbus-send --system --print-reply --dest='com.redhat.RHSM1' \
    '/com/redhat/RHSM1/RegisterServer' \
    com.redhat.RHSM1.RegisterServer.Stop string:"" > /dev/null
```