### PR TITLE
1952228: fix formatting of log error messages

### DIFF
--- a/src/subscription_manager/cli_command/environments.py
+++ b/src/subscription_manager/cli_command/environments.py
@@ -70,7 +70,7 @@ class EnvironmentsCommand(OrgCommand):
             log.debug("Successfully retrieved environment list from server.")
         except connection.RestlibException as re:
             log.exception(re)
-            log.error(u"Error: Unable to retrieve environment list from server: {re}").format(re=re)
+            log.error("Error: Unable to retrieve environment list from server: {re}".format(re=re))
             system_exit(os.EX_SOFTWARE, str(re))
         except Exception as e:
             handle_exception(_("Error: Unable to retrieve environment list from server"), e)

--- a/src/subscription_manager/cli_command/identity.py
+++ b/src/subscription_manager/cli_command/identity.py
@@ -115,7 +115,7 @@ class IdentityCommand(UserPassCommand):
             raise ge
         except connection.RestlibException as re:
             log.exception(re)
-            log.error(u"Error: Unable to generate a new identity for the system: {re}").format(re=re)
+            log.error("Error: Unable to generate a new identity for the system: {re}".format(re=re))
             system_exit(os.EX_SOFTWARE, str(re))
         except Exception as e:
             handle_exception(_("Error: Unable to generate a new identity for the system"), e)

--- a/src/subscription_manager/cli_command/owners.py
+++ b/src/subscription_manager/cli_command/owners.py
@@ -62,7 +62,7 @@ class OwnersCommand(UserPassCommand):
 
         except connection.RestlibException as re:
             log.exception(re)
-            log.error(u"Error: Unable to retrieve org list from server: {re}").format(re=re)
+            log.error("Error: Unable to retrieve org list from server: {re}".format(re=re))
             system_exit(os.EX_SOFTWARE, str(re))
         except Exception as e:
             handle_exception(_("Error: Unable to retrieve org list from server"), e)


### PR DESCRIPTION
Call `format()` on the strings, not on the return value of `log.error()` (which is `None`).