### PR TITLE
1951057: Cherry Pick to Add in memory read of cache, delete SCA cert with not needed.

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -629,7 +629,9 @@ The
 .B refresh
 command pulls the latest subscription data from the server. Normally, the system polls the subscription management service at a set interval (4 hours by default) to check for any changes in the available subscriptions. The
 .B refresh
-command checks with the subscription management service right then, outside the normal interval.
+command checks with the subscription management service right then, outside the normal interval. Use of the
+.B refresh
+command will clear caches related to the content access mode of the system and allow the system to retrieve fresh data as necessary.
 
 .TP
 .B --force

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -20,6 +20,7 @@ Classes here track various information last sent to the server, compare
 this with the current state, and perform an update on the server if
 necessary.
 """
+import copy
 import logging
 import os
 import socket
@@ -189,6 +190,86 @@ class CacheManager(object):
         else:
             log.debug("No changes.")
             return 0  # No updates performed.
+
+
+class InMemoryCache(object):
+    """
+    Store, in-memory only, some values in a thread-safe way.
+    """
+
+    def __init__(self):
+        self._cache = {}
+        self._lock = threading.RLock()
+
+    def __enter__(self):
+        """
+        Allow this cache object to be used as a context manager.
+        This only acquires the lock. The lock will be released in __exit__.
+        :return:
+        """
+        self._lock.acquire()
+        log.debug("{self}: lock acquired".format(self=self))
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Release the lock on exit
+        :param exc_type:
+        :param exc_val:
+        :param exc_tb:
+        :return:
+        """
+        self._lock.release()
+        log.debug("{self}: lock released".format(self=self))
+
+    def write_cache(self, key, data):
+        """
+        Overwrite the contents of the cache with data.
+        :param data: the contents
+        :return:
+        """
+        self._lock.acquire()
+        self._cache[key] = copy.deepcopy(data)
+        self._lock.release()
+        return copy.deepcopy(self._safe_get(key))
+
+    def read_cache_only(self, key=None):
+        """
+        Return the contents of the cache
+        :return:
+        """
+        self._lock.acquire()
+        if key is not None:
+            data = copy.deepcopy(self._safe_get(key))
+        else:
+            data = copy.deepcopy(self._cache)
+        self._lock.release()
+        return data
+
+    def _safe_get(self, key):
+        """
+        Try to read the key from the _cache dict, this could fail if the _cache is some how
+        modified to something that doesn't have a "get" method
+        :param key:
+        :return:
+        """
+        try:
+            data = self._cache.get(key, None)
+            return data
+        except AttributeError:
+            log.debug('Looks like the _cache was modified by something else, it was not a dict')
+            return None
+
+
+class ReadThroughInMemoryCache(InMemoryCache):
+    """
+    A thread-safe in-memory cache that will retrieve values from an underlying source on a cache
+    miss
+    """
+    def read(self, key, on_cache_miss):
+        data = self.read_cache_only(key=key)
+        if data is None:
+            data = self.write_cache(key, on_cache_miss())
+        return data
 
 
 class StatusCache(CacheManager):
@@ -1004,7 +1085,6 @@ class SupportedResourcesCache(ConsumerCache):
     CACHE_FILE = "/var/lib/rhsm/cache/supported_resources.json"
 
     DEFAULT_VALUE = []
-
     # We will try to get new list of supported resources at leas once a day
     TIMEOUT = 60 * 60 * 24
 

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -97,6 +97,9 @@ class CacheManager(object):
     def _cache_exists(self):
         return os.path.exists(self.CACHE_FILE)
 
+    def exists(self):
+        return self._cache_exists()
+
     def write_cache(self, debug=True):
         """
         Write the current cache to disk. Should only be done after

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -20,7 +20,6 @@ Classes here track various information last sent to the server, compare
 this with the current state, and perform an update on the server if
 necessary.
 """
-import copy
 import logging
 import os
 import socket
