### PR TITLE
ENT-3328: 1898563: move syspurpose subcommands within the 'syspurpose' command

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -35,7 +35,23 @@ _subscription_manager_attach()
 
 _subscription_manager_syspurpose()
 {
-  local opts="--show ${_subscription_manager_common_opts}"
+  local opts="addons role service-level usage --show ${_subscription_manager_common_opts}"
+
+  case "${2}" in
+      addons|\
+      role|\
+      usage)
+      "_subscription_manager_$2" "${1}" "${2}"
+      return 0
+      ;;
+      service-level)
+      "_subscription_manager_service_level" "${1}" "${2}"
+      return 0
+      ;;
+      *)
+      ;;
+  esac
+
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }
 

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -77,64 +77,52 @@ has specific options available for each command, depending on what operation is 
 6. release
 
 .IP
-7. addons
+7. import
 
 .IP
-8. role
+8. redeem
 
 .IP
-9. service-level
+9. list
 
 .IP
-10. usage
+10. refresh
 
 .IP
-11. import
+11. environments
 
 .IP
-12. redeem
+12. repos
 
 .IP
-13. list
+13. orgs
 
 .IP
-14. refresh
+14. plugins
 
 .IP
-15. environments
+15. identity
 
 .IP
-16. repos
+16. facts
 
 .IP
-17. orgs
+17. clean
 
 .IP
-18. plugins
+18. config
 
 .IP
-19. identity
+19. version
 
 .IP
-20. facts
+20. status
 
 .IP
-21. clean
+21. deprecated commands: addons, role, service-level, subscribe, unsubscribe, usage, and activate
 
 .IP
-22. config
-
-.IP
-23. version
-
-.IP
-24. status
-
-.IP
-25. deprecated commands: subscribe, unsubscribe, and activate
-
-.IP
-26. repo-override
+22. repo-override
 
 
 .SS COMMON OPTIONS
@@ -388,15 +376,34 @@ command displays the current configured syspurpose
 .I preferences
 for the system.
 
+.PP
+The
+.B syspurpose
+command has subcommands for all the various syspurpose preferences and attributes:
+
+.IP
+1. addons
+
+.IP
+2. role
+
+.IP
+3. service-level
+
+.IP
+4. usage
+
+
 .TP
 .B --show
 Shows the system's current set of syspurpose preference formatted as JSON. Single-valued entries for which there is no value will be included in the output with a value of "". List entries which have no value will be included in the output with a value of "[]" (less the quotes).
 
 
-.SS ADDONS OPTIONS
+.PP
+.SS addons options
 The
 .B addons
-command displays the current configured addons system purpose attribute
+subcommand displays the current configured addons system purpose attribute
 .I preference
 for products installed on the system. For example, if the addons preference is ADDON1, then a subscription with a ADDON1 addon is selected when auto-attaching subscriptions to the system.
 
@@ -437,10 +444,10 @@ Removes all addons from the list of requested addons.
 Identifies the organization for which the addons applies.
 
 
-.SS ROLE OPTIONS
+.SS role options
 The
 .B role
-command displays the current configured role
+subcommand displays the current configured role
 .I preference
 for products installed on the system. For example, if the role preference is "Red Hat Enterprise Linux Server", then a subscription with a "Red Hat Enterprise Linux Server" role is selected when auto-attaching subscriptions to the system.
 
@@ -477,10 +484,10 @@ Removes any previously set role preference.
 Identifies the organization for which the role applies.
 
 
-.SS SERVICE-LEVEL OPTIONS
+.SS service-level options
 The
 .B service-level
-command displays the current configured service level
+subcommand displays the current configured service level
 .I preference
 for products installed on the system. For example, if the service-level preference is standard, then a subscription with a standard service level is selected when auto-attaching subscriptions to the system.
 
@@ -521,10 +528,10 @@ Service level to apply to this system
 Removes any previously set service-level preference.
 
 
-.SS USAGE OPTIONS
+.SS usage options
 The
 .B usage
