### PR TITLE
1886772: Clear content access mode cache on refresh

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -484,7 +484,9 @@ The
 .B refresh
 command pulls the latest subscription data from the server. Normally, the system polls the subscription management service at a set interval (4 hours by default) to check for any changes in the available subscriptions. The
 .B refresh
-command checks with the subscription management service right then, outside the normal interval.
+command checks with the subscription management service right then, outside the normal interval. Use of the
+.B refresh
+command will clear caches related to the content access mode of the system and allow the system to retrieve fresh data as necessary.
 
 .TP
 .B --force

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -95,6 +95,9 @@ class CacheManager(object):
     def _cache_exists(self):
         return os.path.exists(self.CACHE_FILE)
 
+    def exists(self):
+        return self._cache_exists()
+
     def write_cache(self, debug=True):
         """
         Write the current cache to disk. Should only be done after

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -862,6 +862,11 @@ class RefreshCommand(CliCommand):
             if content_access.exists():
                 content_access.remove()
 
+            # Also remove the content access mode cache to be sure we display
+            # SCA or regular mode correctly
+            content_access_mode = inj.require(inj.CONTENT_ACCESS_MODE_CACHE)
+            if content_access_mode.exists():
+                content_access_mode.delete_cache()
             if self.options.force is True:
                 # get current consumer identity
                 consumer_identity = inj.require(inj.IDENTITY)

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -20,9 +20,11 @@ import six
 
 from subscription_manager import syspurposelib
 from subscription_manager import managercli, managerlib
+from subscription_manager.cache import ContentAccessCache, \
+    ContentAccessModeCache
 from subscription_manager.entcertlib import CONTENT_ACCESS_CERT_TYPE
 from subscription_manager.injection import provide, \
-        CERT_SORTER, PROD_DIR
+        CERT_SORTER, PROD_DIR, CONTENT_ACCESS_CACHE, CONTENT_ACCESS_MODE_CACHE
 from rhsmlib.services.products import InstalledProducts
 from subscription_manager.managercli import AVAILABLE_SUBS_MATCH_COLUMNS
 from subscription_manager.printing_utils import format_name, columnize, \
@@ -407,6 +409,31 @@ class TestRefreshCommand(TestCliProxyCommand):
 
     def test_force_option(self):
         self.cc.main(["--force"])
+
+
+class TestRefreshCommandWithDoCommand(SubManFixture):
+    command_class = managercli.RefreshCommand
+
+    def setUp(self):
+        super(TestRefreshCommandWithDoCommand, self).setUp()
+        self.cc = self.command_class()
+
+    def test_cache_removed(self):
+        # lots of mocking basically to show that the injected content access
+        # cache and content access mode caches are cleared on each run of the
+        # refresh command
+        self.cc.assert_should_be_registered = Mock(return_value=True)
+        mock_content_access_cache = Mock(spec=ContentAccessCache)
+        mock_content_access_cache.return_value.exists.return_value = True
+        provide(CONTENT_ACCESS_CACHE, mock_content_access_cache)
+        mock_content_access_mode_cache = Mock(spec=ContentAccessModeCache)
+        mock_content_access_mode_cache.return_value.exists.return_value = True
+        provide(CONTENT_ACCESS_MODE_CACHE, mock_content_access_mode_cache)
+        self.cc.main([""])
+        mock_content_access_cache.return_value.remove.assert_called_once()
+        mock_content_access_mode_cache.return_value.delete_cache.assert_called_once()
+        mock_content_access_cache.return_value.exists.assert_called_once()
+        mock_content_access_mode_cache.return_value.exists.assert_called_once()
 
 
 class TestIdentityCommand(TestCliProxyCommand):


### PR DESCRIPTION
A backport of #2554 to subscription-manager-1.24.