### PR TITLE
Added new syspurpose command; ENT-3060

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -631,10 +631,13 @@ class BaseRestLib(object):
             if os.path.isdir('/tmp/sub-man') is False:
                 os.mkdir('/tmp/sub-man')
             if 'SUBMAN_DEBUG_SAVE_TRACEBACKS' in os.environ:
-                with tempfile.NamedTemporaryFile(dir='/tmp/sub-man', prefix='traceback-', delete=False) as tmp_file:
-                    traceback.print_stack(file=tmp_file)
+                with tempfile.NamedTemporaryFile(
+                        dir='/tmp/sub-man',
+                        mode='w',
+                        prefix='traceback-',
+                        delete=False) as tmp_file:
+                    traceback.print_stack(file=tmp_file.file)
                     print(green_col + '    traceback saved in: %s' % tmp_file.name + end_col)
-                    # print(dir(tmp_file))
                     print()
 
     @staticmethod

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -29,6 +29,7 @@ import readline
 import socket
 import six.moves
 import sys
+import json
 from time import localtime, strftime, strptime
 
 from rhsm.certificate import CertificateException
@@ -567,13 +568,13 @@ class CliCommand(AbstractCLICommand):
             handle_exception("exception caught in subscription-manager", err)
 
 
-class SyspurposeCommand(CliCommand):
+class AbstractSyspurposeCommand(CliCommand):
     """
     Abstract command for manipulating an attribute of system purpose.
     """
 
     def __init__(self, name, shortdesc=None, primary=False, attr=None, commands=('set', 'unset', 'show', 'list')):
-        super(SyspurposeCommand, self).__init__(name, shortdesc=shortdesc, primary=primary)
+        super(AbstractSyspurposeCommand, self).__init__(name, shortdesc=shortdesc, primary=primary)
         self.commands = commands
         self.attr = attr
 
@@ -635,6 +636,7 @@ class SyspurposeCommand(CliCommand):
         to_unset = getattr(self.options, 'unset', None)
         to_add = getattr(self.options, 'to_add', None)
         to_remove = getattr(self.options, 'to_remove', None)
+        to_show = getattr(self.options, 'show', None)
 
         if to_set:
             self.options.set = self.options.set.strip()
@@ -664,7 +666,7 @@ class SyspurposeCommand(CliCommand):
                             attr=self.attr
                         )
                     )
-            elif to_unset or to_set or to_add or to_remove:
+            elif to_unset or to_set or to_add or to_remove or to_show:
                 pass
             else:
                 system_exit(ERR_NOT_REGISTERED_CODE, ERR_NOT_REGISTERED_MSG)
@@ -997,8 +999,12 @@ class OrgCommand(UserPassCommand):
         self._org = None
         if not hasattr(self, "_org_help_text"):
             self._org_help_text = _("specify organization")
-        self.parser.add_option("--org", dest="org", metavar="ORG_KEY",
-            help=self._org_help_text)
+        self.parser.add_option(
+            "--org",
+            dest="org",
+            metavar="ORG_KEY",
+            help=self._org_help_text
+        )
 
     @staticmethod
     def _get_org(org):
@@ -1012,6 +1018,82 @@ class OrgCommand(UserPassCommand):
         if not self._org:
             self._org = self._get_org(self.options.org)
         return self._org
+
+
+class SyspurposeCommand(CliCommand):
+    """
+    Syspurpose command for generic actions. This command will be used for all
+    syspurpose actions in the future and it will replace addons, role,
+    service-level and usage commands. It will be possible to set service-type
+    using this command.
+
+    Note: when the system is not registered, then it doesn't make any sense to
+    synchronize syspurpose values with candlepin server, because consumer
+    does not exist.
+    """
+
+    def __init__(self):
+        """
+        Initialize the syspurpose command
+        """
+        short_desc = _("Generic system purpose command")
+        super(SyspurposeCommand, self).__init__(
+            "syspurpose",
+            short_desc,
+            primary=False
+        )
+        self.parser.add_option(
+            "--show",
+            action="store_true",
+            help=_("show current system purpose")
+        )
+
+    def _get_synced_store(self):
+        """
+        Try to get SyncedStore.
+        TODO: refactor (remove) this, when AbstractSyspurposeCommand is merged to SyspurposeCommand
+        :return: Instance of SyncedStore or None
+        """
+        try:
+            from syspurpose.files import SyncedStore
+            return SyncedStore(uep=self.cp, consumer_uuid=self.identity.uuid)
+        except ImportError:
+            return None
+
+    def _validate_options(self):
+        """
+        Validate provided options
+        :return: None
+        """
+        # When no CLI options are provided, then show current syspurpose values
+        if self.options.show is not True:
+            self.options.show = True
+
+    def _do_command(self):
+        """
+        Own implementation of all actions
+        :return: None
+        """
+        self._validate_options()
+
+        content = {}
+        if self.options.show is True:
+            if self.is_registered():
+                try:
+                    self.cp = self.cp_provider.get_consumer_auth_cp()
+                except connection.RestlibException as err:
+                    log.exception(re)
+                    log.debug("Error: Unable to retrieve system purpose from server")
+                except Exception as err:
+                    log.debug("Error: Unable to retrieve system purpose from server: %s" % err)
+                else:
+                    self.store = self._get_synced_store()
+                    if self.store is not None:
+                        sync_result = self.store.sync()
+                        content = sync_result.result
+            else:
+                content = syspurposelib.read_syspurpose()
+            print(json.dumps(content, indent=2, ensure_ascii=False, sort_keys=True))
 
 
 class CleanCommand(CliCommand):
