### PR TITLE
improve the help message for attach --auto

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2083,7 +2083,7 @@ class AttachCommand(CliCommand):
         self.parser.add_option("--quantity", dest="quantity",
             help=_("Number of subscriptions to attach. May not be used with an auto-attach."))
         self.parser.add_option("--auto", action='store_true',
-            help=_("Automatically attach compatible subscriptions to this system. This is the default action."))
+            help=_("Automatically attach the best-matched compatible subscriptions to this system. This is the default action."))
         self.parser.add_option("--servicelevel", dest="service_level",
                                help=_("Automatically attach only subscriptions matching the specified service level; only used with --auto"))
         self.parser.add_option("--file", dest="file",


### PR DESCRIPTION
There's a discrepancy between the man page and attach --help. The man page for attach --auto says that it:

"Automatically attaches the *best-matched* compatible subscription or subscriptions to the system."

However, attach --help omits the word "best-matched". Today, my colleague wrongly assumed from --help that subscription-manager attaches all compatible subscriptions with the --auto option. This is not true though. It indeed attaches only the best-matched ones. This commit fixes the confusing --help text by adding the "best-matched" word to it.

Thanks @larskarlitski for pointing this out!