### PR TITLE
Two fixes of issues related to suse

### DIFF
--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -357,7 +357,7 @@ class RepoFileBase(object):
         if not self.path_exists(self.repos_dir):
             log.debug('The directory %s does not exist. Trying to create it' % self.PATH)
             try:
-                os.makedirs(name=self.repos_dir, mode=0o755, exist_ok=True)
+                os.makedirs(name=self.repos_dir, mode=0o755)
             except Exception as err:
                 log.warning('Unable to create directory: %s, error: %s' % (self.repos_dir, err))
         else:

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -266,7 +266,7 @@ Source0: %{name}-%{version}.tar.gz
 %if %{use_cockpit}
 Source1: %{name}-cockpit-%{version}.tar.gz
 %endif
-%if 0%{?suse_version}
+%if (0%{?suse_version} && 0%{?suse_version} < 1500)
 Source2: subscription-manager-rpmlintrc
 %endif
 


### PR DESCRIPTION
* One issue is related to building rpm on new suse box
* Second issue is related to os.makedirs. Argument exist_ok
  is not necessary and it is not supported on Python2