### PR TITLE
Added new stage for running libdnf unit tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,12 @@ pipeline {
             // publishCoverage adapters: [jacocoAdapter('coverage.xml')]
           }
         }
+        // Unit tests of libdnf plugins
+        stage('Libdnf unit') {
+          steps {
+            sh readFile(file: 'jenkins/libdnf-tests.sh')
+          }
+        }
 //         stage('OpenSuSE 15') {
 //           agent { label 'opensuse15' }
 //           steps { sh readFile(file: 'jenkins/suse-tests.sh') }

--- a/jenkins/libdnf-tests.sh
+++ b/jenkins/libdnf-tests.sh
@@ -1,0 +1,11 @@
+echo "GIT_COMMIT:" "${GIT_COMMIT}"
+
+export BUILD_DIR='./build'
+
+cd './src/dnf-plugins/product-id'
+rm -rf "${BUILD_DIR}"
+mkdir "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+cmake ../ -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
+make
+CTEST_OUTPUT_ON_FAILURE=1 make test


### PR DESCRIPTION
* Unit tests for libdnf are run in parallel with other tests,
  because it is not related to other Python code