### PR TITLE
1672805: 'Addons' is failing spell check and should be changed to 'Ad…

### DIFF
--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -268,7 +268,7 @@ class SubscriptionStatus extends React.Component {
             add_ons = (
                 <div>
                     <label>
-                        { _("Addons:  ") }
+                        { _("Add-ons:  ") }
                         <span className="value">
                             { _(String(subscriptionsClient.toArray(this.props.syspurpose["addons"]).join(", "))) }
                         </span>


### PR DESCRIPTION
…d-ons' to match documentation

Cherry-picked to subscription-manager-1.28