### PR TITLE
1801570: drop scrollkeeper/rarian as a dependency from rhsm-gtk

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -453,17 +453,11 @@ Requires: font(cantarell)
 Requires: %{?suse_version:dejavu} %{!?suse_version:dejavu-sans-fonts}
 %endif
 
-%if !0%{?suse_version}
-Requires(post): scrollkeeper
-Requires(postun): scrollkeeper
-%else
-%endif
 
 %description -n rhsm-gtk
 This package contains GUI and widgets used by subscription-manager-gui
 and RHSM initial_setup module for Anaconda.
 %endif
-
 
 %if %{use_subman_gui}
 %package -n subscription-manager-gui
@@ -482,6 +476,12 @@ Requires: rhsm-gtk = %{version}-%{release}
 # Renamed from -gnome, so obsolete it properly
 Obsoletes: %{name}-gnome < 1.0.3-1
 Provides: %{name}-gnome = %{version}-%{release}
+
+%if !0%{?suse_version}
+Requires(post): scrollkeeper
+Requires(postun): scrollkeeper
+%else
+%endif
 
 %description -n subscription-manager-gui
 This package contains a GTK+ graphical interface for configuring and


### PR DESCRIPTION
The rarian / scrollkeeper dependency has been moved to subscription-manager-gui
package as this is the package which actually makes use of it at this time.