### PR TITLE
1850919: False positive log "rhsmd process exceeded runtime and was k…

### DIFF
--- a/etc-conf/rhsmd.cron
+++ b/etc-conf/rhsmd.cron
@@ -15,5 +15,4 @@ sleep $rhsmd_timeout;
 ps_check=$(pgrep -f '/usr/libexec/rhsmd')
 if [ -n "$ps_check" ]; then
   pkill -f '/usr/libexec/rhsmd' >/dev/null 2>&1
-  logger -t rhsmd -p user.warn "rhsmd process exceeded runtime and was killed." >/dev/null 2>&1
 fi


### PR DESCRIPTION
…illed."