@@ -193,86 +192,6 @@ class CacheManager(object):
         else:
             log.debug("No changes.")
             return 0  # No updates performed.
-
-
-class InMemoryCache(object):
-    """
-    Store, in-memory only, some values in a thread-safe way.
-    """
-
-    def __init__(self):
-        self._cache = {}
-        self._lock = threading.RLock()
-
-    def __enter__(self):
-        """
-        Allow this cache object to be used as a context manager.
-        This only acquires the lock. The lock will be released in __exit__.
-        :return:
-        """
-        self._lock.acquire()
-        log.debug("{self}: lock acquired".format(self=self))
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """
-        Release the lock on exit
-        :param exc_type:
-        :param exc_val:
-        :param exc_tb:
-        :return:
-        """
-        self._lock.release()
-        log.debug("{self}: lock released".format(self=self))
-
-    def write_cache(self, key, data):
-        """
-        Overwrite the contents of the cache with data.
-        :param data: the contents
-        :return:
-        """
-        self._lock.acquire()
-        self._cache[key] = copy.deepcopy(data)
-        self._lock.release()
-        return copy.deepcopy(self._safe_get(key))
-
-    def read_cache_only(self, key=None):
-        """
-        Return the contents of the cache
-        :return:
-        """
-        self._lock.acquire()
-        if key is not None:
-            data = copy.deepcopy(self._safe_get(key))
-        else:
-            data = copy.deepcopy(self._cache)
-        self._lock.release()
-        return data
-
-    def _safe_get(self, key):
-        """
-        Try to read the key from the _cache dict, this could fail if the _cache is some how
-        modified to something that doesn't have a "get" method
-        :param key:
-        :return:
-        """
-        try:
-            data = self._cache.get(key, None)
-            return data
-        except AttributeError:
-            log.debug('Looks like the _cache was modified by something else, it was not a dict')
-            return None
-
-
-class ReadThroughInMemoryCache(InMemoryCache):
-    """
-    A thread-safe in-memory cache that will retrieve values from an underlying source on a cache
-    miss
-    """
-    def read(self, key, on_cache_miss):
-        data = self.read_cache_only(key=key)
-        if data is None:
-            data = self.write_cache(key, on_cache_miss())
-        return data
 
 
 class StatusCache(CacheManager):
@@ -1024,31 +943,6 @@ class SyspurposeValidFieldsCache(ConsumerCache):
             return self.DEFAULT_VALUE
 
 
-class ContentAccessModeCache(CacheManager):
-    """
-    Cache the content access mode that is used for current identity.
-    """
-
-    CACHE_FILE = "/var/lib/rhsm/cache/content_access_mode.json"
-
-    def __init__(self, content_access_mode=None):
-        self.content_access_mode = content_access_mode or {}
-
-    def to_dict(self):
-        return self.content_access_mode
-
-    def _load_data(self, open_file):
-        try:
-            self.content_access_mode = json.loads(open_file.read()) or {}
-            return self.content_access_mode
-        except IOError as err:
-            log.error("Unable to read cache: %s" % self.CACHE_FILE)
-            log.exception(err)
-        except ValueError:
-            # Ignore json file parse error
-            pass
-
-
 class CurrentOwnerCache(ConsumerCache):
     """
     Cache information about current owner (organization)
@@ -1061,6 +955,54 @@ class CurrentOwnerCache(ConsumerCache):
 
     def _sync_with_server(self, uep, consumer_uuid, *args, **kwargs):
         return uep.getOwner(consumer_uuid)
+
+    def _is_cache_obsoleted(self, uep, identity, *args, **kwargs):
+        """
+        We don't know if the cache is valid until we get valid response
+        :param uep: object representing connection to candlepin server
+        :param identity: consumer identity
+        :param args: other arguments
+        :param kwargs: other keyed arguments
+        :return: True, when cache is obsoleted or validity of cache is unknown.
+        """
+        if uep is None:
+            cp_provider = inj.require(inj.CP_PROVIDER)
+            uep = cp_provider.get_consumer_auth_cp()
+        if hasattr(uep.conn, 'is_consumer_cert_key_valid') and uep.conn.is_consumer_cert_key_valid is True:
+            return False
+        else:
+            return True
+
+
+class ContentAccessModeCache(ConsumerCache):
+    """
+    Cache information about current owner (organization), specifically, the content access mode.
+    This value is used independently.
+    """
+
+    # Grab the current owner (and hence the content_access_mode of that owner) at most, once per
+    # 4 hours
+    TIMEOUT = 60 * 60 * 4
+
+    CACHE_FILE = "/var/lib/rhsm/cache/content_access_mode.json"
+
+    def __init__(self, data=None):
+        super(ContentAccessModeCache, self).__init__(data=data)
+
+    def _sync_with_server(self, uep, consumer_uuid, *args, **kwargs):
+        try:
+            current_owner = uep.getOwner(consumer_uuid)
+        except Exception:
+            log.debug("Error checking for content access mode,"
+                      "defaulting to assuming not in Simple Content Access mode")
+        else:
+            if "contentAccessMode" in current_owner:
+                return current_owner["contentAccessMode"]
+            else:
+                log.debug("The owner returned from the server did not contain a "
+                          "'content_access_mode'. Perhaps the connected Entitlement Server doesn't"
+                          "support 'content_access_mode'?")
+        return "unknown"
 
     def _is_cache_obsoleted(self, uep, identity, *args, **kwargs):
         """

