### PR TITLE
Include D-Bus sender in User-Agent http header

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -973,6 +973,8 @@ class UEPConnection(BaseConnection):
         user_agent = "RHSM/1.0 (cmd=%s)" % utils.cmd_name(sys.argv)
         if 'client_version' in kwargs:
             user_agent += kwargs['client_version']
+        if 'dbus_sender' in kwargs:
+            user_agent += kwargs['dbus_sender']
         super(UEPConnection, self).__init__(user_agent=user_agent, **kwargs)
 
     def _load_supported_resources(self):

--- a/src/rhsmlib/client_info.py
+++ b/src/rhsmlib/client_info.py
@@ -1,0 +1,82 @@
+from __future__ import print_function, division, absolute_import
+
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+"""
+This module holds information about current state of client application
+like sender of D-bus method, current subscription-manager command (register,
+attach, ...), dnf command, etc.
+"""
+
+import logging
+import dbus
+
+from rhsmlib.utils import Singleton, no_reinitialization
+from rhsmlib.dbus import dbus_utils
+
+log = logging.getLogger(__name__)
+
+
+class DBusSender(Singleton):
+    """
+    This class holds information about current sender of D-Bus method
+    """
+
+    @no_reinitialization
+    def __init__(self):
+        self._cmd_line = None
+
+    @property
+    def cmd_line(self):
+        with self:
+            return self._cmd_line
+
+    @cmd_line.setter
+    def cmd_line(self, cmd_line):
+        with self:
+            self._cmd_line = cmd_line
+
+    @staticmethod
+    def get_cmd_line(sender, bus=None):
+        """
+        Try to get command line of sender
+        :param sender: sender
+        :param bus: bus
+        :return:
+        """
+        if bus is None:
+            bus = dbus.SystemBus()
+        cmd_line = dbus_utils.command_of_sender(bus, sender)
+        if cmd_line is not None and type(cmd_line) == str:
+            # Store only first argument of command line (no argument including username or password)
+            cmd_line = cmd_line.split()[0]
+        return cmd_line
+
+    def set_cmd_line(self, sender, cmd_line=None, bus=None):
+        """
+        This method set sender's command line in the singleton object
+        :return: None
+        """
+        if cmd_line is None:
+            self.cmd_line = self.get_cmd_line(sender, bus)
+        else:
+            self.cmd_line = cmd_line
+        log.debug("D-Bus sender: %s (cmd-line: %s)" % (sender, self.cmd_line))
+
+    def reset_cmd_line(self):
+        """
+        Reset sender's command line
+        :return: None
+        """
+        self.cmd_line = None

--- a/src/rhsmlib/dbus/__init__.py
+++ b/src/rhsmlib/dbus/__init__.py
@@ -1,5 +1,0 @@
-from __future__ import print_function, division, absolute_import
-
-from rhsmlib.dbus.constants import *  # NOQA
-from rhsmlib.dbus.exceptions import *  # NOQA
-from rhsmlib.dbus.util import *  # NOQA

--- a/src/rhsmlib/dbus/base_object.py
+++ b/src/rhsmlib/dbus/base_object.py
@@ -101,6 +101,7 @@ class BaseObject(dbus.service.Object):
         constants.DBUS_PROPERTIES_INTERFACE,
         in_signature='s',
         out_signature='a{sv}')
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def GetAll(self, _, sender=None):
 

--- a/src/rhsmlib/dbus/dbus_utils.py
+++ b/src/rhsmlib/dbus/dbus_utils.py
@@ -38,7 +38,8 @@ def command_of_pid(pid):
     try:
         with open("/proc/%d/cmdline" % pid, "r") as f:
             cmd = f.readlines()[0].replace('\0', " ").strip()
-    except:
+    except Exception as err:
+        log.warning('Unable to get cmdline of PID: %s, error: %s' % (pid, err))
         return None
     return cmd
 

--- a/src/rhsmlib/dbus/objects/attach.py
+++ b/src/rhsmlib/dbus/objects/attach.py
@@ -46,6 +46,7 @@ class AttachDBusObject(base_object.BaseObject):
         constants.ATTACH_INTERFACE,
         in_signature='sa{sv}s',
         out_signature='s')
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def AutoAttach(self, service_level, proxy_options, locale, sender=None):
         self.ensure_registered()
