### PR TITLE
Fix rogue count: it's a int not a string

### DIFF
--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -306,8 +306,8 @@ class EntCertUpdateAction(object):
         # entitlement directory before we go to delete expired certs.
         rogue_count = len(self.report.rogue)
         if rogue_count > 0:
-            print(ungettext("%s local certificate has been deleted.",
-                            "%s local certificates have been deleted.",
+            print(ungettext("%d local certificate has been deleted.",
+                            "%d local certificates have been deleted.",
                             rogue_count) % rogue_count)
             self.ent_dir.refresh()
 


### PR DESCRIPTION
  File "/usr/lib/zypp/plugins/services/rhsm", line 69, in run
    return action()
  File "/usr/lib64/python2.7/site-packages/subscription_manager/entcertlib.py", line 42, in _do_update
    return action.perform()
  File "/usr/lib64/python2.7/site-packages/subscription_manager/entcertlib.py", line 128, in perform
    self.delete(rogue_serials)
  File "/usr/lib64/python2.7/site-packages/subscription_manager/entcertlib.py", line 311, in delete
    rogue_count) % rogue_count)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf6' in position 30: ordinal not in range(128)