--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -153,14 +153,13 @@ class EntCertUpdateAction(object):
             content_access_certs = self._find_content_access_certs()
             update_data = None
             if len(content_access_certs) > 0:
-                # This address BZ: 1448855, 1450862
-                if len(expected) < len(content_access_certs):
-                    obsolete_certs = []
-                    for cont_access_cert in content_access_certs:
-                        if cont_access_cert.serial not in expected:
-                            obsolete_certs.append(cont_access_cert)
-                    log.info('Deleting obsolete content access certificate')
-                    self.delete(obsolete_certs)
+                # This addresses BZs: 1448855, 1450862
+                obsolete_certs = []
+                for cont_access_cert in content_access_certs:
+                    if cont_access_cert.serial not in expected:
+                        obsolete_certs.append(cont_access_cert)
+                log.info('Deleting obsolete content access certificate')
+                self.delete(obsolete_certs)
                 update_data = self.content_access_cache.check_for_update()
                 for content_access_cert in content_access_certs:
                     self.content_access_cache.update_cert(content_access_cert, update_data)

--- a/src/subscription_manager/injectioninit.py
+++ b/src/subscription_manager/injectioninit.py
@@ -22,8 +22,9 @@ from subscription_manager.cache import ProductStatusCache, \
     InstalledProductsManager, PoolTypeCache, ReleaseStatusCache, \
     RhsmIconCache, ContentAccessCache, PoolStatusCache, \
     SyspurposeComplianceStatusCache, SupportedResourcesCache, \
-    AvailableEntitlementsCache, CurrentOwnerCache, SyspurposeValidFieldsCache, \
-    ReadThroughInMemoryCache
+    AvailableEntitlementsCache, ContentAccessModeCache, \
+    CurrentOwnerCache, SyspurposeValidFieldsCache
+
 from subscription_manager.cert_sorter import CertSorter
 from subscription_manager.certdirectory import EntitlementDirectory
 from subscription_manager.certdirectory import ProductDirectory
@@ -58,7 +59,7 @@ def init_dep_injection():
     inj.provide(inj.ENTITLEMENT_STATUS_CACHE, EntitlementStatusCache, singleton=True)
     inj.provide(inj.SYSTEMPURPOSE_COMPLIANCE_STATUS_CACHE, SyspurposeComplianceStatusCache, singleton=True)
     inj.provide(inj.RHSM_ICON_CACHE, RhsmIconCache, singleton=True)
