### PR TITLE
1844508: subscription-manager should send its version in the User-Age…

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -152,7 +152,9 @@ class BaseConnection(object):
             token=None,
             user_agent=None,
             correlation_id=None,
-            timeout=None):
+            timeout=None,
+            **kwargs
+    ):
 
         restlib_class = restlib_class or Restlib
         self.host = host or config.get('server', 'hostname')
@@ -421,6 +423,8 @@ class ContentConnection(BaseConnection):
     def __init__(self, cert_dir=None, **kwargs):
         log.debug("ContentConnection")
         user_agent = "RHSM-content/1.0 (cmd=%s)" % utils.cmd_name(sys.argv)
+        if 'client_version' in kwargs:
+            user_agent += kwargs['client_version']
         cert_dir = cert_dir or '/etc/pki/entitlement'
         super(ContentConnection, self).__init__(handler='/', cert_dir=cert_dir, user_agent=user_agent,
                                                 **kwargs)
@@ -934,6 +938,8 @@ class UEPConnection(BaseConnection):
         Must specify only one method of authentication.
         """
         user_agent = "RHSM/1.0 (cmd=%s)" % utils.cmd_name(sys.argv)
+        if 'client_version' in kwargs:
+            user_agent += kwargs['client_version']
         super(UEPConnection, self).__init__(user_agent=user_agent, **kwargs)
 
     def _load_supported_resources(self):

--- a/src/subscription_manager/cp_provider.py
+++ b/src/subscription_manager/cp_provider.py
@@ -17,6 +17,7 @@ import base64
 import json
 
 from subscription_manager.identity import ConsumerIdentity
+from subscription_manager import utils
 import rhsm.connection as connection
 
 
@@ -48,8 +49,23 @@ class CPProvider(object):
     def __init__(self):
         self.set_connection_info()
         self.correlation_id = None
+        self.username = None
+        self.password = None
         self.token = None
         self.token_username = None
+        self.cdn_hostname = None
+        self.cdn_port = None
+        self.cert_file = None
+        self.key_file = None
+        self.server_hostname = None
+        self.server_port = None
+        self.server_prefix = None
+        self.proxy_hostname = None
+        self.proxy_port = None
+        self.proxy_user = None
+        self.proxy_password = None
+        self.no_proxy = None
+        self.restlib_class = None
 
     # Reread the config file and prefer arguments over config values
     # then recreate connections
@@ -117,6 +133,13 @@ class CPProvider(object):
         self.no_auth_cp = None
         self.keycloak_auth_cp = None
 
+    def get_client_version(self):
+        """
+        Try to get version of subscription manager
+        :return: string with version of subscription-manager
+        """
+        return " subscription-manager/%s" % utils.get_client_versions()['subscription-manager']
+
     def get_consumer_auth_cp(self):
         if not self.consumer_auth_cp:
             self.consumer_auth_cp = connection.UEPConnection(
@@ -130,7 +153,9 @@ class CPProvider(object):
                     cert_file=self.cert_file, key_file=self.key_file,
                     correlation_id=self.correlation_id,
                     no_proxy=self.no_proxy,
-                    restlib_class=self.restlib_class)
+                    restlib_class=self.restlib_class,
+                    client_version=self.get_client_version()
+            )
         return self.consumer_auth_cp
 
     def get_keycloak_auth_cp(self, token):
@@ -170,8 +195,9 @@ class CPProvider(object):
                 correlation_id=self.correlation_id,
                 no_proxy=self.no_proxy,
                 restlib_class=self.restlib_class,
-                token=self.token
-                )
+                token=self.token,
+                client_version=self.get_client_version()
+        )
         return self.keycloak_auth_cp
 
     def get_basic_auth_cp(self):
@@ -188,7 +214,9 @@ class CPProvider(object):
                     password=self.password,
                     correlation_id=self.correlation_id,
                     no_proxy=self.no_proxy,
-                    restlib_class=self.restlib_class)
+                    restlib_class=self.restlib_class,
+                    client_version=self.get_client_version()
+            )
         return self.basic_auth_cp
 
     def get_no_auth_cp(self):
@@ -203,16 +231,21 @@ class CPProvider(object):
                     proxy_password=self.proxy_password,
                     correlation_id=self.correlation_id,
                     no_proxy=self.no_proxy,
-                    restlib_class=self.restlib_class)
+                    restlib_class=self.restlib_class,
+                    client_version=self.get_client_version()
+            )
         return self.no_auth_cp
 
     def get_content_connection(self):
         if not self.content_connection:
-            self.content_connection = connection.ContentConnection(host=self.cdn_hostname,
-                                                                   ssl_port=self.cdn_port,
-                                                                   proxy_hostname=self.proxy_hostname,
-                                                                   proxy_port=self.proxy_port,
-                                                                   proxy_user=self.proxy_user,
-                                                                   proxy_password=self.proxy_password,
-                                                                   no_proxy=self.no_proxy)
+            self.content_connection = connection.ContentConnection(
+                host=self.cdn_hostname,
+                ssl_port=self.cdn_port,
+                proxy_hostname=self.proxy_hostname,
+                proxy_port=self.proxy_port,
+                proxy_user=self.proxy_user,
+                proxy_password=self.proxy_password,
+                no_proxy=self.no_proxy,
+                client_version=self.get_client_version()
+            )
         return self.content_connection

--- a/test/test_cp_provider.py
+++ b/test/test_cp_provider.py
@@ -1,0 +1,106 @@
+from __future__ import print_function, division, absolute_import
+
+# Copyright (c) 2010 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from mock import patch
+
+from subscription_manager.cp_provider import CPProvider
+
+
+class CPProviderTests(unittest.TestCase):
+    """
+    Test case used for testing method in CPProvider (provider of connection to Candlepin server)
+    """
+
+    def setUp(self):
+        """
+        Initialization before each test
+        """
+        self.cp_provider = CPProvider()
+
+    def test_create_cp_provider(self):
+        """
+        Simple test of creating instance
+        """
+        self.assertIsNotNone(self.cp_provider)
+
+    def test_get_consumer_auth_cp(self):
+        """
+        Test of getting connection to candlepin server using consumer certificate
+        """
+        connection = self.cp_provider.get_consumer_auth_cp()
+        self.assertIsNotNone(connection)
+
+    @patch('subscription_manager.cp_provider.utils.get_client_versions')
+    def test_consumer_auth_setting_user_agent_version(self, mock_client_version):
+        mock_client_version.return_value = {
+            'subscription-manager': '1.23.45'
+        }
+        connection = self.cp_provider.get_consumer_auth_cp()
+        self.assertTrue('subscription-manager/1.23.45' in connection.conn.user_agent)
+
+    def test_get_basic_auth_cp(self):
+        """
+        Test of getting connection to candlepin server using username/password
+        """
+        self.cp_provider.set_user_pass(username='admin', password='admin')
+        connection = self.cp_provider.get_basic_auth_cp()
+        self.assertIsNotNone(connection)
+
+    @patch('subscription_manager.cp_provider.utils.get_client_versions')
+    def test_basic_auth_setting_user_agent_version(self, mock_client_version):
+        mock_client_version.return_value = {
+            'subscription-manager': '1.23.45'
+        }
+        self.cp_provider.set_user_pass(username='admin', password='admin')
+        connection = self.cp_provider.get_basic_auth_cp()
+        self.assertTrue('subscription-manager/1.23.45' in connection.conn.user_agent)
+
+    def test_get_no_auth_cp(self):
+        """
+        Test of getting connection to candlepin server not using authentication
+        """
+        connection = self.cp_provider.get_no_auth_cp()
+        self.assertIsNotNone(connection)
+
+    @patch('subscription_manager.cp_provider.utils.get_client_versions')
+    def test_no_auth_setting_user_agent_version(self, mock_client_version):
+        mock_client_version.return_value = {
+            'subscription-manager': '1.23.45'
+        }
+        connection = self.cp_provider.get_no_auth_cp()
+        self.assertTrue('subscription-manager/1.23.45' in connection.conn.user_agent)
+
+    def test_get_content_conn(self):
+        """
+        Test of getting connection to content server (yum repository)
+        """
+        self.cp_provider.set_content_connection_info(cdn_hostname=None, cdn_port=None)
+        connection = self.cp_provider.get_content_connection()
+        self.assertIsNotNone(connection)
+
+    @patch('subscription_manager.cp_provider.utils.get_client_versions')
+    def test_content_conn_setting_user_agent_version(self, mock_client_version):
+        mock_client_version.return_value = {
+            'subscription-manager': '1.23.45'
+        }
+        self.cp_provider.set_content_connection_info(cdn_hostname=None, cdn_port=None)
+        connection = self.cp_provider.get_content_connection()
+        self.assertTrue('subscription-manager/1.23.45' in connection.conn.user_agent)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1844508
* Added version into User-agent header
* Improvements of setting client version in HTTP request
* Added **kwargs to BaseConnection. Thus it was possible to add
  client_version keyed argument to call of ContentConnection()
  and UEPConnection()
* Added several unit tests