### PR TITLE
Detecting of cloud providers; ENT-3288

### DIFF
--- a/etc-conf/cloud/aws.conf
+++ b/etc-conf/cloud/aws.conf
@@ -1,0 +1,7 @@
+[aws]
+cloud_provider_metadata_url = "http://169.254.169.254/latest/dynamic/instance-identity/document"
+cloud_provider_metadata_type = "json"
+cloud_provider_signature_url = "http://169.254.169.254/latest/dynamic/instance-identity/signature"
+cloud_provider_signature_type = "json"
+metadata_cache_file = "/var/lib/rhsm/cache/aws_metadata.json"
+signature_cache_file = "/var/lib/rhsm/cache/aws_signature.json"

--- a/src/rhsmlib/cloud/README.md
+++ b/src/rhsmlib/cloud/README.md
@@ -1,0 +1,8 @@
+RHSM & Cloud
+============
+
+This package contains modules for detecting cloud providers and collecting cloud metadata. These
+metadata then can be for example reported in system facts. Currently three main cloud providers
+are supported: Amazon Web Services, Microsoft Azure and Google Cloud Platform. If you want to add
+support for another cloud provider, then add subclasses of CloudCollector and CloudDetector to
+some module in providers sub-package and modify list of supported classes in utils.py 

--- a/src/rhsmlib/cloud/colector.py
+++ b/src/rhsmlib/cloud/colector.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+This module implements base class for collecting metadata from cloud provider
+"""
+
+
+class CloudCollector(object):
+    """
+    Base class for collecting metadata and signature of metadata from cloud
+    provider. The most of logic is implemented in this class. Subclasses
+    for concrete cloud providers usually contains only default values in
+    class attributes. All values will be usually loaded from configuration
+    files of cloud providers. It is/will be still possible to implement
+    custom method for e.g. getting metadata from cloud provider.
+    """
+
+    # Unique ID of cloud provider
+    # (e.g. "aws", "azure", "gcp", etc.)
+    CLOUD_PROVIDER_ID = None
+
+    # Path to configuration file of collector (ini file)
+    # (e.g. /etc/rhsm/cloud_providers/cool_cloud.conf
+    COLLECTOR_CONF_FILE = None
+
+    # Default value of server URL providing metadata
+    # (e.g. http://1.2.3.4./path/to/metadata/document)
+    CLOUD_PROVIDER_METADATA_URL = None
+
+    # Type of metadata document returned by server
+    # (e.g. json, xml)
+    CLOUD_PROVIDER_METADATA_TYPE = None
+
+    # Default value of server URL providing signature of metadata
+    # (e.g. http://1.2.3.4/path/to/signature/document)
+    CLOUD_PROVIDER_SIGNATURE_URL = None
+
+    # Type of signature document returned by server
+    # (e.g. json, xml, pem)
+    CLOUD_PROVIDER_SIGNATURE_TYPE = None
+
+    # Default value of path to cache file holding metadata
+    # (e.g. /var/lib/rhsm/cache/cool_cloud_metadata.json)
+    METADATA_CACHE_FILE = None
+
+    # Default value of path to  holding signature of metadata
+    # (e.g. /var/lib/rhsm/cache/cool_cloud_signature.json)
+    SIGNATURE_CACHE_FILE = None
+
+    def __init__(self):
+        """
+        Initialize instance of CloudCollector
+        """
+        self.metadata = None
+        self.signature = None
+
+    def _get_collector_configuration_from_file(self):
+        """
+        Get configuration of collector from json file
+        :return: True, when it was possible to load configuration file of collector
+        """
+        raise NotImplementedError
+
+    def _get_metadata_from_cache(self):
+        """
+        Method for gathering metadata from cache file
+        :return: string containing metadata
+        """
+        raise NotImplementedError
+
+    def _get_metadata_from_server(self):
+        """
+        Method for gathering metadata from server
+        :return: string containing metadata
+        """
+        raise NotImplementedError
+
+    def _get_signature_from_cache_file(self):
+        """
+        Try to get signature from cache file
+        :return: string containing signature
+        """
+        raise NotImplementedError
+
+    def _get_signature_from_server(self):
+        """
+        Method for gathering signature of metadata from server
+        :return:
+        """
+        raise NotImplementedError
+
+    def get_signature(self):
+        """
+        Public method for getting signature (cache file or server)
+        :return:
+        """
+        raise NotImplementedError
+
+    def get_metadata(self):
+        """
+        Public method for getting metadata (cache file or server)
+        :return:
+        """
+        raise NotImplementedError
+
+    def is_running_on_cloud(self):
+        """
+        Return True, when server can really server providing metadata information
+        :return: True if the system is running on AWS cloud
+        """
+        # TODO: not sure about this method
+        raise NotImplementedError

--- a/src/rhsmlib/cloud/collector.py
+++ b/src/rhsmlib/cloud/collector.py
@@ -57,7 +57,7 @@ class CloudCollector(object):
     # (e.g. /var/lib/rhsm/cache/cool_cloud_metadata.json)
     METADATA_CACHE_FILE = None
 
-    # Default value of path to  holding signature of metadata
+    # Default value of path to holding signature of metadata
     # (e.g. /var/lib/rhsm/cache/cool_cloud_signature.json)
     SIGNATURE_CACHE_FILE = None
 
@@ -115,12 +115,4 @@ class CloudCollector(object):
         Public method for getting metadata (cache file or server)
         :return:
         """
-        raise NotImplementedError
-
-    def is_running_on_cloud(self):
-        """
-        Return True, when server can really server providing metadata information
-        :return: True if the system is running on AWS cloud
-        """
-        # TODO: not sure about this method
         raise NotImplementedError

--- a/src/rhsmlib/cloud/detector.py
+++ b/src/rhsmlib/cloud/detector.py
@@ -15,7 +15,7 @@
 #
 
 """
-This module implement base class for detecting cloud provider
+This module implements the base class for detecting cloud provider
 """
 
 

