### PR TITLE
Remove extra '%' in string

### DIFF
--- a/src/subscription_manager/cli_command/config.py
+++ b/src/subscription_manager/cli_command/config.py
@@ -39,7 +39,7 @@ class ConfigCommand(CliCommand):
                 # Allow adding CLI options only for sections and names listed in defaults
                 if s in rhsm.config.DEFAULTS and name in rhsm.config.DEFAULTS[s]:
                     self.parser.add_option("--" + s + "." + name, dest=(s + "." + name),
-                                           help=_("Section: {s}, Name: %{name}").format(s=s, name=name))
+                                           help=_("Section: {s}, Name: {name}").format(s=s, name=name))
 
     def _validate_options(self):
         if self.options.list:


### PR DESCRIPTION
Accidentally introduced with the refactoring of managercli.py, i.e.
commit 9a9b37c24f4d1fbe7acc69829f52b8bf082544fa