### PR TITLE
1859532: Role --list handle wrong proxy conf (unregistered case)

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -685,6 +685,8 @@ class SyspurposeCommand(CliCommand):
                 server_response = self.cp.getOwnerSyspurposeValidFields(org_key)
             except connection.RestlibException as rest_err:
                 log.warning("Unable to get list of valid fields using REST API: %s" % rest_err)
+            except ProxyException:
+                system_exit(os.EX_UNAVAILABLE, _("Proxy connection failed, please check your settings."))
             else:
                 if 'systemPurposeAttributes' in server_response:
                     server_response = post_process_received_data(server_response)


### PR DESCRIPTION
* https://bugzilla.redhat.com/show_bug.cgi?id=1859532
* When system is not registered, rhsm.conf contains wrong proxy
  configuration and following command is used:

```
[root@localhost ~]#   subscription-manager role --list --username user --password secret
```

  then traceback was printed to stdout.
* The decent message about wrong proxy configuration is printed
  to stdout now.