--- a/src/rhsmlib/cloud/detector.py
+++ b/src/rhsmlib/cloud/detector.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+This module implement base class for detecting cloud provider
+"""
+
+
+class CloudDetector(object):
+    """
+    Base class used for detecting cloud provider
+    """
+
+    ID = None
+
+    def __init__(self, hw_info):
+        """
+        Initialize cloud detector
+        """
+        self.hw_info = hw_info
+
+    def is_vm(self):
+        """
+        Is current system virtual machine?
+        :return: Return True, when it is virtual machine; otherwise return False
+        """
+        return 'virt.is_guest' in self.hw_info and self.hw_info['virt.is_guest'] is True
+
+    def is_running_on_cloud(self):
+        """
+        Try to guess cloud provider using collected hardware information (output of dmidecode, virt-what, etc.)
+        :return: True, when we detected sign of cloud provider in hw info; Otherwise return False
+        """
+        raise NotImplementedError
+
+    def is_likely_running_on_cloud(self):
+        """
+        When all subclasses cannot detect cloud provider using method is_running_on_cloud, because cloud provider
+        started to provide something else in output of dmidecode, then try to use this heuristics method
+        :return: Float value representing probability that vm is running using specific cloud provider
+        """
+        raise NotImplementedError

--- a/src/rhsmlib/cloud/providers/aws.py
+++ b/src/rhsmlib/cloud/providers/aws.py
@@ -78,11 +78,16 @@ class AWSCloudDetector(CloudDetector):
 
         # We know that AWS uses mostly KVM and it uses Xen in some cases
         if 'virt.host_type' in self.hw_info:
-            # It seems that KVM is used more ofter
+            # It seems that KVM is used more often
             if 'kvm' in self.hw_info['virt.host_type']:
                 probability += 0.3
             elif 'xen' in self.hw_info['virt.host_type']:
                 probability += 0.2
+
+        # Every system UUID of VM running on AWS EC2 starts with EC2 string. Not strong sign, but
+        # it can increase probability a little
+        if 'dmi.system.uuid' in self.hw_info and self.hw_info['dmi.system.uuid'].lower().startswith('ec2'):
+            probability += 0.1
 
         # Try to find "Amazon EC2", "Amazon" or "AWS" keywords in output of dmidecode
         found_amazon = False

--- a/src/rhsmlib/cloud/providers/aws.py
+++ b/src/rhsmlib/cloud/providers/aws.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+This is module implementing detector and metadata collector of virtual machine running on AWS
+"""
+
+from rhsmlib.cloud.detector import CloudDetector
+
+
+class AWSCloudDetector(CloudDetector):
+    """
+    Detector of cloud machine
+    """
+
+    ID = 'aws'
+
+    def __init__(self, hw_info):
+        """
+        Initialize instance of AWSCloudDetector
+        """
+        super(AWSCloudDetector, self).__init__(hw_info)
+
+    def is_vm(self):
+        """
+        Is system running on virtual machine or not
+        :return: True, when machine is running on VM; otherwise return False
+        """
+        return super(AWSCloudDetector, self).is_vm()
+
+    def is_running_on_cloud(self):
+        """
+        Try to guess if cloud provider is AWS using collected hardware information (output of dmidecode,
+        virt-what, etc.)
+        :return: True, when we detected sign of AWS in hardware information; Otherwise return False
+        """
+
+        # The system has to be VM
+        if self.is_vm() is False:
+            return False
+        # This is valid for AWS systems using Xen
+        if 'dmi.bios.version' in self.hw_info and 'amazon' in self.hw_info['dmi.bios.version']:
+            return True
+        # This is valid for AWS systems using KVM
+        if 'dmi.bios.vendor' in self.hw_info and 'Amazon EC2' in self.hw_info['dmi.bios.vendor']:
+            return True
+        # Try to get output from virt-what
+        if 'virt.host_type' in self.hw_info and 'aws' in self.hw_info['virt.host_type']:
+            return True
+        # In other cases return False
+        return False
+
+    def is_likely_running_on_cloud(self):
+        """
+        Return non-zero value, when the machine is virtual machine and it is running on kvm/xen and
+        some Amazon string can be found in output of dmidecode
+        :return: Float value representing probability that vm is running on AWS
+        """
+        probability = 0.0
+
+        # When the machine is not virtual machine, then there is probably zero chance that the machine
+        # is running on AWS
+        if self.is_vm() is False:
+            return 0.0
+
+        # We know that AWS uses mostly KVM and it uses Xen in some cases
+        if 'virt.host_type' in self.hw_info:
+            # It seems that KVM is used more ofter
+            if 'kvm' in self.hw_info['virt.host_type']:
+                probability += 0.3
+            elif 'xen' in self.hw_info['virt.host_type']:
+                probability += 0.2
+
+        # Try to find "Amazon EC2", "Amazon" or "AWS" keywords in output of dmidecode
+        found_amazon = False
+        found_amazon_ec2 = False
+        found_aws = False
+        for hw_item in self.hw_info.values():
+            if type(hw_item) != str:
+                continue
+            if 'amazon ec2' in hw_item.lower():
+                found_amazon_ec2 = True
+            elif 'amazon' in hw_item.lower():
+                found_amazon = True
+            elif 'aws' in hw_item.lower():
+                found_aws = True
+        if found_amazon_ec2 is True:
+            probability += 0.3
+        if found_amazon is True:
+            probability += 0.2
+        if found_aws is True:
+            probability += 0.1
+
+        return probability
+
+
+# Some temporary smoke testing code. You can test this module using:
+# sudo PYTHONPATH=./src:./syspurse/src python3 -m rhsmlib.cloud.providers.aws
+if __name__ == '__main__':
+    # Gather only information about hardware and virtualization
+    from rhsmlib.facts.host_collector import HostCollector
+    from rhsmlib.facts.hwprobe import HardwareCollector
+    _facts = {}
+    _facts.update(HostCollector().get_all())
+    _facts.update(HardwareCollector().get_all())
+    _aws_cloud_detector = AWSCloudDetector(_facts)
+    _result = _aws_cloud_detector.is_running_on_cloud()
+    _probability = _aws_cloud_detector.is_likely_running_on_cloud()
+    print('>>> debug <<< result: %s, probability: %6.3f' % (_result, _probability))

--- a/src/rhsmlib/cloud/providers/azure.py
+++ b/src/rhsmlib/cloud/providers/azure.py
@@ -30,7 +30,7 @@ class AzureCloudDetector(CloudDetector):
 
     def __init__(self, hw_info):
         """
-        Initialize instance of AWSCloudDetector
+        Initialize instance of AzureCloudDetector
         """
         super(AzureCloudDetector, self).__init__(hw_info)
 
@@ -45,7 +45,7 @@ class AzureCloudDetector(CloudDetector):
         """
         Try to guess if cloud provider is Azure using collected hardware information (output of dmidecode,
         virt-what, etc.)
-        :return: True, when we detected sign of AWS in hardware information; Otherwise return False
+        :return: True, when we detected sign of Azure in hardware information; Otherwise return False
         """
 
         # The system has to be VM
@@ -60,7 +60,7 @@ class AzureCloudDetector(CloudDetector):
 
     def is_likely_running_on_cloud(self):
         """
-        Return non-zero value, when the machine is virtual machine and it is running on hyperv and
+        Return non-zero value, when the machine is virtual machine and it is running on Hyper-V and
         some Microsoft string can be found in output of dmidecode
         :return: Float value representing probability that vm is running on Azure
         """
