### PR TITLE
[1.28] 1967780: improve placeholders in help text

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -357,7 +357,7 @@ class CliCommand(AbstractCLICommand):
     def _add_proxy_options(self):
         """ Add proxy options that apply to sub-commands that require network connections. """
         self.parser.add_option("--proxy", dest="proxy_url",
-                               default=None, help=_("proxy URL in the form of proxy_hostname:proxy_port"))
+                               default=None, help=_("proxy URL in the form of hostname:port"))
         self.parser.add_option("--proxyuser", dest="proxy_user",
                                 default=None, help=_("user for HTTP proxy with basic authentication"))
         self.parser.add_option("--proxypassword", dest="proxy_password",


### PR DESCRIPTION
When describing the format of the argument for '--proxy', use different
(and generic) placeholders to describe the format needed; do not use the
same names of configuration keys to avoid potential confusion.

(cherry picked from commit 7ea27a2ddd037b15fbbca56488882ed49b60e256)

Backport of #2665 to 1.28.