### PR TITLE
1894450: Fix issue with identity command; ENT-3235

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -235,7 +235,6 @@ class BaseConnection(object):
             proxy_description = "http_proxy=%s:%s " % \
                                 (normalized_host(self.proxy_hostname),
                                  safe_int(self.proxy_port))
-        auth_description = None
         # initialize connection
         self.conn = restlib_class(self.host, self.ssl_port, self.handler,
                                   username=self.username, password=self.password,
@@ -502,6 +501,9 @@ class BaseRestLib(object):
         self.proxy_password = proxy_password
         self.smoothed_rt = None
         self.token = token
+        # We set this to None, because we don't know the truth unless we get
+        # first response from the server using cert/key connection
+        self.is_consumer_cert_key_valid = None
 
         # Setup basic authentication if specified:
         if username and password:
@@ -725,6 +727,7 @@ class BaseRestLib(object):
                      "headers": dict(response.getheaders())
                 }
                 if response.status == 200:
+                    self.is_consumer_cert_key_valid = True
                     break  # this client cert worked, no need to try more
                 elif self.cert_dir:
                     log.debug("Unable to get valid response: %s from CDN: %s" %
@@ -734,6 +737,7 @@ class BaseRestLib(object):
                 if self.cert_file and not self.cert_dir:
                     id_cert = certificate.create_from_file(self.cert_file)
                     if not id_cert.is_valid():
+                        self.is_consumer_cert_key_valid = False
                         raise ExpiredIdentityCertException()
                 if not self.cert_dir:
                     raise

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -150,6 +150,7 @@ class TestCurrentOwnerCache(unittest.TestCase):
         self.uep.conn.is_consumer_cert_key_valid = None
         self.uep.getOwner = Mock(return_value={'key': 'dummy_owner'})
         self.assertEqual(self.uep.getOwner.call_count, 0)
+        self.current_owner_cache.write_cache = Mock()
         owner = self.current_owner_cache.read_data(uep=self.uep, identity=self.identity)
         self.uep.getOwner.assert_called_once()
         self.assertEqual(owner, {'key': 'dummy_owner'})
@@ -160,6 +161,7 @@ class TestCurrentOwnerCache(unittest.TestCase):
         """
         self.uep.conn.is_consumer_cert_key_valid = False
         self.uep.getOwner = Mock(return_value={'key': 'another_owner'})
+        self.current_owner_cache.write_cache = Mock()
         self.assertEqual(self.uep.getOwner.call_count, 0)
         owner = self.current_owner_cache.read_data(uep=self.uep, identity=self.identity)
         self.uep.getOwner.assert_called_once()
@@ -174,6 +176,7 @@ class TestCurrentOwnerCache(unittest.TestCase):
         self.uep.conn.is_consumer_cert_key_valid = True
         self.uep.getOwner = Mock(return_value={'key': 'dummy_owner'})
         self.current_owner_cache.read_cache_only = Mock(return_value=self.CACHE_FILE_CONTENT)
+        self.current_owner_cache.write_cache = Mock()
         owner = self.current_owner_cache.read_data(uep=self.uep, identity=self.identity)
         self.assertEqual(self.uep.getOwner.call_count, 0)
         self.assertTrue(self.identity.uuid in self.CACHE_FILE_CONTENT)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1894450
* The subscription-manager identity returned wrong values after
  removing consumer from candlepin server. When there was
  cache file /var/lib/rhsm/cache/current_owner.json, then
  the identity command only returned content of this cache
  file.
* The cache file can be used, when previous REST API call
  using consumer cert/key was successful and the validity
  of consumer UUID was proved.
* Added several unit tests