### PR TITLE
cockpit: Enable subscription-manager in dnf in tests

### DIFF
--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -134,6 +134,8 @@ class SubscriptionsCase(MachineCase):
 
         # make sure that rhsm skips certificate checks for the server
         m.execute("sed -i -e 's/insecure = 0/insecure = 1/g' /etc/rhsm/rhsm.conf")
+        # enable subscriptions in dnf
+        m.execute("sed -i -e '/enabled/ s/0/1/' /etc/yum/pluginconf.d/subscription-manager.conf")
 
         # Apply some extra cleanups on rhel-atomic.  These cleanups
         # are necessary because all changes to /etc after a "atomic


### PR DESCRIPTION
Most recent RHEL 8.4 cloud image does not enable it by default any more.

----

This got caught in the [most recent rhel-8-4 test image refresh](https://github.com/cockpit-project/bots/pull/1684), where [almost all sub-man tests fail](https://logs.cockpit-project.org/logs/pull-1684-20210216-175536-6f31a40d-rhel-8-4-candlepin-subscription-manager/log.html). I sent a similar PR for cockpit in https://github.com/cockpit-project/cockpit/pull/15356