### PR TITLE
cockpit: Lower cockpit-ws dependency to Recommends

### DIFF
--- a/etc-conf/subscription-manager-cockpit.desktop.in
+++ b/etc-conf/subscription-manager-cockpit.desktop.in
@@ -2,6 +2,7 @@
 _Name=Red Hat Subscription Manager
 Icon=subscription-manager
 Type=Application
+TryExec=/usr/libexec/cockpit-desktop
 Exec=/usr/libexec/cockpit-desktop /cockpit/@localhost/subscriptions/index.html
 Terminal=false
 Categories=System;X-Red-Hat-Base;

--- a/integration-tests/vm.install
+++ b/integration-tests/vm.install
@@ -1,11 +1,7 @@
 #!/bin/sh
 set -eux
 
-if [ ! -f /usr/libexec/cockpit-ws ]; then
-    dnf install -y cockpit
-fi
-
-dnf install -y python3-devel openssl-devel intltool
+dnf install -y cockpit-ws python3-devel openssl-devel intltool
 
 cd /var/tmp
 

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -763,8 +763,9 @@ BuildArch: noarch
 Requires: subscription-manager
 Requires: cockpit-bridge
 Requires: cockpit-shell
-Requires: cockpit-ws
 Requires: rhsm-icons
+# Used by desktop UI, but not necessary for web UI
+Recommends: cockpit-ws
 
 %description -n subscription-manager-cockpit
 Subscription Manager Cockpit UI


### PR DESCRIPTION
Cockpit web UI pages should not depend on the cockpit web server. It is
perfectly reasonable and often desirable to not run the web server on a
managed machine, and log in through the host switcher and SSH instead.

However, in this case the dependency is there because of the cockpit
desktop integration. We mostly care about the default OS installation
there, so lower it to Recommends (which are installed by default) and
guard the .desktop file with a `TryExec=`.

 - [x] blocks on rhel-8.4 repo fix: https://github.com/cockpit-project/bots/pull/1984