### PR TITLE
[1.28] 1971693: syspurpose: adjust deprecation messages

### DIFF
--- a/syspurpose/man/syspurpose.8
+++ b/syspurpose/man/syspurpose.8
@@ -23,7 +23,7 @@ Red Hat subscription management entitlement server (Customer Portal or Satellite
 6).  The \fIshow\fP command displays the current system purpose.
 .PP
 The 'syspurpose' command is deprecated and will be removed in a future major release. 
-Please use the 'subscription-manager syspurpose' command going forward.
+Please use the subscription-manager modules going forward.
 
 .SH COMMANDS
 .TP

--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -156,7 +156,7 @@ def setup_arg_parser():
     """
     parser = argparse.ArgumentParser(prog="syspurpose", description="System Syspurpose Management Tool",
                                      epilog=_("The 'syspurpose' command is deprecated and will be removed in a future major release."
-                                                " Please use the 'subscription-manager syspurpose' command going forward."))
+                                                " Please use the subscription-manager modules going forward."))
 
     subparsers = parser.add_subparsers(help="sub-command help")
 
@@ -351,7 +351,7 @@ def main():
               "Please run syspurpose on the host.\n"))
 
     print(_("The 'syspurpose' command is deprecated and will be removed in a future major release."
-        " Please use the 'subscription-manager syspurpose' command going forward."), file=sys.stderr)
+        " Please use the subscription-manager modules going forward."), file=sys.stderr)
     try:
         from subscription_manager.identity import Identity
         from subscription_manager.cp_provider import CPProvider


### PR DESCRIPTION
Do not refer to the `syspurpose` module of `subscription-manager`, as it does not manage all the syspurpose attributes on its own.
Adopt a more generic text (kindly provided by John Sefler) that points to use the appropriate module of `subscription-manager`.