### PR TITLE
1950015: fix typos in syspurpose(8)

### DIFF
--- a/syspurpose/man/syspurpose.8
+++ b/syspurpose/man/syspurpose.8
@@ -72,11 +72,11 @@ Add value(s) to a specific list property. E.g. \fB"syspurpose add addons foo
 bar"\fP is identical to \fB"syspurpose add-addons foo bar"\fP.
 .TP
 \fBsyspurpose remove \fIPROPERTY\fP \fIVALUE\fP\fP
-Clear value(s) from a specific list property. E.g. \fBsyspurpose remove addons
-foo bar\fP is identical to \fBsyspurpose remove-addons foo bar\fP.
+Clear value(s) from a specific list property. E.g. \fB"syspurpose remove addons
+foo bar"\fP is identical to \fB"syspurpose remove-addons foo bar"\fP.
 .TP
 \fBsyspurpose unset \fIPROPERTY\fP \fIVALUE\fP\fP
-Clear set addons. E.g. \fBsyspurpose unset addons \fP is identical to \fBsyspurpose unset-addons\fP.
+Clear set addons. E.g. \fB"syspurpose unset addons"\fP is identical to \fB"syspurpose unset-addons"\fP.
 
 Only "addons" acts as a list property.  The other properties only accept a
 single value.
@@ -88,11 +88,11 @@ Display a summary of the available commands
 
 .SH EXAMPLES
 .TP
-\fBsyspurpose set-role "RHEL Server"\fP
-Indicate that this system should consume a RHEL Server subscription:
+\fBsyspurpose set-role "Red Hat Enterprise Linux Server"\fP
+Indicate that this system should consume a RHEL Server subscription.
 .TP
 \fBsyspurpose unset-role\fP
-Clear a previously set role
+Clear a previously set role.
 
 .SH BUGS
 This tool is part of Red Hat Subscription Manager. To file bugs against this


### PR DESCRIPTION
- enclose commands within double quotes
- fix value of the example role to something more actual
- end sentences with period