### PR TITLE
[1.28] jenkins: switch stylish job to Python 3

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,58 @@
+[flake8]
+ignore =
+    # E117: over-indented
+    # mostly a consequence of W504 issues
+    E117,
+    # E121: continuation line under-indented for hanging indent
+    # wrong indentation of continuation lines
+    E121,
+    # E122: continuation line missing indentation or outdented
+    # wrong indentation of continuation lines
+    E122,
+    # E123: closing bracket does not match indentation of opening bracket's line
+    # mostly wrongly indented closing bracket
+    E123,
+    # E124: closing bracket does not match visual indentation
+    # mostly wrongly indented closing bracket
+    E124,
+    # E125: continuation line with same indent as next logical line
+    # wrong indentation of continuation lines
+    E125,
+    # E126: continuation line over-indented for hanging indent
+    # wrong indentation of continuation lines
+    E126,
+    # E127: continuation line over-indented for visual indent
+    # wrong indentation of continuation lines
+    E127,
+    # E128, continuation line under-indented for visual indent
+    # wrong indentation of continuation lines
+    E128,
+    # E131: continuation line unaligned for hanging indent
+    # wrong indentation of continuation lines
+    E131,
+    # E265: block comment should start with '# '
+    # comments and commented code need a space after '#'
+    E265,
+    # E402: module level import not at top of file
+    E402,
+    # E501: line too long (* > 300 characters)
+    # triggered by very long text string in tests
+    E501,
+    # E713 test for membership should be 'not in'
+    E713,
+    # E714 test for object identity should be 'is not'
+    E714,
+    # E722: do not use bare 'except'
+    # done a lot, needs to be fixed by catching all what is needed
+    E722,
+    # E731: do not assign a lambda expression, use a def
+    E731,
+    # E741: ambiguous variable name '*'
+    # mostly for variables 'l', which ought to get more specific names
+    E741,
+    # W504: line break after binary operator
+    # we break after binary operators, newer style breaks before
+    W504,
+    # W605: invalid escape sequence '*'
+    # it is a DeprecationWarning since Python 3.6, will become SyntaxError
+    W605

--- a/.flake8
+++ b/.flake8
@@ -50,6 +50,12 @@ ignore =
     # E741: ambiguous variable name '*'
     # mostly for variables 'l', which ought to get more specific names
     E741,
