### PR TITLE
Improved loggin of rhsmcertd and spec file updated

### DIFF
--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -298,9 +298,16 @@ auto_register(gpointer data)
         // No need to repeat this action again
         return false;
     } else {
-        warn ("(Auto-registration) failed (%d), retry will occur on next run.", status);
         auto_register_attempt++;
-        return TRUE;
+        if (auto_register_attempt < MAX_AUTO_REGISTER_ATTEMPTS) {
+            warn ("(Auto-registration) failed (%d), retry will occur on next run.", status);
+        } else {
+            warn ("(Auto-registration) failed (%d), the number of attempts reached the max limit: %d",
+                  status, MAX_AUTO_REGISTER_ATTEMPTS);
+            // Return False to not repeat this again
+            return false;
+        }
+        return true;
     }
 }
 

--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -137,7 +137,7 @@ def _main(options, log):
         log.warning('The rhsmcertd process has been disabled by configuration.')
         sys.exit(-1)
 
-    # Was script exectured with --auto-register option
+    # Was script executed with --auto-register option
     if options.auto_register is True:
         _auto_register(cp_provider, log)
 

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -319,6 +319,8 @@ Requires: python3-dbus
 Requires: %{?suse_version:dbus-1-python} %{!?suse_version:dbus-python}
 %endif
 
+Requires: python-requests
+
 %if %{use_yum}
 Requires: %{?suse_version:yum} %{!?suse_version:yum >= 3.2.29-73}
 %endif


### PR DESCRIPTION
* Improved logging of rhsmcertd, when we try to do
  re-attempts of automatic registration
* Updated .spec file, because subscription-manager
  requires rpm python-rquests
* Fixed one typo