### PR TITLE
1924921: Fix getting releases, when SCA is used

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -428,9 +428,16 @@ class ContentConnection(BaseConnection):
         super(ContentConnection, self).__init__(handler='/', cert_dir=cert_dir, user_agent=user_agent,
                                                 **kwargs)
 
-    def get_versions(self, path):
+    def get_versions(self, path, cert_key_pairs=None):
+        """
+        Get list of available release versions from the given path
+        :param path: path, where is simple text file containing supported release versions
+        :param cert_key_pairs: optional argument including list of supported cert and keys
+            to reduce number of failed http requests.
+        :return:
+        """
         handler = "%s/%s" % (self.handler, path)
-        result = self.conn.request_get(handler)
+        result = self.conn.request_get(handler, cert_key_pairs=cert_key_pairs)
 
         return result
 

--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -296,11 +296,27 @@ class EntitlementDirectory(CertificateDirectory):
         return [x for x in self.list_with_content_access() if self._check_key(x) and x.is_valid()]
 
     def list(self):
+        """
+        List entitlement certificates that do not have SCA type
+        :return: list of entitlement certs
+        """
         certs = super(EntitlementDirectory, self).list()
         return [cert for cert in certs if cert.entitlement_type != CONTENT_ACCESS_CERT_TYPE]
 
     def list_with_content_access(self):
+        """
+        List all entitlement certificates
+        :return: list of entitlement certs
+        """
         return super(EntitlementDirectory, self).list()
+
+    def list_with_sca_mode(self):
+        """
+        List only entitlement certificates that do have SCA type
+        :return:
+        """
+        certs = super(EntitlementDirectory, self).list()
+        return [cert for cert in certs if cert.entitlement_type == CONTENT_ACCESS_CERT_TYPE]
 
     def list_for_product(self, product_id):
         """

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -320,7 +320,7 @@ class SubManFixture(unittest.TestCase):
 
     # The ContentConnection used for reading release versions from
     # the cdn. The injected one uses this.
-    def _get_release_versions(self, listing_path):
+    def _get_release_versions(self, path, cert_key_pairs=None):
         return self._release_versions
 
     # For changing injection consumer id to one that fails "is_valid"

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -345,6 +345,10 @@ class StubEntitlementDirectory(StubCertificateDirectory):
     def list_with_content_access(self):
         return super(StubEntitlementDirectory, self).list()
 
+    def list_with_sca_mode(self):
+        certs = super(StubEntitlementDirectory, self).list()
+        return [cert for cert in certs if cert.entitlement_type == CONTENT_ACCESS_CERT_TYPE]
+
 
 class StubProductDirectory(StubCertificateDirectory, ProductDirectory):
     """

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -18,6 +18,7 @@ import mock
 import six.moves.http_client
 import socket
 from rhsm.https import ssl
+from rhsm import certificate2
 
 from . import stubs
 from . import fixture
@@ -164,8 +165,12 @@ class TestCdnReleaseVerionProvider(fixture.SubManFixture):
                                            gpg=None, enabled="0")
 
         stub_product = stubs.StubProduct("rhel-6")
-        stub_entitlement_certs = [stubs.StubEntitlementCertificate(stub_product,
-                                                                   content=[stub_content_6])]
+        stub_entitlement_certs = [
+            stubs.StubEntitlementCertificate(
+                stub_product,
+                content=[stub_content_6]
+            )
+        ]
 
         self.ent_dir = stubs.StubEntitlementDirectory(stub_entitlement_certs)
 
@@ -173,6 +178,31 @@ class TestCdnReleaseVerionProvider(fixture.SubManFixture):
 
         releases = cdn_rv_provider.get_releases()
         self.assertEqual([], releases)
+
+    def test_get_releases_rhel_from_sca_ent_cert(self):
+
+        stub_content_6 = stubs.StubContent(
+            "c6",
+            required_tags="rhel-6",
+            gpg=None,
+            enabled="1"
+        )
+
+        stub_product = stubs.StubProduct("rhel-6")
+        stub_entitlement_certs = [
+            stubs.StubEntitlementCertificate(
+                stub_product,
+                content=[stub_content_6],
+                entitlement_type=certificate2.CONTENT_ACCESS_CERT_TYPE
+            )
+        ]
+
+        self.ent_dir = stubs.StubEntitlementDirectory(stub_entitlement_certs)
+
+        cdn_rv_provider = self._get_cdn_rv_provider()
+
+        releases = cdn_rv_provider.get_releases()
+        self.assertNotEqual([], releases)
 
     def test_get_releases_throws_exception(self):
         cdn_rv_provider = self._get_cdn_rv_provider()


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1924921
* Card ID: ENT-3528
* When there was SCA certificate, then this cert was ignored
* Revert one change introduced during implementation of --token
  - We try to use only entitlement cert for accessing CDN
    that is related to installed product (not all entitlement
    certs). It reduce failed connection attempts for long list
    of installed entitlement certs.
* Added one unit test and fixed one existing unit test