### PR TITLE
ENT-3758: RHEL 8.5 Cherry pick Requests

### DIFF
--- a/syspurpose/man/syspurpose.8
+++ b/syspurpose/man/syspurpose.8
@@ -21,6 +21,9 @@ The \fIset\fP, \fIunset\fP, \fIadd\fP, and \fIremove\fP commands modify the
 local system purpose, and when possible will report the updated settings to the
 Red Hat subscription management entitlement server (Customer Portal or Satellite
 6).  The \fIshow\fP command displays the current system purpose.
+.PP
+The 'syspurpose' command is deprecated and will be removed in a future major release. 
+Please use the 'subscription-manager syspurpose' command going forward.
 
 .SH COMMANDS
 .TP

--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -154,7 +154,9 @@ def setup_arg_parser():
     Sets up argument parsing for the syspurpose tool.
     :return: An argparse.ArgumentParser ready to use to parse_args
     """
-    parser = argparse.ArgumentParser(prog="syspurpose", description="System Syspurpose Management Tool")
+    parser = argparse.ArgumentParser(prog="syspurpose", description="System Syspurpose Management Tool",
+                                     epilog=_("The 'syspurpose' command is deprecated and will be removed in a future major release."
+                                                " Please use the 'subscription-manager syspurpose' command going forward."))
 
     subparsers = parser.add_subparsers(help="sub-command help")
 
@@ -348,6 +350,8 @@ def main():
         print(_("WARNING: Setting syspurpose in containers has no effect.\n"
               "Please run syspurpose on the host.\n"))
 
+    print(_("The 'syspurpose' command is deprecated and will be removed in a future major release."
+        " Please use the 'subscription-manager syspurpose' command going forward."), file=sys.stderr)
     try:
         from subscription_manager.identity import Identity
         from subscription_manager.cp_provider import CPProvider


### PR DESCRIPTION
Backported [62f4ee8](https://github.com/candlepin/subscription-manager/commit/911221395339566890e6b5d049d3d8158a5eaf3e) Warning message about the Depreciation of Syspurpose

Also Backported: [9a9b37c](https://github.com/candlepin/subscription-manager/commit/a36e10ff9afb50ae7fa2f586cac45435f42cf8a8)
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1928072
When SCA mode is used for selected organization, then do
not try to do auto-attach at all and print info message
We use the same message as is already used for
command attach --auto
Implemented this functionality, because old message was
generated by candlepin server. Look at following candlepin PR:
candlepin/candlepin#2947