### PR TITLE
1953069: bash: fix listing of config options

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -100,7 +100,7 @@ _subscription_manager_clean()
 _subscription_manager_config()
 {
   # TODO: we could probably generate the options from the help
-  CONFIG_OPTS=$(LANG=C subscription-manager config --help | sed -ne "s|\s*\(\-\-.*\..*\)\=.*\..*|\1|p")
+  CONFIG_OPTS=$(LANG=C subscription-manager config --help | sed -ne "s|\s*\(\-\-.*\..*\)\s.*|\1|p")
   local opts="--list --remove
               ${CONFIG_OPTS}
               -h --help"


### PR DESCRIPTION
Adapt the sed regexp scraping the help text of config after the switch
from optparse to argparse. In particular, the help text for options with
arguments changed from "--foo=VALUE" to "--foo VALUE".