### PR TITLE
Slightly improve our container detection

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -105,16 +105,21 @@ DEFAULTS = {
 def in_container():
     """
     Are we running in a docker container or not?
-
-    Assumes that if we see host rhsm configuration shared with us, we must
-    be running in a container.
     """
     # For development in containers we must be able to turn container detection
     # off
     if os.environ.get('SMDEV_CONTAINER_OFF', False):
         return False
-    if os.path.exists(HOST_CONFIG_DIR):
-        return True
+    # Known locations to check for as an easy way to detect whether
+    # we are running in a container
+    locations = [
+        # The host rhsm configuration was shared with us, so assume
+        # we must be running in a container
+        HOST_CONFIG_DIR,
+    ]
+    for fn in locations:
+        if os.path.exists(fn):
+            return True
     return False
 
 

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -113,6 +113,13 @@ def in_container():
     # Known locations to check for as an easy way to detect whether
     # we are running in a container
     locations = [
+        # podman:
+        # https://github.com/containers/podman/issues/6192
+        # https://github.com/containers/podman/issues/3586#issuecomment-661918679
+        '/run/.containerenv',
+        # docker:
+        # https://github.com/moby/moby/issues/18355
+        '/.dockerenv',
         # The host rhsm configuration was shared with us, so assume
         # we must be running in a container
         HOST_CONFIG_DIR,


### PR DESCRIPTION
Assuming that a particualr directory was mounted in a container is not a strong way to detect whether we are running in a container. Check for well-known files of podman and docker first.