### PR TITLE
1951053: Fix issue with dnf/yum variables

### DIFF
--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -83,6 +83,9 @@ class ModulesProfile(object):
         module_list = []
         if dnf is not None and libdnf is not None:
             base = dnf.Base()
+            # Read yum/dnf variables from <install_root>/etc/yum/vars and <install_root>/etc/dnf/vars
+            # See: https://bugzilla.redhat.com/show_bug.cgi?id=1863039
+            base.conf.substitutions.update_from_etc(base.conf.installroot)
             base.read_all_repos()
             try:
                 base.fill_sack()


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1951053
* Card ID: ENT-2809
* When dnf/yum variable is created in /etc/dnf/vars or
  /etc/yum/vars using echo "foo" > /etc/dnf/vars/variable,
  then this variable is used by dnf plugin uploadprofile
* It is not possible to create unit tests for this case
  and it is also not possible to create functional tests,
  because non-root user cannot run such functional test
* PR for RHEL8.4. Original PR: #2569

(cherry picked from commit 2cd76421c9dfee334e0ef555df96263390918445)