### PR TITLE
[1.28] cockpit: backport CI fixes

### DIFF
--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -340,7 +340,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_not_present(dialog_register_button_sel)
 
         b.click("label:contains('Insights') a:contains('Not connected')")
-        b.wait_present('.modal-body:contains("This system is not connected")')
+        b.wait_visible('.modal-body:contains("This system is not connected")')
         b.click('.modal-footer button.apply')
         with b.wait_timeout(360):
             b.wait_not_present('.modal-dialog')
@@ -348,17 +348,17 @@ class TestSubscriptions(SubscriptionsCase):
         # HACK - this should eventually not be necessary
         m.execute("insights-client --check-results")
 
-        b.wait_present("label:contains('Insights') a[href='http://cloud.redhat.com/insights/inventory/123-nice-id']")
-        b.wait_present("label:contains('Insights') a:contains('3 hits, including important')")
+        b.wait_visible("label:contains('Insights') a[href='http://cloud.redhat.com/insights/inventory/123-nice-id']")
+        b.wait_visible("label:contains('Insights') a:contains('3 hits, including important')")
 
         b.click("label:contains('Insights') a:contains('Connected to Insights')")
-        b.wait_present('.modal-body:contains("Next Insights data upload")')
-        b.wait_present('.modal-body:contains("Last Insights data upload")')
+        b.wait_visible('.modal-body:contains("Next Insights data upload")')
+        b.wait_visible('.modal-body:contains("Last Insights data upload")')
         b.click("a:contains('Disconnect from Insights')")
         b.click("button:contains('Disconnect from Insights')")
         b.wait_not_present('.modal-dialog')
 
-        b.wait_present("label:contains('Insights') a:contains('Not connected')")
+        b.wait_visible("label:contains('Insights') a:contains('Not connected')")
 
     def testSubAndInAndFail(self):
         m = self.machine
@@ -380,16 +380,16 @@ class TestSubscriptions(SubscriptionsCase):
         with b.wait_timeout(360):
             b.wait_not_present(dialog_register_button_sel)
 
-        b.wait_present("label:contains('Insights') a:contains('Connected to Insights')")
+        b.wait_visible("label:contains('Insights') a:contains('Connected to Insights')")
 
         # Break the next upload and expect the warning triangle to tell us about it
         m.execute("mv /etc/insights-client/machine-id /etc/insights-client/machine-id.lost")
         m.execute("systemctl start insights-client")
 
-        b.wait_present("label:contains('Insights') i.pficon-warning-triangle-o")
+        b.wait_visible("label:contains('Insights') i.pficon-warning-triangle-o")
 
         b.click("label:contains('Insights') a:contains('Connected to Insights')")
-        b.wait_present('.modal-body:contains("The last Insights data upload has failed")')
+        b.wait_visible('.modal-body:contains("The last Insights data upload has failed")')
         b.click("button.cancel")
 
         # Unbreak it and retry.
@@ -430,7 +430,7 @@ class TestSubscriptionsPackages(SubscriptionsCase, PackageCase):
         b.set_input_text("#subscription-register-password", "admin")
         b.set_input_text("#subscription-register-org", "admin")
         b.set_checked("#subscription-insights", True)
-        b.wait_present('.modal-body:contains("The insights-client package will be installed")')
+        b.wait_visible('.modal-body:contains("The insights-client package will be installed")')
         b.click('.modal-footer button.apply')
         with b.wait_timeout(360):
             b.wait_not_present(".modal-dialog")
@@ -438,7 +438,7 @@ class TestSubscriptionsPackages(SubscriptionsCase, PackageCase):
         # Connecting to Insights will not have worked because the
         # insights-client binary is not actually there.
 
-        b.wait_present(".alert-danger:contains('not-found')")
+        b.wait_visible(".alert-danger:contains('not-found')")
 
         # Try again with the connection dialog.
 
@@ -447,11 +447,11 @@ class TestSubscriptionsPackages(SubscriptionsCase, PackageCase):
         m.execute("pkcon refresh")
 
         b.click("label:contains('Insights') a:contains('Not connected')")
-        b.wait_present('.modal-body:contains("This system is not connected")')
-        b.wait_present('.modal-body:contains("The insights-client package will be installed")')
+        b.wait_visible('.modal-body:contains("This system is not connected")')
+        b.wait_visible('.modal-body:contains("The insights-client package will be installed")')
         b.click('.modal-footer button.apply')
         with b.wait_timeout(360):
-            b.wait_present('.modal-footer:contains("not-found")')
+            b.wait_visible('.modal-footer:contains("not-found")')
         b.click('.modal-footer button.cancel')
 
         m.execute("test -f /stamp-insights-client-999-1")

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -151,13 +151,15 @@ class SubscriptionsCase(MachineCase):
 [insights-client]
 gpg=False
 auto_config=False
-base_url=127.0.0.1:8888/r/insights
+base_url=localhost:8888/r/insights
+cert_verify=False
 username=admin
 password=foobar
-insecure_connection=True
 """)
 
         m.upload(["files/mock-insights"], "/var/tmp")
+        # this re-uses cockpit ws certificate, so ensure that it exists
+        m.execute("systemctl start cockpit")
         m.spawn("/var/tmp/mock-insights", "mock-insights")
 
     def wait_subscription(self, product, is_subscribed):

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -120,7 +120,8 @@ class SubscriptionsCase(MachineCase):
         m = self.machine
 
         # wait for candlepin to be active and verify
-        self.candlepin.execute("systemctl start tomcat")
+        # this changed in https://github.com/cockpit-project/bots/pull/1768
+        self.candlepin.execute("if [ -x /root/run-candlepin ]; then /root/run-candlepin; else systemctl start tomcat; fi")
 
         # download product info from the candlepin machine
         def download_product(product):

--- a/integration-tests/run
+++ b/integration-tests/run
@@ -70,7 +70,7 @@ bots:
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time
 integration-test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 220
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 236
 	git archive FETCH_HEAD -- test/common | tar -x -C integration-tests --strip-components=1 -f -
 
 node_modules:

--- a/test/files/mock-insights
+++ b/test/files/mock-insights
@@ -20,8 +20,10 @@
 from http.server import *
 import json
 import re
+import ssl
 
-systems = { }
+systems = {}
+
 
 class handler(BaseHTTPRequestHandler):
     def match(self, p):
@@ -134,7 +136,11 @@ class handler(BaseHTTPRequestHandler):
         self.send_response(404)
         self.end_headers()
 
+
 def insights_server(port):
-    HTTPServer(('', port), handler).serve_forever()
+    httpd = HTTPServer(('', port), handler)
+    httpd.socket = ssl.wrap_socket(httpd.socket, certfile='/etc/cockpit/ws-certs.d/0-self-signed.cert', server_side=True)
+    httpd.serve_forever()
+
 
 insights_server(8888)


### PR DESCRIPTION
Backport of #2504, #2408, and #2586 to 1.28 to fix (and then enable) the cockpit CI.