### PR TITLE
1850624: Uncaught JSONDecodeError when content_access.json is empty

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -702,8 +702,15 @@ class ContentAccessCache(object):
 
     def check_for_update(self):
         if self.exists():
-            data = json.loads(self.read())
-            last_update = parse_date(data["lastUpdate"])
+            try:
+                data = json.loads(self.read())
+                last_update = parse_date(data["lastUpdate"])
+            except (ValueError, KeyError) as err:
+                log.debug("Cache file {file} is corrupted: {err}".format(
+                    file=self.CACHE_FILE,
+                    err=err
+                ))
+                last_update = None
         else:
             last_update = None
         return self._query_for_update(if_modified_since=last_update)


### PR DESCRIPTION
This is a cherry-pick of commit : 90e3201f03730ce4c55bab37a4d2de176f15526e

No other changes have been made aside from those in that commit.