### PR TITLE
cockpit: Fix AppStream launchable metainfo

### DIFF
--- a/cockpit/org.candlepinproject.subscription_manager.metainfo.xml
+++ b/cockpit/org.candlepinproject.subscription_manager.metainfo.xml
@@ -10,7 +10,7 @@
     </p>
   </description>
   <extends>org.cockpit_project.cockpit</extends>
-  <launchable type="cockpit-manifest">subscription-manager-cockpit</launchable>
+  <launchable type="cockpit-manifest">subscriptions</launchable>
   <url type="homepage">https://candlepinproject.org/</url>
   <update_contact>candlepin_AT_lists.fedorahosted.org</update_contact>
 </component>


### PR DESCRIPTION
`<launchable>` must coincide with the actual URL path defined by the
manifest.

https://bugzilla.redhat.com/show_bug.cgi?id=1856638