### PR TITLE
Enable subman to run normally in containers for development/test

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -109,6 +109,10 @@ def in_container():
     Assumes that if we see host rhsm configuration shared with us, we must
     be running in a container.
     """
+    # For development in containers we must be able to turn container detection
+    # off
+    if os.environ.get('SMDEV_CONTAINER_OFF', False):
+        return False
     if os.path.exists(HOST_CONFIG_DIR):
         return True
     return False


### PR DESCRIPTION
This allows us to turn off subscription-manager's container detection for development and test purposes.
For the test to operate properly once in a container we need some other source of truth about whether we are in a container or not.
This is provided via the SUBMAN_TEST_IN_CONTAINER environment variable. As we have yet to containerize our test environment this defaults to False if not present in the environement.