### PR TITLE
1847910: Do not include dnf plugins in libdnf RPM.

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1321,7 +1321,6 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %if %{create_libdnf_rpm}
 %files -n libdnf-plugin-subscription-manager
 %defattr(-,root,root,-)
-%{python_sitelib}/dnf-plugins/*
 %{_libdir}/libdnf/plugins/product-id.so
 %else
 # DNF RPM


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1847910#c9
* Do not include plugin for DNF in libdnf RPM. This RPM should
  include only libdnf plugin.