### PR TITLE
1855893: Generate redhat.repo properly; ENT-2636

### DIFF
--- a/src/dnf-plugins/subscription-manager.py
+++ b/src/dnf-plugins/subscription-manager.py
@@ -144,10 +144,9 @@ class SubscriptionManager(dnf.Plugin):
         else:
             log.debug('Skipping updating of entitlement certificates')
 
-        if cache_only or config.in_container():
-            log.debug('Generating redhat.repo only from installed entitlement certificates and cache files')
-            repo_action_invoker = RepoActionInvoker(cache_only=cache_only)
-            repo_action_invoker.update()
+        log.debug('Generating redhat.repo')
+        repo_action_invoker = RepoActionInvoker(cache_only=cache_only)
+        repo_action_invoker.update()
 
     @staticmethod
     def _warn_expired():


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1855893
* When full_refresh_on_yum is set to 1, then the dnf plugin
  subscription-manager did not update redhat.repo properly
  according content-override. This issue was caused by too
  agresive optimization. It was introduced in PR: #2210