### PR TITLE
jenkins: switch stylish job to Python 3

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -50,6 +50,12 @@ ignore =
     # E741: ambiguous variable name '*'
     # mostly for variables 'l', which ought to get more specific names
     E741,
+    # F821: undefined name '*'
+    F821,
+    # F841: local variable '*' is assigned to but never used
+    # possibly either mistakes (variables that were supposed to be used),
+    # or really no more needed variables
+    F841,
     # W504: line break after binary operator
     # we break after binary operators, newer style breaks before
     W504,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,10 +7,9 @@ pipeline {
     // stage('prepare') {steps {echo 'prepare'}}
     stage('Test') {
       parallel {
-        stage('Python 2 stylish') {
-          agent { label 'subman-centos7' }
+        stage('Python stylish') {
           steps {
-            sh readFile(file: 'jenkins/stylish-tests.sh')
+            sh readFile(file: 'jenkins/python3-stylish-tests.sh')
           }
         }
         stage('Fedora tito') {

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -682,7 +682,7 @@ class MigrationEngine(object):
     def register(self, credentials, org, environment):
         # For registering the machine, use the CLI tool to reuse the username/password (because the GUI will prompt for them again)
         # Prepended a \n so translation can proceed without hitch
-        print ("")
+        print("")
         print(_("Attempting to register system to destination server..."))
         cmd = ['subscription-manager', 'register']
 


### PR DESCRIPTION
subscription-manager does not support Python 2 anymore, so switch the stylish script to the Python 3 version.

Also, stop using the `subman-centos7` agent for it, as it clearly does not support Python 3; the default `subman` agent will work fine.