### PR TITLE
1832990: Add rhsm.no_insights config option, improve messaging

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -85,6 +85,15 @@ package_profile_on_trans = 0
 # polling is used instead.
 inotify = 1
 
+# Disable registration to insights on registration with subscription-manager
+# With the no_insights option set to 0, and provided the "--no-insights" option
+# is not passed during execution of "subscription-manager register", insights-client
+# if installed will register to Red Hat Insights.
+# With the no_insights option set to 1 regardless of the use or lack of the "--no-insights" option
+# during registration with subscription-manager, the system will not be automatically registered
+# with Red Hat Insights.
+no_insights = 0
+
 [rhsmcertd]
 # Interval to run cert check (in minutes):
 certCheckInterval = 240

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -224,6 +224,11 @@ inotify
 .RS 4
 Inotify is used for monitoring changes in directories with certificates. Currently only the /etc/pki/consumer directory is monitored by the rhsm.service. When this directory is mounted using a network file system without inotify notification support (e.g. NFS), then disabling inotify is strongly recommended. When inotify is disabled, periodical directory polling is used instead.
 .RE
+.PP
+no_insights
+.RS 4
+When this option is enabled (set to 1), insights-client will not automatically register the system to Red Hat Insights after successful registration using "subscription-manager register" regardless of the usage of the "--no-insights" command-line option. When this option is disabled (set to 0), insights-client, if installed, will automatically register the system to Red Hat Insights after a successful registration using "subscription-manager register" so long as the "--no-insights" option is not provided.
+.RE
 .SH "[RHSMCERTD] OPTIONS"
 .PP
 certCheckInterval

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -76,7 +76,8 @@ RHSM_DEFAULTS = {
         'pluginconfdir': '/etc/rhsm/pluginconf.d',
         'auto_enable_yum_plugins': '1',
         'package_profile_on_trans': '0',
-        'inotify': '1'
+        'inotify': '1',
+        'no_insights': '0',
         }
 
 RHSMCERTD_DEFAULTS = {

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -28,7 +28,6 @@ import re
 import readline
 import socket
 import six.moves
-import subprocess
 import sys
 from time import localtime, strftime, strptime
 
@@ -65,7 +64,8 @@ from subscription_manager.overrides import Overrides, Override
 from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.printing_utils import columnize, format_name, \
         none_wrap_columnize_callback, echo_columnize_callback, highlight_by_filter_string_columnize_cb
-from subscription_manager.utils import generate_correlation_id
+from subscription_manager.utils import generate_correlation_id, is_insights_installed, \
+    is_insights_register_enabled, is_insights_unregister_enabled, is_true_value
 from subscription_manager.syspurposelib import save_sla_to_syspurpose_metadata, \
         get_syspurpose_valid_fields, post_process_received_data
 from subscription_manager.packageprofilelib import PackageProfileActionInvoker
@@ -1564,7 +1564,8 @@ class RegisterCommand(UserPassCommand):
             else:
                 owner_key = self._determine_owner_key(admin_cp)
                 environment_id = self._get_environment_id(admin_cp, owner_key, self.options.environment)
-
+                if is_true_value(conf["rhsm"]["no_insights"]):
+                    self.options.no_insights = True
                 consumer = service.register(
                     owner_key,
                     activation_keys=self.options.activation_keys,
@@ -1657,15 +1658,16 @@ class RegisterCommand(UserPassCommand):
 
         if self.options.no_insights:
             print(_('Red Hat Insights registration disabled.'))
-            if self._is_insights_installed():
+            if is_insights_installed():
                 print(_('To opt into Red Hat Insights, run "insights-client --register".'))
             else:
                 print(_('To opt into Red Hat Insights, install the insights-client package '
                         'and run "insights-client --register".'))
         else:
-            print(_('Red Hat Insights registration enabled.'))
-            if not self._is_insights_installed():
+            if not is_insights_installed():
                 print(_('To use Red Hat Insights, install the insights-client package.'))
+            elif is_insights_register_enabled():
+                print(_('Red Hat Insights registration enabled.'))
             print(_('To opt out of Red Hat Insights, run "insights-client --unregister" '
                     'or reregister with "--no-insights".'))
 
@@ -1753,11 +1755,6 @@ class RegisterCommand(UserPassCommand):
             readline.clear_history()
         return owner_key
 
-    def _is_insights_installed(self):
-        with open('/dev/null', 'w') as devnull:
-            returncode = subprocess.call('which insights-client', stdout=devnull, stderr=devnull, shell=True)
-        return returncode == 0
-
 
 class UnRegisterCommand(CliCommand):
 
@@ -1800,6 +1797,8 @@ class UnRegisterCommand(CliCommand):
         restart_virt_who()
 
         print(_("System has been unregistered."))
+        if is_insights_installed() and is_insights_unregister_enabled():
+            print(_("Red Hat Insights will also unregister."))
 
 
 class AddonsCommand(SyspurposeCommand, OrgCommand):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -7,16 +7,18 @@ from . import stubs
 
 from tempfile import mkdtemp
 
-from mock import Mock, patch
+from mock import Mock, patch, ANY
 from rhsm.utils import ServerUrlParseErrorEmpty, \
     ServerUrlParseErrorNone, ServerUrlParseErrorPort, \
     ServerUrlParseErrorScheme, ServerUrlParseErrorJustScheme
 from subscription_manager.utils import parse_server_info, \
     parse_baseurl_info, format_baseurl, \
     get_version, get_client_versions, unique_list_items, \
-    get_server_versions, friendly_join, is_true_value, url_base_join,\
-    ProductCertificateFilter, EntitlementCertificateFilter,\
-    is_simple_content_access, is_process_running, get_process_names
+    get_server_versions, friendly_join, is_true_value, url_base_join, \
+    ProductCertificateFilter, EntitlementCertificateFilter, \
+    is_simple_content_access, is_process_running, get_process_names, is_insights_register_enabled, \
+    is_insights_installed, check_returncode, check_output, call_subprocess
+from subprocess import CalledProcessError
 from .stubs import StubProductCertificate, StubProduct, StubEntitlementCertificate
 from .fixture import SubManFixture
 
@@ -989,3 +991,118 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
         res = get_process_names()
         res = list(res)
         self.assertEquals(res, [fake_process_name], "Expected an empty list, Actual: %s" % res)
+
+
+class TestIsInsightsRegisterEnabled(fixture.SubManFixture):
+    """
+    This is a group of tests for the is_insights_register_enabled method.
+    As the method depends on "check_returncode", it does not test the functionality of that.
+    """
+    def setUp(self):
+        check_returncode_patch = patch('subscription_manager.utils.check_returncode')
+        self.check_returncode_mock = check_returncode_patch.start()
+        self.addCleanup(check_returncode_patch.stop)
+
+    def test_is_insights_register_enabled(self):
+        self.check_returncode_mock.return_value = 0
+        self.assertTrue(is_insights_register_enabled())
+        self._assert_called_correct_cmd()
+
+    def test_is_insights_register_disabled(self):
+        self.check_returncode_mock.return_value = 1
+        self.assertFalse(is_insights_register_enabled())
+        self._assert_called_correct_cmd()
+
+    def _assert_called_correct_cmd(self):
+        self.check_returncode_mock.assert_called_with('systemctl is-enabled insights-register.path')
+
+
+class TestIsInsightsInstalled(fixture.SubManFixture):
+    """
+    This is a group of tests for the is_insights_installed method.
+    As the method depends on "check_returncode", it does not test the functionality of that.
+    """
+
+    def setUp(self):
+        check_returncode_patch = patch('subscription_manager.utils.check_returncode')
+        self.check_returncode_mock = check_returncode_patch.start()
+        self.addCleanup(check_returncode_patch.stop)
+
+    def test_is_insights_client_installed(self):
+        self.check_returncode_mock.return_value = 0
+        self.assertTrue(is_insights_installed())
+        self._assert_called_correct_cmd()
+
+    def test_is_insights_client_not_installed(self):
+        self.check_returncode_mock.return_value = 1
+        self.assertFalse(is_insights_installed())
+        self._assert_called_correct_cmd()
+
+    def _assert_called_correct_cmd(self):
+        self.check_returncode_mock.assert_called_with('which insights-client')
+
+
+class TestCheckReturnCode(fixture.SubManFixture):
+    """
+    This is a group of tests for the check_returncode method.
+    As the method depends on "call_subprocess", it does not test the functionality of that.
+    """
+
+    def setUp(self):
+        call_subprocess_patch = patch('subscription_manager.utils.call_subprocess')
+        self.call_subprocess_mock = call_subprocess_patch.start()
+        self.addCleanup(call_subprocess_patch.stop)
+
+    def test_check_returncode(self):
+        call_subprocess_result = ('output', 0)
+        cmd = 'which which'  # Could be anything
+        self.call_subprocess_mock.return_value = call_subprocess_result
+        self.assertEqual(check_returncode(cmd), call_subprocess_result[1])
+        self.call_subprocess_mock.assert_called_with(cmd)
+
+
+class TestCheckOutput(fixture.SubManFixture):
+    """
+    This is a group of tests for the check_output method.
+    As the method depends on "call_subprocess", it does not test the functionality of that.
+    """
+
+    def setUp(self):
+        call_subprocess_patch = patch('subscription_manager.utils.call_subprocess')
+        self.call_subprocess_mock = call_subprocess_patch.start()
+        self.addCleanup(call_subprocess_patch.stop)
+
+    def test_check_output(self):
+        call_subprocess_result = ('output', 0)
+        cmd = 'which which'  # Could be anything
+        self.call_subprocess_mock.return_value = call_subprocess_result
+        self.assertEqual(check_output(cmd), call_subprocess_result[0])
+        self.call_subprocess_mock.assert_called_with(cmd)
+
+
+class TestCallSubprocess(fixture.SubManFixture):
+    """
+    This is a group of tests for the check_output method.
+    As the method depends on "call_subprocess", it does not test the functionality of that.
+    """
+
+    def setUp(self):
+        check_output_patch = patch('subprocess.check_output')
+        self.check_output_mock = check_output_patch.start()
+        self.addCleanup(check_output_patch.stop)
+
+    def test_call_subprocess(self):
+        call_subprocess_result = 'output'
+        cmd = 'which which'  # Could be anything
+        self.check_output_mock.return_value = call_subprocess_result
+        self.assertEqual(call_subprocess(cmd), (call_subprocess_result, 0))
+        self.check_output_mock.assert_called_with(cmd, stderr=ANY, shell=True)
+
+    def test_call_subprocess_error(self):
+        call_subprocess_result = 'output'
+        cmd = 'which which'  # Could be anything
+        to_raise = CalledProcessError(1, cmd, call_subprocess_result)
+        self.check_output_mock.return_value = call_subprocess_result
+        self.check_output_mock.side_effect = to_raise
+        self.assertEqual(call_subprocess(cmd), (call_subprocess_result, to_raise.returncode))
+        self.check_output_mock.assert_called_with(cmd, stderr=ANY, shell=True)


### PR DESCRIPTION
Improves messaging for auto insights register and unregister.
Now we check to see that insights-register.path is enabled before
messaging anything about automatic insights registration.

Likewise for unregistration.