### PR TITLE
1886745: Fix __init__ of CPProvider; ENT-3147

### DIFF
--- a/src/subscription_manager/cp_provider.py
+++ b/src/subscription_manager/cp_provider.py
@@ -47,7 +47,6 @@ class CPProvider(object):
 
     # Initialize with default connection info from the config file
     def __init__(self):
-        self.set_connection_info()
         self.correlation_id = None
         self.username = None
         self.password = None
@@ -55,8 +54,8 @@ class CPProvider(object):
         self.token_username = None
         self.cdn_hostname = None
         self.cdn_port = None
-        self.cert_file = None
-        self.key_file = None
+        self.cert_file = ConsumerIdentity.certpath()
+        self.key_file = ConsumerIdentity.keypath()
         self.server_hostname = None
         self.server_port = None
         self.server_prefix = None

--- a/test/test_cp_provider.py
+++ b/test/test_cp_provider.py
@@ -41,6 +41,18 @@ class CPProviderTests(unittest.TestCase):
         """
         self.assertIsNotNone(self.cp_provider)
 
+    def test_cert_file_is_not_none(self):
+        """
+        Test that cp_provider is not created without default cert file
+        """
+        self.assertEqual(self.cp_provider.cert_file, '/etc/pki/consumer/cert.pem')
+
+    def test_key_file_is_not_none(self):
+        """
+        Test that cp_provider is not created without default key file
+        """
+        self.assertEqual(self.cp_provider.key_file, '/etc/pki/consumer/key.pem')
+
     def test_get_consumer_auth_cp(self):
         """
         Test of getting connection to candlepin server using consumer certificate

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1602,7 +1602,7 @@ class TestServiceLevelCommand(TestCliProxyCommand):
             self.assertEqual(e.code, os.EX_USAGE)
 
     def test_set_allows_list_good(self):
-        self.cc.main(["--set", "two","--org","test"])
+        self.cc.main(["--set", "two", "--org", "test"])
         self.cc._validate_options()
 
     def test_org_requires_list_good(self):


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1886745
* The initialization of variables in CPProvider caused this
  regression. It was introduced in the PR: #2328
* The path to concumer cert and consumer key was None.
* Added two unit tests