@@ -1282,7 +1364,7 @@ class AutohealCommand(CliCommand):
             self._toggle(self.options.enable or False)
 
 
-class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
+class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
 
     def __init__(self):
 
@@ -1318,9 +1400,14 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
         if not self.is_registered():
             if self.options.list:
                 if not (self.options.username and self.options.password) and not self.options.token:
-                    system_exit(os.EX_USAGE, _("Error: you must register or specify --username and --password to list service levels"))
+                    system_exit(
+                        os.EX_USAGE,
+                        _("Error: you must register or specify --username and --password to list service levels")
+                    )
             elif self.options.unset or self.options.set:
                 pass  # RHBZ 1632248 : User should be able to set/unset while not registered.
+            elif self.options.show:
+                pass  # When system is not registered, then user should have ability to display current value
             else:
                 system_exit(ERR_NOT_REGISTERED_CODE, ERR_NOT_REGISTERED_MSG)
 
@@ -1335,6 +1422,8 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
             elif self.options.username and self.options.password:
                 self.cp_provider.set_user_pass(self.username, self.password)
                 self.cp = self.cp_provider.get_basic_auth_cp()
+            elif not self.is_registered() and self.options.show:
+                pass
             else:
                 # get an UEP as consumer
                 self.cp = self.cp_provider.get_consumer_auth_cp()
@@ -1391,14 +1480,17 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
         self.cp.updateConsumer(self.identity.uuid, service_level=service_level)
 
     def show_service_level(self):
-        consumer = self.cp.getConsumer(self.identity.uuid)
-        if 'serviceLevel' not in consumer:
-            system_exit(os.EX_UNAVAILABLE, _("Error: The service-level command is not supported by the server."))
-        service_level = consumer['serviceLevel'] or ""
-        if service_level:
-            print(_("Current service level: %s") % service_level)
+        if self.is_registered():
+            consumer = self.cp.getConsumer(self.identity.uuid)
+            if 'serviceLevel' not in consumer:
+                system_exit(os.EX_UNAVAILABLE, _("Error: The service-level command is not supported by the server."))
+            service_level = consumer['serviceLevel'] or ""
+            if service_level:
+                print(_("Current service level: %s") % service_level)
+            else:
+                print(_("Service level preference not set"))
         else:
-            print(_("Service level preference not set"))
+            super(ServiceLevelCommand, self).show()
 
     def list_service_levels(self):
         org_key = self.options.org
@@ -1433,7 +1525,7 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
                 raise e
 
 
-class UsageCommand(SyspurposeCommand, OrgCommand):
+class UsageCommand(AbstractSyspurposeCommand, OrgCommand):
 
     def __init__(self):
         shortdesc = _("Manage usage setting for this system")
@@ -1817,7 +1909,7 @@ class UnRegisterCommand(CliCommand):
         print(_("System has been unregistered."))
 
 
-class AddonsCommand(SyspurposeCommand, OrgCommand):
+class AddonsCommand(AbstractSyspurposeCommand, OrgCommand):
 
     def __init__(self):
         shortdesc = _("Modify or view the addons attribute of the system purpose")
@@ -3185,7 +3277,7 @@ class OverrideCommand(CliCommand):
             print(columnize(names, echo_columnize_callback, *values, indent=2) + "\n")
 
 
