### PR TITLE
[1.28] cockpit: Invoke setup.py with python3

### DIFF
--- a/integration-tests/run
+++ b/integration-tests/run
@@ -39,8 +39,8 @@ $(COCKPIT_TAR): cockpit/node_modules
 	make -C cockpit dist-gzip
 
 $(SUBMAN_TAR):
-	fn=$$(python ./setup.py --fullname); \
-	python ./setup.py sdist && \
+	fn=$$(python3 ./setup.py --fullname); \
+	python3 ./setup.py sdist && \
         mv dist/$$fn.tar.gz $(SUBMAN_TAR)
 
 $(SMBEXT_TAR):


### PR DESCRIPTION
python does not exist any more, and integration-tests/vm.install only
installs python3. The latter also calls `python3 ./setup.py`, so be
consistent.

(cherry picked from commit f9e6342d0262f0ef7576d06346f290dd87851c42)

Backport of one commit of #2380 to 1.28, to fix the cockpit CI.