-    inj.provide(inj.CONTENT_ACCESS_MODE_CACHE, ReadThroughInMemoryCache, singleton=True)
+    inj.provide(inj.CONTENT_ACCESS_MODE_CACHE, ContentAccessModeCache, singleton=True)
     inj.provide(inj.CURRENT_OWNER_CACHE, CurrentOwnerCache, singleton=True)
     inj.provide(inj.SYSPURPOSE_VALID_FIELDS_CACHE, SyspurposeValidFieldsCache)
     inj.provide(inj.SUPPORTED_RESOURCES_CACHE, SupportedResourcesCache, singleton=True)

--- a/src/subscription_manager/injectioninit.py
+++ b/src/subscription_manager/injectioninit.py
@@ -21,10 +21,9 @@ from subscription_manager.cache import ProductStatusCache, \
     EntitlementStatusCache, OverrideStatusCache, ProfileManager, \
     InstalledProductsManager, PoolTypeCache, ReleaseStatusCache, \
     RhsmIconCache, ContentAccessCache, PoolStatusCache, \
-    SyspurposeComplianceStatusCache, ContentAccessModeCache, \
-    SupportedResourcesCache, AvailableEntitlementsCache, \
-    CurrentOwnerCache, SyspurposeValidFieldsCache
-
+    SyspurposeComplianceStatusCache, SupportedResourcesCache, \
+    AvailableEntitlementsCache, CurrentOwnerCache, SyspurposeValidFieldsCache, \
+    ReadThroughInMemoryCache
 from subscription_manager.cert_sorter import CertSorter
 from subscription_manager.certdirectory import EntitlementDirectory
 from subscription_manager.certdirectory import ProductDirectory
@@ -59,7 +58,7 @@ def init_dep_injection():
     inj.provide(inj.ENTITLEMENT_STATUS_CACHE, EntitlementStatusCache, singleton=True)
     inj.provide(inj.SYSTEMPURPOSE_COMPLIANCE_STATUS_CACHE, SyspurposeComplianceStatusCache, singleton=True)
     inj.provide(inj.RHSM_ICON_CACHE, RhsmIconCache, singleton=True)
-    inj.provide(inj.CONTENT_ACCESS_MODE_CACHE, ContentAccessModeCache, singleton=True)
+    inj.provide(inj.CONTENT_ACCESS_MODE_CACHE, ReadThroughInMemoryCache, singleton=True)
     inj.provide(inj.CURRENT_OWNER_CACHE, CurrentOwnerCache, singleton=True)
     inj.provide(inj.SYSPURPOSE_VALID_FIELDS_CACHE, SyspurposeValidFieldsCache)
     inj.provide(inj.SUPPORTED_RESOURCES_CACHE, SupportedResourcesCache, singleton=True)

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1091,6 +1091,11 @@ class RefreshCommand(CliCommand):
             if content_access.exists():
                 content_access.remove()
 
+            # Also remove the content access mode cache to be sure we display
+            # SCA or regular mode correctly
+            content_access_mode = inj.require(inj.CONTENT_ACCESS_MODE_CACHE)
+            if content_access_mode.exists():
+                content_access_mode.delete_cache()
             if self.options.force is True:
                 # get current consumer identity
                 consumer_identity = inj.require(inj.IDENTITY)

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -223,7 +223,7 @@ class SubManFixture(unittest.TestCase):
         inj.provide(inj.ENTITLEMENT_STATUS_CACHE, stubs.StubEntitlementStatusCache())
         inj.provide(inj.POOL_STATUS_CACHE, stubs.StubPoolStatusCache())
         inj.provide(inj.PROD_STATUS_CACHE, stubs.StubProductStatusCache())
