### PR TITLE
1857491: add a newline to split a message into 2 lines

### DIFF
--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -345,7 +345,7 @@ def main():
 
     # Syspurpose is not intended to be used in containers for the time being (could change later).
     if in_container():
-        print(_("WARNING: Setting syspurpose in containers has no effect."
+        print(_("WARNING: Setting syspurpose in containers has no effect.\n"
               "Please run syspurpose on the host.\n"))
 
     try:


### PR DESCRIPTION
Steps to Reproduce:
[root@d686d25831f3 /]# syspurpose set-role "Red Hat Enterprise Linux Server"
WARNING: Setting syspurpose in containers has no effect.
Please run syspurpose on the host.
role set to "Red Hat Enterprise Linux Server".
[root@d686d25831f3 /]#
