### PR TITLE
ENT-2779: call format() on translated string

### DIFF
--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -313,8 +313,8 @@ class AbstractSyspurposeCommand(CliCommand):
         if syspurpose is not None and self.attr in syspurpose and syspurpose[self.attr]:
             val = syspurpose[self.attr]
             values = val if not isinstance(val, list) else ", ".join(val)
-            print(_("Current {name}: {val}".format(name=self.name.capitalize(),
-                                                   val=values)))
+            print(_("Current {name}: {val}").format(name=self.name.capitalize(),
+                                                    val=values))
         else:
             print(_("{name} not set.").format(name=self.name.capitalize()))
 


### PR DESCRIPTION
Replace the placeholders in the translated string rather than the
English string, as the English string with replacements cannot be
translated.

RHBZ: 1663390, 1663402, 1663429
Card ID: ENT-2779