### PR TITLE
WIP: 1846193: Print warning, when SCA, act. key any auto-attach is used

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1388,6 +1388,58 @@ class UEPConnection(BaseConnection):
             method += '&hypervisor_id=%s' % self.sanitize(hypervisor_id)
         return self.conn.request_get(method)
 
+    def getActivationKey(self, activation_key_id):
+        """
+        Try to get information about activation key
+        :param activation_key_id: ID of activation key
+        :return: JSON document with information about activation key
+        """
+
+        # TODO: call REST API call, when issue in candlepin described in this BZ:
+        #       https://bugzilla.redhat.com/show_bug.cgi?id=1965306 is fixed.
+        # method = f'/activation_keys/{activation_key_id}'
+        # return self.conn.request_get(method)
+
+        # Mock response from candlepin server ATM
+        result = """
+{
+  "created" : "2021-05-27T09:04:28+0000",
+  "updated" : "2021-05-27T09:04:28+0000",
+  "id" : "ff80808179acee1a0179ad1164fa0b52",
+  "name" : "auto1-test",
+  "description" : null,
+  "owner" : {
+    "id" : "ff80808179acee1a0179acee52060003",
+    "key" : "snowwhite",
+    "displayName" : "Snow White",
+    "href" : "/owners/snowwhite"
+  },
+  "releaseVer" : {
+    "releaseVer" : null
+  },
+  "serviceLevel" : null,
+  "usage" : null,
+  "role" : null,
+  "addOns" : [ ],
+  "autoAttach" : true,
+  "pools" : [ ],
+  "products" : [ ],
+  "contentOverrides" : [ ]
+}
+        """
+        return result
+
+    def getOwnerActivationKeys(self, owner_key):
+        """
+        Try to get information about activation keys for given owner (organization).
+        Note: user has to have admin rights for give organization to be able to get
+        data from this REST API endpoint.
+        :param owner_key: ID of owner
+        :return: JSON document with information about activation keys
+        """
+        method = f'/owners/{owner_key}/activation_keys'
+        return self.conn.request_get(method)
+
     def unregisterConsumer(self, consumerId):
         """
          Deletes a consumer from candlepin server

--- a/src/subscription_manager/cli_command/attach.py
+++ b/src/subscription_manager/cli_command/attach.py
@@ -127,7 +127,7 @@ class AttachCommand(CliCommand):
         # BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1826300
         if self.auto_attach is True:
             if is_simple_content_access(uep=self.cp, identity=self.identity):
-                self._print_ignore_auto_attach_mesage()
+                self._print_ignore_auto_attach_message()
                 return 0
 
         installed_products_num = 0

--- a/src/subscription_manager/cli_command/cli.py
+++ b/src/subscription_manager/cli_command/cli.py
@@ -108,7 +108,7 @@ class CliCommand(AbstractCLICommand):
 
         self.correlation_id = generate_correlation_id()
 
-    def _print_ignore_auto_attach_mesage(self):
+    def _print_ignore_auto_attach_message(self):
         """
         This message is shared by attach command and register command, because
         both commands can do auto-attach.


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1846193
* When system is registered using activation keys to organization
  using SCA mode and at least one activation key has enabled
  auto-attach, then it is necessary to print warning message
  about ignoring auto-attach.
* Refactored a little _do_command() method. The method was split
  into several _do_* methods, because the _do_method() was too
  long.
* There is bug in candlepin, which prevent fixing this issue:
  https://bugzilla.redhat.com/show_bug.cgi?id=1965306
* The response from candlepin server is mocked
* TODO:
  - Finish this bug fix, when issues is fixed properly in
    candlepin server
  - Add unit test for this case, when we are sure how is this
    issue fixed in candlepin server