### PR TITLE
1826300: Ignore auto-attach, when SCA mode is used; ENT-2341

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1829,6 +1829,23 @@ class AttachCommand(CliCommand):
         if self.options.pool or self.options.file:
             self.auto_attach = False
 
+        # Do not try to do auto-attach, when simple content access mode is used
+        # BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1826300
+        if self.auto_attach is True:
+            if is_simple_content_access(uep=self.cp, identity=self.identity):
+                owner_name = ""
+                try:
+                    owner = self.cp.getOwner(self.identity.uuid)
+                except Exception as err:
+                    handle_exception(_("Error: Unable to retrieve org list from server"), err)
+                else:
+                    owner_name = owner['displayName']
+                # We could also display owner ID: `owner_id = owner['key']` (not sure)
+                print(_('Ignoring request to auto-attach. '
+                        'It is disabled for organization: "%s", because Simple Content Access is in use.')
+                      % owner_name)
+                return 0
+
         installed_products_num = 0
         return_code = 0
         report = None


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1826300
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1831082
* When simple content access mode is used, then do not try to
  auto-attach and print appropriate message to stdout.

This is just a backport/cherry-pick of 7a187c99a0914726ad9cd30892bc6e6b48a1131c for subscription-manager-1.24*