### PR TITLE
Revert "cockpit: Enable subscription-manager in dnf in tests"

### DIFF
--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -134,8 +134,6 @@ class SubscriptionsCase(MachineCase):
 
         # make sure that rhsm skips certificate checks for the server
         m.execute("sed -i -e 's/insecure = 0/insecure = 1/g' /etc/rhsm/rhsm.conf")
-        # enable subscriptions in dnf
-        m.execute("sed -i -e '/enabled/ s/0/1/' /etc/yum/pluginconf.d/subscription-manager.conf")
 
         # Apply some extra cleanups on rhel-atomic.  These cleanups
         # are necessary because all changes to /etc after a "atomic


### PR DESCRIPTION
Reverts candlepin/subscription-manager#2447

This was really the wrong thing to do. Ideally rhsm would revert the recent change that broke the default subscription-manager.conf, but if that really has to stay, then subscription-manager-cockpit needs another approach of figuring out whether subscriptions are really required.