### PR TITLE
ENT-2472: Use -flto in compile and link flags.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ INCLUDE_SYSPURPOSE ?= 0
 VERSION ?= $(shell git describe | awk ' { sub(/subscription-manager-/,"")};1' )
 
 # inherit from env if set so rpm can override
-CFLAGS ?= -g -Wall
-LDFLAGS ?=
+CFLAGS ?= -g -Wall -flto
+LDFLAGS ?= -flto
 
 RHSMCERTD_CFLAGS = `pkg-config --cflags glib-2.0`
 RHSMCERTD_LDFLAGS = `pkg-config --libs glib-2.0`

--- a/setup.py
+++ b/setup.py
@@ -467,7 +467,14 @@ setup(
     setup_requires=setup_requires,
     install_requires=install_requires,
     tests_require=test_require,
-    ext_modules=[Extension('rhsm._certificate', ['src/certificate.c'],
-                           libraries=['ssl', 'crypto'])],
+    ext_modules=[
+        Extension(
+            'rhsm._certificate',
+            ['src/certificate.c'],
+            libraries=['ssl', 'crypto'],
+            extra_compile_args=["-flto"],
+            extra_link_args=["-flto"]
+        )
+    ],
     test_suite='nose.collector',
 )


### PR DESCRIPTION
* Modified Makefile and setup.py to use -flto flags
* I confirmed that everything (rhsmcertd and certificate Python module) works as expected