@@ -76,7 +76,7 @@ class AzureCloudDetector(CloudDetector):
             if 'hyperv' in self.hw_info['virt.host_type']:
                 probability += 0.3
 
-        # Try to find "Amazon EC2", "Amazon" or "AWS" keywords in output of dmidecode
+        # Try to find "Azure" or "Microsoft" keywords in output of dmidecode
         found_microsoft = False
         found_azure = False
         for hw_item in self.hw_info.values():

--- a/src/rhsmlib/cloud/providers/azure.py
+++ b/src/rhsmlib/cloud/providers/azure.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+This is module implementing detector and metadata collector of virtual machine running on Azure
+"""
+
+from rhsmlib.cloud.detector import CloudDetector
+
+
+class AzureCloudDetector(CloudDetector):
+    """
+    Detector of cloud machine
+    """
+
+    ID = 'azure'
+
+    def __init__(self, hw_info):
+        """
+        Initialize instance of AWSCloudDetector
+        """
+        super(AzureCloudDetector, self).__init__(hw_info)
+
+    def is_vm(self):
+        """
+        Is system running on virtual machine or not
+        :return: True, when machine is running on VM; otherwise return False
+        """
+        return super(AzureCloudDetector, self).is_vm()
+
+    def is_running_on_cloud(self):
+        """
+        Try to guess if cloud provider is Azure using collected hardware information (output of dmidecode,
+        virt-what, etc.)
+        :return: True, when we detected sign of AWS in hardware information; Otherwise return False
+        """
+
+        # The system has to be VM
+        if self.is_vm() is False:
+            return False
+        # This is valid for virtual machines running on Azure
+        if 'dmi.chassis.asset_tag' in self.hw_info and \
+                self.hw_info['dmi.chassis.asset_tag'] == '7783-7084-3265-9085-8269-3286-77':
+            return True
+        # In other cases return False
+        return False
+
+    def is_likely_running_on_cloud(self):
+        """
+        Return non-zero value, when the machine is virtual machine and it is running on hyperv and
+        some Microsoft string can be found in output of dmidecode
+        :return: Float value representing probability that vm is running on Azure
+        """
+        probability = 0.0
+
+        # When the machine is not virtual machine, then there is probably zero chance that the machine
+        # is running on Azure
+        if self.is_vm() is False:
+            return 0.0
+
+        # We know that Azure uses only HyperV
+        if 'virt.host_type' in self.hw_info:
+            # It seems that KVM is used more ofter
+            if 'hyperv' in self.hw_info['virt.host_type']:
+                probability += 0.3
+
+        # Try to find "Amazon EC2", "Amazon" or "AWS" keywords in output of dmidecode
+        found_microsoft = False
+        found_azure = False
+        for hw_item in self.hw_info.values():
+            if type(hw_item) != str:
+                continue
+            if 'microsoft' in hw_item.lower():
+                found_microsoft = True
+            elif 'azure' in hw_item.lower():
+                found_azure = True
+        if found_microsoft is True:
+            probability += 0.3
+        if found_azure is True:
+            probability += 0.1
+
+        return probability
+
+
+# Some temporary smoke testing code. You can test this module using:
+# sudo PYTHONPATH=./src:./syspurse/src python3 -m rhsmlib.cloud.providers.azure
+if __name__ == '__main__':
+    # Gather only information about hardware and virtualization
+    from rhsmlib.facts.host_collector import HostCollector
+    from rhsmlib.facts.hwprobe import HardwareCollector
+    _facts = {}
+    _facts.update(HostCollector().get_all())
+    _facts.update(HardwareCollector().get_all())
+    _azure_cloud_detector = AzureCloudDetector(_facts)
+    _result = _azure_cloud_detector.is_running_on_cloud()
+    _probability = _azure_cloud_detector.is_likely_running_on_cloud()
+    print('>>> debug <<< result: %s, %6.3f' % (_result, _probability))

--- a/src/rhsmlib/cloud/providers/azure.py
+++ b/src/rhsmlib/cloud/providers/azure.py
@@ -73,7 +73,6 @@ class AzureCloudDetector(CloudDetector):
 
         # We know that Azure uses only HyperV
         if 'virt.host_type' in self.hw_info:
-            # It seems that KVM is used more ofter
             if 'hyperv' in self.hw_info['virt.host_type']:
                 probability += 0.3
 

--- a/src/rhsmlib/cloud/providers/gcp.py
+++ b/src/rhsmlib/cloud/providers/gcp.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+This is module implementing detector and metadata collector of virtual machine running on Google Cloud Platform
+"""
+
+from rhsmlib.cloud.detector import CloudDetector
+
+
+class GCPCloudDetector(CloudDetector):
+    """
+    Detector of cloud provider
+    """
+
+    ID = 'gcp'
+
+    def __init__(self, hw_info):
+        """
+        Initialize instance of AWSCloudDetector
+        """
+        super(GCPCloudDetector, self).__init__(hw_info)
+
+    def is_vm(self):
+        """
+        Is system running on virtual machine or not
+        :return: True, when machine is running on VM; otherwise return False
+        """
+        return super(GCPCloudDetector, self).is_vm()
+
+    def is_running_on_cloud(self):
+        """
+        Try to guess if cloud provider is GCP using collected hardware information (output of dmidecode,
+        virt-what, etc.)
+        :return: True, when we detected sign of AWS in hardware information; Otherwise return False
+        """
+
+        # The system has to be VM
+        if self.is_vm() is False:
+            return False
+        # This is valid for virtual machines running on Google Cloud Platform
+        if 'dmi.bios.vendor' in self.hw_info and \
+                'google' in self.hw_info['dmi.bios.vendor'].lower():
+            return True
+        # In other cases return False
+        return False
+
+    def is_likely_running_on_cloud(self):
+        """
+        Return non-zero value, when the machine is virtual machine and it is running on kvm and
+        some google string can be found in output of dmidecode
+        :return: Float value representing probability that vm is running on GPC
+        """
+        probability = 0.0
+
+        # When the machine is not virtual machine, then there is probably zero chance that the machine
+        # is running on GPC
+        if self.is_vm() is False:
+            return 0.0
+
+        # We know that Azure uses only HyperV
+        if 'virt.host_type' in self.hw_info:
+            # It seems that KVM is used more ofter
+            if 'kvm' in self.hw_info['virt.host_type']:
+                probability += 0.3
+
+        # Try to find "Amazon EC2", "Amazon" or "AWS" keywords in output of dmidecode
+        found_google = False
+        found_gcp = False
+        for hw_item in self.hw_info.values():
+            if type(hw_item) != str:
+                continue
+            if 'google' in hw_item.lower():
+                found_google = True
+            elif 'gcp' in hw_item.lower():
+                found_gcp = True
+        if found_google is True:
+            probability += 0.3
+        if found_gcp is True:
+            probability += 0.1
+
+        return probability
+
+
+# Some temporary smoke testing code. You can test this module using:
+# sudo PYTHONPATH=./src:./syspurse/src python3 -m rhsmlib.cloud.providers.gcp
+if __name__ == '__main__':
+    # Gather only information about hardware and virtualization
+    from rhsmlib.facts.host_collector import HostCollector
+    from rhsmlib.facts.hwprobe import HardwareCollector
+    _facts = {}
+    _facts.update(HostCollector().get_all())
+    _facts.update(HardwareCollector().get_all())
+    _gcp_cloud_detector = GCPCloudDetector(_facts)
+    _result = _gcp_cloud_detector.is_running_on_cloud()
+    _probability = _gcp_cloud_detector.is_likely_running_on_cloud()
+    print('>>> debug <<< result: %s, %6.3f' % (_result, _probability))
+

