### PR TITLE
1831082: Better messages for attach --auto for SCA mode; ENT-3175

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -5100,6 +5100,17 @@ msgstr "Erreur : le fichier « %s » n'existe pas ou ne peut pas être lu."
 msgid "Please enter a valid numeric pool ID."
 msgstr "Veuillez saisir un ID de pool numérique valide."
 
+# translation manually copied from candlepin
+#: src/subscription_manager/managercli.py:2166
+#, python-format
+msgid ""
+"Ignoring request to auto-attach. It is disabled for org \"{owner_id}\" because of "
+"the content access mode setting."
+msgstr ""
+"Requête auto-attach ignorée. L'organisation \"{owner_id}\" a déjà la fonction auto-"
+"attach désactivée à cause de la configuration de mode d'accès au contenu."
+
+
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys
 #: src/subscription_manager/managercli.py:1766
 #, python-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -4842,6 +4842,14 @@ msgstr "エラー: ファイル \"%s\" が存在せず、読み取りできま�
 msgid "Please enter a valid numeric pool ID."
 msgstr "有効なプール ID (数値) を入力してください。"
 
+# translation manually copied from candlepin
+#: src/subscription_manager/managercli.py:2166
+#, python-format
+msgid ""
+"Ignoring request to auto-attach. It is disabled for org \"{owner_id}\" because of "
+"the content access mode setting."
+msgstr "自動割り当ての要求を無視します。これは、コンテンツアクセスモードの設定により、組織 \"{owner_id}\" に対して無効となっています。"
+
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys
 #: src/subscription_manager/managercli.py:1766
 #, python-format

--- a/po/ko.po
+++ b/po/ko.po
@@ -4898,6 +4898,14 @@ msgstr "오류: 파일 \"%s\"은 존재하지 않거나 읽을 수 없습니다.
 msgid "Please enter a valid numeric pool ID."
 msgstr "유효한 숫자 풀 ID를 입력하십시오."
 
+# translation manually copied from candlepin
+#: src/subscription_manager/managercli.py:2166
+#, python-format
+msgid ""
+"Ignoring request to auto-attach. It is disabled for org \"{owner_id}\" because of "
+"the content access mode setting."
+msgstr "자동 첨부 요청을 무시합니다. 콘텐츠 액세스 모드 설정으로 인해 {owner_id}\" 조직에 대해 비활성화되어 있습니다."
+
 #: src/subscription_manager/managercli.py:1766
 #, python-format
 msgid "Successfully attached a subscription for: %s"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4878,6 +4878,14 @@ msgstr "错误：文件 \"%s\" 不存在或者无法读取"
 msgid "Please enter a valid numeric pool ID."
 msgstr "请输入有效数字池 ID。"
 
+# translation manually copied from candlepin
+#: src/subscription_manager/managercli.py:2166
+#, python-format
+msgid ""
+"Ignoring request to auto-attach. It is disabled for org \"{owner_id}\" because of "
+"the content access mode setting."
+msgstr "忽略自动附加的请求。 因为内容访问模式的设置 ，组织“ {owner_id}”禁用了这个功能。"
+
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
 #: src/subscription_manager/managercli.py:1766
 #, python-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4867,6 +4867,14 @@ msgstr "錯誤：認證檔案「%s」不存在或無法讀取。"
 msgid "Please enter a valid numeric pool ID."
 msgstr "請輸入一組有效的數字集區 ID。"
 
+# translation manually copied from candlepin
+#: src/subscription_manager/managercli.py:2166
+#, python-format
+msgid ""
+"Ignoring request to auto-attach. It is disabled for org \"{owner_id}\" because of "
+"the content access mode setting."
+msgstr "忽略自动附加的请求。 因为内容访问模式的设置 ，组织“ {owner_id}”禁用了这个功能。"
+
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
 #: src/subscription_manager/managercli.py:1766
 #, python-format

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2066,11 +2066,15 @@ class AttachCommand(CliCommand):
         if self.auto_attach is True:
             if is_simple_content_access(uep=self.cp, identity=self.identity):
                 owner = get_current_owner(self.cp, self.identity)
-                owner_name = owner['displayName']
-                # We could also display owner ID: `owner_id = owner['key']` (not sure)
-                print(_('Ignoring request to auto-attach. '
-                        'It is disabled for organization: "%s", because Simple Content Access is in use.')
-                      % owner_name)
+                # We displayed Owner name: `owner_name = owner['displayName']`, but such behavior
+                # was not consistent with rest of subscription-manager
+                # Look at this comment: https://bugzilla.redhat.com/show_bug.cgi?id=1826300#c8
+                owner_id = owner['key']
+                print(_(
+                        'Ignoring request to auto-attach. '
+                        'It is disabled for org "{owner_id}" because of the content access mode setting.'
+                        ).format(owner_id=owner_id)
+                      )
                 return 0
 
         installed_products_num = 0


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1831082
* Changed message a little. We do not show organization name, but
  we show organization id to be consistent with other messages
* Copied translation for some languages (fr, ko, jp, cn) from
  candlepin server