### PR TITLE
1862415: Print proper message, when consumer is deleted; ENT-2709

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -901,6 +901,8 @@ class ConsumerCache(CacheManager):
                 log.warning("Unable to get data for %s using REST API: %s" % (self.__class__, rest_err))
                 log.debug("Deleting cache file: %s", self.CACHE_FILE)
                 self.delete_cache()
+                # Raise exception again to be able to display error message in exception
+                raise rest_err
             else:
                 # Write data to cache
                 data = {identity.uuid: current_data}


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1862415
* Play game with exceptions properly and handle gone exception
  in CliCommand class
* Messages should be consistent across all commands, when consumer
  is deleted from server. Only following message should be used
  in all cases:

```
  Consumer profile "aabbccdd-aaaa-bbbb-cccc-aabbccddeeff" has been
  deleted from the server. You can use command clean or unregister
  to remove local profile.
```

This message used to be displayed in this case:

```
   Unit aabbccdd-aaaa-bbbb-cccc-aabbccddeeff has been deleted
```
