### PR TITLE
[1.28] ENT-2779: call format() on translated string

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -830,8 +830,8 @@ class SyspurposeCommand(CliCommand):
         if syspurpose is not None and self.attr in syspurpose and syspurpose[self.attr]:
             val = syspurpose[self.attr]
             values = val if not isinstance(val, list) else ", ".join(val)
-            print(_("Current {name}: {val}".format(name=self.name.capitalize(),
-                                                   val=values)))
+            print(_("Current {name}: {val}").format(name=self.name.capitalize(),
+                                                    val=values))
         else:
             print(_("{name} not set.").format(name=self.name.capitalize()))
 


### PR DESCRIPTION
Replace the placeholders in the translated string rather than the
English string, as the English string with replacements cannot be
translated.

RHBZ: 1663390, 1663402, 1663429
Card ID: ENT-2779

(cherry picked from commit b5f9bbe8a4e0c8c07fb0a3ed8ad5acff0323b967)

Backport of #2557 to 1.28.