-        inj.provide(inj.CONTENT_ACCESS_MODE_CACHE, stubs.StubReadThroughInMemoryCache())
+        inj.provide(inj.CONTENT_ACCESS_MODE_CACHE, stubs.StubContentAccessModeCache())
         inj.provide(inj.SUPPORTED_RESOURCES_CACHE, stubs.StubSupportedResourcesCache())
         inj.provide(inj.SYSPURPOSE_VALID_FIELDS_CACHE, stubs.StubSyspurposeValidFieldsCache())
         inj.provide(inj.CURRENT_OWNER_CACHE, stubs.StubCurrentOwnerCache)

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -223,7 +223,7 @@ class SubManFixture(unittest.TestCase):
         inj.provide(inj.ENTITLEMENT_STATUS_CACHE, stubs.StubEntitlementStatusCache())
         inj.provide(inj.POOL_STATUS_CACHE, stubs.StubPoolStatusCache())
         inj.provide(inj.PROD_STATUS_CACHE, stubs.StubProductStatusCache())
-        inj.provide(inj.CONTENT_ACCESS_MODE_CACHE, stubs.StubContentAccessModeCache())
+        inj.provide(inj.CONTENT_ACCESS_MODE_CACHE, stubs.StubReadThroughInMemoryCache())
         inj.provide(inj.SUPPORTED_RESOURCES_CACHE, stubs.StubSupportedResourcesCache())
         inj.provide(inj.SYSPURPOSE_VALID_FIELDS_CACHE, stubs.StubSyspurposeValidFieldsCache())
         inj.provide(inj.CURRENT_OWNER_CACHE, stubs.StubCurrentOwnerCache)

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -26,8 +26,8 @@ from rhsm import config
 from subscription_manager.cert_sorter import CertSorter
 from subscription_manager.cache import EntitlementStatusCache, ProductStatusCache, \
         OverrideStatusCache, ProfileManager, InstalledProductsManager, ReleaseStatusCache, \
-        PoolStatusCache, ContentAccessModeCache, SupportedResourcesCache, AvailableEntitlementsCache, \
-        SyspurposeValidFieldsCache, CurrentOwnerCache
+        PoolStatusCache, ContentAccessModeCache, SupportedResourcesCache, ReadThroughInMemoryCache, \
+        SyspurposeValidFieldsCache, CurrentOwnerCache, AvailableEntitlementsCache
 from subscription_manager.facts import Facts
 from subscription_manager.lock import ActionLock
 from rhsm.certificate import GMT
@@ -129,7 +129,7 @@ def stubInitConfig():
 
 # create a global CFG object,then replace it with our own that candlepin
 # read from a stringio
-#config.get_config_parser(config_file="test/rhsm.conf")
+#config.initConfig(config_file="test/rhsm.conf")
 config.CFG = StubConfig()
 
 # we are not actually reading test/rhsm.conf, it's just a placeholder
@@ -721,15 +721,6 @@ class StubReleaseStatusCache(ReleaseStatusCache):
         self.server_status = None
 
 
-class StubAvailableEntitlementsCache(AvailableEntitlementsCache):
-
-    def write_cache(self, debug=False):
-        pass
-
-    def delete_cache(self):
-        self.server_status = None
-
-
 class StubContentAccessModeCache(ContentAccessModeCache):
 
     def write_cache(self, debug=False):
@@ -746,6 +737,23 @@ class StubSupportedResourcesCache(SupportedResourcesCache):
 
     def delete_cache(self):
         self.server_status = None
+
+
+class StubAvailableEntitlementsCache(AvailableEntitlementsCache):
+
+    def write_cache(self, debug=False):
+        pass
+
+    def delete_cache(self):
+        self.server_status = None
+
+
+class StubReadThroughInMemoryCache(ReadThroughInMemoryCache):
+
+    def __init__(self):
+        super(ReadThroughInMemoryCache, self).__init__()
+        # Remove the lock, so as not to block tests run in parallel
+        self._lock = mock.Mock()
 
 
 class StubSyspurposeValidFieldsCache(SyspurposeValidFieldsCache):

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -26,7 +26,7 @@ from rhsm import config
 from subscription_manager.cert_sorter import CertSorter
 from subscription_manager.cache import EntitlementStatusCache, ProductStatusCache, \
         OverrideStatusCache, ProfileManager, InstalledProductsManager, ReleaseStatusCache, \
