### PR TITLE
1904541: Catch ProxyException when checking available orgs

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -687,8 +687,8 @@ class AbstractSyspurposeCommand(CliCommand):
             # Try to get current organization key. It is property of OrgCommand.
             # Every Syspurpose command has to be subclass of OrgCommand too
             # must have used credentials in command if not registered to proceed
-            org_key = self.org
             try:
+                org_key = self.org
                 server_response = self.cp.getOwnerSyspurposeValidFields(org_key)
             except connection.RestlibException as rest_err:
                 log.warning("Unable to get list of valid fields using REST API: %s" % rest_err)


### PR DESCRIPTION
When the proxy configured is bad the call to check for the available orgs fails. Moving this inside the try block just below it's original position allows us to have consistent messaging about the proxy exception.