@@ -71,6 +72,7 @@ class AttachDBusObject(base_object.BaseObject):
         constants.ATTACH_INTERFACE,
         in_signature='asia{sv}s',
         out_signature='as')
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def PoolAttach(self, pools, quantity, proxy_options, locale, sender=None):
         self.ensure_registered()

--- a/src/rhsmlib/dbus/objects/config.py
+++ b/src/rhsmlib/dbus/objects/config.py
@@ -57,6 +57,7 @@ class ConfigDBusObject(base_object.BaseObject):
     @util.dbus_service_method(
         constants.CONFIG_INTERFACE,
         in_signature='svs')
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def Set(self, property_name, new_value, locale, sender=None):
         """
@@ -103,6 +104,7 @@ class ConfigDBusObject(base_object.BaseObject):
     @util.dbus_service_method(
         constants.CONFIG_INTERFACE,
         in_signature='a{sv}s')
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def SetAll(self, configuration, locale, sender=None):
         """
@@ -150,6 +152,7 @@ class ConfigDBusObject(base_object.BaseObject):
         constants.CONFIG_INTERFACE,
         in_signature='s',
         out_signature='a{sv}')
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def GetAll(self, locale, sender=None):
         """
@@ -173,6 +176,7 @@ class ConfigDBusObject(base_object.BaseObject):
         constants.CONFIG_INTERFACE,
         in_signature='ss',
         out_signature='v')
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def Get(self, property_name, locale, sender=None):
         """

--- a/src/rhsmlib/dbus/objects/consumer.py
+++ b/src/rhsmlib/dbus/objects/consumer.py
@@ -48,6 +48,7 @@ class ConsumerDBusObject(base_object.BaseObject):
         constants.CONSUMER_INTERFACE,
         in_signature='s',
         out_signature='s')
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def GetUuid(self, locale, sender=None):
         """

--- a/src/rhsmlib/dbus/objects/entitlement.py
+++ b/src/rhsmlib/dbus/objects/entitlement.py
@@ -23,6 +23,7 @@ from rhsmlib.services.entitlement import EntitlementService
 from subscription_manager.injectioninit import init_dep_injection
 from subscription_manager.i18n import Locale
 
+
 init_dep_injection()
 
 log = logging.getLogger(__name__)
@@ -44,6 +45,7 @@ class EntitlementDBusObject(base_object.BaseObject):
         in_signature='ss',
         out_signature='s'
     )
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def GetStatus(self, on_date, locale, sender=None):
         """
@@ -63,8 +65,8 @@ class EntitlementDBusObject(base_object.BaseObject):
         Locale.set(locale)
 
         try:
-            # get_status doesn't need a Candlepin connection
-            status = EntitlementService(None).get_status(on_date=on_date, force=True)
+            cp = self.build_uep(options={})
+            status = EntitlementService(cp).get_status(on_date=on_date, force=True)
         except Exception as e:
             log.exception(e)
             raise dbus.DBusException(str(e))
@@ -90,6 +92,7 @@ class EntitlementDBusObject(base_object.BaseObject):
         in_signature='a{sv}a{sv}s',
         out_signature='s'
     )
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def GetPools(self, options, proxy_options, locale, sender=None):
         """
@@ -141,6 +144,7 @@ class EntitlementDBusObject(base_object.BaseObject):
         in_signature='a{sv}s',
         out_signature='s'
     )
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def RemoveAllEntitlements(self, proxy_options, locale, sender=None):
         """
@@ -164,6 +168,7 @@ class EntitlementDBusObject(base_object.BaseObject):
         in_signature='asa{sv}s',
         out_signature='s'
     )
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def RemoveEntitlementsByPoolIds(self, pool_ids, proxy_options, locale, sender=None):
         """
@@ -191,6 +196,7 @@ class EntitlementDBusObject(base_object.BaseObject):
         in_signature='asa{sv}s',
         out_signature='s'
     )
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def RemoveEntitlementsBySerials(self, serials, proxy_options, locale, sender=None):
         """
@@ -213,7 +219,8 @@ class EntitlementDBusObject(base_object.BaseObject):
 
         return json.dumps(removed_serials)
 
