### PR TITLE
1880920 - print a warning for invalid addons

### DIFF
--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -261,6 +261,7 @@ class AbstractSyspurposeCommand(CliCommand):
 
     def add(self):
         self._add(self.options.to_add)
+        self._are_provided_values_valid(self.options.to_add)
         success_msg = _("{attr} updated.").format(attr=self.name)
         # When there is several options to add, then format of command is following
         # subscription-manager command --add opt1 --add opt2

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -574,6 +574,22 @@ class TestAddonsCommand(TestCliCommand):
     def test_unset_and_add_and_remove(self):
         self._test_exception(['--add', 'test', '--remove', 'item', '--unset'])
 
+    def test_add_valid_value(self):
+        with patch.object(self.cc, '_get_valid_fields') as mock_get_valid_fields:
+            mock_get_valid_fields.return_value = {'addons': ['ADDON1', 'ADDON3', 'ADDON2']}
+            self.assertTrue(self.cc._is_provided_value_valid('ADDON1'))
+            with Capture() as cap:
+                self.assertEqual(self.cc._are_provided_values_valid(['ADDON1']), [])
+            self.assertNotIn('Warning: Provided value', cap.out)
+
+    def test_add_invalid_value(self):
+        with patch.object(self.cc, '_get_valid_fields') as mock_get_valid_fields:
+            mock_get_valid_fields.return_value = {'addons': ['ADDON1', 'ADDON3', 'ADDON2']}
+            self.assertFalse(self.cc._is_provided_value_valid('test'))
+            with Capture() as cap:
+                self.assertEqual(self.cc._are_provided_values_valid(['test']), ['test'])
+            self.assertIn('Warning: Provided value', cap.out)
+
 
 class TestListCommand(TestCliProxyCommand):
     command_class = managercli.ListCommand


### PR DESCRIPTION
Refactor an internal helper function to check for multiple values at once, rather than a single one; use it to validate the addons to add.