### PR TITLE
1924166: improve man text of syspurpose --show

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -384,7 +384,7 @@ for the system.
 
 .TP
 .B --show
-Shows the system's current set of syspurpose preference. This is output in the form of a blob of json. Single-valued entries for which there is no value will be included in the output with a value of "". List entries which have no value will be included in the output with a value of "[]" (less the quotes).
+Shows the system's current set of syspurpose preference formatted as JSON. Single-valued entries for which there is no value will be included in the output with a value of "". List entries which have no value will be included in the output with a value of "[]" (less the quotes).
 
 
 .SS ADDONS OPTIONS


### PR DESCRIPTION
Spell "JSON" properly, and simplify the wording about it.