### PR TITLE
[1.28] 1930037: cockpit: ensure /etc/pki/product exist

### DIFF
--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -129,6 +129,7 @@ class SubscriptionsCase(MachineCase):
             self.candlepin.download("/home/admin/candlepin/generated_certs/%s.pem" % prod_id, filename)
             m.upload([filename], "/etc/pki/product")
 
+        m.execute("mkdir -p /etc/pki/product")
         download_product(PRODUCT_SNOWY)
         download_product(PRODUCT_SHARED)
 


### PR DESCRIPTION
Make sure that /etc/pki/product exist before copying certificates into
it, as minimal/KVM RHEL images do not have /etc/pki/product.

Card ID: ENT-3683

(cherry picked from commit 2c178d5b9dce848fd2d8d8df6223994e873a8973)