### PR TITLE
1956654: Fix issue with proxy and cockpit plugin

### DIFF
--- a/cockpit/src/subscriptions-client.js
+++ b/cockpit/src/subscriptions-client.js
@@ -290,6 +290,13 @@ client.registerSystem = (subscriptionDetails, update_progress) => {
         if (subscriptionDetails.proxy_password) {
             connection_options.proxy_password = dbus_str(subscriptionDetails.proxy_password);
         }
+    } else {
+        // When user decide to not use proxy settings (checkbox "Use proxy server" is not checked),
+        // then set empty strings to all proxy options and do not use values from configuration file
+        connection_options.proxy_hostname = dbus_str('');
+        connection_options.proxy_port = dbus_str('');
+        connection_options.proxy_user = dbus_str('');
+        connection_options.proxy_password = dbus_str('');
     }
 
     console.debug('connection_options:', connection_options);

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -179,18 +179,22 @@ class BaseConnection(object):
         else:
             info = utils.get_env_proxy_info()
 
-            self.proxy_hostname = proxy_hostname or \
-                                  config.get('server', 'proxy_hostname') or \
-                                  info['proxy_hostname']
-            self.proxy_port = proxy_port or \
-                              config.get('server', 'proxy_port') or \
-                              info['proxy_port']
-            self.proxy_user = proxy_user or \
-                              config.get('server', 'proxy_user') or \
-                              info['proxy_username']
-            self.proxy_password = proxy_password or \
-                                  config.get('server', 'proxy_password') or \
-                                  info['proxy_password']
+            if proxy_hostname is not None:
+                self.proxy_hostname = proxy_hostname
+            else:
+                self.proxy_hostname = config.get('server', 'proxy_hostname') or info['proxy_hostname']
+            if proxy_port is not None:
+                self.proxy_port = proxy_port
+            else:
+                self.proxy_port = config.get('server', 'proxy_port') or info['proxy_port']
+            if proxy_user is not None:
+                self.proxy_user = proxy_user
+            else:
+                self.proxy_user = config.get('server', 'proxy_user') or info['proxy_username']
+            if proxy_password is not None:
+                self.proxy_password = proxy_password
+            else:
+                self.proxy_password = config.get('server', 'proxy_password') or info['proxy_password']
 
         self.cert_file = cert_file
         self.key_file = key_file


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1956654
* Originally it was reported in comment in this BZ:
  https://bugzilla.redhat.com/show_bug.cgi?id=1744696#8
* When user decided to not use proxy in cockpit plugin despite
  some proxy settings are set in rhsm.conf, then cockpit
  plugin and rhsm.service still wanted to use proxy settings
  from rhsm.conf. This issue is fixed in this commit
* Added some unit tests
* Fixed few unit tests related to HTTP_PROXY env. var. for the
  case, when some proxy setting is in the /etc/rhsm.rhsm.conf
  on testing machine (unit tests tried to read this
  configuration file)