### PR TITLE
1896715: Set proper read permissions on certs - 1.24 [ENT-3274]

### DIFF
--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -520,6 +520,7 @@ class Certificate(object):
         else:
             f.write(self.x509.as_pem())
         f.close()
+        os.chmod(path, 0o644)
         self.path = path
 
     def delete(self):


### PR DESCRIPTION
To test:
I used the Centos7 vagrant instance
Run as root:

rm -f /etc/pki/entitlement/*
umask 022
subscription-manager refresh
~~~
All local data refreshed
~~~
ls -al /etc/pki/entitlement/
~~~
-rw-r--r--.  1 root root  3243 Nov 10 08:30 7926654778781108730-key.pem
-rw-r--r--.  1 root root 28229 Nov 10 08:30 7926654778781108730.pem
~~~
rm -f /etc/pki/entitlement/*
umask 077
subscription-manager refresh
~~~
All local data refreshed
~~~
ls -al /etc/pki/entitlement/
~~~
-rw-r--r--.  1 root root  3243 Nov 10 08:32 7926654778781108730-key.pem
-rw-------.  1 root root 28229 Nov 10 08:32 7926654778781108730.pem <--------------This will change to 644 after applying the patch 
~~~