-    def reload(self):
+    @staticmethod
+    def reload():
         entitlement_service = EntitlementService()
         # TODO: find better solution
         entitlement_service.identity.reload()

--- a/src/rhsmlib/dbus/objects/products.py
+++ b/src/rhsmlib/dbus/objects/products.py
@@ -55,6 +55,7 @@ class ProductsDBusObject(base_object.BaseObject):
         constants.PRODUCTS_INTERFACE,
         in_signature='sa{sv}s',
         out_signature='s')
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def ListInstalledProducts(self, filter_string, proxy_options, locale, sender=None):
 

--- a/src/rhsmlib/dbus/objects/syspurpose.py
+++ b/src/rhsmlib/dbus/objects/syspurpose.py
@@ -90,6 +90,7 @@ class SyspurposeDBusObject(base_object.BaseObject):
         constants.SYSPURPOSE_INTERFACE,
         in_signature='s',
         out_signature='s')
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def GetSyspurpose(self, locale, sender=None):
         """
@@ -168,6 +169,7 @@ class SyspurposeDBusObject(base_object.BaseObject):
         in_signature='a{sv}s',
         out_signature='s'
     )
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def SetSyspurpose(self, syspurpose_values, locale, sender):
         """

--- a/src/rhsmlib/dbus/objects/unregister.py
+++ b/src/rhsmlib/dbus/objects/unregister.py
@@ -50,6 +50,7 @@ class UnregisterDBusObject(base_object.BaseObject):
         constants.UNREGISTER_INTERFACE,
         in_signature='a{sv}s',
         out_signature='')
+    @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def Unregister(self, proxy_options, locale, sender=None):
         """

--- a/src/rhsmlib/utils.py
+++ b/src/rhsmlib/utils.py
@@ -1,0 +1,152 @@
+from __future__ import print_function, division, absolute_import
+
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+"""
+This module includes several utils that could be used by several client
+applications.
+"""
+
+
+import threading
+
+
+def no_reinitialization(init_method):
+    """
+    Decorator of singleton __init__ method. When the __init__ method will be wrapped using
+    this decorator, then the __init__ method will be called only once, when the first instance
+    is created.
+    :param init_method: the __init__ method of singleton object
+    :return: wrapper function
+    """
+
+    def wrapper(*args, **kwargs):
+        if len(args) > 0:
+            self = args[0]
+
+            # Using this wrapper with something else will cause exception
+            assert hasattr(self, "_initialized") is True, \
+                "The {cls} does not include _initialized attribute".format(cls=self.__class__)
+            assert hasattr(self, '_lock') is True, \
+                "The {cls} does not include _lock attribute".format(cls=self.__class__)
+
+            # When we know that the object contains _lock, then we can lock it
+            self._lock.acquire(blocking=True)
+
+            # Encapsulate init method in try-finally statement, because anything can
+            # happen in the init_method
+            try:
+                if self._initialized is True:
+                    return
+                init_method(*args, **kwargs)
+            finally:
+                self._initialized = True
+                self._lock.release()
+        else:
+            raise AssertionError("The wrapper method was called without any argument")
+
+    return wrapper
+
+
+class Singleton(object):
+    """
+    Singleton and parent for singletons. Please use decorator for __init__ method like this:
+
+    class Child(Singleton):
+        @no_reinitialization
+        def __init__(self, foo, bar=None):
+            self.foo = foo
+            self.bar = bar
+
+    The behavior of singleton without using @no_reinitialization is usually not desired,
+    because __init__() would re-initialize instance of singleton everytime it is called.
+
+    When singleton is used in application using thread, then you can lock the object using
+    two different methods. First recommended method is using with statement, because
+    Singleton has __enter__ and __exit__ methods implemented and instance of RLock is
+    acquired and released there. You can use something like this:
+
+    with Singleton() as singleton:
+        print(singleton._lock._is_owner())
+
+    You can also use manual locking, but it use it carefully, because you can easily
+    cause deadlock. It is recommended to use at least try-finally statement:
+
+    singleton = Singleton()
+    singleton.lock()
+    try:
+        print(singleton._lock._is_owner())
+    finally:
+        singleton.unlock()
+
+    The unlock() method can handle gracefully the situation, when the lock is not locked.
+    """
+    _instance = None
+    _initialized = False
+
+    _lock = None
+
+    def __new__(cls, *args, **kwargs):
+        """
+        Function called, when new instance of Singleton is requested
+        """
+        if cls._lock is None:
+            cls._lock = threading.RLock()
+
+        cls._lock.acquire(blocking=True)
+        if not isinstance(cls._instance, cls):
+            # When there is not existing instance, then create first one
+            cls._instance = object.__new__(cls)
+        cls._lock.release()
+
+        return cls._instance
+
+    def lock(self):
+        """
+        Lock the sender using RLock. Thus one thread can lock acquire this lock several times,
+        but other threads can not acquire this lock until the lock is completely unlocked.
+        :return: None
+        """
+        self._lock.acquire()
+
+    def unlock(self):
+        """
+        Try to unlock the RLock.
+        :return: None
+        """
+        try:
+            self._lock.release()
+        except RuntimeError:
+            # When the lock is not acquired, then attempt of releasing raises this exception
+            # The lock has method _is_owner(), but it is not intended for using outside threading
+            # package.
+            pass
+
+    def __enter__(self):
+        """
+        When using: `with dbus_sender:` lock the sender at the beginning
+        :return: None
+        """
+        self.lock()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        When using `with dbus_sender:` unlock the sender at the end
+        :param exc_type: Exception type
+        :param exc_val: Exception value
+        :param exc_tb: Traceback of exception
+        :return: None
+        """
+        self.unlock()

