### PR TITLE
1959048: improve wording for missing or empty syspurpose values

### DIFF
--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -211,11 +211,14 @@ class AbstractSyspurposeCommand(CliCommand):
                         ))
                         self._print_valid_values(valid_fields)
                     else:
-                        print(_('Warning: This org does not have any subscriptions with an available "{attr}" is empty.').format(
+                        print(_('Warning: There are no available values for the system purpose "{attr}" '
+                                'from the available subscriptions in this organization.').format(
                             attr=self.attr
                         ))
                 else:
-                    print(_('Warning: This org does not have any subscriptions with an available "{attr}"').format(
+                    print(_('Warning: This organization does not have any subscriptions that provide a '
+                            'system purpose "{attr}".  This setting will not influence auto-attaching '
+                            'subscriptions.').format(
                         attr=self.attr
                     ))
 
@@ -344,9 +347,12 @@ class AbstractSyspurposeCommand(CliCommand):
                 # Print values
                 self._print_valid_values(valid_fields)
             else:
-                print(_('This org does not have any subscriptions with an available "{syspurpose_attr}"').format(syspurpose_attr=self.attr))
+                print(_('There are no available values for the system purpose "{syspurpose_attr}" '
+                        'from the available subscriptions in this '
+                        'organization.').format(syspurpose_attr=self.attr))
         else:
-            print(_('This org does not have any subscriptions with an available "{syspurpose_attr}"').format(syspurpose_attr=self.attr))
+            print(_('This organization does not have any subscriptions that provide a system '
+                    'purpose "{syspurpose_attr}.').format(syspurpose_attr=self.attr))
 
     def sync(self):
         return syspurposelib.SyspurposeSyncActionCommand().perform(include_result=True)[1]


### PR DESCRIPTION
Try to improve and make more coherent the messages for missing
syspurpose attributes in the current subscription, or for an empty list
of values available.

Updates commit f4d903a88422ee661dc66459305d993b892be91a.