--- a/src/rhsmlib/cloud/providers/gcp.py
+++ b/src/rhsmlib/cloud/providers/gcp.py
@@ -108,4 +108,3 @@ if __name__ == '__main__':
     _result = _gcp_cloud_detector.is_running_on_cloud()
     _probability = _gcp_cloud_detector.is_likely_running_on_cloud()
     print('>>> debug <<< result: %s, %6.3f' % (_result, _probability))
-

--- a/src/rhsmlib/cloud/providers/gcp.py
+++ b/src/rhsmlib/cloud/providers/gcp.py
@@ -30,7 +30,7 @@ class GCPCloudDetector(CloudDetector):
 
     def __init__(self, hw_info):
         """
-        Initialize instance of AWSCloudDetector
+        Initialize instance of GCPCloudDetector
         """
         super(GCPCloudDetector, self).__init__(hw_info)
 
@@ -45,7 +45,7 @@ class GCPCloudDetector(CloudDetector):
         """
         Try to guess if cloud provider is GCP using collected hardware information (output of dmidecode,
         virt-what, etc.)
-        :return: True, when we detected sign of AWS in hardware information; Otherwise return False
+        :return: True, when we detected sign of GCP in hardware information; Otherwise return False
         """
 
         # The system has to be VM
@@ -71,13 +71,11 @@ class GCPCloudDetector(CloudDetector):
         if self.is_vm() is False:
             return 0.0
 
-        # We know that Azure uses only HyperV
-        if 'virt.host_type' in self.hw_info:
-            # It seems that KVM is used more ofter
-            if 'kvm' in self.hw_info['virt.host_type']:
-                probability += 0.3
+        # We know that GCP uses only KVM at the end of 2020
+        if 'virt.host_type' in self.hw_info and 'kvm' in self.hw_info['virt.host_type']:
+            probability += 0.3
 
-        # Try to find "Amazon EC2", "Amazon" or "AWS" keywords in output of dmidecode
+        # Try to find "Google" or "gcp" keywords in output of dmidecode
         found_google = False
         found_gcp = False
         for hw_item in self.hw_info.values():

--- a/src/rhsmlib/cloud/utils.py
+++ b/src/rhsmlib/cloud/utils.py
@@ -57,12 +57,23 @@ def detect_cloud_provider():
     log.debug('Trying to detect cloud provider')
 
     # First try to detect cloud providers using strong signs
+    cloud_list = []
     for cloud_detector in cloud_detectors:
         cloud_detected = cloud_detector.is_running_on_cloud()
         if cloud_detected is True:
-            return [cloud_detector.ID]
+            cloud_list.append(cloud_detector.ID)
 
-    log.error('No cloud provider detected using strong signs')
+    # When only one cloud provider was detected, then return the list with
+    # one cloud provider. Print error in other cases and try to detect cloud providers
+    # using heuristics methods
+    if len(cloud_list) == 1:
+        return cloud_list
+    elif len(cloud_list) == 0:
+        log.error('No cloud provider detected using strong signs')
+    elif len(cloud_list) > 1:
+        log.error('More than one cloud provider detected using strong signs ({providers})'.format(
+            providers=", ".join(cloud_list)
+        ))
 
     # When no cloud provider detected using strong signs, because behavior of cloud providers
     # has changed, then try to detect cloud provider using some heuristics
@@ -73,7 +84,7 @@ def detect_cloud_provider():
             cloud_list.append((probability, cloud_detector.ID))
     # Sort list according probability (provider with highest probability first)
     cloud_list.sort(reverse=True)
-    # We care only about order, not probability in the result
+    # We care only about order, not probability in the result (filter probability out)
     cloud_list = [item[1] for item in cloud_list]
 
     if len(cloud_list) == 0:

--- a/src/rhsmlib/cloud/utils.py
+++ b/src/rhsmlib/cloud/utils.py
@@ -83,7 +83,7 @@ def detect_cloud_provider():
 
 
 # Some temporary smoke testing code. You can test this module using:
-# sudo PYTHONPATH=./src:./syspurse/src python3 -m rhsmlib.cloud.aws
+# sudo PYTHONPATH=./src:./syspurse/src python3 -m rhsmlib.cloud.utils
 if __name__ == '__main__':
     _result = detect_cloud_provider()
     print('>>> debug <<< result: %s' % _result)

