### PR TITLE
1868734: Fix issue with syspurpose attrs. set in act. key; ENT-2851

### DIFF
--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -134,10 +134,18 @@ class RegisterService(object):
         if save_syspurpose is True:
             syspurposelib.write_syspurpose(syspurpose)
 
-        syspurpose_dict = {'service_level_agreement': consumer['serviceLevel'] if 'serviceLevel' in list(consumer.keys()) else '',
-                          'role': consumer['role'] if 'role' in list(consumer.keys()) else '',
-                          'usage': consumer['usage'] if 'usage' in list(consumer.keys()) else '',
-                          'addons': consumer['addOns'] if 'addOns' in list(consumer.keys()) else []}
+        syspurpose_dict = {
+            'service_level_agreement': consumer['serviceLevel'] if 'serviceLevel' in list(consumer.keys()) else '',
+            'role': consumer['role'] if 'role' in list(consumer.keys()) else '',
+            'usage': consumer['usage'] if 'usage' in list(consumer.keys()) else '',
+            'addons': consumer['addOns'] if 'addOns' in list(consumer.keys()) else []
+        }
+
+        # Try to do three-way merge and then save result to syspurpose.json file
+        local_result = syspurposelib.merge_syspurpose_values(remote=syspurpose_dict, base={})
+        syspurposelib.write_syspurpose(local_result)
+
+        # Save syspurpose attributes from consumer to cache file
         syspurposelib.write_syspurpose_cache(syspurpose_dict)
 
         return consumer

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -164,6 +164,38 @@ def get_syspurpose_valid_fields(uep=None, identity=None):
     return valid_fields
 
 
+def merge_syspurpose_values(local=None, remote=None, base=None):
+    """
+    Try to do three-way merge of local, remote and base dictionaries.
+    Note: when remote is None, then this method will call REST API.
+    :param local: dictionary with local values
+    :param remote: dictionary with remote values
+    :param base: dictionary with cached values
+    :return: Dictionary with local result
+    """
+
+    if SyncedStore is None:
+        return {}
+
+    synced_store = SyncedStore(uep=None)
+
+    if local is None:
+        local = synced_store.get_local_contents()
+    if remote is None:
+        remote = synced_store.get_remote_contents()
+    if base is None:
+        base = synced_store.get_cached_contents()
+
+    result = synced_store.merge(
+        local=local,
+        remote=remote,
+        base=base
+    )
+    local_result = {key: result[key] for key in result if result[key]}
+    log.debug('local result: %s ' % local_result)
+    return local_result
+
+
 class SyspurposeSyncActionInvoker(certlib.BaseActionInvoker):
     """
     Used by rhsmcertd to sync the syspurpose values locally with those from the Server.

--- a/syspurpose/src/syspurpose/files.py
+++ b/syspurpose/src/syspurpose/files.py
@@ -547,7 +547,22 @@ class SyncedStore(object):
         return current_value != value or current_value is None
 
     @staticmethod
-    def update_file(path, data):
+    def _create_missing_dir(dir_path):
+        """
+        Try to create missing directory
+        :param dir_path: path to directory
+        :return: None
+        """
+        # Check if the directory exists
+        if not os.path.isdir(dir_path):
+            log.debug('Trying to create directory: %s' % dir_path)
+            try:
+                os.makedirs(dir_path, mode=0o755, exist_ok=True)
+            except Exception as err:
+                log.warning('Unable to create directory: %s, error: %s' % (dir_path, err))
+
+    @classmethod
+    def update_file(cls, path, data):
         """
         Write the contents of data to file in the first mode we can (effectively to create or update
         the file)
@@ -557,21 +572,9 @@ class SyncedStore(object):
         """
 
         # Check if /etc/rhsm/syspurpose directory exists
-        if not os.path.isdir(USER_SYSPURPOSE_DIR):
-            # If not create the file
-            log.debug('Trying to create directory: %s' % USER_SYSPURPOSE_DIR)
-            try:
-                os.makedirs(USER_SYSPURPOSE_DIR, mode=0o755, exist_ok=True)
-            except Exception as err:
-                log.warning('Unable to create directory: %s, error: %s' % (USER_SYSPURPOSE_DIR, err))
-
+        cls._create_missing_dir(USER_SYSPURPOSE_DIR)
         # Check if /var/lib/rhsm/cache/ directory exists
-        if not os.path.isdir(CACHE_DIR):
-            log.debug('Creating directory: %s' % CACHE_DIR)
-            try:
-                os.makedirs(CACHE_DIR, mode=0o755, exist_ok=True)
-            except Exception as err:
-                log.warning('Unable to create directory: %s, error: %s' % (CACHE_DIR, err))
+        cls._create_missing_dir(CACHE_DIR)
 
         # Then we can try to create syspurpose.json file
         modes = ['w+']


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1868734
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1875988
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1875624
* This bug was probably caused by optimization, when we tried to
  reduce number of REST API calls during registration. This effort
  had side-effects described in BZs. In general, when some
  syspurpose attribute is set on activation key or ogranization
  then these syspurpose attributes are ignored during registration
  and these syspurpose values are deleted from consumer.
* Solution for this issues: values returned in consumer
  JSON object are used in three-way merge during registration.
  No extra REST API call is required.
* Refactored some code
* TODO: more refactoring and more testing