### PR TITLE
1959048: improve wording for invalid syspurpose values

### DIFF
--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -198,23 +198,17 @@ class AbstractSyspurposeCommand(CliCommand):
             if self.is_registered() or \
                     (self.options.username and self.options.password) or \
                     self.options.token:
-                if self.attr in valid_fields:
-                    if len(valid_fields[self.attr]) > 0:
-                        # TRANSLATORS: this is used to quote a string
-                        quoted_values = [_("\"{value}\"").format(value=value)
-                                         for value in invalid_values]
-                        printable_values = friendly_join(quoted_values)
-                        print(ungettext('Warning: Provided value {vals} is not included in the list of valid values',
-                                        'Warning: Provided values {vals} are not included in the list of valid values',
-                                        invalid_values_len).format(
-                            vals=printable_values
-                        ))
-                        self._print_valid_values(valid_fields)
-                    else:
-                        print(_('Warning: There are no available values for the system purpose "{attr}" '
-                                'from the available subscriptions in this organization.').format(
-                            attr=self.attr
-                        ))
+                if len(valid_fields.get(self.attr, [])) > 0:
+                    # TRANSLATORS: this is used to quote a string
+                    quoted_values = [_("\"{value}\"").format(value=value)
+                                     for value in invalid_values]
+                    printable_values = friendly_join(quoted_values)
+                    print(ungettext('Warning: Provided value {vals} is not included in the list of valid values',
+                                    'Warning: Provided values {vals} are not included in the list of valid values',
+                                    invalid_values_len).format(
+                        vals=printable_values
+                    ))
+                    self._print_valid_values(valid_fields)
                 else:
                     print(_('Warning: This organization does not have any subscriptions that provide a '
                             'system purpose "{attr}".  This setting will not influence auto-attaching '
@@ -333,26 +327,22 @@ class AbstractSyspurposeCommand(CliCommand):
 
     def list(self):
         valid_fields = self._get_valid_fields()
-        if self.attr in valid_fields:
-            if len(valid_fields[self.attr]) > 0:
-                line = '+-------------------------------------------+'
-                print(line)
-                translated_string = _('Available {syspurpose_attr}').format(syspurpose_attr=self.attr)
-                # Print translated string (the length could be different) in the center of the line
-                line_len = len(line)
-                trans_str_len = len(translated_string)
-                empty_space_len = int((line_len - trans_str_len) / 2)
-                print(empty_space_len * ' ' + translated_string)
-                print(line)
-                # Print values
-                self._print_valid_values(valid_fields)
-            else:
-                print(_('There are no available values for the system purpose "{syspurpose_attr}" '
-                        'from the available subscriptions in this '
-                        'organization.').format(syspurpose_attr=self.attr))
+        if len(valid_fields.get(self.attr, [])) > 0:
+            line = '+-------------------------------------------+'
+            print(line)
+            translated_string = _('Available {syspurpose_attr}').format(syspurpose_attr=self.attr)
+            # Print translated string (the length could be different) in the center of the line
+            line_len = len(line)
+            trans_str_len = len(translated_string)
+            empty_space_len = int((line_len - trans_str_len) / 2)
+            print(empty_space_len * ' ' + translated_string)
+            print(line)
+            # Print values
+            self._print_valid_values(valid_fields)
         else:
-            print(_('This organization does not have any subscriptions that provide a system '
-                    'purpose "{syspurpose_attr}.').format(syspurpose_attr=self.attr))
+            print(_('There are no available values for the system purpose "{syspurpose_attr}" '
+                    'from the available subscriptions in this '
+                    'organization.').format(syspurpose_attr=self.attr))
 
     def sync(self):
         return syspurposelib.SyspurposeSyncActionCommand().perform(include_result=True)[1]

--- a/src/subscription_manager/cli_command/service_level.py
+++ b/src/subscription_manager/cli_command/service_level.py
@@ -179,7 +179,9 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
                 for sla in slas:
                     print(sla)
             else:
-                print(_('This org does not have any subscriptions with an available "service level".'))
+                print(_('There are no available values for the system purpose "{syspurpose_attr}" '
+                        'from the available subscriptions in this '
+                        'organization.').format(syspurpose_attr="service_level"))
         except UnauthorizedException as e:
             raise e
         except connection.RemoteServerException as e:

--- a/test/cli_command_test/test_addons.py
+++ b/test/cli_command_test/test_addons.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+from contextlib import ExitStack
 
 from ..test_managercli import TestCliCommand
 from subscription_manager import syspurposelib
@@ -72,3 +73,11 @@ class TestAddonsCommand(TestCliCommand):
             with Capture() as cap:
                 self.assertEqual(self.cc._are_provided_values_valid(['test']), ['test'])
             self.assertIn('Warning: Provided value', cap.out)
+
+    def test_no_valid_values(self):
+        with ExitStack() as stack:
+            mock_get_valid_fields = stack.enter_context(patch.object(self.cc, '_get_valid_fields'))
+            cap = stack.enter_context(Capture())
+            mock_get_valid_fields.return_value = {'addons': []}
+            self.assertFalse(self.cc._is_provided_value_valid('test'))
+            self.assertIn('Warning: This organization does not have', cap.out)


### PR DESCRIPTION
Improve a bit more the wording for invalid syspurpose values:
- drop the distinction between missing syspurpose attribute and empty list of available values for it, because it is not that needed in the end (hard to diagnose, and not actionable by the user anyway)
- adopt the same message also for "service_level", as it uses a slightly different implementation of a syspurpose command