+    # F821: undefined name '*'
+    F821,
+    # F841: local variable '*' is assigned to but never used
+    # possibly either mistakes (variables that were supposed to be used),
+    # or really no more needed variables
+    F841,
     # W504: line break after binary operator
     # we break after binary operators, newer style breaks before
     W504,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,9 @@ pipeline {
   stages {
     stage('Test') {
       parallel {
-        stage('Python 2 stylish') {
-          agent { label 'subman-centos7' }
+        stage('Python stylish') {
           steps {
-            sh readFile(file: 'jenkins/stylish-tests.sh')
+            sh readFile(file: 'jenkins/python3-stylish-tests.sh')
           }
         }
         stage('tito') {

--- a/build_ext/setup.py
+++ b/build_ext/setup.py
@@ -20,8 +20,8 @@ test_require = [
 ]
 
 install_requires = [
-    'pep8==1.5.7',
-    'flake8==3.0.4',
+    'pep8',
+    'flake8',
     'pyflakes',
     'lxml'
 ]

--- a/jenkins/python3-stylish-tests.sh
+++ b/jenkins/python3-stylish-tests.sh
@@ -19,8 +19,8 @@ cd $WORKSPACE
 
 sudo yum clean expire-cache
 sudo yum-builddep -y subscription-manager.spec || true  # ensure we install any missing rpm deps
-virtualenv env -p python3
-source env/bin/activate
+virtualenv env-stylish -p python3
+source env-stylish/bin/activate
 
 make install-pip-requirements
 

--- a/jenkins/python3-tests.sh
+++ b/jenkins/python3-tests.sh
@@ -18,8 +18,8 @@ echo "GIT_COMMIT:" "${GIT_COMMIT}"
 
 sudo yum clean expire-cache
 sudo yum-builddep -y subscription-manager.spec || true # ensure we install any missing rpm deps
-virtualenv env -p python3 --system-site-packages || virtualenv env --system-site-packages || true
-source env/bin/activate
+virtualenv env-tests -p python3 --system-site-packages || virtualenv env-tests --system-site-packages || true
+source env-tests/bin/activate
 pip install -I -r test-requirements.txt
 
 # so we can run these all everytime, we don't actually fail on each step, so checkout for output

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -96,6 +96,7 @@ class NullHandler(logging.Handler):
     def emit(self, record):
         pass
 
+
 h = NullHandler()
 logging.getLogger("rhsm").addHandler(h)
 

--- a/src/rhsm/m2cryptossl.py
+++ b/src/rhsm/m2cryptossl.py
@@ -87,4 +87,5 @@ class SSLContext(object):
         else:
             return self.m2context.load_cert(certfile, keyfile)
 
+
 SSLError = _ssl.SSLError

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2706,7 +2706,7 @@ class ReposCommand(CliCommand):
         repos_to_modify = {}
 
         if not len(repos):
-            print (_("This system has no repositories available through subscriptions."))
+            print(_("This system has no repositories available through subscriptions."))
             return 1
 
         for (status, repoid) in repo_actions:
@@ -2849,7 +2849,7 @@ class ConfigCommand(CliCommand):
                     print('   %s = %s%s%s' % (name, indicator1, value, indicator2))
                 print()
             print(_("[] - Default value in use"))
-            print ("\n")
+            print("\n")
         elif self.options.remove:
             for r in self.options.remove:
                 section = r.split('.')[0]

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -680,7 +680,7 @@ class MigrationEngine(object):
     def register(self, credentials, org, environment):
         # For registering the machine, use the CLI tool to reuse the username/password (because the GUI will prompt for them again)
         # Prepended a \n so translation can proceed without hitch
-        print ("")
+        print("")
         print(_("Attempting to register system to destination server..."))
         cmd = ['subscription-manager', 'register']
 

--- a/src/subscription_manager/scripts/rhn_migrate_classic_to_rhsm.py
+++ b/src/subscription_manager/scripts/rhn_migrate_classic_to_rhsm.py
@@ -38,6 +38,7 @@ def system_exit(code, msgs=None):
             sys.stderr.write(six.text_type(msg) + '\n')
     sys.exit(code)
 
+
 _LIBPATH = "/usr/share/rhsm"
 # add to the path if need be
 if _LIBPATH not in sys.path:

--- a/src/subscription_manager/scripts/rhsm_facts_service.py
+++ b/src/subscription_manager/scripts/rhsm_facts_service.py
@@ -39,5 +39,6 @@ def main():
     except Exception:
         log.exception("DBus service startup failed")
 
+
 if __name__ == "__main__":
     main()

--- a/src/subscription_manager/scripts/sat5to6.py
+++ b/src/subscription_manager/scripts/sat5to6.py
@@ -38,6 +38,7 @@ def system_exit(code, msgs=None):
             sys.stderr.write(six.text_type(msg) + '\n')
     sys.exit(code)
 
+
 # quick check to see if you are a super-user.
 if os.getuid() != 0:
     sys.stderr.write('Error: this command requires root access to execute\n')

--- a/src/subscription_manager/scripts/subscription_manager_gui.py
+++ b/src/subscription_manager/scripts/subscription_manager_gui.py
@@ -106,6 +106,7 @@ def system_exit(code, msgs=None):
             sys.stderr.write(str(msg) + '\n')
     sys.exit(code)
 
+
 BUS_NAME = "com.redhat.SubscriptionManagerGUI"
 BUS_PATH = "/gui"
 
@@ -231,6 +232,7 @@ def main():
     except Exception as e:
         log.exception(e)
         system_exit(1, e)
+
 
 if __name__ == '__main__':
     main()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,5 +16,4 @@ simplejson
 mock
 Sphinx==1.8.5;python_version<="2.7"
 Sphinx>=1.8.5;python_version>="3.0"
-git+https://github.com/alikins/pyqver.git#egg=pyqver
 git+https://github.com/awood/nose-xvfb.git#egg=nose-xvfb


### PR DESCRIPTION
Cherry picked commit from #2621

subscription-manager does not support Python 2 anymore, so switch the
stylish script to the Python 3 version.

Also, stop using the 'subman-centos7' agent for it, as it clearly does
not support Python 3; the default 'subman' agent will work fine.