### PR TITLE
1868936: Do not print traceback, when profile upload failed

### DIFF
--- a/test/fixture.py
+++ b/test/fixture.py
@@ -490,6 +490,9 @@ def set_up_mock_sp_store(mock_sp_store):
     def get_local_contents():
         return contents
 
+    def get_cached_contents():
+        return contents
+
     def update_local(data):
         global contents
         contents = data
@@ -502,5 +505,6 @@ def set_up_mock_sp_store(mock_sp_store):
     mock_sp_store.return_value.local_contents = mock_sp_store_contents
     mock_sp_store.return_value.get_local_contents = Mock(side_effect=get_local_contents)
     mock_sp_store.return_value.update_local = Mock(side_effect=update_local)
+    mock_sp_store.return_value.get_cached_contents = Mock(side_effect=get_cached_contents)
 
     return mock_sp_store, mock_sp_store_contents


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1868936
* When it is not possible to upload profile to server during
  registration, then do not print traceback to console
* This issue has been partially fixed in this PR:  #2305
  but this commit should avoid printing any warning message
  to console. When REST API endpoint is not available,
  then profile will be uploaded next time by `rhsmcertd`
* Added unit test for this case
* Added one unit test for normal registration