### PR TITLE
Add ability to search for a cert by product name

### DIFF
--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -330,6 +330,23 @@ class EntitlementDirectory(CertificateDirectory):
                     entitlements.append(cert)
         return entitlements
 
+    def list_for_product_name(self, product_name, case_sensitive=True):
+        """
+        Returns all entitlement certificates providing access to the given
+        product by name.
+        """
+        entitlements = []
+        for cert in self.list():
+            for cert_product in cert.products:
+                if case_sensitive is True:
+                    if product_name == cert_product.name:
+                        entitlements.append(cert)
+                else:
+                    if product_name.casefold() == cert_product.name.casefold():
+                        entitlements.append(cert)
+
+        return entitlements
+
     def list_for_pool_id(self, pool_id):
         """
         Returns all entitlement certificates provided by the given

--- a/test/test_certdirectory.py
+++ b/test/test_certdirectory.py
@@ -207,6 +207,7 @@ class EntitlementDirectoryWithCertsTest(DirectoryWithCertsTest):
 
         mock_product = MagicMock()
         mock_product.id = '123456789'
+        mock_product.name = 'product1'
 
         self.mock_cert = MagicMock()
         self.mock_cert.serial = '37'
@@ -260,6 +261,14 @@ class EntitlementDirectoryWithCertsTest(DirectoryWithCertsTest):
     def test_list_for_product_match(self):
         res = self.d.list_for_product('123456789')
         self.assertTrue(isinstance(res, list))
+
+    def test_list_for_product_name(self):
+        res = self.d.list_for_product_name('product1')
+        self.assertIsInstance(res, list)
+
+    def test_list_for_product_name_case(self):
+        res = self.d.list_for_product_name('proDUCT1', case_sensitive=False)
+        self.assertIsInstance(res, list)
 
 
 class ProductCertificateDirectoryTest(DirectoryTest):


### PR DESCRIPTION
I'm looking at using the certs pulled down for a `file` repo (provided by sat6 -> pulp).  Since I'm not in control of my product IDs (they get created up there), I added a way to find my certs by Product Name.

This will let me do something like:

```python
import subscription_manager.certdirectory
ent_cert_dir = subscription_manager.certdirectory.EntitlementDirectory()
ent_cert_dir.list_for_product_name('My Product')
```

To find the cert for use.