### PR TITLE
Stop releasing to f31 (f31 is no longer supported)

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -1,6 +1,6 @@
 [fedora]
 releaser = tito.release.FedoraGitReleaser
-branches = master f33 f32 f31
+branches = master f33 f32
 
 [rhel-7.1]
 releaser = tito.release.DistGitReleaser


### PR DESCRIPTION
This just removes f31 from our tito fedora releaser because f31 is no longer supported.