--- a/src/rhsmlib/cloud/utils.py
+++ b/src/rhsmlib/cloud/utils.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+This module contains several utils used for VMs running on clouds
+"""
+
+import logging
+
+from rhsmlib.facts.host_collector import HostCollector
+from rhsmlib.facts.hwprobe import HardwareCollector
+
+from rhsmlib.cloud.providers.aws import AWSCloudDetector
+from rhsmlib.cloud.providers.azure import AzureCloudDetector
+from rhsmlib.cloud.providers.gcp import GCPCloudDetector
+
+# List of classes with supported cloud providers
+CLOUD_DETECTORS = [
+    AWSCloudDetector,
+    AzureCloudDetector,
+    GCPCloudDetector
+]
+
+log = logging.getLogger(__name__)
+
+
+def detect_cloud_provider():
+    """
+    This method tries to detect cloud provider using hardware information provided by dmidecode.
+    When there is strong sign that the VM is running on one of the cloud provider, then return
+    list containing only one provider. When there is no strong sign of one cloud provider, then
+    try to detect cloud provider using heuristics methods. In this case this method will return
+    list of all cloud providers sorted according detected probability
+    :return: List of string representing detected cloud providers. E.g. ['aws'] or ['aws', 'gcp']
+    """
+
+    # Gather only information about hardware and virtualization
+    facts = {}
+    facts.update(HostCollector().get_all())
+    facts.update(HardwareCollector().get_all())
+
+    cloud_detectors = [cls(facts) for cls in CLOUD_DETECTORS]
+
+    log.debug('Trying to detect cloud provider')
+
+    # First try to detect cloud providers using strong signs
+    for cloud_detector in cloud_detectors:
+        cloud_detected = cloud_detector.is_running_on_cloud()
+        if cloud_detected is True:
+            return [cloud_detector.ID]
+
+    log.error('No cloud provider detected using strong signs')
+
+    # When no cloud provider detected using strong signs, because behavior of cloud providers
+    # has changed, then try to detect cloud provider using some heuristics
+    cloud_list = []
+    for cloud_detector in cloud_detectors:
+        probability = cloud_detector.is_likely_running_on_cloud()
+        if probability > 0.0:
+            cloud_list.append((probability, cloud_detector.ID))
+    # Sort list according probability (provider with highest probability first)
+    cloud_list.sort(reverse=True)
+    # We care only about order, not probability in the result
+    cloud_list = [item[1] for item in cloud_list]
+
+    if len(cloud_list) == 0:
+        log.error('No cloud provider detected using heuristics')
+
+    return cloud_list
+
+
+# Some temporary smoke testing code. You can test this module using:
+# sudo PYTHONPATH=./src:./syspurse/src python3 -m rhsmlib.cloud.aws
+if __name__ == '__main__':
+    _result = detect_cloud_provider()
+    print('>>> debug <<< result: %s' % _result)

--- a/src/rhsmlib/facts/all.py
+++ b/src/rhsmlib/facts/all.py
@@ -18,21 +18,24 @@ from rhsmlib.facts import host_collector
 from rhsmlib.facts import hwprobe
 from rhsmlib.facts import insights
 from rhsmlib.facts import kpatch
+from rhsmlib.facts import cloud_facts
 
 
 class AllFactsCollector(collector.FactsCollector):
     def __init__(self):
         self.collectors = [
-            collector.StaticFactsCollector(),
-            host_collector.HostCollector(),
-            hwprobe.HardwareCollector(),
-            custom.CustomFactsCollector(),
-            insights.InsightsCollector(),
-            kpatch.KPatchCollector()
+            collector.StaticFactsCollector,
+            host_collector.HostCollector,
+            hwprobe.HardwareCollector,
+            custom.CustomFactsCollector,
+            insights.InsightsCollector,
+            kpatch.KPatchCollector,
+            cloud_facts.CloudFactsCollector
         ]
 
     def get_all(self):
         results = {}
-        for fact_collector in self.collectors:
+        for fact_collector_cls in self.collectors:
+            fact_collector = fact_collector_cls(collected_hw_info=results)
             results.update(fact_collector.get_all())
         return results

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -22,13 +22,15 @@ import json
 import socket
 import subscription_manager.injection as inj
 
+from rhsmlib.cloud.providers.aws import AWSCloudDetector
 from rhsmlib.facts import collector
 from rhsm.https import httplib
 
 
 log = logging.getLogger(__name__)
 
-AWS_INSTANCE_URL = "169.254.169.254"
+AWS_INSTANCE_IP = "169.254.169.254"
+AWS_INSTANCE_PATH = '/latest/dynamic/instance-identity/document'
 AWS_INSTANCE_TIMEOUT = 5
 
 
@@ -51,17 +53,27 @@ class CloudFactsCollector(collector.FactsCollector):
 
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
     def get_aws_instance_id(self):
+        """
+        Try to get instance ID of machine running on AWS
+        :return: dictionary containing {"aws_instance_id": some_instance_ID}, when the machine is running on
+            AWS cloud; otherwise returns empty dictionary {}
+        """
         values = {}
-        if not self._collected_hw_info['dmi.bios.version'].find('amazon') >= 0:
-            return ""
+
+        # Is the machine running on VM and is it AWS?
+        aws_cloud_detector = AWSCloudDetector(self._collected_hw_info)
+        if aws_cloud_detector.is_running_on_cloud() is False:
+            return {}
+
+        # Try to read instance ID from cache first
         facts_cache = inj.require(inj.FACTS).read_cache_only() or {}
         if 'aws_instance_id' in facts_cache:
             return {'aws_instance_id': facts_cache['aws_instance_id']}
 
+        # If the cache file does not include the instance ID, then try to
+        # get instance ID from metadata provider
         try:
-            conn = httplib.HTTPConnection(AWS_INSTANCE_URL, timeout=AWS_INSTANCE_TIMEOUT)
-            conn.request('GET', '/latest/dynamic/instance-identity/document')
-            response = conn.getresponse()
+            response = self.get_aws_metadata()
             output = response.read()
             values = self.parse_content(output)
         except (httplib.HTTPException, ValueError, socket.timeout) as e:
@@ -73,9 +85,25 @@ class CloudFactsCollector(collector.FactsCollector):
             else:
                 return {}
 
-    def parse_content(self, content):
+    @staticmethod
+    def get_aws_metadata():
+        """
+        Try to get AWS metadata
+        :return: http response
+        """
+        conn = httplib.HTTPConnection(AWS_INSTANCE_IP, timeout=AWS_INSTANCE_TIMEOUT)
+        conn.request('GET', AWS_INSTANCE_PATH)
+        response = conn.getresponse()
+        return response
+
+    @staticmethod
+    def parse_content(content):
+        """
+        Parse content returned from AWS metadata provider
+        :param content: string of JSON document
+        :return: Dictionary containing values from parsed JSON document
+        """
         try:
-            doc_values = json.loads(content)
-            return doc_values
+            return json.loads(content)
         except ValueError as e:
             raise ValueError('Failed to parse json data with error: %s', str(e))

--- a/src/rhsmlib/facts/collector.py
+++ b/src/rhsmlib/facts/collector.py
@@ -105,7 +105,7 @@ class FactsCollector(object):
 
 class StaticFactsCollector(FactsCollector):
     def __init__(self, static_facts=None, **kwargs):
-        super(FactsCollector, self).__init__(**kwargs)
+        super(StaticFactsCollector, self).__init__(**kwargs)
         if static_facts is None:
             static_facts = {}
         self.static_facts = static_facts

--- a/src/rhsmlib/facts/host_collector.py
+++ b/src/rhsmlib/facts/host_collector.py
@@ -21,7 +21,6 @@ from rhsmlib.facts import cleanup
 from rhsmlib.facts import virt
 from rhsmlib.facts import firmware_info
 from rhsmlib.facts import collector
-from rhsmlib.facts import cloud_facts
 
 log = logging.getLogger(__name__)
 

--- a/src/rhsmlib/facts/host_collector.py
+++ b/src/rhsmlib/facts/host_collector.py
@@ -62,14 +62,6 @@ class HostCollector(collector.FactsCollector):
         )
         virt_collector_info = virt_collector.get_all()
 
-        cloud_collector = cloud_facts.CloudFactsCollector(
-            prefix=self.prefix,
-            testing=self.testing,
-            collected_hw_info=firmware_info_dict
-        )
-        cloud_facts_info = cloud_collector.get_all()
-
-        host_facts.update(cloud_facts_info)
         host_facts.update(virt_collector_info)
         host_facts.update(firmware_info_dict)
 

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -930,6 +930,8 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %endif
 
 %dir %{python_sitearch}/rhsmlib/candlepin
+%dir %{python_sitearch}/rhsmlib/cloud
+%dir %{python_sitearch}/rhsmlib/cloud/providers
 %dir %{python_sitearch}/rhsmlib/compat
 %dir %{python_sitearch}/rhsmlib/dbus
 %dir %{python_sitearch}/rhsmlib/dbus/facts
@@ -1087,6 +1089,8 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %dir %{python_sitearch}/rhsmlib
 %{python_sitearch}/rhsmlib/*.py*
 %{python_sitearch}/rhsmlib/candlepin/*.py*
+%{python_sitearch}/rhsmlib/cloud/*.py*
+%{python_sitearch}/rhsmlib/cloud/providers/*.py*
 %{python_sitearch}/rhsmlib/compat/*.py*
 %{python_sitearch}/rhsmlib/facts/*.py*
 %{python_sitearch}/rhsmlib/services/*.py*
@@ -1096,6 +1100,8 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %if %{with python3}
 %{python_sitearch}/rhsmlib/__pycache__
 %{python_sitearch}/rhsmlib/candlepin/__pycache__
+%{python_sitearch}/rhsmlib/cloud/__pycache__
+%{python_sitearch}/rhsmlib/cloud/providers/__pycache__
 %{python_sitearch}/rhsmlib/compat/__pycache__
 %{python_sitearch}/rhsmlib/dbus/__pycache__
 %{python_sitearch}/rhsmlib/dbus/facts/__pycache__

--- a/test/rhsmlib_test/test_aws_instance.py
+++ b/test/rhsmlib_test/test_aws_instance.py
@@ -42,7 +42,12 @@ class TestInsightsCollector(unittest.TestCase):
 
     @patch('rhsm.https.httplib.HTTPConnection')
     def test_get_instance_id(self, MockConn):
-        self.collector = cloud_facts.CloudFactsCollector(collected_hw_info={"dmi.bios.version": "4.2.amazon"})
+        self.collector = cloud_facts.CloudFactsCollector(
+            collected_hw_info={
+                "virt.is_guest": True,
+                "dmi.bios.version": "4.2.amazon"
+            }
+        )
         self.mock_facts.return_value.read_cache_only.return_value = {}
         MockConn.return_value.getresponse.return_value.read.return_value = \
             '{"privateIp": "10.158.112.84", \
@@ -54,7 +59,12 @@ class TestInsightsCollector(unittest.TestCase):
 
     @patch('rhsm.https.httplib.HTTPConnection')
     def test_get_not_aws_instance(self, MockConn):
-        self.collector = cloud_facts.CloudFactsCollector(collected_hw_info={"dmi.bios.version": "1.0.cloud"})
+        self.collector = cloud_facts.CloudFactsCollector(
+            collected_hw_info={
+                "virt.is_guest": True,
+                "dmi.bios.version": "1.0.cloud"
+            }
+        )
         self.mock_facts.return_value.read_cache_only.return_value = {}
         MockConn.return_value.getresponse.return_value.read.return_value = \
             "{'privateIp' : '10.158.112.84', \
@@ -65,7 +75,12 @@ class TestInsightsCollector(unittest.TestCase):
 
     @patch('rhsm.https.httplib.HTTPConnection')
     def test_get_not_instance_id(self, MockConn):
-        self.collector = cloud_facts.CloudFactsCollector(collected_hw_info={"dmi.bios.version": "4.2.amazon"})
+        self.collector = cloud_facts.CloudFactsCollector(
+            collected_hw_info={
+                "virt.is_guest": True,
+                "dmi.bios.version": "4.2.amazon"
+            }
+        )
         self.mock_facts.return_value.read_cache_only.return_value = {}
         MockConn.return_value.getresponse.return_value.read.return_value = \
             "{'privateIp' : '10.158.112.84', \
@@ -76,7 +91,12 @@ class TestInsightsCollector(unittest.TestCase):
     # test ensures that exception is captured and does not impede
     @patch('rhsm.https.httplib.HTTPConnection')
     def test_get_bad_json(self, MockConn):
-        self.collector = cloud_facts.CloudFactsCollector(collected_hw_info={"dmi.bios.version": "4.2.amazon"})
+        self.collector = cloud_facts.CloudFactsCollector(
+            collected_hw_info={
+                "virt.is_guest": True,
+                "dmi.bios.version": "4.2.amazon"
+            }
+        )
         self.mock_facts.return_value.read_cache_only.return_value = {}
         MockConn.return_value.getresponse.return_value.read.return_value = \
             "other text stuff"
@@ -86,7 +106,12 @@ class TestInsightsCollector(unittest.TestCase):
     # test ensures that exception is captured and does not impede
     @patch('rhsm.https.httplib.HTTPConnection')
     def test_get_timeout(self, MockConn):
-        self.collector = cloud_facts.CloudFactsCollector(collected_hw_info={"dmi.bios.version": "4.2.amazon"})
+        self.collector = cloud_facts.CloudFactsCollector(
+            collected_hw_info={
+                "virt.is_guest": True,
+                "dmi.bios.version": "4.2.amazon"
+            }
+        )
         self.mock_facts.return_value.read_cache_only.return_value = {}
         MockConn.return_value.getresponse.side_effect = socket.timeout
         facts = self.collector.get_all()
@@ -95,7 +120,12 @@ class TestInsightsCollector(unittest.TestCase):
     # test ensures that exception is captured and does not impede
     @patch('rhsm.https.httplib.HTTPConnection')
     def test_get_http_error(self, MockConn):
-        self.collector = cloud_facts.CloudFactsCollector(collected_hw_info={"dmi.bios.version": "4.2.amazon"})
+        self.collector = cloud_facts.CloudFactsCollector(
+            collected_hw_info={
+                "virt.is_guest": True,
+                "dmi.bios.version": "4.2.amazon"
+            }
+        )
         self.mock_facts.return_value.read_cache_only.return_value = {}
         MockConn.return_value.getresponse.side_effect = httplib.HTTPException(mock.Mock(return_value={'status': 500}), 'error')
         facts = self.collector.get_all()
@@ -103,7 +133,12 @@ class TestInsightsCollector(unittest.TestCase):
 
     @patch('rhsm.https.httplib.HTTPConnection')
     def test_get_instance_id_from_cache(self, MockConn):
-        self.collector = cloud_facts.CloudFactsCollector(collected_hw_info={"dmi.bios.version": "4.2.amazon"})
+        self.collector = cloud_facts.CloudFactsCollector(
+            collected_hw_info={
+                "virt.is_guest": True,
+                "dmi.bios.version": "4.2.amazon"
+            }
+        )
         self.mock_facts.return_value.read_cache_only.return_value = {"aws_instance_id": CACHED_AWS_INSTANCE_ID}
         # does not get read if in cache already
         MockConn.return_value.getresponse.return_value.read.return_value = \

--- a/test/rhsmlib_test/test_cloud.py
+++ b/test/rhsmlib_test/test_cloud.py
@@ -1,0 +1,357 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+Module for testing Python all modules from Python package rhsmlib.cloud
+"""
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from mock import patch, Mock
+
+from rhsmlib.cloud.providers import aws, azure, gcp
+from rhsmlib.cloud.utils import detect_cloud_provider
+
+
+class TestAWSDetector(unittest.TestCase):
+    """
+    Class used for testing detector of AWS
+    """
+
+    def test_aws_not_vm(self):
+        """
+        Test for the case, when the machine is host (not virtual machine)
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': False,
+            'dmi.bios.version': 'cool hardware company'
+        }
+        aws_detector = aws.AWSCloudDetector(facts)
+        is_vm = aws_detector.is_vm()
+        self.assertFalse(is_vm)
+
+    def test_aws_vm_using_xen(self):
+        """
+        Test for the case, when the vm is running on AWS Xen
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'xen',
+            'dmi.bios.version': 'amazon'
+        }
+        aws_detector = aws.AWSCloudDetector(facts)
+        is_vm = aws_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_aws_xen_vm = aws_detector.is_running_on_cloud()
+        self.assertTrue(is_aws_xen_vm)
+
+    def test_aws_vm_using_kvm(self):
+        """
+        Test for the case, when the vm is running on AWS KVM
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.version': '1.0',
+            'dmi.bios.vendor': 'Amazon EC2'
+        }
+        aws_detector = aws.AWSCloudDetector(facts)
+        is_vm = aws_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_aws_kvm_vm = aws_detector.is_running_on_cloud()
+        self.assertTrue(is_aws_kvm_vm)
+
+    def test_vm_not_on_aws_cloud(self):
+        """
+        Test for the case, when the vm is not running on AWS
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.version': '1.0',
+            'dmi.bios.vendor': 'Foo'
+        }
+        aws_detector = aws.AWSCloudDetector(facts)
+        is_vm = aws_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_aws_vm = aws_detector.is_running_on_cloud()
+        self.assertFalse(is_aws_vm)
+
+    def test_vm_without_dmi_bios_info(self):
+        """
+        Test for the case, when MS BIOS does not provide any useful information for our code
+        """
+        # We will mock facts using simple dictionary
+        facts = {}
+        aws_detector = aws.AWSCloudDetector(facts)
+        is_vm = aws_detector.is_vm()
+        self.assertFalse(is_vm)
+        is_aws_vm = aws_detector.is_running_on_cloud()
+        self.assertFalse(is_aws_vm)
+
+
+class TestAzureDetector(unittest.TestCase):
+    """
+    Class used for testing detector of Azure
+    """
+
+    def test_azure_not_vm(self):
+        """
+        Test for the case, when the machine is host (not virtual machine)
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': False,
+            'dmi.bios.version': 'cool hardware company'
+        }
+        azure_detector = azure.AzureCloudDetector(facts)
+        is_vm = azure_detector.is_vm()
+        self.assertFalse(is_vm)
+
+    def test_azure_vm(self):
+        """
+        Test for the case, when the vm is running on Azure
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'hyperv',
+            'dmi.bios.version': '090008',
+            'dmi.chassis.asset_tag': '7783-7084-3265-9085-8269-3286-77'
+        }
+        azure_detector = azure.AzureCloudDetector(facts)
+        is_vm = azure_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_azure_vm = azure_detector.is_running_on_cloud()
+        self.assertTrue(is_azure_vm)
+
+    def test_vm_not_on_azure_cloud(self):
+        """
+        Test for the case, when the vm is not running on AWS
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'hyperv',
+            'dmi.bios.version': '090008',
+            'dmi.bios.vendor': 'Foo'
+        }
+        azure_detector = azure.AzureCloudDetector(facts)
+        is_vm = azure_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_azure_vm = azure_detector.is_running_on_cloud()
+        self.assertFalse(is_azure_vm)
+
+    def test_vm_without_dmi_bios_info(self):
+        """
+        Test for the case, when MS BIOS does not provide any useful information for our code
+        """
+        # We will mock facts using simple dictionary
+        facts = {}
+        azure_detector = azure.AzureCloudDetector(facts)
+        is_vm = azure_detector.is_vm()
+        self.assertFalse(is_vm)
+        is_azure_vm = azure_detector.is_running_on_cloud()
+        self.assertFalse(is_azure_vm)
+
+
+class TestGCPDetector(unittest.TestCase):
+    """
+    Class used for testing detector of GCP
+    """
+
+    def test_gcp_not_vm(self):
+        """
+        Test for the case, when the machine is host (not virtual machine)
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': False,
+            'dmi.bios.version': 'cool hardware company'
+        }
+        gcp_detector = gcp.GCPCloudDetector(facts)
+        is_vm = gcp_detector.is_vm()
+        self.assertFalse(is_vm)
+
+    def test_gcp_vm(self):
+        """
+        Test for the case, when the vm is running on GCP
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.version': 'Google',
+            'dmi.bios.vendor': 'Google'
+        }
+        gcp_detector = gcp.GCPCloudDetector(facts)
+        is_vm = gcp_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_gcp_vm = gcp_detector.is_running_on_cloud()
+        self.assertTrue(is_gcp_vm)
+
+    def test_vm_not_on_gcp_cloud(self):
+        """
+        Test for the case, when the vm is not running on GCP
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.version': '1.0',
+            'dmi.bios.vendor': 'Foo'
+        }
+        gcp_detector = gcp.GCPCloudDetector(facts)
+        is_vm = gcp_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_gcp_vm = gcp_detector.is_running_on_cloud()
+        self.assertFalse(is_gcp_vm)
+
+
+class TestCloudUtils(unittest.TestCase):
+    """
+    Class for testing rhsmlib.cloud.utils module
+    """
+    def setUp(self):
+        """
+        Set up two mocks that are used in all tests
+        """
+        host_collector_patcher = patch('rhsmlib.cloud.utils.HostCollector')
+        self.host_collector_mock = host_collector_patcher.start()
+        self.host_fact_collector_instance = Mock()
+        self.host_collector_mock.return_value = self.host_fact_collector_instance
+        self.addCleanup(host_collector_patcher.stop)
+
+        hardware_collector_patcher = patch('rhsmlib.cloud.utils.HardwareCollector')
+        self.hardware_collector_mock = hardware_collector_patcher.start()
+        self.hw_fact_collector_instance = Mock()
+        self.hardware_collector_mock.return_value = self.hw_fact_collector_instance
+        self.addCleanup(hardware_collector_patcher.stop)
+
+    def test_detect_cloud_provider_aws(self):
+        """
+        Test the case, when detecting of aws works as expected
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm'
+        }
+        hw_facts = {
+            'dmi.bios.vendor': 'Amazon EC2'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        self.hw_fact_collector_instance.get_all.return_value = hw_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['aws'])
+
+    def test_detect_cloud_provider_aws_heuristics(self):
+        """
+        Test the case, when detecting of aws does not work using strong signs, but it is necessary
+        to use heuristics method
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm'
+        }
+        hw_facts = {
+            'dmi.bios.vendor': 'AWS',
+            'dmi.bios.version': '1.0'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        self.hw_fact_collector_instance.get_all.return_value = hw_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['aws', 'gcp'])
+
+    def test_detect_cloud_provider_gcp(self):
+        """
+        Test the case, when detecting of gcp works as expected
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm'
+        }
+        hw_facts = {
+            'dmi.bios.vendor': 'Google',
+            'dmi.bios.version': 'Google'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        self.hw_fact_collector_instance.get_all.return_value = hw_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['gcp'])
+
+    def test_detect_cloud_provider_gcp_heuristics(self):
+        """
+        Test the case, when detecting of gcp does not work using strong signs, but it is necessary
+        to use heuristics method
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm'
+        }
+        hw_facts = {
+            'dmi.bios.vendor': 'Foo Company',
+            'dmi.bios.version': '1.0',
+            'dmi.chassis.asset_tag': 'Google Cloud'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        self.hw_fact_collector_instance.get_all.return_value = hw_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['gcp', 'aws'])
+
+    def test_detect_cloud_provider_azure(self):
+        """
+        Test the case, when detecting of azure works as expected
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'hyperv',
+        }
+        hw_facts = {
+            'dmi.bios.vendor': 'Foo company',
+            'dmi.bios.version': '1.0',
+            'dmi.chassis.asset_tag': '7783-7084-3265-9085-8269-3286-77'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        self.hw_fact_collector_instance.get_all.return_value = hw_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['azure'])
+
+    def test_detect_cloud_provider_azure_heuristics(self):
+        """
+        Test the case, when detecting of azure does not work using strong signs, but it is necessary
+        to use heuristics method
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'hyperv',
+        }
+        hw_facts = {
+            'dmi.bios.vendor': 'Microsoft',
+            'dmi.bios.version': '1.0',
+            'dmi.system.manufacturer': 'Google',
+            'dmi.chassis.manufacturer': 'Amazon'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        self.hw_fact_collector_instance.get_all.return_value = hw_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['azure', 'gcp', 'aws'])

