### PR TITLE
[1.28] 1878736: use our i18n functions instead of dnf ones

### DIFF
--- a/src/dnf-plugins/product-id.py
+++ b/src/dnf-plugins/product-id.py
@@ -20,9 +20,10 @@ import logging
 from subscription_manager.productid import ProductManager
 from subscription_manager.utils import chroot
 from subscription_manager.injectioninit import init_dep_injection
+from subscription_manager.i18n import ugettext as _
 from rhsm.certificate import create_from_pem
 
-from dnfpluginscore import _, logger
+from dnfpluginscore import logger
 import dnf
 import dnf.base
 import dnf.sack

--- a/src/dnf-plugins/subscription-manager.py
+++ b/src/dnf-plugins/subscription-manager.py
@@ -26,10 +26,11 @@ from subscription_manager.entcertlib import EntCertActionInvoker
 from rhsmlib.facts.hwprobe import ClassicCheck
 from subscription_manager.utils import chroot, is_simple_content_access
 from subscription_manager.injectioninit import init_dep_injection
+from subscription_manager.i18n import ugettext as _
 from rhsm import logutil
 from rhsm import config
 
-from dnfpluginscore import _, logger
+from dnfpluginscore import logger
 import dnf
 
 if six.PY3:

--- a/src/dnf-plugins/upload-profile.py
+++ b/src/dnf-plugins/upload-profile.py
@@ -21,11 +21,12 @@ packages, enabled repositories, modules).
 """
 
 
-from dnfpluginscore import _, logger
+from dnfpluginscore import logger
 import dnf.cli
 
 from subscription_manager import packageprofilelib
 from subscription_manager.injectioninit import init_dep_injection
+from subscription_manager.i18n import ugettext as _
 
 
 @dnf.plugin.register_command


### PR DESCRIPTION
The messages in the dnf plugins are extracted as part of our rhsm
catalog; hence, use the subscription-manager.i18n module to translate
them, rather than using dnfpluginscore (which uses a different catalog
name).

Card ID: ENT-3076

(cherry picked from commit afd7137264feeffe1fe8d0b1cacb1505a00f9ee5)

Backport of #2565 to 1.28.