### PR TITLE
1948521 - Delete server repo file

### DIFF
--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -231,10 +231,13 @@ class RepoActionInvoker(BaseActionInvoker):
 
     @classmethod
     def delete_repo_file(cls):
-        for repo_class, _dummy in get_repo_file_classes():
+        for repo_class, server_val_repo_class in get_repo_file_classes():
             repo_file = repo_class()
+            server_val_repo_file = server_val_repo_class()
             if os.path.exists(repo_file.path):
                 os.unlink(repo_file.path)
+            if os.path.exists(server_val_repo_file.path):
+                os.unlink(server_val_repo_file.path)
         # When the repo is removed, also remove the override tracker
         WrittenOverrideCache.delete_cache()
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1948521

In case of sub-man clean or sub-man register --force the old data should be deleted completely. For doing this, the file /var/lib/rhsm/repo_server_val/redhat.repo should be deleted, too. 

The delete_repo_file method is used in both cases: 'clean' and during unregistering step in 'register --force'