### PR TITLE
1938878: Fix issues discovered by static code analyzers

### DIFF
--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -409,10 +409,12 @@ get_int_from_config_file (GKeyFile * key_file, const char *group, const char *ke
         // handling trailing white space for a config file value. Since
         // we are on a lesser version, we have to deal with it ourselves
         // since by default it returns 0.
-        char *str_value =
-            g_key_file_get_string (key_file, group, key, NULL);
-        g_strchomp (str_value);
-        value = atoi (str_value);
+        char *str_value = g_key_file_get_string (key_file, group, key, NULL);
+        if(str_value != NULL) {
+            g_strchomp(str_value);
+            value = atoi(str_value);
+            free(str_value);
+        }
     }
     return value;
 }

--- a/src/dnf-plugins/product-id/CMakeLists.txt
+++ b/src/dnf-plugins/product-id/CMakeLists.txt
@@ -55,6 +55,8 @@ file (COPY "${PROJECT_SOURCE_DIR}/test_data/corrupted_compressed_productid.pem.g
         DESTINATION "${PROJECT_BINARY_DIR}/test_data/")
 file (COPY "${PROJECT_SOURCE_DIR}/test_data/59803427316a729fb1d67fd08e7d0c8ccd2a4a5377729b747b76345851bdba6c-productid.gz"
         DESTINATION "${PROJECT_BINARY_DIR}/test_data/")
+file (COPY "${PROJECT_SOURCE_DIR}/test_data/cert_dir/71.pem"
+        DESTINATION "${PROJECT_BINARY_DIR}/test_data/cert_dir/")
 
 include_directories(${GLIB_INCLUDE_DIRS})
 include_directories(${GIO_INCLUDE_DIRS})

--- a/src/dnf-plugins/product-id/product-id.c
+++ b/src/dnf-plugins/product-id/product-id.c
@@ -66,6 +66,8 @@ PluginHandle *pluginInitHandle(int version, PluginMode mode, DnfPluginInitData *
         handle->version = version;
         handle->mode = mode;
         handle->context = pluginGetContext(initData);
+    } else {
+        error("Unable to allocate memory for plugin handle");
     }
 
     return handle;
@@ -471,10 +473,9 @@ int pluginHook(PluginHandle *handle, PluginHookId id, DnfPluginHookData *hookDat
 }
 
 void writeRepoMap(ProductDb *productDb) {
-    GError *err = NULL;
-    writeProductDb(productDb, &err);
+    int ret = writeProductDb(productDb);
 
-    if (err) {
+    if (ret != 0) {
         error("Unable to write productdb to file: %s", PRODUCTDB_FILE);
     }
 }
@@ -778,7 +779,7 @@ int fetchProductId(DnfRepo *repo, RepoProductId *repoProductId) {
         printError("Unable to get information about CA certificate", tmp_err);
         tmp_err = NULL;
     } else {
-        if (client_cert) {
+        if (ca_cert) {
             debug("SSL CA cert: %s", ca_cert);
         } else {
             debug("SSL CA cert has not been used");

--- a/src/dnf-plugins/product-id/productdb.h
+++ b/src/dnf-plugins/product-id/productdb.h
@@ -29,7 +29,7 @@ typedef struct {
 ProductDb * initProductDb();
 void freeProductDb(ProductDb *productDb);
 void readProductDb(ProductDb *productDb, GError **err);
-void writeProductDb(ProductDb *productDb, GError **err);
+gboolean writeProductDb(ProductDb *productDb);
 void addRepoId(ProductDb *productDb, const char *productId, const char *repoId);
 GSList *getRepoIds(ProductDb *productDb, const char *productId);
 gboolean removeProductId(ProductDb *productDb, const char *productId);

--- a/src/dnf-plugins/product-id/test-productdb.c
+++ b/src/dnf-plugins/product-id/test-productdb.c
@@ -150,6 +150,9 @@ void testReadFile(dbFixture *fixture, gconstpointer ignored) {
     g_file_delete(testJsonFile, NULL, NULL);
     g_object_unref(ioStream);
     g_object_unref(testJsonFile);
+    if(err != NULL) {
+        g_error_free(err);
+    }
 }
 
 void testReadCorruptedFile(dbFixture *fixture, gconstpointer ignored) {
@@ -226,6 +229,7 @@ void testWriteFile(dbFixture *fixture, gconstpointer ignored) {
     (void)ignored;
     ProductDb *db = fixture->db;
     GError *err = NULL;
+    gboolean ret;
 
     addRepoId(db, "69", "rhel");
     addRepoId(db, "69", "jboss");
@@ -235,7 +239,9 @@ void testWriteFile(dbFixture *fixture, gconstpointer ignored) {
     gchar *path = g_file_get_path(testJsonFile);
     db->path = path;
 
-    writeProductDb(db, &err);
+    ret = writeProductDb(db);
+
+    g_assert_true(ret);
 
     g_free(path);
     g_file_delete(testJsonFile, NULL, NULL);


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1938878
* Card ID: ENT-3680
* Fixed several issues in C code discoved by static code
  analyzers in rhsmcertd and libdnf plugin product-ide
* Fixed CMakeLists.txt: one testing data file (71.pem)
  was not copied to 'cert_dir' directory
* Fixed unit test in test-product-id.c. It is not possible
  to call pluginGetContext directly with new version
  of libdnf