### PR TITLE
1637083: remove the unset PROPERTY VALUE from the Generic Commands

### DIFF
--- a/syspurpose/man/syspurpose.8
+++ b/syspurpose/man/syspurpose.8
@@ -74,9 +74,6 @@ bar"\fP is identical to \fB"syspurpose add-addons foo bar"\fP.
 \fBsyspurpose remove \fIPROPERTY\fP \fIVALUE\fP\fP
 Clear value(s) from a specific list property. E.g. \fB"syspurpose remove addons
 foo bar"\fP is identical to \fB"syspurpose remove-addons foo bar"\fP.
-.TP
-\fBsyspurpose unset \fIPROPERTY\fP \fIVALUE\fP\fP
-Clear set addons. E.g. \fB"syspurpose unset addons"\fP is identical to \fB"syspurpose unset-addons"\fP.
 
 Only "addons" acts as a list property.  The other properties only accept a
 single value.


### PR DESCRIPTION
Incorrectly added a section to the Generic Commands.  Removed in this PR.