### PR TITLE
Add subscription-manager dependency to apt-katello-transport

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -14,7 +14,7 @@ X-Python3-Version: >= 3.2
 
 Package: python-subscription-manager
 Architecture: amd64
-Depends: ${python:Depends}, ${misc:Depends}, python-dbus, python-rpm, virt-what, python-debian, python-gobject, python-decorator
+Depends: ${python:Depends}, ${misc:Depends}, python-dbus, python-rpm, virt-what, python-debian, python-gobject, python-decorator, apt-transport-katello (>= ${source:Version})
 Suggests: python-subscription-manager-doc
 Description: RHSM subscription-manager (Python 2)
  .


### PR DESCRIPTION
Add a dependency to the subscription-manager package for Debian and
Ubuntu to depend on apt-transport-katello which is necessary to receive content from Foreman.

This PR is a reaction to the following community feedback: 

> to be able to use the repository on the foreman host the package apt-transport-katello is also needed, could this package be a part of the dependencies when installing python3-subscription-manager?

See [Foreman Community Forum](https://community.theforeman.org/t/ubuntu-client/22691/4?u=maximilian)