### PR TITLE
1886772: Add in memory read through cache, delete SCA cert when not n…

### DIFF
--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -153,14 +153,13 @@ class EntCertUpdateAction(object):
             content_access_certs = self._find_content_access_certs()
             update_data = None
             if len(content_access_certs) > 0:
-                # This address BZ: 1448855, 1450862
-                if len(expected) < len(content_access_certs):
-                    obsolete_certs = []
-                    for cont_access_cert in content_access_certs:
-                        if cont_access_cert.serial not in expected:
-                            obsolete_certs.append(cont_access_cert)
-                    log.info('Deleting obsolete content access certificate')
-                    self.delete(obsolete_certs)
+                # This addresses BZs: 1448855, 1450862
+                obsolete_certs = []
+                for cont_access_cert in content_access_certs:
+                    if cont_access_cert.serial not in expected:
+                        obsolete_certs.append(cont_access_cert)
+                log.info('Deleting obsolete content access certificate')
+                self.delete(obsolete_certs)
                 update_data = self.content_access_cache.check_for_update()
                 for content_access_cert in content_access_certs:
                     self.content_access_cache.update_cert(content_access_cert, update_data)

--- a/src/subscription_manager/injectioninit.py
+++ b/src/subscription_manager/injectioninit.py
@@ -17,13 +17,11 @@ from __future__ import print_function, division, absolute_import
 import subscription_manager.injection as inj
 
 
-from subscription_manager.cache import ProductStatusCache, \
-    EntitlementStatusCache, OverrideStatusCache, ProfileManager, \
-    InstalledProductsManager, PoolTypeCache, ReleaseStatusCache, \
-    RhsmIconCache, ContentAccessCache, PoolStatusCache, \
-    SyspurposeComplianceStatusCache, ContentAccessModeCache, \
-    SupportedResourcesCache, AvailableEntitlementsCache, \
-    CurrentOwnerCache, SyspurposeValidFieldsCache
+from subscription_manager.cache import ProductStatusCache, EntitlementStatusCache, \
+    OverrideStatusCache, ProfileManager, InstalledProductsManager, PoolTypeCache, \
+    ReleaseStatusCache, RhsmIconCache, ContentAccessCache, PoolStatusCache, \
+    SyspurposeComplianceStatusCache, SupportedResourcesCache, AvailableEntitlementsCache, \
+    CurrentOwnerCache, SyspurposeValidFieldsCache, ReadThroughInMemoryCache
 
 from subscription_manager.cert_sorter import CertSorter
 from subscription_manager.certdirectory import EntitlementDirectory
@@ -59,7 +57,7 @@ def init_dep_injection():
     inj.provide(inj.ENTITLEMENT_STATUS_CACHE, EntitlementStatusCache, singleton=True)
     inj.provide(inj.SYSTEMPURPOSE_COMPLIANCE_STATUS_CACHE, SyspurposeComplianceStatusCache, singleton=True)
     inj.provide(inj.RHSM_ICON_CACHE, RhsmIconCache, singleton=True)
-    inj.provide(inj.CONTENT_ACCESS_MODE_CACHE, ContentAccessModeCache, singleton=True)
+    inj.provide(inj.CONTENT_ACCESS_MODE_CACHE, ReadThroughInMemoryCache, singleton=True)
     inj.provide(inj.CURRENT_OWNER_CACHE, CurrentOwnerCache, singleton=True)
     inj.provide(inj.SYSPURPOSE_VALID_FIELDS_CACHE, SyspurposeValidFieldsCache)
     inj.provide(inj.SUPPORTED_RESOURCES_CACHE, SupportedResourcesCache, singleton=True)

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -50,6 +50,7 @@ from rhsm.config import DEFAULT_PORT, DEFAULT_PREFIX, DEFAULT_HOSTNAME, \
 
 from subscription_manager.i18n import ugettext as _
 
+
 log = logging.getLogger(__name__)
 
 
