### PR TITLE
1870567: Fix issue with locale and D-Bus method GetStatus; ENT-2772

### DIFF
--- a/cockpit/src/index.js
+++ b/cockpit/src/index.js
@@ -135,6 +135,7 @@ function initStore(rootElement) {
             subscriptionsView.page,
             {
                 status: subscriptionsClient.subscriptionStatus.status,
+                status_msg: subscriptionsClient.subscriptionStatus.status_msg,
                 products:subscriptionsClient.subscriptionStatus.products,
                 error: subscriptionsClient.subscriptionStatus.error,
                 syspurpose: subscriptionsClient.syspurposeStatus.info,

--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -59,13 +59,13 @@ class Listing extends React.Component {
                         attaching_in_progress: false,
                         attach_button_text: _("Auto-attach")
                     });
-                })
+                });
         }
     }
     render() {
         if (this.props.children) {
             let auto_attach_btn_disabled;
-            auto_attach_btn_disabled = this.state.attaching_in_progress || this.props.status === 'Unknown';
+            auto_attach_btn_disabled = this.state.attaching_in_progress || this.props.status === 'unknown';
             return (
                 <div>
                     <div className="installed-products-line">
@@ -178,8 +178,11 @@ class DismissableError extends React.Component {
 
 /* Show subscriptions status of the system, offer to register/unregister the system
  * Expected properties:
- * status       subscription status
+ * status       subscription status ID
+ * status_msg   subscription status message
  * error        error message to show (in Curtains if not connected, as a dismissable alert otherwise)
+ * syspurpose
+ * syspurpose_status
  * dismissError callback, triggered for the dismissable error in connected state
  * register     callback, triggered when user clicks on register
  * unregister   callback, triggered when user clicks on unregister
@@ -294,13 +297,13 @@ class SubscriptionStatus extends React.Component {
                 </div>
             </div>
         );
-        if (this.props.status === 'Unknown') {
+        if (this.props.status === 'unknown') {
             label = <label>{ `${_("Status")}: ${_("This system is currently not registered.")}` }</label>;
             action = (<button className="btn btn-primary"
                               onClick={this.handleRegisterSystem}>{_("Register")}</button>
             );
         } else {
-            label = <label>{ `${_("Status")}: ${this.props.status}` }</label>;
+            label = <label>{ `${_("Status")}: ${this.props.status_msg}` }</label>;
             action = (<button className="btn btn-primary" disabled={isUnregistering}
                               onClick={this.handleUnregisterSystem}>{_("Unregister")}</button>
             );
@@ -331,7 +334,8 @@ class SubscriptionStatus extends React.Component {
 
 /* Show subscriptions status of the system and registered products, offer to register/unregister the system
  * Expected properties:
- * status       subscription status
+ * status       subscription status ID
+ * status_msg   subscription status message
  * error        error message to show (in Curtains if not connected, as a dismissable alert otherwise
  * dismissError callback, triggered for the dismissable error in connected state
  * products     subscribed products (properties as in subscriptions-client)
@@ -343,6 +347,7 @@ class SubscriptionsPage extends React.Component {
         let icon;
         let description;
         let message;
+
         if (this.props.status === "service-unavailable") {
             icon = <div className="fa fa-exclamation-circle"/>;
             message = _("The rhsm service is unavailable. Make sure subscription-manager is installed " +

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -226,7 +226,8 @@ class TestSubscriptions(SubscriptionsCase):
         self.wait_subscription(PRODUCT_SNOWY, True)
 
         # unregister
-        b.click(unregister_button_sel)
+        with b.wait_timeout(360):
+            b.click(unregister_button_sel)
 
     def testRegisterWithKey(self):
         b = self.browser

--- a/src/rhsmlib/dbus/objects/entitlement.py
+++ b/src/rhsmlib/dbus/objects/entitlement.py
@@ -64,7 +64,7 @@ class EntitlementDBusObject(base_object.BaseObject):
 
         try:
             # get_status doesn't need a Candlepin connection
-            status = EntitlementService(None).get_status(on_date)
+            status = EntitlementService(None).get_status(on_date=on_date, force=True)
         except Exception as e:
             log.exception(e)
             raise dbus.DBusException(str(e))

--- a/src/rhsmlib/services/syspurpose.py
+++ b/src/rhsmlib/services/syspurpose.py
@@ -21,16 +21,6 @@ from subscription_manager import injection as inj
 from subscription_manager.i18n import ugettext as _
 
 
-STATUS_MAP = {'valid': _('Matched'),
-        'invalid': _('Mismatched'),
-        'partial': _('Partial'),
-        'matched': _('Matched'),
-        'mismatched': _('Mismatched'),
-        'not specified': _('Not Specified'),
-        'disabled': _('Disabled'),
-        'unknown': _('Unknown')}
-
-
 class Syspurpose(object):
 
     def __init__(self, cp):
@@ -68,4 +58,17 @@ class Syspurpose(object):
         :param status: syspurpose status
         :return: Translated sttring with status
         """
-        return STATUS_MAP.get(status, STATUS_MAP['unknown'])
+        # Status map has to be here, because we have to translate strings
+        # when function is called (not during start of application) due to
+        # rhsm.service which can run for very long time
+        status_map = {
+            'valid': _('Matched'),
+            'invalid': _('Mismatched'),
+            'partial': _('Partial'),
+            'matched': _('Matched'),
+            'mismatched': _('Mismatched'),
+            'not specified': _('Not Specified'),
+            'disabled': _('Disabled'),
+            'unknown': _('Unknown')
+        }
+        return status_map.get(status, status_map['unknown'])

--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -29,23 +29,26 @@ from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 
+# Strings used for status of products
 FUTURE_SUBSCRIBED = "future_subscribed"
 SUBSCRIBED = "subscribed"
 NOT_SUBSCRIBED = "not_subscribed"
 EXPIRED = "expired"
 PARTIALLY_SUBSCRIBED = "partially_subscribed"
 
-# Used when we are unregistered, or offline for a long period of time:
+# Strings used fot status of system
+# Warning: Do not change following strings, because these strings
+# are in D-Bus API. The API is used by other applications (Anaconda,
+# Cockpit, GNOME, ...)
+VALID = 'valid'
+INVALID = 'invalid'
+PARTIAL = 'partial'
+DISABLED = 'disabled'
 UNKNOWN = "unknown"
+
 
 SOCKET_FACT = 'cpu.cpu_socket(s)'
 RAM_FACT = 'memory.memtotal'
-
-STATUS_MAP = {'valid': _('Current'),
-        'partial': _('Insufficient'),
-        'invalid': _('Invalid'),
-        'disabled': _('Disabled'),
-        'unknown': _('Unknown')}
 
 RHSM_VALID = 0
 RHSM_EXPIRED = 1
@@ -117,7 +120,7 @@ class ComplianceManager(object):
         self.reasons = Reasons([], self)
         self.supports_reasons = False
 
-        self.system_status = 'unknown'
+        self.system_status = UNKNOWN
 
         self.valid_entitlement_certs = []
 
@@ -129,7 +132,7 @@ class ComplianceManager(object):
             try:
                 self.status = self.cp_provider.get_consumer_auth_cp().getCompliance(self.identity.uuid, self.on_date)
             except Exception as e:
-                log.warn("Failed to get compliance data from the server")
+                log.warning("Failed to get compliance data from the server")
                 log.exception(e)
                 self.status = None
         return self.status
@@ -163,12 +166,12 @@ class ComplianceManager(object):
             self.system_status = status['status']
         # Some old candlepin versions do not return 'status' with information
         elif status['nonCompliantProducts']:
-            self.system_status = 'invalid'
+            self.system_status = INVALID
         elif self.partially_valid_products or self.partial_stacks or \
                 self.reasons.reasons:
-            self.system_status = 'partial'
+            self.system_status = PARTIAL
         else:
-            self.system_status = 'unknown'
+            self.system_status = UNKNOWN
 
         # For backward compatability with old find first invalid date,
         # we drop one second from the compliant until from server (as
@@ -190,7 +193,7 @@ class ComplianceManager(object):
             if pid not in self.valid_products and pid not in \
                     self.partially_valid_products and pid not in \
                     unentitled_pids:
-                log.warn("Installed product %s not present in response from "
+                log.warning("Installed product %s not present in response from "
                          "server." % pid)
                 unentitled_pids.append(pid)
 
@@ -198,7 +201,7 @@ class ComplianceManager(object):
             prod_cert = self.product_dir.find_by_product(unentitled_pid)
             # Ignore anything server thinks we have but we don't.
             if prod_cert is None:
-                log.warn("Server reported installed product not on system: %s" %
+                log.warning("Server reported installed product not on system: %s" %
                          unentitled_pid)
                 continue
             self.unentitled_products[unentitled_pid] = prod_cert
@@ -259,8 +262,30 @@ class ComplianceManager(object):
 
                     product_dict.setdefault(product.id, []).append(ent_cert)
 
+    def get_system_status_id(self):
+        return self.system_status
+
+    @staticmethod
+    def get_status_map():
+        """
+        Get status map
+        :return: status map
+        """
+        # Status map has to be here, because we have to translate strings
+        # when function is called (not during start of application) due to
+        # rhsm.service which can run for very long time
+        status_map = {
+            VALID: _('Current'),
+            PARTIAL: _('Insufficient'),
+            INVALID: _('Invalid'),
+            DISABLED: _('Disabled'),
+            UNKNOWN: _('Unknown')
+        }
+        return status_map
+
     def get_system_status(self):
-        return STATUS_MAP.get(self.system_status, STATUS_MAP['unknown'])
+        status_map = self.get_status_map()
+        return status_map.get(self.system_status, status_map[UNKNOWN])
 
     def are_reasons_supported(self):
         # Check if the candlepin in use supports status
@@ -272,7 +297,7 @@ class ComplianceManager(object):
         Return true if the results of this cert sort indicate our
         entitlements are completely valid.
         """
-        return self.system_status == 'valid' or self.system_status == 'disabled'
+        return self.system_status == VALID or self.system_status == DISABLED
 
     def is_registered(self):
         return inj.require(inj.IDENTITY).is_valid()

--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -185,6 +185,7 @@ class Locale(object):
         :param language: String representing locale
                 (e.g. de, de_DE, de_DE.utf-8, de_DE.UTF-8)
         """
+        global LOCALE
         lang = None
 
         if language != '':
@@ -194,6 +195,7 @@ class Locale(object):
             else:
                 # Try to find given language
                 try:
+                    log.debug('Trying to use locale: %s' % language)
                     lang = gettext.translation(APP, DIR, languages=[language])
                 except IOError as err:
                     log.info('Could not import locale for %s: %s' % (language, err))

--- a/src/subscription_manager/reasons.py
+++ b/src/subscription_manager/reasons.py
@@ -72,6 +72,21 @@ class Reasons(object):
             result[reason_name].append(reason['message'])
         return result
 
+    def get_reason_ids_map(self):
+        result = {}
+        for reason in self.reasons:
+            if 'attributes' in reason and 'product_id' in reason['attributes']:
+                reason_id = reason['attributes']['product_id']
+                if reason_id not in result:
+                    result[reason_id] = []
+                if reason['key'] in [res['key'] for res in result[reason_id]]:
+                    continue
+                result[reason_id].append({
+                    'key': reason['key'],
+                    'product_name': reason['attributes']['name']
+                })
+        return result
+
     def get_stack_subscriptions(self, stack_id):
         result = set([])
         for s in self.sorter.valid_entitlement_certs:

--- a/test/rhsm/unit/connection_tests.py
+++ b/test/rhsm/unit/connection_tests.py
@@ -96,14 +96,23 @@ class ConnectionTests(unittest.TestCase):
 
     @mock.patch('locale.getlocale')
     def test_has_proper_language_header_utf8(self, mock_locale):
+        # First test it with Japanese
         mock_locale.return_value = ('ja_JP', 'UTF-8')
-        self.cp = UEPConnection()
+        self.cp.conn.headers = {}
+        self.cp.conn._set_accept_language_in_header()
         self.assertEqual(self.cp.conn.headers['Accept-Language'], 'ja-jp')
+
+        # Test that another rest api call would be called with different locale
+        mock_locale.return_value = ('es_ES', 'UTF-8')
+        self.cp.conn.headers = {}
+        self.cp.conn._set_accept_language_in_header()
+        self.assertEqual(self.cp.conn.headers['Accept-Language'], 'es-es')
 
     @mock.patch('locale.getlocale')
     def test_has_proper_language_header_not_utf8(self, mock_locale):
         mock_locale.return_value = ('ja_JP', '')
-        self.cp = UEPConnection()
+        self.cp.conn.headers = {}
+        self.cp.conn._set_accept_language_in_header()
         self.assertEqual(self.cp.conn.headers['Accept-Language'], 'ja-jp')
 
     def test_get_environment_urlencoding(self):

--- a/test/rhsmlib_test/test_entitlement.py
+++ b/test/rhsmlib_test/test_entitlement.py
@@ -74,17 +74,33 @@ class TestEntitlementService(InjectionMockingTest):
         self.mock_identity.is_valid.return_value = True
 
         mock_reasons = mock.Mock(spec=Reasons, name="Reasons").return_value
-        mock_reasons.get_name_message_map.return_value = {"RHEL": ["Not supported by a valid subscription"]}
+        mock_reasons.get_name_message_map.return_value = {
+            "RHEL": ["Not supported by a valid subscription"]
+        }
+        mock_reasons.get_reason_ids_map.return_value = {
+            '69': {
+                'key': 'NOTCOVERED',
+                'product_name': 'RHEL'
+            }
+        }
 
         mock_sorter = self.mock_sorter_class.return_value
         mock_sorter.get_system_status.return_value = "Invalid"
+        mock_sorter.get_system_status_id.return_value = 'invalid'
         mock_sorter.reasons = mock_reasons
         mock_sorter.is_valid.return_value = False
 
         expected_value = {
             'status': 'Invalid',
+            'status_id': 'invalid',
             'reasons': {
                 'RHEL': ['Not supported by a valid subscription']
+            },
+            'reason_ids': {
+                '69': {
+                    'key': 'NOTCOVERED',
+                    'product_name': 'RHEL'
+                }
             },
             'valid': False
         }
@@ -102,15 +118,29 @@ class TestEntitlementService(InjectionMockingTest):
 
         mock_reasons = mock.Mock(spec=Reasons, name="Reasons").return_value
         mock_reasons.get_name_message_map.return_value = {"RHEL": ["Not supported by a valid subscription"]}
+        mock_reasons.get_reason_ids_map.return_value = {
+            '69': {
+                'key': 'NOTCOVERED',
+                'product_name': 'RHEL'
+            }
+        }
 
         mock_sorter.get_system_status.return_value = "Invalid"
+        mock_sorter.get_system_status_id.return_value = 'invalid'
         mock_sorter.reasons = mock_reasons
         mock_sorter.is_valid.return_value = False
 
         expected_value = {
             'status': 'Invalid',
+            'status_id': 'invalid',
             'reasons': {
                 'RHEL': ['Not supported by a valid subscription']
+            },
+            'reason_ids': {
+                '69': {
+                    'key': 'NOTCOVERED',
+                    'product_name': 'RHEL'
+                }
             },
             'valid': False
         }
@@ -136,7 +166,13 @@ class TestEntitlementService(InjectionMockingTest):
         service = EntitlementService()
 
         self.mock_identity.is_valid.return_value = False
-        expected_value = {'status': 'Unknown', 'reasons': {}, 'valid': False}
+        expected_value = {
+            'status': 'Unknown',
+            'status_id': 'unknown',
+            'reasons': {},
+            'reason_ids': {},
+            'valid': False
+        }
         self.assertEqual(expected_value, service.get_status())
 
     def test_only_accepts_correct_pool_subsets(self):

--- a/test/test_cert_sorter.py
+++ b/test/test_cert_sorter.py
@@ -120,7 +120,8 @@ class CertSorterTests(SubManFixture):
         self.status_mgr.server_status = None
         sorter = CertSorter()
         sorter.is_registered = Mock(return_value=True)
-        expected = subscription_manager.cert_sorter.STATUS_MAP['unknown']
+        status_map = subscription_manager.cert_sorter.ComplianceManager.get_status_map()
+        expected = status_map[subscription_manager.cert_sorter.UNKNOWN]
         self.assertEqual(expected, sorter.get_system_status())
 
     @patch('subscription_manager.cache.InstalledProductsManager.update_check')
@@ -130,7 +131,8 @@ class CertSorterTests(SubManFixture):
         self.status_mgr.server_status = None
         sorter = CertSorter()
         sorter.is_registered = Mock(return_value=False)
-        expected = subscription_manager.cert_sorter.STATUS_MAP['unknown']
+        status_map = subscription_manager.cert_sorter.ComplianceManager.get_status_map()
+        expected = status_map[subscription_manager.cert_sorter.UNKNOWN]
         self.assertEqual(expected, sorter.get_system_status())
 
     def test_unentitled_products(self):


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1870567
* There were three reasons, why locale og GetStatus returned
  strings with wrong locale
  * REST API calls were called with wrong Accept-Language header,
    because the header was set for session and it was used for
    all REST API calls
  * Some strings (e.g. "Invalid") were translated during start
    of rhsm.service according system settings of locale and then
    these translated strings were used
  * Some strings are translated on candlepin server. Unfortunately
    some translated strings were saved in cache files and strings
    with unwanted translations were returned by GetStatus method
* So, some global variables with translated strings were moved
  to methods. Thus these strings are translated everytime, when
  method si called
* Caching of /var/lib/rhsm/cache/entitlement_status.json is
  disabled for rhsm.service to avoid returning strings with
  unwanted translation
* HTTP header with Accept-Language is set for every REST API call
* JSON document returned by GetStatus method was extended. So
  it includes now "status_id" and "reason_ids" with untranslated
  reasons. It can be used for checks in code.
* Modified and extended some unit tests