### PR TITLE
1615429: Fix sorting of plugin hooks

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2512,7 +2512,8 @@ class PluginsCommand(CliCommand):
             # get_slots is nicely sorted for presentation
             for slot in self.plugin_manager.get_slots():
                 print(slot)
-                for hook in sorted(self.plugin_manager._slot_to_funcs[slot]):
+                for hook in sorted(self.plugin_manager._slot_to_funcs[slot],
+                                   key=lambda func: func.__name__):
                     hook_key = six.get_method_self(hook).__class__.get_plugin_key()
                     print("\t%s.%s" % (hook_key, hook.__name__))
 


### PR DESCRIPTION
We were recently able to reproduce this.
This solution is already verified via QE.