-        PoolStatusCache, ContentAccessModeCache, SupportedResourcesCache, ReadThroughInMemoryCache, \
+        PoolStatusCache, ContentAccessModeCache, SupportedResourcesCache, \
         SyspurposeValidFieldsCache, CurrentOwnerCache, AvailableEntitlementsCache
 from subscription_manager.facts import Facts
 from subscription_manager.lock import ActionLock
@@ -129,7 +129,7 @@ def stubInitConfig():
 
 # create a global CFG object,then replace it with our own that candlepin
 # read from a stringio
-#config.initConfig(config_file="test/rhsm.conf")
+#config.get_config_parser(config_file="test/rhsm.conf")
 config.CFG = StubConfig()
 
 # we are not actually reading test/rhsm.conf, it's just a placeholder
@@ -721,6 +721,15 @@ class StubReleaseStatusCache(ReleaseStatusCache):
         self.server_status = None
 
 
+class StubAvailableEntitlementsCache(AvailableEntitlementsCache):
+
+    def write_cache(self, debug=False):
+        pass
+
+    def delete_cache(self):
+        self.server_status = None
+
+
 class StubContentAccessModeCache(ContentAccessModeCache):
 
     def write_cache(self, debug=False):
@@ -737,23 +746,6 @@ class StubSupportedResourcesCache(SupportedResourcesCache):
 
     def delete_cache(self):
         self.server_status = None
-
-
-class StubAvailableEntitlementsCache(AvailableEntitlementsCache):
-
-    def write_cache(self, debug=False):
-        pass
-
-    def delete_cache(self):
-        self.server_status = None
-
-
-class StubReadThroughInMemoryCache(ReadThroughInMemoryCache):
-
-    def __init__(self):
-        super(ReadThroughInMemoryCache, self).__init__()
-        # Remove the lock, so as not to block tests run in parallel
-        self._lock = mock.Mock()
 
 
 class StubSyspurposeValidFieldsCache(SyspurposeValidFieldsCache):

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -20,9 +20,11 @@ import six
 
 from subscription_manager import syspurposelib
 from subscription_manager import managercli, managerlib
+from subscription_manager.cache import ContentAccessCache, \
+    ContentAccessModeCache
 from subscription_manager.entcertlib import CONTENT_ACCESS_CERT_TYPE
 from subscription_manager.injection import provide, \
-        CERT_SORTER, PROD_DIR
+        CERT_SORTER, PROD_DIR, CONTENT_ACCESS_CACHE, CONTENT_ACCESS_MODE_CACHE
 from rhsmlib.services.products import InstalledProducts
 from subscription_manager.managercli import AVAILABLE_SUBS_MATCH_COLUMNS
 from subscription_manager.printing_utils import format_name, columnize, \
@@ -407,6 +409,31 @@ class TestRefreshCommand(TestCliProxyCommand):
 
     def test_force_option(self):
         self.cc.main(["--force"])
+
+
+class TestRefreshCommandWithDoCommand(SubManFixture):
+    command_class = managercli.RefreshCommand
+
+    def setUp(self):
+        super(TestRefreshCommandWithDoCommand, self).setUp()
+        self.cc = self.command_class()
+
+    def test_cache_removed(self):
+        # lots of mocking basically to show that the injected content access
+        # cache and content access mode caches are cleared on each run of the
+        # refresh command
+        self.cc.assert_should_be_registered = Mock(return_value=True)
+        mock_content_access_cache = Mock(spec=ContentAccessCache)
+        mock_content_access_cache.return_value.exists.return_value = True
+        provide(CONTENT_ACCESS_CACHE, mock_content_access_cache)
+        mock_content_access_mode_cache = Mock(spec=ContentAccessModeCache)
+        mock_content_access_mode_cache.return_value.exists.return_value = True
+        provide(CONTENT_ACCESS_MODE_CACHE, mock_content_access_mode_cache)
+        self.cc.main([""])
+        mock_content_access_cache.return_value.remove.assert_called_once()
+        mock_content_access_mode_cache.return_value.delete_cache.assert_called_once()
+        mock_content_access_cache.return_value.exists.assert_called_once()
+        mock_content_access_mode_cache.return_value.exists.assert_called_once()
 
 
 class TestIdentityCommand(TestCliProxyCommand):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -408,6 +408,7 @@ class TestGetServerVersions(fixture.SubManFixture):
         instance.is_registered_with_classic.return_value = False
         self._inject_mock_valid_consumer()
         MockUep.supports_resource.return_value = True