@@ -173,7 +174,6 @@ def is_simple_content_access(uep=None, identity=None, owner=None):
     :param owner: reference on current owner
     :return: True, when current owner uses contentAccesMode equal to org_environment. False otherwise.
     """
-
     if identity is None:
         identity = inj.require(inj.IDENTITY)
 
@@ -181,40 +181,43 @@ def is_simple_content_access(uep=None, identity=None, owner=None):
     if identity.uuid is None:
         return False
 
-    content_access_mode = None
-
     # We have to load it here, because we don't want to add another class to dependency injection
-
-    # Try to use cached data to minimize numbers of REST API calls
     cache = inj.require(inj.CONTENT_ACCESS_MODE_CACHE)
-    data = cache.read_cache_only()
-    if data is not None:
-        if identity.uuid in data:
-            content_access_mode = data[identity.uuid]
-
-    if content_access_mode is None:
-        if uep is None:
-            cp_provider = inj.require(inj.CP_PROVIDER)
-            uep = cp_provider.get_consumer_auth_cp()
-
-        if owner is None:
-            try:
-                owner = uep.getOwner(identity.uuid)
-            except Exception as err:
-                log.debug("Unable to get owner: %s" % str(err))
-                return False
-        if 'contentAccessMode' in owner:
-            content_access_mode = owner['contentAccessMode']
-
-        # Write cache to file
-        data = {identity.uuid: content_access_mode}
-        cache.content_access_mode = data
-        cache.write_cache(debug=False)
-
+    content_access_mode = cache.read(
+        key=identity.uuid,
+        on_cache_miss=lambda: get_content_access_mode(uep=uep,
+                                                      identity=identity,
+                                                      owner=owner))
     if content_access_mode == "org_environment":
         return True
 
     return False
+
+
+def get_content_access_mode(uep=None, identity=None, owner=None):
+    """
+    Return the content access mode of the current owner
+    :param uep: connection to candlepin server
+    :param identity: reference on current identity
+    :param owner: reference on current owner
+    :return:
+    """
+    if identity is None:
+        identity = inj.require(inj.IDENTITY)
+
+    if uep is None:
+        cp_provider = inj.require(inj.CP_PROVIDER)
+        uep = cp_provider.get_consumer_auth_cp()
+
+    if owner is None:
+        try:
+            owner = uep.getOwner(identity.uuid)
+        except Exception as err:
+            log.debug("Unable to get owner: %s" % str(err))
+            return False
+    if 'contentAccessMode' in owner:
+        return owner['contentAccessMode']
+    return None
 
 
 def get_current_owner(uep=None, identity=None):

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -223,7 +223,7 @@ class SubManFixture(unittest.TestCase):
         inj.provide(inj.ENTITLEMENT_STATUS_CACHE, stubs.StubEntitlementStatusCache())
         inj.provide(inj.POOL_STATUS_CACHE, stubs.StubPoolStatusCache())
         inj.provide(inj.PROD_STATUS_CACHE, stubs.StubProductStatusCache())
-        inj.provide(inj.CONTENT_ACCESS_MODE_CACHE, stubs.StubContentAccessModeCache())
+        inj.provide(inj.CONTENT_ACCESS_MODE_CACHE, stubs.StubReadThroughInMemoryCache())
         inj.provide(inj.SUPPORTED_RESOURCES_CACHE, stubs.StubSupportedResourcesCache())
         inj.provide(inj.SYSPURPOSE_VALID_FIELDS_CACHE, stubs.StubSyspurposeValidFieldsCache())
         inj.provide(inj.CURRENT_OWNER_CACHE, stubs.StubCurrentOwnerCache)

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -26,8 +26,8 @@ from rhsm import config
 from subscription_manager.cert_sorter import CertSorter
 from subscription_manager.cache import EntitlementStatusCache, ProductStatusCache, \
         OverrideStatusCache, ProfileManager, InstalledProductsManager, ReleaseStatusCache, \
-        PoolStatusCache, ContentAccessModeCache, SupportedResourcesCache, AvailableEntitlementsCache, \
-        SyspurposeValidFieldsCache, CurrentOwnerCache
+        PoolStatusCache, SupportedResourcesCache, AvailableEntitlementsCache, \
+        SyspurposeValidFieldsCache, CurrentOwnerCache, ReadThroughInMemoryCache
 from subscription_manager.facts import Facts
 from subscription_manager.lock import ActionLock
 from rhsm.certificate import GMT
@@ -726,15 +726,6 @@ class StubAvailableEntitlementsCache(AvailableEntitlementsCache):
         self.server_status = None
 
 
-class StubContentAccessModeCache(ContentAccessModeCache):
-
-    def write_cache(self, debug=False):
-        pass
-
-    def delete_cache(self):
-        self.server_status = None
-
-
 class StubSupportedResourcesCache(SupportedResourcesCache):
 
     def write_cache(self, debug=False):
@@ -760,6 +751,14 @@ class StubCurrentOwnerCache(CurrentOwnerCache):
 
     def delete_cache(self):
         self.server_status = None
+
+
+class StubReadThroughInMemoryCache(ReadThroughInMemoryCache):
+
+    def __init__(self):
+        super(ReadThroughInMemoryCache, self).__init__()
+        # Remove the lock, so as not to block tests run in parallel
+        self._lock = mock.Mock()
 
 
 class StubPool(object):

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -34,11 +34,10 @@ from .stubs import StubProduct, StubProductCertificate, StubCertificateDirectory
 from .fixture import SubManFixture
 
 from rhsm import ourjson as json
-from subscription_manager.cache import ProfileManager, \
-    InstalledProductsManager, EntitlementStatusCache, \
-    PoolTypeCache, ReleaseStatusCache, ContentAccessCache, \
-    PoolStatusCache, ContentAccessModeCache, SupportedResourcesCache, \
-    AvailableEntitlementsCache, CurrentOwnerCache
+from subscription_manager.cache import ProfileManager, InstalledProductsManager,\
+    EntitlementStatusCache, PoolTypeCache, ReleaseStatusCache, ContentAccessCache, \
+    PoolStatusCache, SupportedResourcesCache, AvailableEntitlementsCache, CurrentOwnerCache, \
+    InMemoryCache, ReadThroughInMemoryCache
 
 from rhsm.profile import Package, RPMProfile, EnabledReposProfile, ModulesProfile
 
@@ -1056,29 +1055,6 @@ after
         # getting this far means we did not raise an exception :-)
 
 
-class TestContentAccessModeCache(SubManFixture):
-
-    MOCK_CACHE_FILE_CONTENT = '{"7f85da06-5c35-44ba-931d-f11f6e581f89": "entitlement"}'
-
-    def setUp(self):
-        super(TestContentAccessModeCache, self).setUp()
-        self.cache = ContentAccessModeCache()
-
-    def test_reading_nonexisting_cache(self):
-        data = self.cache.read_cache_only()
-        self.assertIsNone(data)
-
-    def test_reading_existing_cache(self):
-        temp_cache_dir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, temp_cache_dir)
-        self.cache.CACHE_FILE = os.path.join(temp_cache_dir, 'content_access_mode.json')
-        with open(self.cache.CACHE_FILE, 'w') as cache_file:
-            cache_file.write(self.MOCK_CACHE_FILE_CONTENT)
-        data = self.cache.read_cache_only()
-        self.assertTrue("7f85da06-5c35-44ba-931d-f11f6e581f89" in data)
-        self.assertEqual(data["7f85da06-5c35-44ba-931d-f11f6e581f89"], "entitlement")
-
-
 class TestSupportedResourcesCache(SubManFixture):
 
     MOCK_CACHE_FILE_CONTENT = '{"a3f43883-315b-4cc4-bfb5-5771946d56d7": {"": "/", "cdn": "/cdn"}}'
@@ -1238,3 +1214,74 @@ class TestAvailableEntitlementsCache(SubManFixture):
         uep.conn.smoothed_rt = 20.0
         timeout = self.cache.timeout()
         self.assertEqual(timeout, self.cache.UBOUND)
+
+
+class TestInMemoryCache(SubManFixture):
+
+    def setUp(self):
+        rlock_patch = patch('subscription_manager.cache.threading.RLock')
+        self.mock_lock = rlock_patch.start()
+        self.addCleanup(rlock_patch.stop)
+        self.cache = InMemoryCache()
+
+    def test_write_cache(self):
+        self.cache.write_cache("test", "value")
+        self.assertEqual(self.cache._cache["test"], "value")
+
+    def test_read_cache_only(self):
+        self.cache._cache["test"] = "value"
+        self.assertEqual(self.cache.read_cache_only("test"), "value")
+
+    def test_safe_get(self):
+        # Break the internal storage of the cache somehow
+        self.cache._cache = None
+        try:
+            res = self.cache._safe_get('item')
+        except Exception:
+            self.fail("Expected the _safe_get method to returh None without raising an exception")
+        else:
+            self.assertEqual(res, None, 'Expected _safe_get to return "None" for missing keys')
+
+
+class TestReadThroughInMemoryCache(SubManFixture):
+
+    def setUp(self):
+        rlock_patch = patch('subscription_manager.cache.threading.RLock')
+        self.mock_lock = rlock_patch.start()
+        self.addCleanup(rlock_patch.stop)
+        self.cache = ReadThroughInMemoryCache()
+
+    def test_read_on_cache_miss(self):
+        key = "item"
+        mock_expensive_function = Mock()
+        mock_expensive_function.return_value = {"thing": "another_thing"}
+        result = self.cache.read(key=key, on_cache_miss=mock_expensive_function)
+        self.assertEqual(result, mock_expensive_function.return_value,
+                         "The result should be equivalent to the return_value of the"
+                         "cache miss function")
+        self.assertNotEqual(id(result), id(mock_expensive_function.return_value),
+                            "The returned value should be a copy of the stored value (to keep the"
+                            "cache thread-safe via immutablity, please note that using any"
+                            "immutable type as the return result from the mock function will cause"
+                            "this to fail such as using strings)")
+        mock_expensive_function.assert_called_once()
+        mock_expensive_function.reset_mock()
+
+        # Now what happens when we ask for the result a second time?
+        second_result = self.cache.read(key=key, on_cache_miss=mock_expensive_function)
+        self.assertEqual(second_result, mock_expensive_function.return_value,
+                         "The result should be equivalent to the return_value of the"
+                         "cache miss function")
+        self.assertNotEqual(id(result), id(second_result))
+        self.assertNotEqual(id(second_result), id(mock_expensive_function.return_value))
+        mock_expensive_function.assert_not_called()
+
+    def test_read(self):
+        key = "item"
+        current_result = "haha"
+        self.cache._cache[key] = current_result
+        mock_expensive_function = Mock()
+        mock_expensive_function.return_value = "expensive_result"
+        result = self.cache.read(key=key, on_cache_miss=mock_expensive_function)
+        self.assertEqual(result, current_result)
+        mock_expensive_function.assert_not_called()


### PR DESCRIPTION
…eeded

This stops bad cache values from incorrectly displaying that
the system is registered to an organization which is running
in Simple Content Access mode.

Now the organization's content access mode is cached only in memory
so as to limit the duration of it's validity to the lifetime of
any of our applications runtime.