### PR TITLE
set permissions on rhsm.conf

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -140,7 +140,9 @@ class RhsmConfigParser(SafeConfigParser):
         with tempfile.NamedTemporaryFile(mode="w", dir=os.path.dirname(self.config_file), delete=False) as fo:
             self.write(fo)
             fo.flush()
+            mode = os.stat(self.config_file).st_mode
             os.rename(fo.name, self.config_file)
+            os.chmod(self.config_file, mode)
 
     def get(self, section, prop):
         """Get a value from rhsm config.


### PR DESCRIPTION
Changes to rhsm.conf start as a tempfile which has mode 0600.
Check the mode of the current rhsm.conf and restore it (typically it
is 0644) on the new rhsm.conf.

BZ: https://bugzilla.redhat.com/1838670

Signed-off-by: Jeffrey Bastian <jbastian@redhat.com>