### PR TITLE
Add f34 target to the fedora releaser

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -1,6 +1,6 @@
 [fedora]
 releaser = tito.release.FedoraGitReleaser
-branches = master f33 f32
+branches = master f34 f33 f32
 
 [rhel-7.1]
 releaser = tito.release.DistGitReleaser


### PR DESCRIPTION
This adds the fedora 34 branch to our fedora releaser.