### PR TITLE
Add nikos' auto assigner

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,16 @@
+name: AutoAssignReviewer
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  auto-assign-reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run assignment of reviewer team
+        uses: nikosmoum/auto-assign-reviewer-team@v0.5
+        with:
+          githubToken: ${{ secrets.AUTOASSIGNREVIEWERSECRET }}
+          teamName: 'client-tools'
+


### PR DESCRIPTION
This PR adds Nikos' PR auto assigner to the project.
It should, in combination with another change to the settings for this repo, allow us to have our PRs automatically assigned for review by a member of the 'client-tools' sub-team of the candlepin org.

You can check that the auto assignment with the round-robin setting has been enabled here: https://github.com/orgs/candlepin/teams/client-tools/edit/review_assignment