### PR TITLE
1952879: extract messages from argparse instead of optparse

### DIFF
--- a/build_ext/build_ext/i18n.py
+++ b/build_ext/build_ext/i18n.py
@@ -213,15 +213,15 @@ class Gettext(BaseCommand):
         shutil.rmtree('tmp')
 
 
-class GettextWithOptParse(Gettext):
+class GettextWithArgparse(Gettext):
     def find_py(self):
         # Can't use super since we're descended from a old-style class
         files = Gettext.find_py(self)
 
-        # We need to grab some strings out of optparse for translation
-        import optparse
-        optparse_source = "%s.py" % os.path.splitext(optparse.__file__)[0]
-        if not os.path.exists(optparse_source):
-            raise RuntimeError("Could not find optparse.py at %s" % optparse_source)
-        files.append(optparse_source)
+        # We need to grab some strings out of argparse for translation
+        import argparse
+        argparse_source = "%s.py" % os.path.splitext(argparse.__file__)[0]
+        if not os.path.exists(argparse_source):
+            raise RuntimeError("Could not find argparse.py at %s" % argparse_source)
+        files.append(argparse_source)
         return files

--- a/setup.py
+++ b/setup.py
@@ -355,17 +355,17 @@ class install_data(_install_data):
             self.data_files.append((icon_dir, icon_source_files))
 
 
-class GettextWithOptParse(i18n.Gettext):
+class GettextWithArgparse(i18n.Gettext):
     def find_py(self):
         # Can't use super since we're descended from a old-style class
         files = i18n.Gettext.find_py(self)
 
-        # We need to grab some strings out of optparse for translation
-        import optparse
-        optparse_source = "%s.py" % os.path.splitext(optparse.__file__)[0]
-        if not os.path.exists(optparse_source):
-            raise RuntimeError("Could not find optparse.py at %s" % optparse_source)
-        files.append(optparse_source)
+        # We need to grab some strings out of argparse for translation
+        import argparse
+        argparse_source = "%s.py" % os.path.splitext(argparse.__file__)[0]
+        if not os.path.exists(argparse_source):
+            raise RuntimeError("Could not find argparse.py at %s" % argparse_source)
+        files.append(argparse_source)
         return files
 
 
@@ -400,7 +400,7 @@ cmdclass = {
     'build_template': template.BuildTemplate,
     'update_trans': i18n.UpdateTrans,
     'uniq_trans': i18n.UniqTrans,
-    'gettext': GettextWithOptParse,
+    'gettext': GettextWithArgparse,
     'lint': lint.Lint,
     'lint_glade': lint.GladeLint,
     'lint_rpm': lint.RpmLint,


### PR DESCRIPTION
Since we recently switched from optparse to argparse, we need to extract
the translatable messages in Python's argparse, rather than optparse.

Followup of commit eef1bb13f8924af9539f98330465c110f2df92b5.