### PR TITLE
1753236: D-Bus Register properly, when org not specified; ENT-2096

### DIFF
--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -208,7 +208,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_not_in_text("body", "Invalid credentials")
 
         # wait for message that we need to specify our org
-        b.wait_in_text("body", "You must specify an organization for new units.")
+        b.wait_in_text("body", "User doc is member of more organizations, but no organization was selected")
 
         # now specify the org
         b.set_input_text("#subscription-register-org", "snowwhite")
@@ -217,7 +217,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # old error should disappear
-        b.wait_not_in_text("body", "You must specify an organization for new units.")
+        b.wait_not_in_text("body", "User doc is member of more organizations, but no organization was selected")
 
         # dialog should disappear
         b.wait_not_present(dialog_register_button_sel)

--- a/src/rhsmlib/dbus/objects/consumer.py
+++ b/src/rhsmlib/dbus/objects/consumer.py
@@ -76,7 +76,6 @@ class ConsumerDBusObject(base_object.BaseObject):
     def ConsumerChanged(self):
         """
         Signal fired, when consumer is created/deleted/changed
-        :param sender:
         :return: None
         """
         log.debug("D-Bus signal %s emitted" % constants.CONSUMER_INTERFACE)

--- a/src/rhsmlib/dbus/util.py
+++ b/src/rhsmlib/dbus/util.py
@@ -48,6 +48,8 @@ def dbus_handle_exceptions(func, *args, **kwargs):
         # Modify severity of some exception here
         if "Ignoring request to auto-attach. It is disabled for org" in err_msg:
             severity = "warning"
+        if hasattr(err, 'severity'):
+            severity = err.severity
         # Raise exception string as JSON string. Thus it can be parsed and printed properly.
         error_msg = json.dumps(
             {

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -169,3 +169,29 @@ class RegisterService(object):
         elif not getattr(self.cp, 'username', None) or not getattr(self.cp, 'password', None):
             if not getattr(self.cp, 'token', None):
                 raise exceptions.ValidationError(_("Error: Missing username or password."))
+
+    def determine_owner_key(self, username, get_owner_cb, no_owner_cb):
+        """
+        Method used for specification of owner key during registration. When there is more than
+        one owners and it is necessary to specify one, then get_owner_cb is called with the list
+        of owners as the argument. When user is not member of any group, then no_owner_cb is called.
+        :param username: Username
+        :param get_owner_cb: Callback method called, when it is necessary determine wanted owner (org)
+        :param no_owner_cb: Callback method called, when user is not member of any owner (org)
+        :return: Owner key (organization)
+        """
+
+        owners = self.cp.getOwnerList(username)
+
+        # When there is no organization, then call callback method for this case
+        if len(owners) == 0:
+            no_owner_cb(username)
+
+        # When there is only one owner, then return key of the owner
+        if len(owners) == 1:
+            return owners[0]['key']
+
+        # When there is more owner, then call callback method for this case
+        owner_key = get_owner_cb(owners)
+
+        return owner_key


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1753236
* When user tries to register using application that uses our
  D-Bus API and no organization is specified, then error is
  raised. Most of our users are member of only one organization
  and they do not aware that they are member of any organization.
  It is hard for them to find the organization ID. So this
  bug fix should automatically select this organization, when
  user is member only of one organization.
* This PR also introduces option to select organization, when
  user is member of more ogranizations. In this case new signal
  UserMemberOfOrgs is triggered. This signal has string argument
  including JSON dump of simplified list of available
  organizations for given user.
* When user is member of no organization, then some exception
  is raised.
* Refactored the code a little. The logic of automatic
  selecting of one organization is shared between sub-man CLI
  and rhsm.service in rhsmlib.services
* Added one unit test for new functionality