### PR TITLE
1832990: Only register insights when server supports "insights_auto_register"

### DIFF
--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -16,7 +16,7 @@ from __future__ import print_function, division, absolute_import
 #
 import os
 
-from mock import Mock, NonCallableMock, patch, MagicMock
+from mock import Mock, NonCallableMock, patch, MagicMock, ANY
 
 from .stubs import StubUEP
 
@@ -35,18 +35,19 @@ class CliRegistrationTests(SubManFixture):
     def setUp(self):
         super(CliRegistrationTests, self).setUp()
         register_patcher = patch('subscription_manager.managercli.register.RegisterService',
-            spec=RegisterService)
+                                 spec=RegisterService)
         self.mock_register = register_patcher.start().return_value
         self.mock_register.register.return_value = MagicMock(name="MockConsumer")
         self.addCleanup(register_patcher.stop)
 
-        get_supported_resources_patcher = patch('subscription_manager.managercli.get_supported_resources')
+        get_supported_resources_patcher = patch(
+            'subscription_manager.managercli.get_supported_resources')
         self.mock_get_resources = get_supported_resources_patcher.start()
         self.mock_get_resources.return_value = ['environments']
         self.addCleanup(self.mock_get_resources.stop)
 
         identity_patcher = patch('subscription_manager.managercli.identity.ConsumerIdentity',
-            spec=ConsumerIdentity)
+                                 spec=ConsumerIdentity)
         self.mock_consumer_identity = identity_patcher.start().return_value
         self.addCleanup(identity_patcher.stop)
 
@@ -68,7 +69,7 @@ class CliRegistrationTests(SubManFixture):
 
     @patch('subscription_manager.managercli.EntCertActionInvoker')
     def test_activation_keys_updates_certs_and_repos(self, mock_entcertlib):
-        self.stub_cp_provider.basic_auth_cp = Mock('rhsm.connection.UEPConnection', new_callable=StubUEP)
+        self.stub_cp_provider.basic_auth_cp = Mock(spec=StubUEP, new_callable=StubUEP)
         self._inject_mock_invalid_consumer()
 
         cmd = RegisterCommand()
@@ -81,19 +82,20 @@ class CliRegistrationTests(SubManFixture):
 
     @patch('subscription_manager.managercli.EntCertActionInvoker')
     def test_consumerid_updates_certs_and_repos(self, mock_entcertlib):
-        self.stub_cp_provider.basic_auth_cp = Mock('rhsm.connection.UEPConnection', new_callable=StubUEP)
+        self.stub_cp_provider.basic_auth_cp = Mock(spec=StubUEP, new_callable=StubUEP)
         self._inject_mock_invalid_consumer()
 
         cmd = RegisterCommand()
         mock_entcertlib = mock_entcertlib.return_value
         self._inject_ipm()
 
-        cmd.main(['register', '--consumerid=123456', '--username=testuser1', '--password=password', '--org=test_org'])
+        cmd.main(['register', '--consumerid=123456', '--username=testuser1', '--password=password',
+                  '--org=test_org'])
         self.mock_register.register.assert_called_once_with(None, consumerid='123456')
         mock_entcertlib.update.assert_called_once()
 
     def test_consumerid_with_distributor_id(self):
-        self.stub_cp_provider.basic_auth_cp = Mock('rhsm.connection.UEPConnection', new_callable=StubUEP)
+        self.stub_cp_provider.basic_auth_cp = Mock(spec=StubUEP, new_callable=StubUEP)
 
         self._inject_mock_invalid_consumer()
         cmd = RegisterCommand()
@@ -102,7 +104,8 @@ class CliRegistrationTests(SubManFixture):
 
         with Capture(silent=True):
             with self.assertRaises(SystemExit) as e:
-                cmd.main(['register', '--consumerid=TaylorSwift', '--username=testuser1', '--password=password', '--org=test_org'])
+                cmd.main(['register', '--consumerid=TaylorSwift', '--username=testuser1',
+                          '--password=password', '--org=test_org'])
                 self.assertEqual(e.code, os.EX_USAGE)
 
     def test_strip_username_and_password(self):
@@ -197,3 +200,49 @@ class CliRegistrationTests(SubManFixture):
                 with self.assertRaises(SystemExit) as e:
                     cmd.main(['register', '--type=candlepin'])
                     self.assertEqual(e.code, os.EX_USAGE)
+
+    def test_no_insights_missing_capability(self):
+        self.stub_cp_provider.basic_auth_cp = StubUEP()
+        self._assert_no_insights_is(True)
+
+    def test_no_insights_missing_capability_cli_option(self):
+        self.stub_cp_provider.basic_auth_cp = StubUEP()
+        self._assert_no_insights_is(True, ['--no-insights'])
+
+    def test_no_insights_with_capability(self):
+        self.stub_cp_provider.basic_auth_cp = StubUEP()
+        self.stub_cp_provider.basic_auth_cp._capabilities = ['insights_auto_register']
+        self._assert_no_insights_is(False)
+
+    def test_no_insights_with_capability_cli_option(self):
+        self.stub_cp_provider.basic_auth_cp = StubUEP()
+        self.stub_cp_provider.basic_auth_cp._capabilities = ['insights_auto_register']
+        self._assert_no_insights_is(True, ['--no-insights'])
+
+    def _assert_no_insights_is(self, expected_no_insights, extra_cli_args=None):
+        self._inject_mock_invalid_consumer()
+        cmd = RegisterCommand()
+        self._inject_ipm()
+        owner_key = 'test_org'
+
+        with Capture(silent=True):
+            cli_args_list = [
+                'register',
+                '--username=testuser1',
+                '--password=password',
+                '--org=%s' % owner_key
+            ]
+            if extra_cli_args is not None:
+                cli_args_list.extend(extra_cli_args)
+            cmd.main(cli_args_list)
+
+        self.mock_register.register.assert_called_once_with(
+                owner_key,
+                activation_keys=ANY,
+                environment=ANY,
+                force=ANY,
+                name=ANY,
+                type=ANY,
+                service_level=ANY,
+                no_insights=expected_no_insights
+        )


### PR DESCRIPTION
A small PR to refine the behaviour of insights auto registration.
When the server does not have the "insights_auto_register" capability, subscription-manager register command will mask the insights-register.path unit (regardless of the presence of "--no-insights" or setting of "no_insights" in the rhsm.conf).

When the server does have the "insights_auto_register" capability (as master CP does now), subscription-manager register command will only mask the insights-register.path unit when given the "--no-insights" cli option or with "no_insights" set in rhsm.conf to something truthy.