### PR TITLE
1941904: actually disable initial-setup in RHEL >= 9, and Fedora too

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -93,9 +93,10 @@
 %global use_inotify 0
 %endif
 
-# Do not ship initial-setup in RHEL 9 and on, as Anaconda can now register
-# during the installation.
-%if (0%{?rhel} && 0%{?rhel} < 9)
+# Do not ship initial-setup in RHEL 9+ and Fedora:
+# - as Anaconda can now register during the installation
+# - it uses old Anaconda APIs that are not supported anymore
+%if 0%{?rhel} >= 9 || 0%{?fedora}
 %global use_initial_setup 0
 %endif
 


### PR DESCRIPTION
The previous change actually did the opposite, i.e. disable initial-setup
on RHEL _older_ than 9.

Also, extend the disabling to Fedora, as the same reasons for disabling
initial-setup in RHEL 9+ apply to recent Fedora versions.