### PR TITLE
[1.28] 1819555: cockpit: translate untranslatable messages

### DIFF
--- a/cockpit/src/insights.jsx
+++ b/cockpit/src/insights.jsx
@@ -374,12 +374,12 @@ function show_status_dialog() {
                           <table>
                             <tbody>
                               <tr>
-                                <th style={{ textAlign: "right", paddingRight: "1em" }}>Next Insights data upload</th>
+                                <th style={{ textAlign: "right", paddingRight: "1em" }}>{_("Next Insights data upload")}</th>
                                 <td>{next_elapse}</td>
                               </tr>
                               { lastupload ?
                               <tr>
-                                <th style={{ textAlign: "right", paddingRight: "1em" }}>Last Insights data upload</th>
+                                <th style={{ textAlign: "right", paddingRight: "1em" }}>{_("Last Insights data upload")}</th>
                                 <td>{moment(lastupload * 1000).calendar()}</td>
                                </tr> : null
                               }
@@ -543,6 +543,7 @@ export class InsightsStatus extends React.Component {
             status = <a onClick={left(show_connect_dialog)}>{_("Not connected")}</a>;
         }
 
-        return <div><label>Insights: {status}</label></div>;
+        let status_string = arrfmt(_("Insights: $0"), status);
+        return <div><label>{status_string}</label></div>;
     }
 }

--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -222,6 +222,7 @@ class SubscriptionStatus extends React.Component {
             );
         }
 
+        let text;
         let label;
         let action;
         let insights;
@@ -298,12 +299,14 @@ class SubscriptionStatus extends React.Component {
             </div>
         );
         if (this.props.status === 'unknown') {
-            label = <label>{ `${_("Status")}: ${_("This system is currently not registered.")}` }</label>;
+            text = _("Status: This system is currently not registered.");
+            label = <label>{text}</label>;
             action = (<button className="btn btn-primary"
                               onClick={this.handleRegisterSystem}>{_("Register")}</button>
             );
         } else {
-            label = <label>{ `${_("Status")}: ${this.props.status_msg}` }</label>;
+            text = cockpit.format(_("Status: $0"), this.props.status_msg);
+            label = <label>{text}</label>;
             action = (<button className="btn btn-primary" disabled={isUnregistering}
                               onClick={this.handleUnregisterSystem}>{_("Unregister")}</button>
             );


### PR DESCRIPTION
Compose a "Status: <status>" string at once avoiding the string puzzle;
also, simplify the way it composed, and assembled later within <label>
tags. The removal of the `...` markup also fixes the extraction of
messages with xgettext; as it seems its JavaScript parser cannot handle
`...`, and thus all the strings after it are not extracted.

Also, mark few more messages for translation.

Card ID: ENT-2265

(cherry picked from commit c0328bfb773ad26c571fd48597568a7e19f66d3b)

Backport of #2574 to 1.28.