### PR TITLE
1967210: Do not print warning, when valid value is provided

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -201,15 +201,23 @@ class RhsmConfigParser(SafeConfigParser):
         if section == "logging" and name == "default_log_level":
             self.is_log_level_valid(value)
 
-    def is_log_level_valid(self, value):
+    def is_log_level_valid(self, value, print_warning=True):
+        """
+        Check if provided default_log_level value is valid or not
+        :param value: value of default_log_level
+        :param print_warning: print warning, when provided value is not valid
+        :return: True, when value is valid. Otherwise return False
+        """
         valid = ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOSET']
         if value not in valid:
-            print("Invalid Log Level: {lvl}, setting to INFO for this run.".format(lvl=value), file=sys.stderr)
-            print(
-                "Please use:  subscription-manager config --logging.default_log_level=<Log Level> to set the default_log_level to a valid value.",
-                file=sys.stderr)
-            valid_str = ", ".join(valid)
-            print("Valid Values: {valid_str}".format(valid_str=valid_str), file=sys.stderr)
+            if print_warning is True:
+                print("Invalid Log Level: {lvl}, setting to INFO for this run.".format(lvl=value), file=sys.stderr)
+                print(
+                    "Please use:  subscription-manager config --logging.default_log_level=<Log Level> to set "
+                    "the default_log_level to a valid value.",
+                    file=sys.stderr)
+                valid_str = ", ".join(valid)
+                print("Valid Values: {valid_str}".format(valid_str=valid_str), file=sys.stderr)
             return False
         return True
 


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1967210
* Card ID: ENT-3927
* When not valid value of default_log_level is set in rhsm.conf
  and valid values is provided using CLI option
  --logging.default_log_level, then do not print warning message
  in this case.
* It was necessary to check CLI options in rhsm Python
  package in logutil.py module. This is little bit hackish,
  because this module should be independent on CLI tools

(cherry picked from commit 0bca7e5a6866858739cfded9d987bca9f6acb04d)