### PR TITLE
Cleanup old *.egg-info dirs in %post

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1396,9 +1396,6 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 
 %pre
 
-# Remove old *.egg-info empty directories not removed be previous versions of RPMs
-# due to this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1927245
-rmdir %{python_sitearch}/subscription_manager-*-*.egg-info 2> /dev/null || true
 
 %if %use_systemd
     %if 0%{?suse_version}
@@ -1501,6 +1498,11 @@ fi
         %insserv_cleanup %{_initrddir}/rhsmcertd
     %endif
 %endif
+
+%posttrans
+# Remove old *.egg-info empty directories not removed be previous versions of RPMs
+# due to this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1927245
+rmdir %{python_sitearch}/subscription_manager-*-*.egg-info --ignore-fail-on-non-empty
 
 %if %{use_subman_gui}
 %postun -n subscription-manager-gui


### PR DESCRIPTION
This moves the deletion/cleanup of old subman egg.info directories from %post (which was too early) to %posttrans which is after the uninstall of the old package. (Thanks Pino and Will)