-class RoleCommand(SyspurposeCommand, OrgCommand):
+class RoleCommand(AbstractSyspurposeCommand, OrgCommand):
     def __init__(self):
         shortdesc = _("Modify system purpose role")
         super(RoleCommand, self).__init__(
@@ -3294,7 +3386,8 @@ class ManagerCLI(CLI):
                     RedeemCommand, ReposCommand, ReleaseCommand, StatusCommand,
                     EnvironmentsCommand, ImportCertCommand, ServiceLevelCommand,
                     VersionCommand, RemoveCommand, AttachCommand, PluginsCommand,
-                    AutohealCommand, OverrideCommand, RoleCommand, UsageCommand]
+                    AutohealCommand, OverrideCommand, RoleCommand, UsageCommand,
+                    SyspurposeCommand]
         CLI.__init__(self, command_classes=commands)
 
     def main(self):

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -94,26 +94,28 @@ def get_sys_purpose_store():
     return store
 
 
-def read_syspurpose(raise_on_error=False):
+def read_syspurpose(synced_store=None, raise_on_error=False):
     """
     Reads the system purpose from the correct location on the file system.
     Makes an attempt to use a SyspurposeStore if available falls back to reading the json directly.
     :return: A dictionary containing the total syspurpose.
     """
     if SyncedStore is not None:
+        if synced_store is None:
+            synced_store = SyncedStore(None)
         try:
-            syspurpose = SyncedStore(None).get_local_contents()
+            content = synced_store.get_local_contents()
         except (OSError, IOError):
-            syspurpose = {}
+            content = {}
     else:
         try:
-            syspurpose = json.load(open(USER_SYSPURPOSE))
+            content = json.load(open(USER_SYSPURPOSE))
         except (os.error, ValueError, IOError):
             # In the event this file could not be read treat it as empty
             if raise_on_error:
                 raise
-            syspurpose = {}
-    return syspurpose
+            content = {}
+    return content
 
 
 def write_syspurpose(values):

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1688,6 +1688,23 @@ class TestReleaseCommand(TestCliProxyCommand):
                 mock_repo_invoker.update.assert_called_with()
 
 
+class TestSyspurposeCommand(TestCliProxyCommand):
+    command_class = managercli.RoleCommand
+
+    def setUp(self):
+        syspurpose_patch = patch('syspurpose.files.SyncedStore')
+        sp_patch = syspurpose_patch.start()
+        self.addCleanup(sp_patch.stop)
+        super(TestSyspurposeCommand, self).setUp(False)
+        self.cc = self.command_class()
+        self.cc.cp = StubUEP()
+        self.cc.cp.registered_consumer_info['role'] = None
+        self.cc.cp._capabilities = ["syspurpose"]
+
+    def test_show_option(self):
+        self.cc.main(["--show"])
+
+
 class TestRoleCommand(TestCliProxyCommand):
     command_class = managercli.RoleCommand
 
@@ -1762,7 +1779,7 @@ class TestRoleCommand(TestCliProxyCommand):
         instance_syspurpose_store = mock_syspurpose.read.return_value
         instance_syspurpose_store.local_contents = {'role': 'Foo'}
 
-        with patch.object(managercli.SyspurposeCommand, 'check_syspurpose_support', Mock(return_value=None)):
+        with patch.object(managercli.AbstractSyspurposeCommand, 'check_syspurpose_support', Mock(return_value=None)):
             super(TestRoleCommand, self).test_main_no_args()
 
     @patch("subscription_manager.syspurposelib.SyncedStore")
@@ -1773,7 +1790,7 @@ class TestRoleCommand(TestCliProxyCommand):
         instance_syspurpose_store = mock_syspurpose.read.return_value
         instance_syspurpose_store.local_contents = {'role': 'Foo'}
 
-        with patch.object(managercli.SyspurposeCommand, 'check_syspurpose_support', Mock(return_value=None)):
+        with patch.object(managercli.AbstractSyspurposeCommand, 'check_syspurpose_support', Mock(return_value=None)):
             super(TestRoleCommand, self).test_main_empty_args()
 
     @patch("subscription_manager.syspurposelib.SyncedStore")


### PR DESCRIPTION
* Added new syspurpose command
* It has only --show option at this moment
* When system is registered, then the sub-man tries to get
  consumer's syspurpose valyes and then do three-way merge
* When system is not registered, then it is possible only
  display values stored in /etc/rhsm/syspurpose/syspurpose.json
* When no options is provided, then current syspurpose values
  are displayed too
* Added unit tests for new command
* Modified a little bit behavior of other syspurpose commands
  (role, usage, addons, service-level). When the system is
  not registered, then --show option print current syspurpose
  value stored in /etc/rhsm/syspurpose/syspurpose.json