--- a/src/subscription_manager/cp_provider.py
+++ b/src/subscription_manager/cp_provider.py
@@ -18,6 +18,9 @@ import json
 
 from subscription_manager.identity import ConsumerIdentity
 from subscription_manager import utils
+
+from rhsmlib.client_info import DBusSender
+
 import rhsm.connection as connection
 
 
@@ -47,6 +50,7 @@ class CPProvider(object):
 
     # Initialize with default connection info from the config file
     def __init__(self):
+        self.set_connection_info()
         self.correlation_id = None
         self.username = None
         self.password = None
@@ -139,6 +143,18 @@ class CPProvider(object):
         """
         return " subscription-manager/%s" % utils.get_client_versions()['subscription-manager']
 
+    @staticmethod
+    def get_dbus_sender():
+        """
+        Try to get D-Bus sender
+        :return: string with d-bus sender
+        """
+        dbus_sender = DBusSender()
+        if dbus_sender.cmd_line is not None:
+            return " dbus_sender=%s" % dbus_sender.cmd_line
+        else:
+            return ""
+
     def get_consumer_auth_cp(self):
         if not self.consumer_auth_cp:
             self.consumer_auth_cp = connection.UEPConnection(
@@ -153,7 +169,8 @@ class CPProvider(object):
                 correlation_id=self.correlation_id,
                 no_proxy=self.no_proxy,
                 restlib_class=self.restlib_class,
-                client_version=self.get_client_version()
+                client_version=self.get_client_version(),
+                dbus_sender=self.get_dbus_sender()
             )
         return self.consumer_auth_cp
 
@@ -195,7 +212,8 @@ class CPProvider(object):
             no_proxy=self.no_proxy,
             restlib_class=self.restlib_class,
             token=self.token,
-            client_version=self.get_client_version()
+            client_version=self.get_client_version(),
+            dbus_sender=self.get_dbus_sender()
         )
         return self.keycloak_auth_cp
 
@@ -214,7 +232,8 @@ class CPProvider(object):
                 correlation_id=self.correlation_id,
                 no_proxy=self.no_proxy,
                 restlib_class=self.restlib_class,
-                client_version=self.get_client_version()
+                client_version=self.get_client_version(),
+                dbus_sender=self.get_dbus_sender()
             )
         return self.basic_auth_cp
 
@@ -231,7 +250,8 @@ class CPProvider(object):
                 correlation_id=self.correlation_id,
                 no_proxy=self.no_proxy,
                 restlib_class=self.restlib_class,
-                client_version=self.get_client_version()
+                client_version=self.get_client_version(),
+                dbus_sender=self.get_dbus_sender()
             )
         return self.no_auth_cp
 
@@ -245,6 +265,7 @@ class CPProvider(object):
                 proxy_user=self.proxy_user,
                 proxy_password=self.proxy_password,
                 no_proxy=self.no_proxy,
-                client_version=self.get_client_version()
+                client_version=self.get_client_version(),
+                dbus_sender=self.get_dbus_sender()
             )
         return self.content_connection

--- a/test/rhsmlib_test/base.py
+++ b/test/rhsmlib_test/base.py
@@ -106,6 +106,9 @@ class DBusObjectTest(unittest.TestCase):
         self.started_event.wait()
         self.result_queue = queue.Queue(maxsize=1)
         self.addCleanup(self.stop_server)
+        sender_patcher = mock.patch("rhsmlib.client_info.DBusSender.get_cmd_line")
+        self.mock_sender_get_cmd_line = sender_patcher.start()
+        self.mock_sender_get_cmd_line.return_value = "nose-unit-test"
 
     def stop_server(self):
         self.server_thread.stop()

--- a/test/rhsmlib_test/test_utils.py
+++ b/test/rhsmlib_test/test_utils.py
@@ -1,0 +1,343 @@
+from __future__ import print_function, division, absolute_import
+
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+"""
+Unit tests for module rhsmlib.utils.
+"""
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import threading
+import time
+
+from rhsmlib.utils import Singleton, no_reinitialization
+
+
+class Child(Singleton):
+    """
+    Class used for testing of Singleton subclass
+    """
+    @no_reinitialization
+    def __init__(self, foo=None, bar=None):
+        self._foo = foo
+        self._bar = bar
+
+    @property
+    def foo(self):
+        with self:
+            return self._foo
+
+    @foo.setter
+    def foo(self, value):
+        with self:
+            self._foo = value
+
+    @property
+    def bar(self):
+        with self:
+            return self._bar
+
+    @bar.setter
+    def bar(self, value):
+        with self:
+            self._bar = value
+
+
+class GrandSon(Child):
+    """
+    Another class used for testing of Singleton subclass.
+    In this subclass is re-initialization of Singleton forbidden
+    using decorator @no_reinitialization
+    """
+    @no_reinitialization
+    def __init__(self, foo=None, bar=None):
+        super(GrandSon, self).__init__(foo=foo, bar=bar)
+
+
+class GrandDaughter(Child):
+    """
+    Another class used for testing of Singleton subclass.
+    Note that Child uses no_reinitialization and this
+    class doesn't.
+    """
+    def __init__(self, foo=None, bar=None):
+        super(GrandDaughter, self).__init__(foo=foo, bar=bar)
+
+
+class Kid(Singleton):
+    """
+    Another class used for testing of Singleton subclass. Calling
+    GrandDaughter() with new arguments will cause re-initialization
+    of singleton. Note that Child uses no_reinitialization and this
+    class doesn't
+    """
+    def __init__(self, foo=None, bar=None):
+        self.foo = foo
+        self.bar = bar
+
+
+class SpoiledChild(Singleton):
+    """
+    Another class used for testing proper unlocking of singleton, when
+    __init__ method raises some exception.
+    """
+
+    @no_reinitialization
+    def __init__(self):
+        raise Exception
+
+
+class SingletonTestCase(unittest.TestCase):
+
+    @staticmethod
+    def _reset_singleton(clazz):
+        """
+        Method for resetting class
+        :param clazz: class to be reseted
+        :return: None
+        """
+        clazz._instance = None
+        clazz._initialized = False
+        clazz._lock = None
+
+    def setUp(self):
+        """
+        This method all singleton instances before each test
+        """
+        # Add here every child of Singleton to be deleted before each test
+        self._reset_singleton(Singleton)
+        self._reset_singleton(Child)
+        self._reset_singleton(GrandSon)
+        self._reset_singleton(GrandDaughter)
+        self._reset_singleton(Kid)
+        self._reset_singleton(SpoiledChild)
+
+    def test_is_singleton(self):
+        """
+        Simple test of singleton
+        """
+        s1 = Singleton()
+        s2 = Singleton()
+        self.assertEqual(id(s1), id(s2))
+
+    def test_simple_locking_and_unlocking(self):
+        """
+        Test simple locking and unlocking using lock() and unlock()
+        """
+        s = Singleton()
+        # Note: the s._lock._is_owned() should not be used in production, because
+        # _lock and _is_owned are not part of public API. It is used here only for
+        # testing purpose
+        self.assertEqual(s._lock._is_owned(), False)
+        s.lock()
+        self.assertEqual(s._lock._is_owned(), True)
+        s.unlock()
+        self.assertEqual(s._lock._is_owned(), False)
+
+    def test_unlocking_of_not_locked_lock(self):
+        """
+        Test that exception is not raised, when we try to unlock not locked lock
+        """
+        s = Singleton()
+        s.unlock()
+        # Note: the s._lock._is_owned() should not be used in production, because
+        # _lock and _is_owned are not part of public API. It is used here only for
+        # testing purpose
+        self.assertEqual(s._lock._is_owned(), False)
+
+    def test_locking_using_enter_exit(self):
+        """
+        Simple test of locking using with statement
+        """
+        with Singleton() as s:
+            self.assertEqual(s._lock._is_owned(), True)
+        s = Singleton()
+        self.assertEqual(s._lock._is_owned(), False)
+
+    def test_is_subclass_singleton(self):
+        """
+        Test of singleton and child of singleton
+
+        """
+        # First create parent to be sure that parent do not influence sub-classes
+        s = Singleton()
+
+        # Do asserts of sub-class
+        self.assertEqual(Child._instance, None)
+        self.assertEqual(Child._initialized, False)
+        self.assertEqual(Child._lock, None)
+
+        # Do own tests of sub-class
+        ch1 = Child()
+        ch2 = Child()
+        self.assertNotEqual(id(s), id(ch1))
+        self.assertEqual(id(ch1), id(ch2))
+
+    def test_child_is_initialized(self):
+        """
+        Test that instance of class is initialized
+        """
+        self.assertEqual(Child._instance, None)
+        self.assertEqual(Child._initialized, False)
+        self.assertEqual(Child._lock, None)
+
+        ch = Child("foo", bar="bar")
+
+        self.assertEqual(ch.bar, "bar")
+        self.assertEqual(ch.foo, "foo")
+        self.assertEqual(ch._initialized, True)
+        self.assertIsNotNone(ch._lock)
+
+    def test_another_child_is_not_reinitialized(self):
+        """
+        Test of decorator no_reinitialization
+        """
+        ch1 = Child("foo", bar="bar")
+        self.assertEqual(ch1.bar, "bar")
+        self.assertEqual(ch1.foo, "foo")
+        ch2 = Child("FOO", bar="BAR")
+        # This singleton should still have still old values
+        self.assertEqual(ch2.bar, "bar")
+        self.assertEqual(ch2.foo, "foo")
+
+    def test_grand_son(self):
+        """
+        Test of decorator no_reinitialization (subclass of child)
+        """
+        ch1 = Child("foo", bar="bar")
+        ch2 = Child("foolish", bar="barista")
+        gs = GrandSon("FOO", bar="BAR")
+        self.assertNotEqual(id(ch1), id(gs))
+        self.assertEqual(ch1.foo, "foo")
+        self.assertEqual(ch2.bar, "bar")
+        self.assertEqual(gs.foo, "FOO")
+        self.assertEqual(gs.bar, "BAR")
+
+    def test_grand_daughter(self):
+        """
+        This test is intended for testing class without decorator no_reinitialization
+        """
+        # Create instance of singleton with some arguments
+        gd1 = GrandDaughter("foo", bar="bar")
+        self.assertEqual(gd1.foo, "foo")
+        self.assertEqual(gd1.bar, "bar")
+        # No try to get instance with some different arguments
+        gd2 = GrandDaughter("FOO", bar="BAR")
+        self.assertEqual(id(gd1), id(gd2))
+        # This singleton should have new values
+        self.assertEqual(gd2.foo, "foo")
+        self.assertEqual(gd2.bar, "bar")
+
+    def test_kid(self):
+        """
+        This test is intended for testing class without decorator no_reinitialization. Parent
+        of this class does not use the decorator no_reinitialization
+        """
+        # Create instance of singleton with some arguments
+        kid1 = Kid("foo", bar="bar")
+        self.assertEqual(kid1.foo, "foo")
+        self.assertEqual(kid1.bar, "bar")
+        # No try to get instance with some different arguments
+        kid2 = Kid("FOO", bar="BAR")
+        self.assertEqual(id(kid1), id(kid2))
+        # This singleton should have new values
+        self.assertEqual(kid2.foo, "FOO")
+        self.assertEqual(kid2.bar, "BAR")
+
+    def test_release_lock_after_exception_in_init(self):
+        """
+        Test proper releasing of singleton, when __init__ method is not implemented
+        as expected (it raises some exception)
+        """
+        # Capture exception
+        self.assertRaises(Exception, SpoiledChild)
+
+        # Test that it was initialized despite exception
+        self.assertIsNotNone(SpoiledChild._instance)
+        self.assertEqual(SpoiledChild._instance._initialized, True)
+        spoiled_child_id = id(SpoiledChild._instance)
+
+        # Test that another calling of SpoiledChild is not destructive
+        spoiled_child = SpoiledChild()
+        self.assertEqual(id(spoiled_child), spoiled_child_id)
+
+    def test_singleton_and_threading(self):
+        """
+        Test creating singletons in two threads
+        """
+
+        def thread_function(foo, bar):
+            """
+            Dummy thread function for testing singleton
+            :param foo: foo argument
+            :param bar: bar argument
+            :return: None
+            """
+            Child(foo=foo, bar=bar)
+            time.sleep(0.3)
+
+        thread01 = threading.Thread(target=thread_function, args=("foo", "bar"))
+        thread01.start()
+        time.sleep(0.1)
+        thread02 = threading.Thread(target=thread_function, args=("FOO", "BAR"))
+        thread02.start()
+        time.sleep(0.1)
+        thread01.join()
+        thread02.join()
+
+        # Create testing singleton
+        test_child = Child()
+        self.assertEqual(test_child.bar, "bar")
+        self.assertEqual(test_child.foo, "foo")
+
+    def test_singleton_threading_and_locking(self):
+        """
+        Test creating singletons in two threads and locking of singleton
+        """
+
+        def thread_function(foo, bar):
+            """
+            Dummy thread function for testing singleton
+            :param foo: foo argument
+            :param bar: bar argument
+            :return: None
+            """
+            with Child() as child:
+                child.foo = foo
+                child.bar = bar
+                time.sleep(0.3)
+
+        # Create testing singleton
+        test_child = Child()
+
+        thread01 = threading.Thread(target=thread_function, args=("foo", "bar"))
+        thread01.start()
+        time.sleep(0.1)
+
+        self.assertEqual(test_child.bar, "bar")
+        self.assertEqual(test_child.foo, "foo")
+
+        thread02 = threading.Thread(target=thread_function, args=("FOO", "BAR"))
+        thread02.start()
+        time.sleep(0.1)
+
+        self.assertEqual(test_child.bar, "BAR")
+        self.assertEqual(test_child.foo, "FOO")
+
+        thread01.join()
+        thread02.join()


### PR DESCRIPTION
* When some application call D-Bus method, then the application
  can be identified using sender argument of the method.
  This argument used to be unused. The sender ID (e.g. ':1:3003')
  can be used for finding of PID and this PID can be used for
  finding command line used for starting the application that
  sent the D-Bus method. This could be e.g.: 'dbus-send',
  'cockpit-bridge', etc. (note: all command line options are
  stripped for security reason to not send username nor password).
  The command line of D-Bus sender is stored in singleton and
  then this command line is added to User-Agent http header
  as 'dbus_sender=cockpit-bridge'
* The sender argument is saved to singleton using decorator
  dbus_handle_sender implemented in rhsmlib.dbus.util.
  When it will not be desired to store sender for some method
  then just don't use this decorator.
* When methods of DomainSocketRegisterDBusObject are used,
  then it is little bit complicated, because system bus
  is not used there, but custom unix socket is used. Thus
  sender argument is not available. It is necessary to save
  sender, when DomainSocketRegisterDBusObject is created using
  com.redha.RHSM.Register.Start method
* It will be possible to do statistics of applications using
  our D-Bus API
* Added implementation of singleton
* Modified some unit tests