-command displays the current configured usage
+subcommand displays the current configured usage
 .I preference
 for products installed on the system. For example, if the usage preference is "Production", then a subscription with a "Production" usage is selected when auto-attaching subscriptions to the system.
 
@@ -981,6 +988,22 @@ This has been replaced with \fBremove\fP.
 .TP
 .B activate
 This has been replaced with \fBredeem\fP.
+
+.TP
+.B addons
+This has been replaced with \fBsyspurpose addons\fP.
+
+.TP
+.B role
+This has been replaced with \fBsyspurpose role\fP.
+
+.TP
+.B service-level
+This has been replaced with \fBsyspurpose service-level\fP.
+
+.TP
+.B usage
+This has been replaced with \fBsyspurpose usage\fP.
 
 .SH USAGE
 .B subscription-manager

--- a/src/subscription_manager/cli.py
+++ b/src/subscription_manager/cli.py
@@ -60,7 +60,7 @@ class AbstractCLICommand(object):
         self.primary = primary
         self.aliases = aliases or []
 
-        self.parser = ArgumentParser(usage=self._get_usage(), description=shortdesc)
+        self.parser = self._create_argparser()
 
     def main(self, args=None):
         raise NotImplementedError("Commands must implement: main(self, args=None)")
@@ -85,6 +85,16 @@ class AbstractCLICommand(object):
         Does the work that this command intends.
         """
         raise NotImplementedError("Commands must implement: _do_command(self)")
+
+    def _create_argparser(self):
+        """
+        Creates an argparse.ArgumentParser object for this command.
+
+        This is done as separate method so subclasses can provide their own
+        ArgumentParser, in case the one provided by this method is not
+        sufficient.
+        """
+        return ArgumentParser(usage=self._get_usage(), description=self.shortdesc)
 
 
 # taken wholseale from rho...

--- a/src/subscription_manager/cli_command/addons.py
+++ b/src/subscription_manager/cli_command/addons.py
@@ -21,10 +21,11 @@ from subscription_manager.cli_command.org import OrgCommand
 
 class AddonsCommand(AbstractSyspurposeCommand, OrgCommand):
 
-    def __init__(self):
+    def __init__(self, subparser=None):
         shortdesc = _("Show or modify the system purpose addons setting")
         super(AddonsCommand, self).__init__(
             "addons",
+            subparser,
             shortdesc=shortdesc,
             primary=False,
             attr='addons',

--- a/src/subscription_manager/cli_command/cli.py
+++ b/src/subscription_manager/cli_command/cli.py
@@ -236,13 +236,11 @@ class CliCommand(AbstractCLICommand):
         config_changed = False
 
         # In testing we sometimes specify args, otherwise use the default:
-        if not args:
-            args = sys.argv[1:]
+        if args is None:
+            args = sys.argv[2:]
 
         (self.options, self.args) = self.parser.parse_known_args(args)
 
-        # we dont need argv[0] in this list...
-        self.args = self.args[1:]
         # check for unparsed arguments
         if self.args:
             for arg in self.args:

--- a/src/subscription_manager/cli_command/role.py
+++ b/src/subscription_manager/cli_command/role.py
@@ -20,10 +20,11 @@ from subscription_manager.i18n import ugettext as _
 
 
 class RoleCommand(AbstractSyspurposeCommand, OrgCommand):
-    def __init__(self):
+    def __init__(self, subparser=None):
         shortdesc = _("Show or modify the system purpose role setting")
         super(RoleCommand, self).__init__(
             "role",
+            subparser,
             shortdesc,
             primary=False,
             attr='role',

--- a/src/subscription_manager/cli_command/service_level.py
+++ b/src/subscription_manager/cli_command/service_level.py
@@ -35,13 +35,14 @@ log = logging.getLogger(__name__)
 
 class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
 
-    def __init__(self):
+    def __init__(self, subparser=None):
 
         shortdesc = _("Show or modify the system purpose service-level setting")
         self._org_help_text = _(
             "specify an organization when listing available service levels using the organization key, only used with --list")
         super(ServiceLevelCommand, self).__init__(
             "service-level",
+            subparser,
             shortdesc,
             False,
             attr="service_level_agreement",

--- a/src/subscription_manager/cli_command/syspurpose.py
+++ b/src/subscription_manager/cli_command/syspurpose.py
@@ -52,6 +52,7 @@ class SyspurposeCommand(CliCommand):
         )
         self.parser.add_argument(
             "--show",
+            dest='syspurpose_show',
             action="store_true",
             help=_("show current system purpose")
         )
@@ -62,8 +63,8 @@ class SyspurposeCommand(CliCommand):
         :return: None
         """
         # When no CLI options are provided, then show current syspurpose values
