### PR TITLE
cockpit: Enable TLS for mock insights server

### DIFF
--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -151,13 +151,15 @@ class SubscriptionsCase(MachineCase):
 [insights-client]
 gpg=False
 auto_config=False
-base_url=127.0.0.1:8888/r/insights
+base_url=localhost:8888/r/insights
+cert_verify=False
 username=admin
 password=foobar
-insecure_connection=True
 """)
 
         m.upload(["files/mock-insights"], "/var/tmp")
+        # this re-uses cockpit ws certificate, so ensure that it exists
+        m.execute("systemctl start cockpit")
         m.spawn("/var/tmp/mock-insights", "mock-insights")
 
     def wait_subscription(self, product, is_subscribed):

--- a/test/files/mock-insights
+++ b/test/files/mock-insights
@@ -20,8 +20,10 @@
 from http.server import *
 import json
 import re
+import ssl
 
-systems = { }
+systems = {}
+
 
 class handler(BaseHTTPRequestHandler):
     def match(self, p):
@@ -134,7 +136,11 @@ class handler(BaseHTTPRequestHandler):
         self.send_response(404)
         self.end_headers()
 
+
 def insights_server(port):
-    HTTPServer(('', port), handler).serve_forever()
+    httpd = HTTPServer(('', port), handler)
+    httpd.socket = ssl.wrap_socket(httpd.socket, certfile='/etc/cockpit/ws-certs.d/0-self-signed.cert', server_side=True)
+    httpd.serve_forever()
+
 
 insights_server(8888)


### PR DESCRIPTION
insights-client 3.0.217-1 dropped the `insecure_connection` option and
only accepts TLS. Change mock-insights to serve TLS. Re-use
cockpit-ws' certificate for that -- we have the key available, it
has the right properties (such as applying to localhost), and reliably
exists in the test environment.

Disable certificate verification, as apparently there is no way to
convince the later stages of insights-client to accept a locally added
CA.

-----

See the lengthy debugging in https://github.com/cockpit-project/bots/pull/1921 for some background. This blocks the [RHEL 8.4 image refresh](https://github.com/cockpit-project/bots/pull/1923), and will also fix your tests for 8.5.