### PR TITLE
Extended D-Bus API - syspurpose methods; ENT-2373

### DIFF
--- a/cockpit/src/subscriptions-client.js
+++ b/cockpit/src/subscriptions-client.js
@@ -565,7 +565,7 @@ client.getSyspurposeStatus = () => {
     let dfd = cockpit.defer();
     if (isRegistering) { return dfd.promise(); }
     return safeDBusCall(syspurposeService, () => {
-        syspurposeService.GetSyspurposeStatus()
+        syspurposeService.GetSyspurposeStatus(userLang)
         .then(result => {
             client.syspurposeStatus.status = result;
         })

--- a/syspurpose/test/syspurpose/test_utils.py
+++ b/syspurpose/test/syspurpose/test_utils.py
@@ -77,7 +77,7 @@ class UtilsTests(SyspurposeTestBase):
         self.assertTrue(os.path.exists(to_create))
 
         with io.open(to_create, 'r', encoding='utf-8') as fp:
-            actual_contents = json.load(fp, encoding='utf-8')
+            actual_contents = json.load(fp)
 
         self.assertDictEqual(actual_contents, test_data)
 


### PR DESCRIPTION
* Added D-Bus method GetValidFields(). Thus it is
  possible to get dictionary of valid attributes
  and values in client applications using
  D-Bus API.
* Added D-Bus method SetSyspurpose(). It is possible
  to set syspurpose value without need of calling
  syspurpose CLI tool
* Added one missing argument to GetSyspurposeStatus
* Fixed method get_owner_syspurpose_valid_fields in
  service.sypurpose module
* Disabled in-memory caching in SyncedStore, because there were
  only troubles with this in rhsm.service, because it runs
  for very long time.
* Removed report attribute from SyncedStore
* Added exception for three-way merge conflict
* Added many unit tests for syspurpose.files