-        if self.options.show is not True:
-            self.options.show = True
+        if self.options.syspurpose_show is not True:
+            self.options.syspurpose_show = True
 
     def _do_command(self):
         """
@@ -73,7 +74,7 @@ class SyspurposeCommand(CliCommand):
         self._validate_options()
 
         content = {}
-        if self.options.show is True:
+        if self.options.syspurpose_show is True:
             if self.is_registered():
                 try:
                     self.cp = self.cp_provider.get_consumer_auth_cp()

--- a/src/subscription_manager/cli_command/syspurpose.py
+++ b/src/subscription_manager/cli_command/syspurpose.py
@@ -20,7 +20,11 @@ import logging
 from rhsm import connection
 
 from subscription_manager import syspurposelib
+from subscription_manager.cli_command.addons import AddonsCommand
 from subscription_manager.cli_command.cli import CliCommand
+from subscription_manager.cli_command.role import RoleCommand
+from subscription_manager.cli_command.service_level import ServiceLevelCommand
+from subscription_manager.cli_command.usage import UsageCommand
 from subscription_manager.i18n import ugettext as _
 
 from syspurpose.files import SyncedStore
@@ -57,6 +61,29 @@ class SyspurposeCommand(CliCommand):
             help=_("show current system purpose")
         )
 
+        # all the subcommands of 'syspurpose'; add them to this list to be
+        # registered as such
+        syspurpose_command_classes = [
+            AddonsCommand,
+            RoleCommand,
+            ServiceLevelCommand,
+            UsageCommand
+        ]
+        # create a subparser for all the subcommands: it is passed to all
+        # the subcommand classes, so they will create an ArgumentParser that
+        # is a child of the 'syspurpose' one, rather than as standalone
+        # parsers
+        subparser = self.parser.add_subparsers(
+            dest='subparser_name',
+            title=_('Syspurpose submodules'),
+            help='',  # trick argparse a bit to not show the {cmd1, cmd2, ..}
+            metavar=''  # trick argparse a bit to not show the {cmd1, cmd2, ..}
+        )
+        self.cli_commands = {}
+        for clazz in syspurpose_command_classes:
+            cmd = clazz(subparser)
+            self.cli_commands[cmd.name] = cmd
+
     def _validate_options(self):
         """
         Validate provided options