--- a/test/rhsmlib_test/test_cloud.py
+++ b/test/rhsmlib_test/test_cloud.py
@@ -99,7 +99,7 @@ class TestAWSDetector(unittest.TestCase):
 
     def test_vm_without_dmi_bios_info(self):
         """
-        Test for the case, when MS BIOS does not provide any useful information for our code
+        Test for the case, when SM BIOS does not provide any useful information for our code
         """
         # We will mock facts using simple dictionary
         facts = {}
@@ -108,6 +108,22 @@ class TestAWSDetector(unittest.TestCase):
         self.assertFalse(is_vm)
         is_aws_vm = aws_detector.is_running_on_cloud()
         self.assertFalse(is_aws_vm)
+
+    def test_vm_system_uuid_starts_with_ec2(self):
+        """
+        Test for the case, when system UUID starts with EC2 string as it is described here:
+        https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'dmi.system.uuid': 'EC2263F8-15F3-4A34-B186-FAD8AB963431'
+        }
+        aws_detector = aws.AWSCloudDetector(facts)
+        is_vm = aws_detector.is_vm()
+        self.assertTrue(is_vm)
+        probability = aws_detector.is_likely_running_on_cloud()
+        self.assertEqual(probability, 0.1)
 
 
 class TestAzureDetector(unittest.TestCase):

--- a/test/rhsmlib_test/test_cloud.py
+++ b/test/rhsmlib_test/test_cloud.py
@@ -371,3 +371,25 @@ class TestCloudUtils(unittest.TestCase):
         self.hw_fact_collector_instance.get_all.return_value = hw_facts
         detected_clouds = detect_cloud_provider()
         self.assertEqual(detected_clouds, ['azure', 'gcp', 'aws'])
+
+    def test_conclict_in_strong_signs(self):
+        """
+        Test the case, when cloud providers change strong signs and there is conflict (two providers
+        are detected using strong signs). In such case result using strong signs should be dropped
+        and heuristics should be used, because strong signs do not work with probability and original
+        order is influenced by the order of classes in 'constant' CLOUD_DETECTORS.
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+        }
+        hw_facts = {
+            'dmi.bios.vendor': 'Google',
+            'dmi.bios.version': 'Google',
+            'dmi.chassis.asset_tag': '7783-7084-3265-9085-8269-3286-77',
+            'dmi.chassis.manufacturer': 'Microsoft'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        self.hw_fact_collector_instance.get_all.return_value = hw_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['gcp', 'azure', 'aws'])


