### PR TITLE
Fixup syspurpose module help text / bash completion

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -33,6 +33,13 @@ _subscription_manager_attach()
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }
 
+_subscription_manager_syspurpose()
+{
+  local opts="--show ${_subscription_manager_common_opts}"
+  COMPREPLY=($(compgen -W "${opts}" -- ${1}))
+}
+
+
 _subscription_manager_role()
 {
   local opts="--list --org --set --show
@@ -258,6 +265,7 @@ _subscription_manager()
       repos|\
       role|\
       status|\
+      syspurpose|\
       unregister|\
       usage|\
       version)

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -375,6 +375,18 @@ Sets the minor (Y-stream) release version to use, such as 6.3.
 Removes any previously set release version preference.
 
 
+.SS SYSPURPOSE OPTIONS
+The
+.B syspurpose
+command displays the current configured syspurpose
+.I preferences
+for the system.
+
+.TP
+.B --show
+Shows the system's current set of syspurpose preference. This is output in the form of a blob of json. Single-valued entries for which there is no value will be included in the output with a value of "". List entries which have no value will be included in the output with a value of "[]" (less the quotes).
+
+
 .SS ADDONS OPTIONS
 The
 .B addons

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1040,7 +1040,7 @@ class SyspurposeCommand(CliCommand):
         """
         Initialize the syspurpose command
         """
-        short_desc = _("Generic system purpose command")
+        short_desc = _("Convenient module for managing all system purpose settings")
         super(SyspurposeCommand, self).__init__(
             "syspurpose",
             short_desc,
@@ -1372,7 +1372,7 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
 
     def __init__(self):
 
-        shortdesc = _("Manage service levels for this system")
+        shortdesc = _("Show or modify the system purpose service-level setting")
         self._org_help_text = _("specify an organization when listing available service levels using the organization key, only used with --list")
         super(ServiceLevelCommand, self).__init__(
             "service-level",
@@ -1532,7 +1532,7 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
 class UsageCommand(AbstractSyspurposeCommand, OrgCommand):
 
     def __init__(self):
-        shortdesc = _("Manage usage setting for this system")
+        shortdesc = _("Show or modify the system purpose usage setting")
         self._org_help_text = _("use set and unset to define the value for this field")
         super(UsageCommand, self).__init__(
             "usage",
@@ -1916,7 +1916,7 @@ class UnRegisterCommand(CliCommand):
 class AddonsCommand(AbstractSyspurposeCommand, OrgCommand):
 
     def __init__(self):
-        shortdesc = _("Modify or view the addons attribute of the system purpose")
+        shortdesc = _("Show or modify the system purpose addons setting")
         super(AddonsCommand, self).__init__(
             "addons",
             shortdesc=shortdesc,
@@ -3287,7 +3287,7 @@ class OverrideCommand(CliCommand):
 
 class RoleCommand(AbstractSyspurposeCommand, OrgCommand):
     def __init__(self):
-        shortdesc = _("Modify system purpose role")
+        shortdesc = _("Show or modify the system purpose role setting")
         super(RoleCommand, self).__init__(
             "role",
             shortdesc,


### PR DESCRIPTION
This adds a small section to the man page for subscription-manager to describe the current functionality of the "syspurpose" command. Additionally, this updates the bash completion to add the syspurpose command and updates the help text for current syspurpose-related commands to be more consistent.