@@ -72,6 +99,17 @@ class SyspurposeCommand(CliCommand):
         :return: None
         """
         self._validate_options()
+
+        # a subcommand was actually invoked, so dispatch it
+        if self.options.subparser_name is not None:
+            subcmd = self.cli_commands[self.options.subparser_name]
+            # set a reference to ourselves in the subcommand being executed;
+            # this way, everything we collected & created in main() is
+            # "forwarded" to the subcommand class (see
+            # AbstractSyspurposeCommand.__getattr__())
+            subcmd.syspurpose_command = self
+            subcmd._do_command()
+            return
 
         content = {}
         if self.options.syspurpose_show is True:

--- a/src/subscription_manager/cli_command/usage.py
+++ b/src/subscription_manager/cli_command/usage.py
@@ -21,11 +21,12 @@ from subscription_manager.i18n import ugettext as _
 
 class UsageCommand(AbstractSyspurposeCommand, OrgCommand):
 
-    def __init__(self):
+    def __init__(self, subparser=None):
         shortdesc = _("Show or modify the system purpose usage setting")
         self._org_help_text = _("use set and unset to define the value for this field")
         super(UsageCommand, self).__init__(
             "usage",
+            subparser,
             shortdesc,
             False,
             attr='usage',

--- a/test/cli_command_test/test_config.py
+++ b/test/cli_command_test/test_config.py
@@ -36,7 +36,7 @@ class TestConfigCommand(TestCliCommand):
         config_command.conf['rhsmd']['processtimeout'] = '300'
         with Capture() as cap:
             self.cc._do_command = self._orig_do_command
-            self.cc.main([""])
+            self.cc.main([])
             self.cc._validate_options()
         self.assertTrue(hostname in cap.out)
 

--- a/test/cli_command_test/test_refresh.py
+++ b/test/cli_command_test/test_refresh.py
@@ -35,7 +35,7 @@ class TestRefreshCommandWithDoCommand(SubManFixture):
         mock_content_access_mode_cache = Mock(spec=ContentAccessModeCache)
         mock_content_access_mode_cache.return_value.exists.return_value = True
         provide(CONTENT_ACCESS_MODE_CACHE, mock_content_access_mode_cache)
-        self.cc.main([""])
+        self.cc.main([])
         mock_content_access_cache.return_value.remove.assert_called_once()
         mock_content_access_mode_cache.return_value.delete_cache.assert_called_once()
         mock_content_access_cache.return_value.exists.assert_called_once()

--- a/test/cli_command_test/test_role.py
+++ b/test/cli_command_test/test_role.py
@@ -266,7 +266,7 @@ class TestRoleCommand(TestCliProxyCommand):
         instance_syspurpose_store.sync.assert_called_once()
 
     def test_is_provided_value_valid(self):
-        self.cc = AbstractSyspurposeCommand("role", shortdesc="role", primary=False, attr="role")
+        self.cc = AbstractSyspurposeCommand("role", None, shortdesc="role", primary=False, attr="role")
         self.cc._get_valid_fields = Mock()
         self.cc._get_valid_fields.return_value = {"role": ["Welcome to the Machine"]}
         res = self.cc._is_provided_value_valid("wElcOme To The mAChiNE")

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -180,7 +180,7 @@ class CliPluginsTests(SubManFixture):
         cmd.plugin_manager = self.manager
 
         with Capture() as cap:
-            cmd.main(['plugins', '--list'])
+            cmd.main(['--list'])
             output = cap.out
             self.assertTrue("PluginClass0" in output)
             self.assertTrue("PluginClass9" in output)
@@ -192,7 +192,7 @@ class CliPluginsTests(SubManFixture):
         cmd.plugin_manager = self.manager
 
         with Capture() as cap:
-            cmd.main(['plugins', '--listhooks'])
+            cmd.main(['--listhooks'])
             output = cap.out
             self.assertTrue("test_0" in output)
             self.assertTrue("test.test_plugins.PluginClass0.test_hook" in output)
@@ -206,7 +206,7 @@ class CliPluginsTests(SubManFixture):
         cmd.plugin_manager = self.manager
 
         with Capture() as cap:
-            cmd.main(['plugins', '--listslots'])
+            cmd.main(['--listslots'])
             output = cap.out
             self.assertTrue("test_0" in output)
             self.assertTrue("test_9" in output)
@@ -218,7 +218,7 @@ class CliPluginsTests(SubManFixture):
         cmd.plugin_manager = self.manager
 
         with Capture() as cap:
-            cmd.main(['plugins', '--verbose'])
+            cmd.main(['--verbose'])
             output = cap.out
             self.assertTrue("plugin_key: test.test_plugins.PluginClass0" in output)
             self.assertTrue("test.test_plugins.PluginClass0: enabled" in output)

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -82,7 +82,7 @@ class CliRegistrationTests(SubManFixture):
         with patch('rhsm.connection.UEPConnection', new_callable=StubUEP) as mock_uep:
             self.stub_cp_provider.basic_auth_cp = mock_uep
             cmd = RegisterCommand()
-            cmd.main(['register', '--force', '--username', 'admin', '--password', 'admin', '--org', 'admin'])
+            cmd.main(['--force', '--username', 'admin', '--password', 'admin', '--org', 'admin'])
 
     @patch('subscription_manager.cli_command.cli.EntCertActionInvoker')
     def test_activation_keys_updates_certs_and_repos(self, mock_entcertlib):
@@ -93,7 +93,7 @@ class CliRegistrationTests(SubManFixture):
         mock_entcertlib = mock_entcertlib.return_value
         self._inject_ipm()
 
-        cmd.main(['register', '--activationkey=test_key', '--org=test_org'])
+        cmd.main(['--activationkey=test_key', '--org=test_org'])
         self.mock_register.register.assert_called_once()
         mock_entcertlib.update.assert_called_once()
 
@@ -106,7 +106,7 @@ class CliRegistrationTests(SubManFixture):
         mock_entcertlib = mock_entcertlib.return_value
         self._inject_ipm()
 
-        cmd.main(['register', '--consumerid=123456', '--username=testuser1', '--password=password', '--org=test_org'])
+        cmd.main(['--consumerid=123456', '--username=testuser1', '--password=password', '--org=test_org'])
         self.mock_register.register.assert_called_once_with(None, consumerid='123456')
         mock_entcertlib.update.assert_called_once()
 
@@ -120,7 +120,7 @@ class CliRegistrationTests(SubManFixture):
 
         with Capture(silent=True):
             with self.assertRaises(SystemExit) as e:
-                cmd.main(['register', '--consumerid=TaylorSwift', '--username=testuser1', '--password=password', '--org=test_org'])
+                cmd.main(['--consumerid=TaylorSwift', '--username=testuser1', '--password=password', '--org=test_org'])
                 self.assertEqual(e.code, os.EX_USAGE)
 
     def test_strip_username_and_password(self):
@@ -222,7 +222,7 @@ class CliRegistrationTests(SubManFixture):
             self.stub_cp_provider.basic_auth_cp = mock_uep
             cmd = RegisterCommand()
             with Capture() as cap:
-                cmd.main(['register', '--force', '--username', 'admin', '--password', 'admin', '--org', 'admin'])
+                cmd.main(['--force', '--username', 'admin', '--password', 'admin', '--org', 'admin'])
                 output = cap.out
                 self.assertTrue("The system has been registered with ID" in output)
                 self.assertTrue("The registered system name is:" in output)
@@ -236,5 +236,5 @@ class CliRegistrationTests(SubManFixture):
 
             with Capture(silent=True):
                 with self.assertRaises(SystemExit) as e:
-                    cmd.main(['register', '--type=candlepin'])
+                    cmd.main(['--type=candlepin'])
                     self.assertEqual(e.code, os.EX_USAGE)

--- a/test/test_remove.py
+++ b/test/test_remove.py
@@ -31,21 +31,21 @@ class CliRemoveTests(fixture.SubManFixture):
         mock_identity = self._inject_mock_valid_consumer()
         managercli.EntCertActionInvoker = StubEntActionInvoker
 
-        cmd.main(['remove', '--all'])
+        cmd.main(['--all'])
         self.assertEqual(cmd.cp.called_unbind_uuid, mock_identity.uuid)
 
         serial1 = '123456'
-        cmd.main(['remove', '--serial=%s' % serial1])
+        cmd.main(['--serial=%s' % serial1])
         self.assertEqual(cmd.cp.called_unbind_serial, [serial1])
         cmd.cp.reset()
 
         serial2 = '789012'
-        cmd.main(['remove', '--serial=%s' % serial1, '--serial=%s' % serial2])
+        cmd.main(['--serial=%s' % serial1, '--serial=%s' % serial2])
         self.assertEqual(cmd.cp.called_unbind_serial, [serial1, serial2])
         cmd.cp.reset()
 
         pool_id1 = '39993922b'
-        cmd.main(['remove', '--serial=%s' % serial1, '--serial=%s' % serial2, '--pool=%s' % pool_id1, '--pool=%s' % pool_id1])
+        cmd.main(['--serial=%s' % serial1, '--serial=%s' % serial2, '--pool=%s' % pool_id1, '--pool=%s' % pool_id1])
         self.assertEqual(cmd.cp.called_unbind_serial, [serial1, serial2])
         self.assertEqual(cmd.cp.called_unbind_pool_id, [pool_id1])
 
@@ -59,7 +59,7 @@ class CliRemoveTests(fixture.SubManFixture):
 
         self._inject_mock_invalid_consumer()
 
-        cmd.main(['remove', '--all'])
+        cmd.main(['--all'])
         self.assertTrue(cmd.entitlement_dir.list_called)
         self.assertTrue(ent.is_deleted)
 
@@ -74,7 +74,7 @@ class CliRemoveTests(fixture.SubManFixture):
         inj.provide(inj.PROD_DIR, StubProductDirectory([]))
         cmd = managercli.RemoveCommand()
 
-        cmd.main(['remove', '--serial=%s' % ent1.serial, '--serial=%s' % ent3.serial, '--pool=%s' % ent4.pool.id])
+        cmd.main(['--serial=%s' % ent1.serial, '--serial=%s' % ent3.serial, '--pool=%s' % ent4.pool.id])
         self.assertTrue(cmd.entitlement_dir.list_called)
         self.assertTrue(ent1.is_deleted)
         self.assertFalse(ent2.is_deleted)

--- a/test/test_unregistration.py
+++ b/test/test_unregistration.py
@@ -33,7 +33,7 @@ class CliUnRegistrationTests(SubManFixture):
 
         # CacheManager.delete_cache = classmethod(lambda cls: None)
 
-        cmd.main(['unregister'])
+        cmd.main([])
         self.assertEqual(mock_injected_identity.uuid, cmd.cp.called_unregister_uuid)
 
     @patch('subscription_manager.managerlib.clean_all_data')
@@ -44,7 +44,7 @@ class CliUnRegistrationTests(SubManFixture):
             self._inject_mock_valid_consumer(uuid=112233)
 
             cmd = managercli.UnRegisterCommand()
-            cmd.main(['unregister'])
+            cmd.main([])
 
             self.assertTrue(mock_uep.unregisterConsumer.called)
             clean_data_mock.assert_called_once_with(backup=False)


### PR DESCRIPTION
As an effort to consolidate the handling of all the syspurpose attributes in a single place, make sure that all the syspurpose attributes are handled as subcommands of the `syspurpose` command (leaving the old commands as deprecated).

First of all, drop the command name from `args` when parsing them: according to the documentation, `ArgumentParser.parse_known_args()` seems to work without the command name as first argument. Since `CliCommand` is parsing the parameters of a specific command, we can drop the command itself in addition to the application name before calling `ArgumentParser.parse_known_args()`; this avoids the need to drop it after parsing. In addition, tweak the check for missing test arguments: `if not foo` is also matched by an empty list, which now is a valid list of arguments to pass for tests. Hence, change it to check for `None` explicitly. Adapt the tests accordingly.

Second, bind the `ArgumentParser` option result of the `--show` parameter of the `syspurpose` command to a less generic variable name to avoid clashes: by default, a `--show` option in `ArgumentParser` is saved as a namespace variable `show`, which will conflicts with the various `--show` options of the subparsers of the other syspurpose subcommands.

Make `AbstractSyspurposeCommand` able to override the `ArgumentParser` created by `AbstractCLICommand` (its grandparent class), so it is possible to create a subparser instead of a standalone parser.

Then, make `SyspurposeCommand` create all the syspurpose subcommands, with their parsers created as subparsers of it; properly dispatch the parsed command line options to the right subcommand when `SyspurposeCommand` is executed.

Finally, change the short description of each subcommand to say that is deprecated when shown in the list of the subscription-command commands.