+        MockUep.get_supported_resources.return_value = {"status": "/status"}
         MockUep.getStatus.return_value = {'version': '101', 'release': '23423c', 'rulesVersion': '6.1'}
         sv = get_server_versions(MockUep)
         self.assertEqual(sv['server-type'], 'Red Hat Subscription Management')
@@ -421,6 +422,7 @@ class TestGetServerVersions(fixture.SubManFixture):
         instance.is_registered_with_classic.return_value = False
         self._inject_mock_valid_consumer()
         MockUep.supports_resource.return_value = True
+        MockUep.get_supported_resources.return_value = {"status": "/status"}
         MockUep.getStatus.return_value = {'version': '101', 'release': '23423c'}
         sv = get_server_versions(MockUep)
         self.assertEqual(sv['server-type'], 'Red Hat Subscription Management')
@@ -434,6 +436,7 @@ class TestGetServerVersions(fixture.SubManFixture):
         instance.is_registered_with_classic.return_value = False
         self._inject_mock_valid_consumer()
         MockUep.supports_resource.return_value = True
+        MockUep.get_supported_resources.return_value = {"status": "/status"}
         MockUep.getStatus.return_value = {}
         sv = get_server_versions(MockUep)
         self.assertEqual(sv['server-type'], 'Red Hat Subscription Management')
@@ -447,6 +450,7 @@ class TestGetServerVersions(fixture.SubManFixture):
         instance.is_registered_with_classic.return_value = False
         self._inject_mock_valid_consumer()
         MockUep.supports_resource.return_value = True
+        MockUep.get_supported_resources.return_value = {"status": "/status"}
 
         dataset = [
             {'version': None, 'release': '123'},
@@ -475,6 +479,7 @@ class TestGetServerVersions(fixture.SubManFixture):
         instance.is_registered_with_classic.return_value = True
         self._inject_mock_valid_consumer()
         MockUep.supports_resource.return_value = True
+        MockUep.get_supported_resources.return_value = {"status": "/status"}
         MockUep.getStatus.return_value = {'version': '101', 'release': '23423c', 'rulesVersion': '6.1'}
         sv = get_server_versions(MockUep)
         self.assertEqual(sv['server-type'], 'RHN Classic and Red Hat Subscription Management')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -14,8 +14,8 @@ from rhsm.utils import ServerUrlParseErrorEmpty, \
 from subscription_manager.utils import parse_server_info, \
     parse_baseurl_info, format_baseurl, \
     get_version, get_client_versions, unique_list_items, \
-    get_server_versions, friendly_join, is_true_value, url_base_join,\
-    ProductCertificateFilter, EntitlementCertificateFilter,\
+    get_server_versions, friendly_join, is_true_value, url_base_join, \
+    ProductCertificateFilter, EntitlementCertificateFilter, \
     is_simple_content_access, is_process_running, get_process_names
 from .stubs import StubProductCertificate, StubProduct, StubEntitlementCertificate
 from .fixture import SubManFixture


### PR DESCRIPTION
…eeded

This stops bad cache values from incorrectly displaying that
the system is registered to an organization which is running
in Simple Content Access mode.

Now the organization's content access mode is cached only in memory
so as to limit the duration of it's validity to the lifetime of
any of our applications runtime.