### PR TITLE
1855437: syspurpose CLI should require sub-man rpm; ENT-2602

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -412,6 +412,7 @@ Group: Productivity/Networking/System
 %else
 Group: System Environment/Base
 %endif
+Requires: %{name} = %{version}-%{release}
 %description -n %{py_package_prefix}-syspurpose
 Provides the syspurpose commandline utility. This utility manages the
 system syspurpose.


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1855437
* RPM including syspurpose CLI tool has dependency on RPM including
  subscription-manager now