### PR DESCRIPTION
* Created new package rhsmlib.cloud. This package contains
  two modules with base classes for:
  - Detecting cloud providers (CloudDetector)
  - Collecting metadata from cloud providers (CloudCollector)
* The Python package 'cloud' contains another package called 'providers'.
  This package contains Python modules implementing subclasses of
  CloudCollector. Each subclass implement detecting of one cloud
  provider. Three main cloud providers are supported ATM:
  - Amazone Web Services (AWS)
  - Microsoft Azure
  - Google Cloud Platform
* Each detector includes two methods for detecting cloud provider.
  First method 'is_running_on_cloud()' uses some unique
  system facts to identify cloud provider. Values of these
  facts can change over time. For this reason there is
  another method called 'is_likely_running_on_cloud' and this
  method uses some heuristics.
* It will be easy to add support for other cloud providers
* Collecting of metadata is not implemented ATM and it will be
  implemented in another commit/PR
* Detecting of AWS cloud provider is used in module cloud_facts
* Changed a little bit logic of collecting facts in 'all'
  Python module to reuse collected facts
* Collecting of cloud facts is not done in host_collector
  to avoid cyclic collecting in the future.
* Added some smoke tests to code to be able to test code
  on VM running on public clouds
* Added several unit tests
* Modified unit tests