### PR TITLE
1858296: Do not report unchanged profile; ENT-2639

### DIFF
--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -93,7 +93,7 @@ class ModulesProfile(object):
             try:
                 modules = base._moduleContainer
             except AttributeError:
-                log.warn("DNF does not provide modulemd functionality")
+                log.warning("DNF does not provide modulemd functionality")
                 return []
             all_module_list = modules.getModulePackages()
 
@@ -105,7 +105,9 @@ class ModulesProfile(object):
                     status = "disabled"
                 installed_profiles = []
                 if status == "enabled":
-                    installed_profiles = modules.getInstalledProfiles(module_pkg.getName())
+                    # It has to be list, because we compare this with cached json document and
+                    # JSON does not support anything like a tuple :-)
+                    installed_profiles = list(modules.getInstalledProfiles(module_pkg.getName()))
                 module_list.append({
                     "name": module_pkg.getName(),
                     "stream": module_pkg.getStream(),

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -142,7 +142,6 @@ def write_syspurpose_cache(values):
     :return:
     """
     try:
-        print ("CACHED_SYSPURPOSE: %s" % CACHED_SYSPURPOSE)
         json.dump(values, open(CACHED_SYSPURPOSE, 'w'), ensure_ascii=True, indent=2)
     except OSError:
         log.warning('Could not write to syspurpose cache %s' % CACHED_SYSPURPOSE)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1858296
* DNF api probably started to return the list of installed profiles
  as tuple. We store cache in JSON document. () == [] is False
* Removed one debug print