### PR TITLE
1847910: DNF plugins are part of sub-man RPM, libdnf RPM; ENT-2536

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -100,6 +100,7 @@
 %endif
 
 %global use_dnf (%{with python3} && (0%{?fedora} || (0%{?rhel}))) || (0%{?rhel} >= 7)
+%global use_libdnf (0%{?fedora} >= 29 || 0%{?rhel} >= 8)
 %global use_yum (0%{?rhel} && 0%{?rhel} <= 7)
 %global use_cockpit 0%{?fedora} || 0%{?rhel} >= 7
 
@@ -322,8 +323,10 @@ Requires: %{?suse_version:dbus-1-python} %{!?suse_version:dbus-python}
 Requires: %{?suse_version:yum} %{!?suse_version:yum >= 3.2.29-73}
 %endif
 
-%if (%{use_dnf} && (0%{?fedora} || 0%{?rhel} >= 8))
-Requires: dnf-plugin-subscription-manager = %{version}
+%if %{use_dnf}
+Requires: dnf >= 1.0.0
+Requires: python3-dnf-plugins-core
+Requires: python3-librepo
 %endif
 
 # Support GTK2 and GTK3 on both SUSE and RHEL...
@@ -397,6 +400,15 @@ BuildRequires: systemd
 
 %if !%{use_container_plugin}
 Obsoletes: subscription-manager-plugin-container
+%endif
+
+%if %{use_dnf}
+# The libdnf plugin is in separate RPM, but shubscription-manager should be dependent
+# on this RPM, because somebody can install microdnf on host and installing of product
+# certs would not work as expected without libdnf plugin
+Requires: libdnf-plugin-subscription-manager = %{version}
+# The dnf plugin is now part of subscription-manager
+Obsoletes: dnf-plugin-subscription-manager
 %endif
 
 %description
@@ -514,43 +526,25 @@ subscriptions
 %endif
 
 
-%if %use_dnf
-%package -n dnf-plugin-subscription-manager
-Summary: Subscription Manager plugins for DNF
+%if %{use_libdnf}
+%package -n libdnf-plugin-subscription-manager
+Summary: Subscription Manager plugin for libdnf
 %if 0%{?suse_version}
 Group: Productivity/Networking/System
 %else
 Group: System Environment/Base
 %endif
-%if (0%{?fedora} >= 29 || 0%{?rhel} >= 8)
 BuildRequires: cmake
 BuildRequires: gcc
 BuildRequires: json-c-devel
 BuildRequires: libdnf-devel >= 0.22.5
 Requires: json-c
 Requires: libdnf >= 0.22.5
-%endif
-# See BZ 1581410 - avoid a circular dependency
-%if (0%{?rhel} < 8)
-Requires: %{name} >= %{version}-%{release}
-%endif
-%if %{with python3}
-Requires: python3-dnf-plugins-core
-Requires: python3-librepo
-%else
-Requires: python2-dnf-plugins-core
-%if (0%{?rhel} == 7)
-Requires: python-librepo
-%else
-Requires: python2-librepo
-%endif
-%endif
-Requires: dnf >= 1.0.0
 
-%description -n dnf-plugin-subscription-manager
-This package provides plugins to interact with repositories and subscriptions
-from the Red Hat entitlement platform; contains subscription-manager and
-product-id plugins.
+%description -n libdnf-plugin-subscription-manager
+This package provides a plugin to interact with repositories from the Red Hat
+entitlement platform; contains only one product-id binary plugin used by
+e.g. microdnf.
 %endif
 
 
@@ -750,7 +744,7 @@ make -f Makefile VERSION=%{version}-%{release} CFLAGS="%{optflags}" \
 python2 ./setup.py build --quiet --gtk-version=%{?gtk3:3}%{?!gtk3:2} --rpm-version=%{version}-%{release}
 %endif
 
-%if (%{use_dnf} && (0%{?fedora} >= 29 || 0%{?rhel} >= 8))
+%if %{use_libdnf}
 pushd src/dnf-plugins/product-id
 %cmake -DCMAKE_BUILD_TYPE="Release"
 %if (0%{?rhel} && 0%{?rhel} <= 8)
@@ -779,7 +773,7 @@ make -f Makefile install VERSION=%{version}-%{release} \
     %{?include_syspurpose:INCLUDE_SYSPURPOSE="1"} \
     %{?exclude_packages}
 
-%if (%{use_dnf} && (0%{?fedora} >= 29 || 0%{?rhel} >= 8))
+%if %{use_libdnf}
 pushd src/dnf-plugins/product-id
 mkdir -p %{buildroot}%{_libdir}/libdnf/plugins
 %if (0%{?rhel} && 0%{?rhel} <= 8)
@@ -1032,6 +1026,10 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
     %{_prefix}/lib/yum-plugins/search-disabled-repos.py*
 %endif
 
+%if %{use_dnf}
+%{python_sitelib}/dnf-plugins/*
+%endif
+
 # zypper plugins
 %if 0%{?suse_version}
 %{_prefix}/lib/zypp/plugins/services/rhsm
@@ -1270,13 +1268,10 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %endif
 
 
-%if %use_dnf
-%files -n dnf-plugin-subscription-manager
+%if %{use_libdnf}
+%files -n libdnf-plugin-subscription-manager
 %defattr(-,root,root,-)
-%{python_sitelib}/dnf-plugins/*
-%if (0%{?fedora} >= 29 || 0%{?rhel} >= 8)
 %{_libdir}/libdnf/plugins/product-id.so
-%endif
 %endif
 
 


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1847910
* Introduction: DNF plugins were in separate RPM and there was
  circular dependency between RPM including subscriptions-manager
  (subscription-manager required rpm with DNF plugin and DNF plugins
  required subscription-manager). DNF plugins were in separate plugin
  due to RHEL7 (dnf was experimental on RHEL7).
* DNF plugins were moved to subscription-manager RPM
* New libdnf-plugin-subscription-manager was introduced, because
  microdnf really needs it. This RPM includes only libdnf plugin.
  It would be inefficient to require dependency of libdnf plugin
  on subscription-manager.