### PR TITLE
Add disable_auto_attach option

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -100,6 +100,8 @@ disable = 0
 auto_registration = 0
 # Interval to run auto-registration (in minutes):
 auto_registration_interval = 60
+# Disable auto attach. Only works when used with auto_registration.
+disable_auto_registration = 1
 
 [logging]
 default_log_level = INFO

--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -101,7 +101,7 @@ auto_registration = 0
 # Interval to run auto-registration (in minutes):
 auto_registration_interval = 60
 # Disable auto attach. Only works when used with auto_registration.
-disable_auto_registration = 1
+disable_auto_attach = 1
 
 [logging]
 default_log_level = INFO

--- a/etc-conf/rhsmcertd.completion.sh
+++ b/etc-conf/rhsmcertd.completion.sh
@@ -11,7 +11,7 @@ _rhsmcertd()
 	first="${COMP_WORDS[1]}"
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	opts="-h --help -c --cert-check-interval --cert-interval -d --debug --heal-interval -i --auto-attach-interval -n --now -s --no-splay -a --auto-registration -r --auto-registration-interval"
+	opts="-h --help -c --cert-check-interval --cert-interval -d --debug --heal-interval -i --auto-attach-interval -n --now -s --no-splay -a --auto-registration -r --auto-registration-interval -x --disable-auto-attach"
 
 	case "${cur}" in
 		-*)

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -85,7 +85,8 @@ RHSMCERTD_DEFAULTS = {
         'splay': '1',
         'disable': '0',
         'auto_registration': '0',
-        'auto_registration_interval': '60'
+        'auto_registration_interval': '60',
+        'disable_auto_attach': '1'
         }
 
 LOGGING_DEFAULTS = {

--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -137,7 +137,7 @@ def _main(options, log):
         log.warning('The rhsmcertd process has been disabled by configuration.')
         sys.exit(-1)
 
-    # Was script exectured with --auto-register option
+    # Was script executed with --auto-register option
     if options.auto_register is True:
         _auto_register(cp_provider, log)
 
@@ -149,6 +149,10 @@ def _main(options, log):
 
     cp = cp_provider.get_consumer_auth_cp()
     cp.supports_resource(None)  # pre-load supported resources; serves as a way of failing before locking the repos
+
+    if options.auto_register is True and options.disable_auto_attach is True:
+        # We only want to disable auto-attach if we've just auto registered
+        cp.updateConsumer(inj.require(inj.IDENTITY).uuid, autoheal=False)
 
     try:
         if options.autoheal:
@@ -209,6 +213,10 @@ def main():
             default=False, help=SUPPRESS_HELP)
     parser.add_option(
             "--auto-register", dest="auto_register", action="store_true",
+            default=False, help="perform auto-registration"
+    )
+    parser.add_option(
+            "--disable-auto-attach", dest="disable_auto_attach", action="store_true",
             default=False, help="perform auto-registration"
     )
 

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -319,6 +319,8 @@ Requires: python3-dbus
 Requires: %{?suse_version:dbus-1-python} %{!?suse_version:dbus-python}
 %endif
 
+Requires: python-requests
+
 %if %{use_yum}
 Requires: %{?suse_version:yum} %{!?suse_version:yum >= 3.2.29-73}
 %endif


### PR DESCRIPTION
This adds an option, rhsmcertd.disable_auto_registration, which when used in combination with the new rhsmcertd.auto_registration option will update the newly created consumer record to disable the auto attach functionality.