### PR TITLE
To delete a deb repo the repo-id is required

### DIFF
--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -435,8 +435,8 @@ if HAS_DEB822:
             repo_dict['id'] = repo.id
             self.repos822.append(Deb822(repo_dict))
 
-        def delete(self, repo):
-            self.repos822[:] = [repo822 for repo822 in self.repos822 if repo822['id'] != repo.id]
+        def delete(self, repo_id):
+            self.repos822[:] = [repo822 for repo822 in self.repos822 if repo822['id'] != repo_id]
 
         def update(self, repo):
             repo_dict = dict([(str(k), str(v)) for (k, v) in repo.items()])
@@ -451,7 +451,7 @@ if HAS_DEB822:
                 return None
 
         def sections(self):
-            return [Repo(repo822) for repo822 in self.repos822]
+            return [repo822['id'] for repo822 in self.repos822]
 
         def fix_content(self, content):
             # Luckily apt ignores all Fields it does not recognize


### PR DESCRIPTION
In repolib the sections() method is used to find out which repositories
should be deleted. Because of the missing repo-id, removed subscriptions
will not be cleared and the repository sources list does list already
deleted repositories. 

In particular, the key fact is that, since AptRepoFile does not inherit from ConfigParser unlike YumRepoFile, then it has to provide behaviour-compatibile ConfigParser APIs. Hence, sections() must returns a list of (string) sections and not a list of Repo objects, and delete() must take a string with the section to remove and not a Repo object.