### PR TITLE
[Cherry pick to 8.5] Bug 1879856 - Warning message shouldnot be displayed when user tries to set valid syspurpose attributes with random case

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -741,7 +741,7 @@ class SyspurposeCommand(CliCommand):
         valid_fields = self._get_valid_fields()
         if self.attr in valid_fields:
             for value in values:
-                if value not in valid_fields[self.attr]:
+                if all([x.casefold() != value.casefold() for x in valid_fields[self.attr]]):
                     invalid_values.append(value)
         invalid_values_len = len(invalid_values)
 

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1947,6 +1947,13 @@ class TestRoleCommand(TestCliProxyCommand):
         instance_syspurpose_store.unset.assert_called_once_with('role')
         instance_syspurpose_store.sync.assert_called_once()
 
+    def test_is_provided_value_valid(self):
+        self.cc = managercli.SyspurposeCommand("role", shortdesc="role", primary=False, attr="role")
+        self.cc._get_valid_fields = Mock()
+        self.cc._get_valid_fields.return_value = {"role": ["Welcome to the Machine"]}
+        res = self.cc._is_provided_value_valid("wElcOme To The mAChiNE")
+        self.assertTrue(res)
+
 
 class TestVersionCommand(TestCliCommand):
     command_class = managercli.VersionCommand


### PR DESCRIPTION
porting fix to subscription-manager-1.28