### PR TITLE
Move cloud detector/collector to cloud-what package

### DIFF
--- a/src/cloud_what/README.md
+++ b/src/cloud_what/README.md
@@ -35,7 +35,7 @@ import logging
 
 from typing import Union
 
-from rhsmlib.cloud._base_provider import BaseCloudProvider
+from cloud_what._base_provider import BaseCloudProvider
 
 
 log = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ class FooCloudProvider(BaseCloudProvider):
     SIGNATURE_CACHE_FILE = None
 
     HTTP_HEADERS = {
-        'user-agent': 'RHSM/1.0',
+        'user-agent': 'cloud-what/1.0',
     }
 
     TIMEOUT = 1.0
@@ -143,6 +143,7 @@ class FooCloudProvider(BaseCloudProvider):
         This method tries to get data from server using GET method
         :param data_type: string representation of data type used in log messages (e.g. "metadata", "signature")
         :param url: URL of GET request
+        :param headers: HTTP headers
         :return: String of body, when request was successful; otherwise return None
         """
         return super(FooCloudProvider, self)._get_data_from_server(data_type, url, headers)
@@ -191,7 +192,7 @@ class FooCloudProvider(BaseCloudProvider):
 ```
 
 When implementation of cloud provider is finished, then please modify list of providers
-in `rhsmlib/cloud/provider.py` accordingly:
+in `cloud_what/provider.py` accordingly:
 
 ```python
 # List of detector classes with supported cloud providers
@@ -202,4 +203,4 @@ CLOUD_PROVIDERS = [
 ```
 
 When implementation of your cloud detector and collector is finished, then please implement some unit tests in
-`test/rhsmlib_test/test_cloud.py` or you can implement tests first if you prefer test driven development.
+`test/cloud_what/test_cloud_what.py` or you can implement tests first if you prefer test driven development.

--- a/src/cloud_what/README.md.orig
+++ b/src/cloud_what/README.md.orig
@@ -1,0 +1,209 @@
+RHSM & Cloud
+============
+
+This package contains modules for detecting cloud providers and collecting cloud metadata. The
+metadata then can be for example reported in system facts. Three main cloud providers are
+supported ATM: Amazon Web Services, Microsoft Azure and Google Cloud Platform. If you want to add
+support for another cloud provider, then add subclasses of CloudProvider to module in `providers`
+sub-package and modify list of supported classes in `provider.py`.
+
+Example: you want to add support for Foo Cloud Provider. You will create package `fcp.py` in
+folder `providers`. Content of `fcp.py` will look like this:
+
+```python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 Foo Company
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+This is module implementing detector and metadata collector of virtual machine running on Foo Cloud Provider
+"""
+
+import logging
+
+from typing import Union
+
+from cloud_what._base_provider import BaseCloudProvider
+
+
+log = logging.getLogger(__name__)
+
+
+class FooCloudProvider(BaseCloudProvider):
+    """
+    Base class for Foo cloud provider
+    """
+
+    CLOUD_PROVIDER_ID = "foo"
+
+    CLOUD_PROVIDER_METADATA_URL = "http://1.2.2.4/metadata/"
+
+    CLOUD_PROVIDER_METADATA_TYPE = "application/json"
+
+    CLOUD_PROVIDER_SIGNATURE_URL = "http://169.254.169.254/signature"
+
+    CLOUD_PROVIDER_SIGNATURE_TYPE = "application/json"
+
+    METADATA_CACHE_FILE = None
+
+    SIGNATURE_CACHE_FILE = None
+
+    HTTP_HEADERS = {
+        'user-agent': 'cloud-what/1.0',
+    }
+
+    TIMEOUT = 1.0
+
+    def __init__(self, hw_info):
+        """
+        Initialize instance of FooCloudDetector
+        """
+        super(FooCloudProvider, self).__init__(hw_info)
+
+    def is_vm(self):
+        """
+        Is system running on virtual machine or not
+        Note: method of parent class parses output of virt-what. You probably
+              do not want to change this method.
+        :return: True, when machine is running on VM; otherwise return False
+        """
+        return super(FooCloudProvider, self).is_vm()
+
+    def is_running_on_cloud(self):
+        """
+        Try to detect Foo cloud provider using strong signs from collected hardware information
+        (output of dmidecode, virt-what, etc.)
+        :return: True, when we detected sign of Foo in hardware information; Otherwise return False
+        """
+
+        # TODO: Check if this is true for Foo Cloud Provider
+        if self.is_vm() is False:
+            return False
+
+        # This is valid for virtual machines running on Foo
+        if 'dmi.chassis.asset_tag' in self.hw_info and \
+                self.hw_info['dmi.chassis.asset_tag'] == 'FOO':
+            return True
+        # In other cases return False
+        return False
+
+    def is_likely_running_on_cloud(self):
+        """
+        Return non-zero value, when the machine is virtual machine and it is running on Foo
+        hypervisor and some Foo string can be found in output of dmidecode.
+        Note: this method uses some heuristics, when you don't have strong signs of
+              cloud provider under full control and cloud provider changed information provided
+              by SM BIOS. This method is used in fallback mode, when no cloud provider
+              cannot be detected using strong signs.
+        :return: Float value representing probability that vm is running on Foo
+        """
+        probability = 0.0
+
+        # TODO: Check if this is true for Foo Cloud Provider
+        if self.is_vm() is False:
+            return 0.0
+
+        if 'dmi.chassis.asset_tag' in self.hw_info and \
+                self.hw_info['dmi.chassis.asset_tag'] == 'FOO':
+            probability += 0.3
+
+        # Try to find "Foo" keyword in output of dmidecode
+        found_foo = False
+        for hw_item in self.hw_info.values():
+            if type(hw_item) != str:
+                continue
+            if 'foo' in hw_item.lower():
+                found_foo = True
+        if found_foo is True:
+            probability += 0.3
+
+        return probability
+
+
+    def _get_metadata_from_cache(self) -> Union[str, None]:
+        """
+        TODO: implement something or return None
+        """
+        raise NotImplementedError
+
+    def _get_data_from_server(self, data_type, url, headers):
+        """
+        This method tries to get data from server using GET method
+        :param data_type: string representation of data type used in log messages (e.g. "metadata", "signature")
+        :param url: URL of GET request
+        :return: String of body, when request was successful; otherwise return None
+        """
+        return super(FooCloudProvider, self)._get_data_from_server(data_type, url, headers)
+
+    def _get_metadata_from_server(self) -> Union[str, None]:
+        """
+        Try to get metadata from server
+        Note: You probably do not want to change this method, when Foo cloud provider supports
+              only one version of IMDS.
+        :return: String with metadata or None
+        """
+        return super(FooCloudProvider, self)._get_metadata_from_server()
+
+    def _get_signature_from_cache_file(self) -> Union[str, None]:
+        """
+        TODO: implement something or return None
+        """
+        raise NotImplementedError
+
+    def _get_signature_from_server(self) -> Union[str, None]:
+        """
+        Method for gathering signature of metadata from server
+        Note: You probably do not want to change this method, when Foo cloud provider supports
+              only one version of IMDS.
+        :return: String containing signature or None
+        """
+        return super(FooCloudProvider, self)._get_signature_from_server()
+
+    def get_signature(self) -> Union[str, None]:
+        """
+        Public method for getting signature (cache file or server).
+        Note: You probably do not want to change this method, when Foo cloud provider supports
+              only one version of IMDS.
+        :return: String containing signature or None
+        """
+        return super(FooCloudProvider, self).get_signature()
+
+    def get_metadata(self) -> Union[str, None]:
+        """
+        Public method for getting metadata (cache file or server). You probabl
+        Note: You probably do not want to change this method, when Foo cloud provider supports
+              only one version of IMDS.
+        :return: String containing metadata or None
+        """
+        return super(FooCloudProvider, self).get_metadata()
+```
+
+When implementation of cloud provider is finished, then please modify list of providers
+in `cloud_what/provider.py` accordingly:
+
+```python
+# List of detector classes with supported cloud providers
+CLOUD_PROVIDERS = [
+    ...,
+    FooCloudProvider
+]
+```
+
+When implementation of your cloud detector and collector is finished, then please implement some unit tests in
+<<<<<<< HEAD:src/cloud_what/README.md
+`test/cloud_what/test_cloud_what.py` or you can implement tests first if you prefer test driven development.
+=======
+`test/rhsmlib_test/test_cloud.py` or you can implement tests first if you prefer test driven development.
+>>>>>>> main:src/rhsmlib/cloud/README.md

--- a/src/cloud_what/_base_provider.py
+++ b/src/cloud_what/_base_provider.py
@@ -64,11 +64,11 @@ class BaseCloudProvider(object):
     CLOUD_PROVIDER_SIGNATURE_TYPE = None
 
     # Default value of path to cache file holding metadata
-    # (e.g. /var/lib/rhsm/cache/cool_cloud_metadata.json)
+    # (e.g. /var/lib/cloud-what/cache/cool_cloud_metadata.json)
     METADATA_CACHE_FILE = None
 
     # Default value of path to holding signature of metadata
-    # (e.g. /var/lib/rhsm/cache/cool_cloud_signature.json)
+    # (e.g. /var/lib/cloud-what/cache/cool_cloud_signature.json)
     SIGNATURE_CACHE_FILE = None
 
     # Custom HTTP headers like user-agent
@@ -166,6 +166,13 @@ class BaseCloudProvider(object):
             "ttl": str(self._token_ttl),
             "token": self._token
         }
+
+        token_cache_dir = os.path.dirname(self.TOKEN_CACHE_FILE)
+        try:
+            os.makedirs(token_cache_dir, exist_ok=True)
+        except OSError as err_msg:
+            log.debug(f'Unable to create cache directory {token_cache_dir}: {err_msg}')
+            return
 
         log.debug(f'Writing {self.CLOUD_PROVIDER_ID} token to file {self.TOKEN_CACHE_FILE}')
 

--- a/src/cloud_what/fact_collector.py
+++ b/src/cloud_what/fact_collector.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+This module contains minimalistic collectors of system facts
+"""
+
+# TODO: Create some service for gathering system facts that could be
+# TODO: used by many applications on Linux.
+
+import os
+import subprocess
+import logging
+
+try:
+    import dmidecode
+except ImportError:
+    dmidecode = None
+
+log = logging.getLogger(__name__)
+
+
+class MiniHostCollector(object):
+    """
+    Minimalistic collector of host facts
+    """
+
+    VIRT_WHAT_PATH = '/usr/sbin/virt-what'
+
+    def get_virt_what(self) -> dict:
+        """
+        Try to call virt-what and parse output from this application
+        :return: dictionary with facts
+        """
+
+        if os.path.isfile(self.VIRT_WHAT_PATH) is False:
+            log.error(f'The {self.VIRT_WHAT_PATH} does not exists')
+            return {}
+
+        try:
+            output = subprocess.check_output(self.VIRT_WHAT_PATH)
+        except Exception as err:
+            log.error(f'Failed to call {self.VIRT_WHAT_PATH}: {err}')
+            return {}
+
+        if isinstance(output, bytes):
+            output = output.decode('utf-8')
+
+        virt_dict = {}
+
+        host_type = ", ".join(output.splitlines())
+
+        # If this is blank, then system is not a guest
+        virt_dict['virt.is_guest'] = bool(host_type)
+
+        if virt_dict['virt.is_guest'] is True:
+            virt_dict['virt.host_type'] = host_type
+        else:
+            virt_dict['virt.host_type'] = "Not Applicable"
+
+        return virt_dict
+
+    def _get_dmi_data(self, func_output, tag, dmi_info):
+        for key, value in func_output.items():
+            for key1, value1 in list(value['data'].items()):
+                # Skip everything that isn't string
+                if not isinstance(value1, str) and not isinstance(value1, bytes):
+                    continue
+
+                nkey = ''.join([tag, key1.lower()]).replace(" ", "_")
+                dmi_info[nkey] = str(value1, 'utf-8')
+
+        return dmi_info
+
+    def get_dmidecode(self) -> dict:
+        """
+        Try to get output from dmidecode. It require dmidecode module
+        :return: Dictionary with facts
+        """
+        if dmidecode is None:
+            log.error('The dmidecode module is not installed. Unable to detect public cloud providers.')
+            return {}
+
+        dmi_data = {
+            "dmi.bios.": dmidecode.bios,
+            "dmi.processor.": dmidecode.processor,
+            "dmi.baseboard.": dmidecode.baseboard,
+            "dmi.chassis.": dmidecode.chassis,
+            "dmi.slot.": dmidecode.slot,
+            "dmi.system.": dmidecode.system,
+            "dmi.memory.": dmidecode.memory,
+            "dmi.connector.": dmidecode.connector,
+        }
+
+        dmi_info = {}
+        for key, func in dmi_data.items():
+            try:
+                func_output = func()
+            except Exception as err:
+                log.error(f'Unable to read system DMI information {func}: {err}')
+            else:
+                dmi_info = self._get_dmi_data(func_output, key, dmi_info)
+        return dmi_info
+
+    def get_all(self) -> dict:
+        virt_dict = self.get_virt_what()
+        dmidecode_dict = self.get_dmidecode()
+        return {**virt_dict, **dmidecode_dict}
+
+
+# We do not need this collector for cloud-what, so it is really dummy
+class MiniCustomFactsCollector(object):
+    @staticmethod
+    def get_all() -> dict:
+        return {}
+
+
+# Some temporary smoke testing code. You can test this module using:
+# sudo PYTHONPATH=./src python3 -m cloud_what.fact_collector
+if __name__ == '__main__':
+    import sys
+
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+
+    collector = MiniHostCollector()
+    facts = collector.get_all()
+    print(f'>>> debug <<<< {facts}')

--- a/src/cloud_what/providers/aws.py
+++ b/src/cloud_what/providers/aws.py
@@ -26,7 +26,7 @@ import os
 
 from typing import Union
 
-from rhsmlib.cloud._base_provider import BaseCloudProvider
+from cloud_what._base_provider import BaseCloudProvider
 
 
 log = logging.getLogger(__name__)
@@ -51,12 +51,10 @@ class AWSCloudProvider(BaseCloudProvider):
 
     CLOUD_PROVIDER_SIGNATURE_TYPE = "text/plain"
 
-    COLLECTOR_CONF_FILE = "/etc/rhsm/cloud/providers/aws.conf"
-
-    TOKEN_CACHE_FILE = "/var/lib/rhsm/cache/aws_token.json"
+    TOKEN_CACHE_FILE = "/var/cache/cloud-what/aws_token.json"
 
     HTTP_HEADERS = {
-        'User-Agent': 'RHSM/1.0'
+        'User-Agent': 'cloud-what/1.0'
     }
 
     def __init__(self, hw_info):
@@ -351,7 +349,6 @@ def _smoke_tests():
     """
     # Gather only information about hardware and virtualization
     from rhsmlib.facts.host_collector import HostCollector
-    from rhsmlib.facts.hwprobe import HardwareCollector
     import sys
 
     root = logging.getLogger()
@@ -365,7 +362,6 @@ def _smoke_tests():
 
     facts = {}
     facts.update(HostCollector().get_all())
-    facts.update(HardwareCollector().get_all())
     aws_cloud_provider = AWSCloudProvider(facts)
     result = aws_cloud_provider.is_running_on_cloud()
     probability = aws_cloud_provider.is_likely_running_on_cloud()
@@ -384,6 +380,6 @@ def _smoke_tests():
 
 
 # Some temporary smoke testing code. You can test this module using:
-# sudo PYTHONPATH=./src python3 -m rhsmlib.cloud.providers.aws
+# sudo PYTHONPATH=./src python3 -m cloud_what.providers.aws
 if __name__ == '__main__':
     _smoke_tests()

--- a/src/cloud_what/providers/aws.py.orig
+++ b/src/cloud_what/providers/aws.py.orig
@@ -1,0 +1,389 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+
+"""
+This is module implementing detector and metadata collector of virtual machine running on AWS
+"""
+
+import requests
+import logging
+import time
+import os
+
+from typing import Union
+
+from cloud_what._base_provider import BaseCloudProvider
+
+
+log = logging.getLogger(__name__)
+
+
+class AWSCloudProvider(BaseCloudProvider):
+    """
+    Base class for AWS cloud provider
+    """
+
+    CLOUD_PROVIDER_ID = "aws"
+
+    CLOUD_PROVIDER_METADATA_URL = "http://169.254.169.254/latest/dynamic/instance-identity/document"
+
+    CLOUD_PROVIDER_METADATA_TYPE = "application/json"
+
+    CLOUD_PROVIDER_TOKEN_URL = "http://169.254.169.254/latest/api/token"
+
+    CLOUD_PROVIDER_TOKEN_TTL = 3600  # the value is in seconds
+
+    CLOUD_PROVIDER_SIGNATURE_URL = "http://169.254.169.254/latest/dynamic/instance-identity/rsa2048"
+
+    CLOUD_PROVIDER_SIGNATURE_TYPE = "text/plain"
+
+    TOKEN_CACHE_FILE = "/var/cache/cloud-what/aws_token.json"
+
+    HTTP_HEADERS = {
+<<<<<<< HEAD:src/cloud_what/providers/aws.py
+        'User-Agent': 'cloud-what/1.0'
+=======
+        'User-Agent': 'RHSM/1.0'
+>>>>>>> main:src/rhsmlib/cloud/providers/aws.py
+    }
+
+    def __init__(self, hw_info):
+        """
+        Initialize instance of AWSCloudDetector
+        """
+        super(AWSCloudProvider, self).__init__(hw_info)
+
+    def is_running_on_cloud(self) -> bool:
+        """
+        Try to guess if cloud provider is AWS using collected hardware information (output of dmidecode,
+        virt-what, etc.)
+        :return: True, when we detected sign of AWS in hardware information; Otherwise return False
+        """
+
+        # The system has to be VM
+        if self.is_vm() is False:
+            return False
+        # This is valid for AWS systems using Xen
+        if 'dmi.bios.version' in self.hw_info and 'amazon' in self.hw_info['dmi.bios.version']:
+            return True
+        # This is valid for AWS systems using KVM
+        if 'dmi.bios.vendor' in self.hw_info and 'Amazon EC2' in self.hw_info['dmi.bios.vendor']:
+            return True
+        # Try to get output from virt-what
+        if 'virt.host_type' in self.hw_info and 'aws' in self.hw_info['virt.host_type']:
+            return True
+        # In other cases return False
+        return False
+
+    def is_likely_running_on_cloud(self) -> float:
+        """
+        Return non-zero value, when the machine is virtual machine and it is running on kvm/xen and
+        some Amazon string can be found in output of dmidecode
+        :return: Float value representing probability that vm is running on AWS
+        """
+        probability = 0.0
+
+        # When the machine is not virtual machine, then there is probably zero chance that the machine
+        # is running on AWS
+        if self.is_vm() is False:
+            return 0.0
+
+        # We know that AWS uses mostly KVM and it uses Xen in some cases
+        if 'virt.host_type' in self.hw_info:
+            # It seems that KVM is used more often
+            if 'kvm' in self.hw_info['virt.host_type']:
+                probability += 0.3
+            elif 'xen' in self.hw_info['virt.host_type']:
+                probability += 0.2
+
+        # Every system UUID of VM running on AWS EC2 starts with EC2 string. Not strong sign, but
+        # it can increase probability a little
+        if 'dmi.system.uuid' in self.hw_info and self.hw_info['dmi.system.uuid'].lower().startswith('ec2'):
+            probability += 0.1
+
+        # Try to find "Amazon EC2", "Amazon" or "AWS" keywords in output of dmidecode
+        found_amazon = False
+        found_amazon_ec2 = False
+        found_aws = False
+        for hw_item in self.hw_info.values():
+            if type(hw_item) != str:
+                continue
+            if 'amazon ec2' in hw_item.lower():
+                found_amazon_ec2 = True
+            elif 'amazon' in hw_item.lower():
+                found_amazon = True
+            elif 'aws' in hw_item.lower():
+                found_aws = True
+        if found_amazon_ec2 is True:
+            probability += 0.3
+        if found_amazon is True:
+            probability += 0.2
+        if found_aws is True:
+            probability += 0.1
+
+        return probability
+
+    def _get_metadata_from_cache(self) -> None:
+        """
+        This cloud collector does not allow to use cache for metadata
+        :return: None
+        """
+        return None
+
+    def _get_token_from_server(self) -> Union[str, None]:
+        """
+        Try to get token from server as it is described in this document:
+
+        https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+
+        When a token is received from server, then the token is also written
+        to the cache file.
+
+        :return: String of token or None, when it wasn't possible to get the token
+        """
+        log.debug(f'Requesting AWS token from {self.CLOUD_PROVIDER_TOKEN_URL}')
+
+        headers = {
+            'X-aws-ec2-metadata-token-ttl-seconds': str(self.CLOUD_PROVIDER_TOKEN_TTL),
+            **self.HTTP_HEADERS
+        }
+
+        http_req = requests.Request(method='PUT', url=self.CLOUD_PROVIDER_TOKEN_URL, headers=headers)
+        prepared_http_req = self._session.prepare_request(http_req)
+        if 'SUBMAN_DEBUG_PRINT_REQUEST' in os.environ:
+            self._debug_print_http_request(prepared_http_req)
+
+        try:
+            response = self._session.send(prepared_http_req, timeout=self.TIMEOUT)
+        except requests.ConnectionError as err:
+            log.error(f'Unable to receive token from AWS: {err}')
+        else:
+            if response.status_code == 200:
+                self._token = response.text
+                self._token_ctime = time.time()
+                self._token_ttl = self.CLOUD_PROVIDER_TOKEN_TTL
+                self._write_token_to_cache_file()
+                return response.text
+            else:
+                log.error(f'Unable to receive token from AWS; status code: {response.status_code}')
+        return None
+
+    def _token_exists(self) -> bool:
+        """
+        Check if security token exists and IMDSv2 should be used?
+        :return: True, when token exists; otherwise return False.
+        """
+        if os.path.exists(self.TOKEN_CACHE_FILE):
+            return True
+        else:
+            return False
+
+    def _get_token(self) -> Union[str, None]:
+        """
+        Try to get the token from in-memory cache. When in-memory cache is not valid, then
+        try to get the token from cache file and when cache file is not valid, then finally
+        try to get the token from AWS server
+        :return: String with the token or None
+        """
+        if self._is_in_memory_cached_token_valid() is True:
+            token = self._token
+        else:
+            token = self._get_token_from_cache_file()
+            if token is None:
+                token = self._get_token_from_server()
+        return token
+
+    def _get_metadata_from_server_imds_v1(self) -> Union[str, None]:
+        """
+        Try to get metadata from server using IMDSv1
+        :return: String with metadata or None
+        """
+        log.debug(f'Trying to get AWS metadata from {self.CLOUD_PROVIDER_METADATA_URL} using IMDSv1')
+
+        return self._get_data_from_server(
+            data_type='metadata',
+            url=self.CLOUD_PROVIDER_METADATA_URL
+        )
+
+    def _get_metadata_from_server_imds_v2(self) -> Union[str, None]:
+        """
+        Try to get metadata from server using IMDSv2
+        :return: String with metadata or None
+        """
+        log.debug(f'Trying to get AWS metadata from {self.CLOUD_PROVIDER_METADATA_URL} using IMDSv2')
+
+        token = self._get_token()
+        if token is None:
+            return None
+
+        headers = {
+            'X-aws-ec2-metadata-token': token,
+            **self.HTTP_HEADERS
+        }
+
+        return self._get_data_from_server(
+            data_type='metadata',
+            url=self.CLOUD_PROVIDER_METADATA_URL,
+            headers=headers
+        )
+
+    def _get_metadata_from_server(self) -> Union[str, None]:
+        """
+        Try to get metadata from server as is described in this document:
+
+        https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+
+        It is possible to use two versions. We will try to use version IMDSv1 first (this version requires
+        only one HTTP request), when the usage of IMDSv1 is forbidden, then we will try to use IMDSv2 version.
+        The version requires two requests (get session TOKEN and then get own metadata using token)
+        :return: String with metadata or None
+        """
+
+        if self._token_exists() is False:
+            # First try to get metadata using IMDSv1
+            metadata = self._get_metadata_from_server_imds_v1()
+
+            if metadata is not None:
+                return metadata
+
+        # When it wasn't possible to get metadata using IMDSv1, then try to get metadata using IMDSv2
+        return self._get_metadata_from_server_imds_v2()
+
+    def _get_signature_from_cache_file(self) -> None:
+        """
+        This cloud collector does not allow to use cache for signature
+        :return: None
+        """
+        return None
+
+    def _get_signature_from_server_imds_v1(self) -> Union[str, None]:
+        """
+        Try to get signature using IMDSv1
+        :return: String of signature or None, when it wasn't possible to get signature from server
+        """
+        log.debug(f'Trying to get AWS signature from {self.CLOUD_PROVIDER_SIGNATURE_URL} using IMDSv1')
+
+        return self._get_data_from_server(
+            data_type='signature',
+            url=self.CLOUD_PROVIDER_SIGNATURE_URL
+        )
+
+    def _get_signature_from_server_imds_v2(self) -> Union[str, None]:
+        """
+        Try to get signature using IMDSv2
+        :return: String of signature or None, when it wasn't possible to get signature from server
+        """
+        log.debug(f'Trying to get AWS signature from {self.CLOUD_PROVIDER_SIGNATURE_URL} using IMDSv2')
+
+        token = self._get_token()
+        if token is None:
+            return None
+
+        headers = {
+            'X-aws-ec2-metadata-token': token,
+            **self.HTTP_HEADERS
+        }
+
+        return self._get_data_from_server(
+            data_type='signature',
+            url=self.CLOUD_PROVIDER_SIGNATURE_URL,
+            headers=headers
+        )
+
+    def _get_signature_from_server(self) -> Union[str, None]:
+        """
+        Try to get signature from server as is described in this document:
+
+        https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/verify-signature.html
+
+        AWS provides several versions signatures (PKCS7, base64-encoded and RSA-2048). We will use
+        the base64-encoded one, because it is easier to send it as part of JSON document. It is
+        possible to get signature using IMDSv1 and IMDSv2. We use same approach of obtaining
+        signature as we use, when we try to obtain metadata. We try use IMDSv1 first, when not
+        possible then we try to use IMDSv2.
+        :return: String with signature or None
+        """
+        signature = None
+        if self._token_exists() is False:
+            signature = self._get_signature_from_server_imds_v1()
+
+        if signature is None:
+            signature = self._get_signature_from_server_imds_v2()
+
+        if signature is not None:
+            signature = f'-----BEGIN PKCS7-----\n{signature}\n-----END PKCS7-----'
+
+        return signature
+
+    def get_metadata(self) -> Union[str, None]:
+        """
+        Try to get metadata from the cache file first. When the cache file is not available, then try to
+        get metadata from server.
+        :return: String with metadata or None
+        """
+        return super(AWSCloudProvider, self).get_metadata()
+
+    def get_signature(self) -> Union[str, None]:
+        """
+        Try to get signature from the cache file first. When the cache file is not available, then try to
+        get signature from server.
+        :return: String with metadata or None
+        """
+        return super(AWSCloudProvider, self).get_signature()
+
+
+def _smoke_tests():
+    """
+    Simple smoke tests of AWS detector and collector
+    :return: None
+    """
+    # Gather only information about hardware and virtualization
+    from rhsmlib.facts.host_collector import HostCollector
+    import sys
+
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+
+    facts = {}
+    facts.update(HostCollector().get_all())
+    aws_cloud_provider = AWSCloudProvider(facts)
+    result = aws_cloud_provider.is_running_on_cloud()
+    probability = aws_cloud_provider.is_likely_running_on_cloud()
+    print(f'>>> debug <<< cloud provider: {result}, probability: {probability}')
+
+    if result is True:
+        metadata = aws_cloud_provider.get_metadata()
+        print(f'>>> debug <<< cloud metadata: {metadata}')
+        signature = aws_cloud_provider.get_signature()
+        print(f'>>> debug <<< metadata signature: {signature}')
+
+        metadata_v2 = aws_cloud_provider._get_metadata_from_server_imds_v2()
+        print(f'>>> debug <<< cloud metadata: {metadata_v2}')
+        signature_v2 = aws_cloud_provider._get_signature_from_server_imds_v2()
+        print(f'>>> debug <<< cloud signature: {signature_v2}')
+
+
+# Some temporary smoke testing code. You can test this module using:
+# sudo PYTHONPATH=./src python3 -m cloud_what.providers.aws
+if __name__ == '__main__':
+    _smoke_tests()

--- a/src/cloud_what/providers/azure.py
+++ b/src/cloud_what/providers/azure.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+
+"""
+This is module implementing detector and metadata collector of virtual machine running on Azure
+"""
+
+import logging
+import json
+from typing import Union, List
+
+from cloud_what._base_provider import BaseCloudProvider
+
+
+log = logging.getLogger(__name__)
+
+
+class AzureCloudProvider(BaseCloudProvider):
+    """
+    Base class for Azure cloud provider
+    """
+
+    CLOUD_PROVIDER_ID = "azure"
+
+    # Microsoft adds new API versions very often, but old versions are supported
+    # for very long time. It would be good to update the version from time to time,
+    # because old versions (three years) are deprecated. It would be good to update
+    # the API version with every minor version of RHEL
+    API_VERSION = "2021-02-01"
+
+    BASE_CLOUD_PROVIDER_METADATA_URL = "http://169.254.169.254/metadata/instance?api-version="
+
+    CLOUD_PROVIDER_METADATA_URL = BASE_CLOUD_PROVIDER_METADATA_URL + API_VERSION
+
+    CLOUD_PROVIDER_METADATA_TYPE = "application/json"
+
+    BASE_CLOUD_PROVIDER_SIGNATURE_URL = "http://169.254.169.254/metadata/attested/document?api-version="
+
+    CLOUD_PROVIDER_SIGNATURE_URL = BASE_CLOUD_PROVIDER_SIGNATURE_URL + API_VERSION
+
+    CLOUD_PROVIDER_SIGNATURE_TYPE = "application/json"
+
+    AZURE_API_VERSIONS_URL = "http://169.254.169.254/metadata/versions"
+
+    METADATA_CACHE_FILE = None
+
+    SIGNATURE_CACHE_FILE = None
+
+    # HTTP header "Metadata" has to be equal to "true" to be able to get metadata
+    HTTP_HEADERS = {
+        'User-Agent': 'cloud-what/1.0',
+        "Metadata": "true"
+    }
+
+    # Increased timeout for Azure, because response can have long delay, when wrong
+    # or too old API_VERSION is used.
+    TIMEOUT = 10.0
+
+    def __init__(self, hw_info):
+        """
+        Initialize instance of AzureCloudDetector
+        """
+        super(AzureCloudProvider, self).__init__(hw_info)
+
+    def is_running_on_cloud(self):
+        """
+        Try to guess if cloud provider is Azure using collected hardware information (output of dmidecode,
+        virt-what, etc.)
+        :return: True, when we detected sign of Azure in hardware information; Otherwise return False
+        """
+
+        # The system has to be VM
+        if self.is_vm() is False:
+            return False
+        # This is valid for virtual machines running on Azure
+        if 'dmi.chassis.asset_tag' in self.hw_info and \
+                self.hw_info['dmi.chassis.asset_tag'] == '7783-7084-3265-9085-8269-3286-77':
+            return True
+        # In other cases return False
+        return False
+
+    def is_likely_running_on_cloud(self):
+        """
+        Return non-zero value, when the machine is virtual machine and it is running on Hyper-V and
+        some Microsoft string can be found in output of dmidecode
+        :return: Float value representing probability that vm is running on Azure
+        """
+        probability = 0.0
+
+        # When the machine is not virtual machine, then there is probably zero chance that the machine
+        # is running on Azure
+        if self.is_vm() is False:
+            return 0.0
+
+        # We know that Azure uses only HyperV
+        if 'virt.host_type' in self.hw_info:
+            if 'hyperv' in self.hw_info['virt.host_type']:
+                probability += 0.3
+
+        if 'dmi.chassis.asset_tag' in self.hw_info and \
+                self.hw_info['dmi.chassis.asset_tag'] == '7783-7084-3265-9085-8269-3286-77':
+            probability += 0.3
+
+        # Try to find "Azure" or "Microsoft" keywords in output of dmidecode
+        found_microsoft = False
+        found_azure = False
+        for hw_item in self.hw_info.values():
+            if type(hw_item) != str:
+                continue
+            if 'microsoft' in hw_item.lower():
+                found_microsoft = True
+            elif 'azure' in hw_item.lower():
+                found_azure = True
+        if found_microsoft is True:
+            probability += 0.3
+        if found_azure is True:
+            probability += 0.1
+
+        return probability
+
+    def get_api_versions(self) -> Union[List[str], None]:
+        """
+        This method tries to get list of API versions currently supported by Azure cloud provider
+        :return: list of API versions or None
+        """
+        api_versions_str = self._get_data_from_server("api_versions", self.AZURE_API_VERSIONS_URL)
+        api_versions = None
+        try:
+            api_versions_dict = json.loads(api_versions_str)
+        except TypeError as err:
+            log.error(f'Unable to decode Azure API versions: {err}')
+        else:
+            if 'apiVersions' in api_versions_dict:
+                api_versions = api_versions_dict['apiVersions']
+        return api_versions
+
+    def _fix_supported_api_version(self) -> Union[str, None]:
+        """
+        Try to get list of supported API versions and set the oldest
+        :return:
+        """
+        api_versions = self.get_api_versions()
+        if api_versions is not None and len(api_versions) > 0:
+            if self.API_VERSION not in api_versions:
+                log.warning(
+                    f'Current Azure IMDS API version {self.API_VERSION} not included in the list of '
+                    f'supported API versions: {api_versions}'
+                )
+            else:
+                log.warning(f'Current Azure IMDS API version {self.API_VERSION} not fully supported')
+            # Get newest version
+            api_version = api_versions[-1]
+            log.warning(f'Changing Azure IMDS API version to: {api_version}')
+            self.API_VERSION = api_version
+            # Fix URL for gathering metadata and signature
+            self.CLOUD_PROVIDER_METADATA_URL = self.BASE_CLOUD_PROVIDER_METADATA_URL + api_version
+            self.CLOUD_PROVIDER_SIGNATURE_URL = self.BASE_CLOUD_PROVIDER_SIGNATURE_URL + api_version
+            return api_version
+        return None
+
+    def _get_metadata_from_cache(self) -> Union[str, None]:
+        """
+        It is not safe to use cache of metadata for Azure cloud provider
+        :return: None
+        """
+        return None
+
+    def _get_data_from_server(self, data_type: str, url: str, headers: dict = None) -> Union[str, None]:
+        """
+        This method tries to get data from server using GET method
+        :param data_type: string representation of data type used in log messages (e.g. "metadata", "signature")
+        :param url: URL of GET request
+        :return: String of body, when request was successful; otherwise return None
+        """
+        return super(AzureCloudProvider, self)._get_data_from_server(data_type, url, headers)
+
+    def _get_metadata_from_server(self) -> Union[str, None]:
+        """
+        Try to get metadata from server
+        :return: String with metadata or None
+        """
+        metadata = super(AzureCloudProvider, self)._get_metadata_from_server()
+        # When it wasn't possible to get metadata with current API version, then try to get list of
+        # supported API versions and select the newest version and try to get metadata once again
+        if metadata is None:
+            api_version = self._fix_supported_api_version()
+            if api_version is not None:
+                metadata = super(AzureCloudProvider, self)._get_metadata_from_server()
+        return metadata
+
+    def _get_signature_from_cache_file(self) -> Union[str, None]:
+        """
+        It is not safe to use cache of signature for Azure cloud provider
+        :return: None
+        """
+        return None
+
+    def _get_signature_from_server(self) -> Union[str, None]:
+        """
+        Method for gathering signature of metadata from server
+        :return: String containing signature or None
+        """
+        signature = super(AzureCloudProvider, self)._get_signature_from_server()
+        if signature is None:
+            api_version = self._fix_supported_api_version()
+            if api_version is not None:
+                signature = super(AzureCloudProvider, self)._get_signature_from_server()
+        return signature
+
+    def get_signature(self) -> Union[str, None]:
+        """
+        Public method for getting signature (cache file or server)
+        :return: String containing signature or None
+        """
+        return super(AzureCloudProvider, self).get_signature()
+
+    def get_metadata(self) -> Union[str, None]:
+        """
+        Public method for getting metadata (cache file or server)
+        :return: String containing metadata or None
+        """
+        return super(AzureCloudProvider, self).get_metadata()
+
+
+def _smoke_tests():
+    """
+    Simple smoke test of azure detector and collector
+    :return: None
+    """
+    # Gather only information about hardware and virtualization
+    from rhsmlib.facts.host_collector import HostCollector
+
+    import sys
+
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+
+    facts = {}
+    facts.update(HostCollector().get_all())
+    azure_cloud_provider = AzureCloudProvider(facts)
+    result = azure_cloud_provider.is_running_on_cloud()
+    probability = azure_cloud_provider.is_likely_running_on_cloud()
+    print('>>> debug <<< result: %s, %6.3f' % (result, probability))
+
+    if result is True:
+        metadata = azure_cloud_provider.get_metadata()
+        signature = azure_cloud_provider.get_signature()
+        print(f'>>> debug <<< metadata: {metadata}')
+        print(f'>>> debug <<< signature: {signature}')
+        api_versions = azure_cloud_provider.get_api_versions()
+        print(f'>>> debug <<< api_versions: {api_versions}')
+
+        # Test getting metadata and signature with too old API version
+        AzureCloudProvider.API_VERSION = '2011-01-01'
+        AzureCloudProvider.CLOUD_PROVIDER_METADATA_URL = \
+            "http://169.254.169.254/metadata/instance?api-version=2011-01-01"
+        AzureCloudProvider.CLOUD_PROVIDER_SIGNATURE_URL = \
+            "http://169.254.169.254/metadata/attested/document?api-version=2011-01-01"
+        azure_cloud_provider = AzureCloudProvider({})
+        azure_cloud_provider._cached_metadata = None
+        azure_cloud_provider._cached_signature = None
+        metadata = azure_cloud_provider.get_metadata()
+        print(f'>>> debug <<< metadata: {metadata}')
+        signature = azure_cloud_provider.get_signature()
+        print(f'>>> debug <<< signature: {signature}')
+
+
+# Some temporary smoke testing code. You can test this module using:
+# sudo PYTHONPATH=./src python3 -m cloud_what.providers.azure
+if __name__ == '__main__':
+    _smoke_tests()

--- a/src/cloud_what/providers/azure.py.orig
+++ b/src/cloud_what/providers/azure.py.orig
@@ -23,7 +23,7 @@ import logging
 import json
 from typing import Union, List
 
-from rhsmlib.cloud._base_provider import BaseCloudProvider
+from cloud_what._base_provider import BaseCloudProvider
 
 
 log = logging.getLogger(__name__)
@@ -62,7 +62,11 @@ class AzureCloudProvider(BaseCloudProvider):
 
     # HTTP header "Metadata" has to be equal to "true" to be able to get metadata
     HTTP_HEADERS = {
+<<<<<<< HEAD:src/cloud_what/providers/azure.py
+        'User-Agent': 'cloud-what/1.0',
+=======
         'User-Agent': 'RHSM/1.0',
+>>>>>>> main:src/rhsmlib/cloud/providers/azure.py
         "Metadata": "true"
     }
 
@@ -243,7 +247,6 @@ def _smoke_tests():
     """
     # Gather only information about hardware and virtualization
     from rhsmlib.facts.host_collector import HostCollector
-    from rhsmlib.facts.hwprobe import HardwareCollector
 
     import sys
 
@@ -258,7 +261,6 @@ def _smoke_tests():
 
     facts = {}
     facts.update(HostCollector().get_all())
-    facts.update(HardwareCollector().get_all())
     azure_cloud_provider = AzureCloudProvider(facts)
     result = azure_cloud_provider.is_running_on_cloud()
     probability = azure_cloud_provider.is_likely_running_on_cloud()
@@ -288,6 +290,6 @@ def _smoke_tests():
 
 
 # Some temporary smoke testing code. You can test this module using:
-# sudo PYTHONPATH=./src python3 -m rhsmlib.cloud.providers.azure
+# sudo PYTHONPATH=./src python3 -m cloud_what.providers.azure
 if __name__ == '__main__':
     _smoke_tests()

--- a/src/cloud_what/providers/gcp.py
+++ b/src/cloud_what/providers/gcp.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+This is module implementing detector and metadata collector of virtual machine running on Google Cloud Platform
+"""
+
+import logging
+import time
+import base64
+
+from typing import Union
+
+from cloud_what._base_provider import BaseCloudProvider
+
+
+log = logging.getLogger(__name__)
+
+
+class GCPCloudProvider(BaseCloudProvider):
+    """
+    Class for GCP cloud provider
+
+    Collector of Google Cloud Platform metadata. Verification of instance identity is described in this document:
+
+    https://cloud.google.com/compute/docs/instances/verifying-instance-identity
+    """
+
+    CLOUD_PROVIDER_ID = "gcp"
+
+    # The "audience" should be some unique URI agreed upon by both the instance and the system verifying
+    # the instance's identity. For example, the audience could be a URL for the connection between the two systems.
+    # In fact this string could be anything.
+    # TODO: use some more generic URL here and move setting this RHSM specific URL to subscription-manager
+    AUDIENCE = "https://subscription.rhsm.redhat.com:443/subscription"
+
+    # Google uses little bit different approach. It provides everything in JSON Web Token (JWT)
+    CLOUD_PROVIDER_METADATA_URL = None
+
+    CLOUD_PROVIDER_METADATA_URL_TEMPLATE = "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience={audience}&format=full"
+
+    # Token (metadata) expires within one hour. Thus it is save to cache the token.
+    CLOUD_PROVIDER_METADATA_TTL = 3600
+
+    CLOUD_PROVIDER_TOKEN_TTL = CLOUD_PROVIDER_METADATA_TTL
+
+    CLOUD_PROVIDER_METADATA_TYPE = "text/html"
+
+    CLOUD_PROVIDER_SIGNATURE_URL = None
+
+    CLOUD_PROVIDER_SIGNATURE_TYPE = None
+
+    HTTP_HEADERS = {
+        'User-Agent': 'cloud-what/1.0',
+        'Metadata-Flavor': 'Google'
+    }
+
+    # Metadata are provided in JWT token and this token is valid for one hour.
+    # Thus it is save to cache this token (see CLOUD_PROVIDER_METADATA_TTL,
+    # self._metadata_token_ctime and self._metadata_token)
+    TOKEN_CACHE_FILE = "/var/cache/cloud-what/gcp_token.json"
+
+    # Nothing to cache for this cloud provider
+    SIGNATURE_CACHE_FILE = None
+
+    def __init__(self, hw_info, audience_url=None):
+        """
+        Initialize instance of GCPCloudDetector
+        """
+        super(GCPCloudProvider, self).__init__(hw_info)
+
+        # Metadata URL can have default or custom "audience"
+        if audience_url is not None:
+            self.CLOUD_PROVIDER_METADATA_URL = self.CLOUD_PROVIDER_METADATA_URL_TEMPLATE.format(
+                audience=audience_url
+            )
+        else:
+            self.CLOUD_PROVIDER_METADATA_URL = self.CLOUD_PROVIDER_METADATA_URL_TEMPLATE.format(
+                audience=self.AUDIENCE
+            )
+
+    def is_running_on_cloud(self):
+        """
+        Try to guess if cloud provider is GCP using collected hardware information (output of dmidecode,
+        virt-what, etc.)
+        :return: True, when we detected sign of GCP in hardware information; Otherwise return False
+        """
+
+        # The system has to be VM
+        if self.is_vm() is False:
+            return False
+        # This is valid for virtual machines running on Google Cloud Platform
+        if 'dmi.bios.vendor' in self.hw_info and \
+                'google' in self.hw_info['dmi.bios.vendor'].lower():
+            return True
+        # In other cases return False
+        return False
+
+    def is_likely_running_on_cloud(self):
+        """
+        Return non-zero value, when the machine is virtual machine and it is running on kvm and
+        some google string can be found in output of dmidecode
+        :return: Float value representing probability that vm is running on GPC
+        """
+        probability = 0.0
+
+        # When the machine is not virtual machine, then there is probably zero chance that the machine
+        # is running on GPC
+        if self.is_vm() is False:
+            return 0.0
+
+        # We know that GCP uses only KVM at the end of 2020
+        if 'virt.host_type' in self.hw_info and 'kvm' in self.hw_info['virt.host_type']:
+            probability += 0.3
+
+        # Try to find "Google" or "gcp" keywords in output of dmidecode
+        found_google = False
+        found_gcp = False
+        for hw_item in self.hw_info.values():
+            if type(hw_item) != str:
+                continue
+            if 'google' in hw_item.lower():
+                found_google = True
+            elif 'gcp' in hw_item.lower():
+                found_gcp = True
+        if found_google is True:
+            probability += 0.3
+        if found_gcp is True:
+            probability += 0.1
+
+        return probability
+
+    def _get_metadata_from_cache(self) -> Union[str, None]:
+        """
+        Try to get metadata (JWT token) from the cache file
+        :return: String with cached token or None
+        """
+        return super(GCPCloudProvider, self)._get_token_from_cache_file()
+
+    def _get_data_from_server(self, data_type: str, url: str, headers: dict = None) -> Union[str, None]:
+        """
+        Try to get data from metadata server
+        """
+        return super(GCPCloudProvider, self)._get_data_from_server(data_type, url, headers)
+
+    def _get_metadata_from_server(self) -> Union[str, None]:
+        """
+        GCP metadata server returns only one file called token
+        :return: String with token or None
+        """
+        token = self._get_data_from_server(data_type="token", url=self.CLOUD_PROVIDER_METADATA_URL)
+        if token is not None:
+            self._token = token
+            self._token_ctime = time.time()
+            self._token_ttl = self.CLOUD_PROVIDER_TOKEN_TTL
+            self._write_token_to_cache_file()
+        return token
+
+    def _get_signature_from_server(self) -> None:
+        """
+        Google returns everything in one file.
+        """
+        return None
+
+    def _get_signature_from_cache_file(self) -> None:
+        """
+        Really no need to cache signature
+        """
+        return None
+
+    def get_signature(self) -> str:
+        """
+        Google returns everything in one file. No need to try to get signature.
+        :return Empty string
+        """
+        return ""
+
+    def get_metadata(self) -> Union[str, None]:
+        """
+        Try to get metadata from in-memory cache, cache or cloud provider server
+        :return: String with metadata or None
+        """
+        if self._is_in_memory_cached_token_valid() is True:
+            return self._token
+        return super(GCPCloudProvider, self).get_metadata()
+
+    def set_audience(self, audience: str) -> None:
+        """
+        Set audience unique identifier (usually some URL). This ID is used in HTTP request
+        to GCP IMDS server
+        :param audience: unique identifier
+        :return: None
+        """
+        self.AUDIENCE = audience
+
+    @staticmethod
+    def decode_jwt(jwt_token: str) -> tuple:
+        """
+        Try to decode metadata stored in JWT token described in this RFC: https://tools.ietf.org/html/rfc7519
+        :param jwt_token: string representing JWT token
+        :return: tuple with: string representing header, string representing metadata and base64 encoded signature
+        """
+        # Get the actual payload part: [0] is JOSE header, [1] is metadata and [2] is signature
+        parts = jwt_token.split('.')
+        if len(parts) >= 3:
+            encoded_jose_header = parts[0]
+            encoded_metadata = parts[1]
+            encoded_signature = parts[2]
+            # Add some extra padding, JWT tokens have padding trimmed - see https://stackoverflow.com/a/49459036
+            encoded_jose_header += '==='
+            encoded_metadata += '==='
+            encoded_signature += '==='
+            # Decode only header and metadata, not signature
+            try:
+                jose_header = base64.b64decode(encoded_jose_header).decode('utf-8')
+            except UnicodeDecodeError as err:
+                log.error(f'Unable to decode JWT JOSE header: {err}')
+                jose_header = None
+            try:
+                metadata = base64.b64decode(encoded_metadata).decode('utf-8')
+            except UnicodeDecodeError as err:
+                log.error(f'Unable to decode JWT metadata: {err}')
+                metadata = None
+            return jose_header, metadata, encoded_signature
+        else:
+            log.warning('JWT token with wrong format')
+            return None, None, None
+
+
+# Note about GCP token
+# --------------------
+#
+# It is possible to verify token, but is not easy to do it on RHEL, because it requires
+# special Python packages that are not available on RHEL. It is recommended to create
+# virtual environment:
+#
+# $ python3 -m venv env
+#
+# Activate virtual environment:
+#
+# $ source env/bin/activate
+#
+# Install required packages:
+#
+# $ pip install --upgrade google-auth
+# $ pip install requests
+#
+# Run following Python script:
+#
+# ```python
+# from cloud_what.providers.gcp import GCPCloudCollector
+# # Import libraries for token verification
+# import google.auth.transport.requests
+# from google.oauth2 import id_token
+# # Get token
+# token = GCPCloudCollector().get_metadata()
+# # Verify token signature and store the token payload
+# request = google.auth.transport.requests.Request()
+# payload = id_token.verify_token(token, request=request, audience=GCPCloudCollector.AUDIENCE)
+# print(payload)
+# ```
+
+
+def _smoke_test():
+    """
+    Simple smoke tests of GCP detector and collector
+    """
+    # Gather only information about hardware and virtualization
+    from rhsmlib.facts.host_collector import HostCollector
+
+    import sys
+
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+
+    facts = {}
+    facts.update(HostCollector().get_all())
+    gcp_cloud_provider = GCPCloudProvider(facts)
+    result = gcp_cloud_provider.is_running_on_cloud()
+    probability = gcp_cloud_provider.is_likely_running_on_cloud()
+    print('>>> debug <<< result: %s, %6.3f' % (result, probability))
+    if result is True:
+        # 1. using default audience
+        token = gcp_cloud_provider.get_metadata()
+        print(f'>>> debug <<< 1. token: {token}')
+        # 2. using some custom audience
+        gcp_cloud_provider = GCPCloudProvider(facts, audience_url="https://localhost:8443/candlepin")
+        token = gcp_cloud_provider.get_metadata()
+        print(f'>>> debug <<< 2. token: {token}')
+
+
+# Some temporary smoke testing code. You can test this module using:
+# sudo PYTHONPATH=./src python3 -m cloud_what.providers.gcp
+if __name__ == '__main__':
+    _smoke_test()

--- a/src/cloud_what/providers/gcp.py.orig
+++ b/src/cloud_what/providers/gcp.py.orig
@@ -24,7 +24,7 @@ import base64
 
 from typing import Union
 
-from rhsmlib.cloud._base_provider import BaseCloudProvider
+from cloud_what._base_provider import BaseCloudProvider
 
 
 log = logging.getLogger(__name__)
@@ -43,7 +43,8 @@ class GCPCloudProvider(BaseCloudProvider):
 
     # The "audience" should be some unique URI agreed upon by both the instance and the system verifying
     # the instance's identity. For example, the audience could be a URL for the connection between the two systems.
-    # In fact this string could be anything. We could read the full URL from rhsm.conf
+    # In fact this string could be anything.
+    # TODO: use some more generic URL here and move setting this RHSM specific URL to subscription-manager
     AUDIENCE = "https://subscription.rhsm.redhat.com:443/subscription"
 
     # Google uses little bit different approach. It provides everything in JSON Web Token (JWT)
@@ -63,14 +64,18 @@ class GCPCloudProvider(BaseCloudProvider):
     CLOUD_PROVIDER_SIGNATURE_TYPE = None
 
     HTTP_HEADERS = {
+<<<<<<< HEAD:src/cloud_what/providers/gcp.py
+        'User-Agent': 'cloud-what/1.0',
+=======
         'User-Agent': 'RHSM/1.0',
+>>>>>>> main:src/rhsmlib/cloud/providers/gcp.py
         'Metadata-Flavor': 'Google'
     }
 
     # Metadata are provided in JWT token and this token is valid for one hour.
     # Thus it is save to cache this token (see CLOUD_PROVIDER_METADATA_TTL,
     # self._metadata_token_ctime and self._metadata_token)
-    TOKEN_CACHE_FILE = "/var/lib/rhsm/cache/gcp_token.json"
+    TOKEN_CACHE_FILE = "/var/cache/cloud-what/gcp_token.json"
 
     # Nothing to cache for this cloud provider
     SIGNATURE_CACHE_FILE = None
@@ -196,6 +201,15 @@ class GCPCloudProvider(BaseCloudProvider):
             return self._token
         return super(GCPCloudProvider, self).get_metadata()
 
+    def set_audience(self, audience: str) -> None:
+        """
+        Set audience unique identifier (usually some URL). This ID is used in HTTP request
+        to GCP IMDS server
+        :param audience: unique identifier
+        :return: None
+        """
+        self.AUDIENCE = audience
+
     @staticmethod
     def decode_jwt(jwt_token: str) -> tuple:
         """
@@ -251,7 +265,7 @@ class GCPCloudProvider(BaseCloudProvider):
 # Run following Python script:
 #
 # ```python
-# from rhsmlib.cloud.providers.gcp import GCPCloudCollector
+# from cloud_what.providers.gcp import GCPCloudCollector
 # # Import libraries for token verification
 # import google.auth.transport.requests
 # from google.oauth2 import id_token
@@ -270,7 +284,6 @@ def _smoke_test():
     """
     # Gather only information about hardware and virtualization
     from rhsmlib.facts.host_collector import HostCollector
-    from rhsmlib.facts.hwprobe import HardwareCollector
 
     import sys
 
@@ -285,7 +298,6 @@ def _smoke_test():
 
     facts = {}
     facts.update(HostCollector().get_all())
-    facts.update(HardwareCollector().get_all())
     gcp_cloud_provider = GCPCloudProvider(facts)
     result = gcp_cloud_provider.is_running_on_cloud()
     probability = gcp_cloud_provider.is_likely_running_on_cloud()
@@ -301,6 +313,6 @@ def _smoke_test():
 
 
 # Some temporary smoke testing code. You can test this module using:
-# sudo PYTHONPATH=./src:./syspurpose/src python3 -m rhsmlib.cloud.providers.gcp
+# sudo PYTHONPATH=./src python3 -m cloud_what.providers.gcp
 if __name__ == '__main__':
     _smoke_test()

--- a/src/cloud_what/setup.py
+++ b/src/cloud_what/setup.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+Setup for cloud-what
+"""
+
+from setuptools import setup
+
+setup(
+    name="cloud-what",
+    version='1.29.14',
+    description='Detection of public cloud provider and gathering metadata from IMDS servers',
+    author='Jiri Hnidek',
+    author_email='chainsaw@redhat.com',
+    url='https://github.com/candlepin/subscription-manager/',
+    license='GPLv2',
+    long_description="""cloud-what enables to detect cloud provider using information provided
+    SM BIOS. The package tries to use dmidecode and virt-what for this purpose. This package
+    also allows to gather metadata and signature from IMDS servers provided by public cloud
+    providers. Three cloud providers are supported at this moment: AWS, Azure and GCP.""",
+    packages=['cloud-what'],
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: GPL License',
+        'License :: OSI Approved :: Python Software Foundation License',
+        'Operating System :: Linux',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
+    install_requires=['dmidecode', 'requests'],
+
+)

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -20,7 +20,7 @@ from __future__ import print_function, division, absolute_import
 import logging
 import json
 
-from rhsmlib.cloud.provider import get_cloud_provider
+from cloud_what.provider import get_cloud_provider
 from rhsmlib.facts import collector
 
 

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -321,8 +321,6 @@ Requires: python3-dbus
 Requires: %{?suse_version:dbus-1-python} %{!?suse_version:dbus-python}
 %endif
 
-Requires: python3-requests
-
 %if %{use_yum}
 Requires: %{?suse_version:yum} %{!?suse_version:yum >= 3.2.29-73}
 %endif
@@ -367,6 +365,8 @@ Requires: %{?suse_version:aaa_base} %{!?suse_version:chkconfig}
 Requires(post): %{?suse_version:aaa_base} %{!?suse_version:chkconfig}
 Requires(preun): %{?suse_version:aaa_base} %{!?suse_version:chkconfig, initscripts}
 %endif
+
+Requires: python3-cloud-what = %{version}-%{release}
 
 BuildRequires: %{?suse_version:python-devel >= 2.6} %{!?suse_version:%{py_package_prefix}-devel}
 BuildRequires: openssl-devel
@@ -698,6 +698,7 @@ Requires: subscription-manager-rhsm-certificates = %{version}-%{release}
 # Required by Fedora packaging guidelines
 %{?python_provide:%python_provide %{py_package_prefix}-rhsm}
 %if %{with python3}
+Requires: python3-cloud-what = %{version}-%{release}
 Requires: python3-rpm
 Provides: python3-rhsm = %{version}-%{release}
 Obsoletes: python3-rhsm <= 1.20.3-1
@@ -798,6 +799,21 @@ This package contains the desktop icons for the graphical interfaces provided fo
 of Red Hat subscriptions. There are many such interfaces, subscription-manager-gui,
 subscription-manager-initial-setup-addon, and subscription-manager-cockpit-plugin primarily.
 %endif
+
+
+%package -n python3-cloud-what
+Summary: Python package for detection of public cloud provider
+License: GPLv2
+BuildArch: noarch
+Requires: python3-requests
+%ifnarch aarch64 ppc ppc64 ppc64le s390 s390x
+Requires:  %{py_package_prefix}-dmidecode %{?dmidecode_version}
+%endif
+
+%description -n python3-cloud-what
+This package contains a Python module for detection and collection of public
+cloud metadata and signatures.
+
 
 %prep
 %setup -q
@@ -956,8 +972,6 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %endif
 
 %dir %{python_sitearch}/rhsmlib/candlepin
-%dir %{python_sitearch}/rhsmlib/cloud
-%dir %{python_sitearch}/rhsmlib/cloud/providers
 %dir %{python_sitearch}/rhsmlib/compat
 %dir %{python_sitearch}/rhsmlib/dbus
 %dir %{python_sitearch}/rhsmlib/dbus/facts
@@ -1121,8 +1135,6 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %dir %{python_sitearch}/rhsmlib
 %{python_sitearch}/rhsmlib/*.py*
 %{python_sitearch}/rhsmlib/candlepin/*.py*
-%{python_sitearch}/rhsmlib/cloud/*.py*
-%{python_sitearch}/rhsmlib/cloud/providers/*.py*
 %{python_sitearch}/rhsmlib/compat/*.py*
 %{python_sitearch}/rhsmlib/facts/*.py*
 %{python_sitearch}/rhsmlib/services/*.py*
@@ -1132,8 +1144,6 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %if %{with python3}
 %{python_sitearch}/rhsmlib/__pycache__
 %{python_sitearch}/rhsmlib/candlepin/__pycache__
-%{python_sitearch}/rhsmlib/cloud/__pycache__
-%{python_sitearch}/rhsmlib/cloud/providers/__pycache__
 %{python_sitearch}/rhsmlib/compat/__pycache__
 %{python_sitearch}/rhsmlib/dbus/__pycache__
 %{python_sitearch}/rhsmlib/dbus/facts/__pycache__
@@ -1370,6 +1380,16 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %defattr(-,root,root,-)
 %dir %{python2_sitearch}/rhsm
 %{python2_sitearch}/rhsm/*
+%endif
+
+%files -n python3-cloud-what
+%defattr(-,root,root,-)
+%dir %{python_sitearch}/cloud_what
+%dir %{python_sitearch}/cloud_what/providers
+%{python_sitearch}/cloud_what/*
+%if %{with python3}
+%{python_sitearch}/cloud_what/__pycache__
+%{python_sitearch}/cloud_what/providers/__pycache__
 %endif
 
 %files -n subscription-manager-rhsm-certificates

--- a/test/cloud_what/test_cloud_what.py
+++ b/test/cloud_what/test_cloud_what.py
@@ -1,0 +1,1131 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+Module for testing Python all modules from Python package cloud_what
+"""
+
+import unittest
+from mock import patch, Mock, call
+import tempfile
+import time
+import json
+
+import requests
+
+from cloud_what.providers import aws, azure, gcp
+from cloud_what.provider import detect_cloud_provider, get_cloud_provider
+
+
+def send_only_imds_v2_is_supported(request, *args, **kwargs):
+    """
+    Mock result, when we try to get metadata using GET method against
+    AWS metadata provider. This mock is for the case, when only IMDSv2
+    is supported by instance.
+    :param request: HTTP request
+    :return: Mock with result
+    """
+    mock_result = Mock()
+
+    if request.method == 'PUT':
+        if request.url == aws.AWSCloudProvider.CLOUD_PROVIDER_TOKEN_URL:
+            if 'X-aws-ec2-metadata-token-ttl-seconds' in request.headers:
+                mock_result.status_code = 200
+                mock_result.text = AWS_TOKEN
+            else:
+                mock_result.status_code = 400
+                mock_result.text = 'Error: TTL for token not specified'
+        else:
+            mock_result.status_code = 400
+            mock_result.text = 'Error: Invalid URL'
+    elif request.method == 'GET':
+        if 'X-aws-ec2-metadata-token' in request.headers.keys():
+            if request.headers['X-aws-ec2-metadata-token'] == AWS_TOKEN:
+                if request.url == aws.AWSCloudProvider.CLOUD_PROVIDER_METADATA_URL:
+                    mock_result.status_code = 200
+                    mock_result.text = AWS_METADATA
+                elif request.url == aws.AWSCloudProvider.CLOUD_PROVIDER_SIGNATURE_URL:
+                    mock_result.status_code = 200
+                    mock_result.text = AWS_SIGNATURE
+                else:
+                    mock_result.status_code = 400
+                    mock_result.text = 'Error: Invalid URL'
+            else:
+                mock_result.status_code = 400
+                mock_result.text = 'Error: Invalid metadata token provided'
+        else:
+            mock_result.status_code = 400
+            mock_result.text = 'Error: IMDSv1 is not supported on this instance'
+    else:
+        mock_result.status_code = 400
+        mock_result.text = 'Error: not supported request method'
+
+    return mock_result
+
+
+def mock_prepare_request(request):
+    return request
+
+
+AWS_METADATA = """
+{
+  "accountId" : "012345678900",
+  "architecture" : "x86_64",
+  "availabilityZone" : "eu-central-1b",
+  "billingProducts" : [ "bp-0124abcd", "bp-63a5400a" ],
+  "devpayProductCodes" : null,
+  "marketplaceProductCodes" : null,
+  "imageId" : "ami-0123456789abcdeff",
+  "instanceId" : "i-abcdef01234567890",
+  "instanceType" : "m5.large",
+  "kernelId" : null,
+  "pendingTime" : "2020-02-02T02:02:02Z",
+  "privateIp" : "12.34.56.78",
+  "ramdiskId" : null,
+  "region" : "eu-central-1",
+  "version" : "2017-09-30"
+}
+"""
+
+AWS_SIGNATURE = """ABCDEFGHIJKLMNOPQRSTVWXYZabcdefghijklmnopqrstvwxyz01234567899w0BBwGggCSABIIB
+73sKICAiYWNjb3VudElkIiA6ICI1NjcwMTQ3ODY4OTAiLAogICJhcmNoaXRlY3R1cmUiIDogIng4
+Nl82NCIsCiAgImF2YWlsYWJpbGl0eVpvbmUiIDogImV1LWNlbnRyYWwtMWIiLAogICJiaWxsaW5n
+UHJvZHVjdHMiIDogWyAiYnAtNmZhNTQwMDYiIF0sCiAgImRldnBheVByb2R1Y3RDb2RlcyIgOiBu
+73sKICAiYWNjb3VudElkIiA6ICI1NjcwMTQ3ODY4OTAiLAogICJhcmNoaXRlY3R1cmUiIDogIng4
+bWktMDgxNmFkNzYyOTc2YzM1ZGIiLAogICJpbnN0YW5jZUlkIiA6ICJpLTBkNTU0YzRmM2JhNWVl
+YTczIiwKICAiaW5zdGFuY2VUeXBlIiA6ICJtNS5sYXJnZSIsCiAgImtlcm5lbElkIiA6IG51bGws
+CiAgInBlbmRpbmdUaW1lIiA6ICIyMDIwLTA0LTI0VDE0OjU3OjQzWiIsCiAgInByaXZhdGVJcCIg
+OiAiMTcyLjMxLjExLjc4IiwKICAicmFtZGlza0lkIiA6IG51bGwsCiAgInJlZ2lvbiIgOiAiZXUt
+Y2VudHJhbC0xIiwKICAidmVyc2lvbiIgOiAiMjAxNy0wOS0zMCIKfQAAAAAAADGCAf8wggH7AgEB
+CiAgInBlbmRpbmdUaW1lIiA6ICIyMDIwLTA0LTI0VDE0OjU3OjQzWiIsCiAgInByaXZhdGVJcCIg
+YXR0bGUxIDAeBgNVBAoTF0FtYXpvbiBXZWIgU2VydmljZXMgTExDAgkAoP6/ot5H9aswDQYJYIZI
+AWUDBAIBBQCgaTAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3DQEJBTEPFw0yMDA5
+MDExNTMyNDhaMC8GCSqGSIb3DQEJBDEiBCCmizT0hDlJmxHtDBaEjql5ZPFaoKy6OSk7qBFREVRk
+iTANBgkqhkiG9w0BAQEFAASCAQAh//5+AaFAcgw/5SoglQ27kQKuThcJYa+QhC2aw4n1GvkvCmyi
+helVMxH33tB9tUei/mapSF3v8jUseRLEbcDVRHf6n6h14Qj2MxtgYanzUCDF8qECYbZ2uSy3JLEP
+iNsndm8nt7XcJC7NRoWJWAsly1VeXVIauA/l7uXmUarDQs5BhFYl7REX4htxg9mCibR6xqU5i8/D
+iTANBgkqhkiG9w0BAQEFAASCAQAh//5+AaFAcgw/5SoglQ27kQKuThcJYa+QhC2aw4n1GvkvCmyi
+tGbafapTj+6KnJAfP0sW7ZbzKclaCPHXQ37z9mc8vtCxEQmCbGL6sj2wtpi4rmRlAAAAAAAA"""
+
+AWS_TOKEN = "ABCDEFGHIJKLMNOPQRSTVWXYZabcdefghijklmnopqrstvwxyz0123=="
+
+
+class TestAWSCloudProvider(unittest.TestCase):
+    """
+    Class used for testing of AWS cloud provider
+    """
+
+    def test_aws_cloud_provider_id(self):
+        """
+        Test of CLOUD_PROVIDER_ID
+        """
+        self.assertEqual(aws.AWSCloudProvider.CLOUD_PROVIDER_ID, "aws")
+        aws_provider = aws.AWSCloudProvider({})
+        self.assertEqual(aws_provider.CLOUD_PROVIDER_ID, "aws")
+
+    def test_aws_not_vm(self):
+        """
+        Test for the case, when the machine is host (not virtual machine)
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': False,
+            'dmi.bios.version': 'cool hardware company'
+        }
+        aws_detector = aws.AWSCloudProvider(facts)
+        is_vm = aws_detector.is_vm()
+        self.assertFalse(is_vm)
+
+    def test_aws_vm_using_xen(self):
+        """
+        Test for the case, when the vm is running on AWS Xen
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'xen',
+            'dmi.bios.version': 'amazon'
+        }
+        aws_detector = aws.AWSCloudProvider(facts)
+        is_vm = aws_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_aws_xen_vm = aws_detector.is_running_on_cloud()
+        self.assertTrue(is_aws_xen_vm)
+
+    def test_aws_vm_using_kvm(self):
+        """
+        Test for the case, when the vm is running on AWS KVM
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.version': '1.0',
+            'dmi.bios.vendor': 'Amazon EC2'
+        }
+        aws_detector = aws.AWSCloudProvider(facts)
+        is_vm = aws_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_aws_kvm_vm = aws_detector.is_running_on_cloud()
+        self.assertTrue(is_aws_kvm_vm)
+
+    def test_vm_not_on_aws_cloud(self):
+        """
+        Test for the case, when the vm is not running on AWS
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.version': '1.0',
+            'dmi.bios.vendor': 'Foo'
+        }
+        aws_detector = aws.AWSCloudProvider(facts)
+        is_vm = aws_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_aws_vm = aws_detector.is_running_on_cloud()
+        self.assertFalse(is_aws_vm)
+
+    def test_vm_without_dmi_bios_info(self):
+        """
+        Test for the case, when SM BIOS does not provide any useful information for our code
+        """
+        # We will mock facts using simple dictionary
+        facts = {}
+        aws_detector = aws.AWSCloudProvider(facts)
+        is_vm = aws_detector.is_vm()
+        self.assertFalse(is_vm)
+        is_aws_vm = aws_detector.is_running_on_cloud()
+        self.assertFalse(is_aws_vm)
+
+    def test_vm_system_uuid_starts_with_ec2(self):
+        """
+        Test for the case, when system UUID starts with EC2 string as it is described here:
+        https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'dmi.system.uuid': 'EC2263F8-15F3-4A34-B186-FAD8AB963431'
+        }
+        aws_detector = aws.AWSCloudProvider(facts)
+        is_vm = aws_detector.is_vm()
+        self.assertTrue(is_vm)
+        probability = aws_detector.is_likely_running_on_cloud()
+        self.assertEqual(probability, 0.1)
+
+    @patch('cloud_what._base_provider.requests.Session')
+    def test_get_metadata_from_server_imds_v1(self, mock_session_class):
+        """
+        Test the case, when metadata are obtained from server using IMDSv1
+        """
+        mock_result = Mock()
+        mock_result.status_code = 200
+        mock_result.text = AWS_METADATA
+        mock_session = Mock()
+        mock_session.send = Mock(return_value=mock_result)
+        mock_session.prepare_request = Mock()
+        mock_session.hooks = {'response': []}
+        mock_session_class.return_value = mock_session
+        aws_collector = aws.AWSCloudProvider({})
+        # Mock that no metadata cache exists
+        aws_collector._get_metadata_from_cache = Mock(return_value=None)
+        metadata = aws_collector.get_metadata()
+        self.assertEqual(metadata, AWS_METADATA)
+
+    @patch('cloud_what._base_provider.requests.Session')
+    def test_get_signature_from_server_imds_v1(self, mock_session_class):
+        """
+        Test the case, when metadata are obtained from server using IMDSv1
+        """
+        mock_result = Mock()
+        mock_result.status_code = 200
+        mock_result.text = AWS_SIGNATURE
+        mock_session = Mock()
+        mock_session.send = Mock(return_value=mock_result)
+        mock_session.prepare_request = Mock()
+        mock_session.hooks = {'response': []}
+        mock_session_class.return_value = mock_session
+
+        aws_collector = aws.AWSCloudProvider({})
+        # Mock that no metadata cache exists
+        aws_collector._get_signature_from_cache = Mock(return_value=None)
+        test_signature = aws_collector.get_signature()
+        signature = '-----BEGIN PKCS7-----\n' + AWS_SIGNATURE + '\n-----END PKCS7-----'
+        self.assertEqual(signature, test_signature)
+
+    @patch('cloud_what._base_provider.requests.Session')
+    def test_get_metadata_from_server_imds_v2(self, mock_session_class):
+        """
+        Test the case, when metadata are obtained from server using IMDSv2
+        """
+        mock_session = Mock()
+        mock_session.send = send_only_imds_v2_is_supported
+        mock_session.prepare_request = Mock(side_effect=mock_prepare_request)
+        mock_session.hooks = {'response': []}
+        mock_session_class.return_value = mock_session
+
+        aws_provider = aws.AWSCloudProvider({})
+        # Mock that no metadata cache exists
+        aws_provider._get_metadata_from_cache = Mock(return_value=None)
+        # Mock that no token cache exists
+        aws_provider._get_token_from_cache_file = Mock(return_value=None)
+        # Mock writing token to cache file
+        aws_provider._write_token_to_cache_file = Mock()
+        # Mock getting metadata using IMDSv1 is disabled by user
+        aws_provider._get_metadata_from_server_imds_v1 = Mock(return_value=None)
+
+        metadata = aws_provider.get_metadata()
+        self.assertEqual(metadata, AWS_METADATA)
+
+    @patch('cloud_what._base_provider.requests.Session')
+    def test_get_signature_from_server_imds_v2(self, mock_session_class):
+        """
+        Test the case, when signature is obtained from server using IMDSv2
+        """
+        mock_session = Mock()
+        mock_session.send = send_only_imds_v2_is_supported
+        mock_session.prepare_request = Mock(side_effect=mock_prepare_request)
+        mock_session.hooks = {'response': []}
+        mock_session_class.return_value = mock_session
+
+        aws_collector = aws.AWSCloudProvider({})
+        # Mock that no metadata cache exists
+        aws_collector._get_metadata_from_cache = Mock(return_value=None)
+        # Mock that no token cache exists
+        aws_collector._get_token_from_cache_file = Mock(return_value=None)
+        # Mock writing token to cache file
+        aws_collector._write_token_to_cache_file = Mock()
+
+        test_signature = aws_collector.get_signature()
+        signature = '-----BEGIN PKCS7-----\n' + AWS_SIGNATURE + '\n-----END PKCS7-----'
+        self.assertEqual(signature, test_signature)
+
+    def test_reading_valid_cached_token(self):
+        """
+        Test reading of valid cached token from file
+        """
+        c_time = str(time.time())
+        ttl = str(aws.AWSCloudProvider.CLOUD_PROVIDER_TOKEN_TTL)
+        token = 'ABCDEFGHy0hY_y8D7e95IIx7aP2bmnzddz0tIV56yZY9oK00F8GUPQ=='
+        valid_token = '{\
+  "ctime": "' + c_time + '",\
+  "ttl": "' + ttl + '",\
+  "token": "' + token + '"\
+}'
+        aws_collector = aws.AWSCloudProvider({})
+        # Create mock of cached toke file
+        with tempfile.NamedTemporaryFile() as tmp_token_file:
+            # Create valid token file
+            tmp_token_file.write(bytes(valid_token, encoding='utf-8'))
+            tmp_token_file.flush()
+            old_token_cache_file = aws_collector.TOKEN_CACHE_FILE
+            aws_collector.TOKEN_CACHE_FILE = tmp_token_file.name
+            test_token = aws_collector._get_token_from_cache_file()
+            self.assertEqual(token, test_token)
+            aws_collector.TOKEN_CACHE_FILE = old_token_cache_file
+
+    def test_reading_invalid_cached_token_corrupted_json_file(self):
+        """
+        Test reading of corrupted cached token from file
+        """
+        c_time = str(time.time())
+        ttl = str(aws.AWSCloudProvider.CLOUD_PROVIDER_TOKEN_TTL)
+        token = 'ABCDEFGHy0hY_y8D7e95IIx7aP2bmnzddz0tIV56yZY9oK00F8GUPQ=='
+        valid_token = '{[\
+  "ctime": "' + c_time + '",\
+  "ttl": "' + ttl + '",\
+  "token": "' + token + '"\
+}]'
+        aws_collector = aws.AWSCloudProvider({})
+        # Create mock of cached toke file
+        with tempfile.NamedTemporaryFile() as tmp_token_file:
+            # Create valid token file
+            tmp_token_file.write(bytes(valid_token, encoding='utf-8'))
+            tmp_token_file.flush()
+            old_token_cache_file = aws_collector.TOKEN_CACHE_FILE
+            aws_collector.TOKEN_CACHE_FILE = tmp_token_file.name
+            test_token = aws_collector._get_token_from_cache_file()
+            self.assertEqual(test_token, None)
+            aws_collector.TOKEN_CACHE_FILE = old_token_cache_file
+
+    def test_reading_invalid_cached_token_wrong_ctime_format(self):
+        """
+        Test reading of cached token from file with invalid time format
+        """
+        ttl = str(aws.AWSCloudProvider.CLOUD_PROVIDER_TOKEN_TTL)
+        token = 'ABCDEFGHy0hY_y8D7e95IIx7aP2bmnzddz0tIV56yZY9oK00F8GUPQ=='
+        # ctime has to be float (unix epoch)
+        valid_token = '{[\
+  "ctime": "Wed Dec 16 16:31:36 CET 2020",\
+  "ttl": "' + ttl + '",\
+  "token": "' + token + '"\
+}]'
+        aws_collector = aws.AWSCloudProvider({})
+        # Create mock of cached toke file
+        with tempfile.NamedTemporaryFile() as tmp_token_file:
+            # Create valid token file
+            tmp_token_file.write(bytes(valid_token, encoding='utf-8'))
+            tmp_token_file.flush()
+            old_token_cache_file = aws_collector.TOKEN_CACHE_FILE
+            aws_collector.TOKEN_CACHE_FILE = tmp_token_file.name
+            test_token = aws_collector._get_token_from_cache_file()
+            self.assertEqual(test_token, None)
+            aws_collector.TOKEN_CACHE_FILE = old_token_cache_file
+
+    def test_reading_invalid_cached_token_missing_key(self):
+        """
+        Test reading of invalid cached token from file
+        """
+        valid_token = '{\
+  "token": "ABCDEFGHy0hY_y8D7e95IIx7aP2bmnzddz0tIV56yZY9oK00F8GUPQ=="\
+}'
+        aws_collector = aws.AWSCloudProvider({})
+        # Create mock of cached toke file
+        with tempfile.NamedTemporaryFile() as tmp_token_file:
+            # Create valid token file
+            tmp_token_file.write(bytes(valid_token, encoding='utf-8'))
+            tmp_token_file.flush()
+            old_token_cache_file = aws_collector.TOKEN_CACHE_FILE
+            aws_collector.TOKEN_CACHE_FILE = tmp_token_file.name
+            test_token = aws_collector._get_token_from_cache_file()
+            self.assertEqual(test_token, None)
+            aws_collector.TOKEN_CACHE_FILE = old_token_cache_file
+
+    def test_reading_timed_out_cached_token(self):
+        """
+        Test reading of cached token from file that is timed out
+        """
+        c_time = str(time.time() - aws.AWSCloudProvider.CLOUD_PROVIDER_TOKEN_TTL - 10)
+        ttl = str(aws.AWSCloudProvider.CLOUD_PROVIDER_TOKEN_TTL)
+        valid_token = '{\
+  "ctime": "' + c_time + '",\
+  "ttl": "' + ttl + '",\
+  "token": "ABCDEFGHy0hY_y8D7e95IIx7aP2bmnzddz0tIV56yZY9oK00F8GUPQ=="\
+}'
+        aws_collector = aws.AWSCloudProvider({})
+        # Create mock of cached toke file
+        with tempfile.NamedTemporaryFile() as tmp_token_file:
+            # Create valid token file
+            tmp_token_file.write(bytes(valid_token, encoding='utf-8'))
+            tmp_token_file.flush()
+            old_token_cache_file = aws_collector.TOKEN_CACHE_FILE
+            aws_collector.TOKEN_CACHE_FILE = tmp_token_file.name
+            test_token = aws_collector._get_token_from_cache_file()
+            self.assertEqual(test_token, None)
+            aws_collector.TOKEN_CACHE_FILE = old_token_cache_file
+
+
+AZURE_METADATA = """
+{
+    "compute": {
+        "azEnvironment": "AzurePublicCloud",
+        "customData": "",
+        "location": "westeurope",
+        "name": "foo-bar",
+        "offer": "RHEL",
+        "osType": "Linux",
+        "placementGroupId": "",
+        "plan": {
+            "name": "",
+            "product": "",
+            "publisher": ""
+        },
+        "platformFaultDomain": "0",
+        "platformUpdateDomain": "0",
+        "provider": "Microsoft.Compute",
+        "publicKeys": [
+            {
+                "keyData": "ssh-rsa SOMEpublicSSHkey user@localhost.localdomain",
+                "path": "/home/user/.ssh/authorized_keys"
+            }
+        ],
+        "publisher": "RedHat",
+        "resourceGroupName": "foo-bar",
+        "resourceId": "/subscriptions/01234567-0123-0123-0123-012345679abc/resourceGroups/foo-bar/providers/Microsoft.Compute/virtualMachines/foo",
+        "sku": "8.1-ci",
+        "storageProfile": {
+            "dataDisks": [],
+            "imageReference": {
+                "id": "",
+                "offer": "RHEL",
+                "publisher": "RedHat",
+                "sku": "8.1-ci",
+                "version": "latest"
+            },
+            "osDisk": {
+                "caching": "ReadWrite",
+                "createOption": "FromImage",
+                "diskSizeGB": "64",
+                "encryptionSettings": {
+                    "enabled": "false"
+                },
+                "image": {
+                    "uri": ""
+                },
+                "managedDisk": {
+                    "id": "/subscriptions/01234567-0123-0123-0123-012345679abc/resourceGroups/FOO-BAR/providers/Microsoft.Compute/disks/foo_OsDisk_1_b21768daf38e48c6a0db7cff1f054b03",
+                    "storageAccountType": ""
+                },
+                "name": "FOO_OsDisk_1_b21768daf38e48c6a0db7cff1f054b03",
+                "osType": "Linux",
+                "vhd": {
+                    "uri": ""
+                },
+                "writeAcceleratorEnabled": "false"
+            }
+        },
+        "subscriptionId": "01234567-0123-0123-0123-012345679abc",
+        "tags": "",
+        "version": "8.1.2020042511",
+        "vmId": "12345678-1234-1234-1234-123456789abc",
+        "vmScaleSetName": "",
+        "vmSize": "Standard_D2s_v3",
+        "zone": ""
+    },
+    "network": {
+        "interface": [
+            {
+                "ipv4": {
+                    "ipAddress": [
+                        {
+                            "privateIpAddress": "172.16.2.5",
+                            "publicIpAddress": "1.2.3.4"
+                        }
+                    ],
+                    "subnet": [
+                        {
+                            "address": "172.16.2.0",
+                            "prefix": "24"
+                        }
+                    ]
+                },
+                "ipv6": {
+                    "ipAddress": []
+                },
+                "macAddress": "000D3A123456"
+            }
+        ]
+    }
+}
+"""
+
+AZURE_SIGNATURE = """
+{"encoding":"pkcs7","signature":"MIIKWQYJKoZIhvcNAQcCoIIKSjCCCkYCAQExDzANBgkqhkiG9w0BAQsFADCB4wYJKoZIhvcNAQcBoIHVBIHSeyJub25jZSI6IjIwMjEwMTA0LTE5NTUzNCIsInBsYW4iOnsibmFtZSI6IiIsInByb2R1Y3QiOiIiLCJwdWJsaXNoZXIiOiIifSwidGltZVN0YW1wIjp7ImNyZWF0ZWRPbiI6IjAxLzA0LzIxIDEzOjU1OjM0IC0wMDAwIiwiZXhwaXJlc09uIjoiMDEvMDQvMjEgMTk6NTU6MzQgLTAwMDAifSwidm1JZCI6ImY5MDRlY2U4LWM2YzEtNGI1Yy04ODFmLTMwOWI1MGYyNWU1NiJ9oIIHszCCB68wggWXoAMCAQICE2sAA9CNXTZWgCfFbjAAAAAD0I0wDQYJKoZIhvcNAQELBQAwTzELMAkGA1UEBhMCVVMxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEgMB4GA1UEAxMXTWljcm9zb2Z0IFJTQSBUTFMgQ0EgMDEwHhcNMjAxMjAzMDExNDQ2WhcNMjExMjAzMDExNDQ2WjAdMRswGQYDVQQDExJtZXRhZGF0YS5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDTmv9qqV0VheHfrysxg99qC9VxpnE9x4pbjsqLNVVssp8pdr3zcfbBPbvOOgvIRv8/JCTrN4ffweJ6eiwYTwKhnxyDhfTOfkRbMOwLn100rNryEkYOC/NymNF1aqNIvRT6X/nplygcLWg2kCZxIXHnNosG2wLrIBlzLhqrMtAzUCz2jmOKGDMu1JxLiT3YAmIRPYbYvJlMTMHhZqe4InhBZxdX/J5XXgzXbL1KzlAQj7aOsh72OPu/cX6ETTzuXCIZibDL3sknZSpZeuNz0pnSC0/B70bGGTxuUZcxNy0dgW1t37pK8EGnW8kxBOO1vWTnR/ca4w+QakXXfcMbAWLtAgMBAAGjggO0MIIDsDCCAQMGCisGAQQB1nkCBAIEgfQEgfEA7wB1AH0+8viP/4hVaCTCwMqeUol5K8UOeAl/LmqXaJl+IvDXAAABdiYztGsAAAQDAEYwRAIgWpDU+ZDd8qLC2OAUWKVqK3DHJ8nd3TiXachxppHeRzQCIEgMrIGHcvT6ue+LCmzDb0MPDwAcYTaG+82aK8kjNgs7AHYAVYHUwhaQNgFK6gubVzxT8MDkOHhwJQgXL6OqHQcT0wwAAAF2JjO1bwAABAMARzBFAiEAmnAnhcGJIERiGZiBG6yoW9vu2zPGH9LDYSe9Tsf3e7ECIHSm4fZ+zKeIFCOSwGlSN8/gELMBJ6DPWMNMQ8TpEyo7MCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPgYJKwYBBAGCNxUHBDEwLwYnKwYBBAGCNxUIh9qGdYPu2QGCyYUbgbWeYYX062CBXYWGjkGHwphQAgFkAgElMIGHBggrBgEFBQcBAQR7MHkwUwYIKwYBBQUHMAKGR2h0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvbXNjb3JwL01pY3Jvc29mdCUyMFJTQSUyMFRMUyUyMENBJTIwMDEuY3J0MCIGCCsGAQUFBzABhhZodHRwOi8vb2NzcC5tc29jc3AuY29tMB0GA1UdDgQWBBRt8786ehWZoL09LrwjfrXi0ypzFzALBgNVHQ8EBAMCBLAwPAYDVR0RBDUwM4Idd2VzdGV1cm9wZS5tZXRhZGF0YS5henVyZS5jb22CEm1ldGFkYXRhLmF6dXJlLmNvbTCBsAYDVR0fBIGoMIGlMIGioIGfoIGchk1odHRwOi8vbXNjcmwubWljcm9zb2Z0LmNvbS9wa2kvbXNjb3JwL2NybC9NaWNyb3NvZnQlMjBSU0ElMjBUTFMlMjBDQSUyMDAxLmNybIZLaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraS9tc2NvcnAvY3JsL01pY3Jvc29mdCUyMFJTQSUyMFRMUyUyMENBJTIwMDEuY3JsMFcGA1UdIARQME4wQgYJKwYBBAGCNyoBMDUwMwYIKwYBBQUHAgEWJ2h0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvbXNjb3JwL2NwczAIBgZngQwBAgEwHwYDVR0jBBgwFoAUtXYMMBHOx5JCTUzHXCzIqQzoC2QwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA0GCSqGSIb3DQEBCwUAA4ICAQCKueIzSjIwc30ZoGMJpEKmYIDK/3Jg5wp7oom9HcECgIL8Ou1s2g3pSXf7NyLQP1ST19bvxQSzPbXBvBcz6phKdtHH7bH2c3uMhy74zSbxQybL0pjse1tT0lyTCWcitPk/8U/E/atQpTshKsnwIdBhkR3LAUQnIXDBAVpV2Njj3rUfI7OpT2tODcRPuGQW631teQULJNbR+Aprmp6/Y42hLFHfmyi2TmR0R/b94anLIie1MIcU8ikYf8/gVniOosKQFfNtmpnuPcnl0tqliQP44rN7ijFudvXz4CIOKocIGF14IsNZypLR2WQB9jo+nOa+XEV4T6BK9W2skxIws7/TT8Ks8PescvV1DYOamgRB2KyTUDsEGFgtNbh3L0h8xKyzAGIU1XbGyWSvtaRGdbH3PU5ERRDMfqOP0twjmxn20leeYKnS+DfiAMakWuguygRhQ50u3ZJKblsRF4zs5r8dE65eIOUl6GIjEvZCy1OCKIb6U/15hmbEiQLtqNqhowLdaoxW2Xpkd/H0icm5FA7YmeoHssJJiE/1kT5r/dtSH9elMaQ8SQ4MfVo/FSKPTIOQK3UzeEyT6QvzQUxQiUZvZA/Cxta8z9R8RSAUtxAMQ7ATYVGJsVxssP6Hk79XlgloevHWS2srVAkFD07tBhhNAAFC6DVz9T0unxhJMDe6kjGCAZEwggGNAgEBMGYwTzELMAkGA1UEBhMCVVMxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEgMB4GA1UEAxMXTWljcm9zb2Z0IFJTQSBUTFMgQ0EgMDECE2sAA9CNXTZWgCfFbjAAAAAD0I0wDQYJKoZIhvcNAQELBQAwDQYJKoZIhvcNAQEBBQAEggEAbyBz+8VYrETncYr9W1FGKD47mNVmvd2NA7RaWaduz/MDDScBgZr1UFxGMnxqBoRsrVD8rRxYTkLo8VLV1UrGWoLlYrbtuKyeoWxj2tFcdQLjDs16/jydY8rINLmMmZGxOnhpPjewCB3epn2pmMTPr1kwJSpD23Jko41MBoYjTnUnYtqZgKDmPFgtcMnIP9cBX5rnBdNfaUg19aJvCZkw4mQkIam9F6xXE9qkqenapywTmNIiczpXOFrzGoCaq0N4yKxZYTvwndefiPPihH4D6TIGLZbKQD0kK/MIvrs+JobW43kTKUKyzyGNhQHmBRDXNDy/bWMOUyjbDpZLYEm9tg=="}
+"""
+
+# Use something from far future
+SUPPORTED_AZURE_VERSIONS = ["2141-06-01", "2141-09-01", "2142-03-01"]
+
+# Real list is much more longer (about 15 items)
+AZURE_API_VERSIONS = json.dumps({"apiVersions": SUPPORTED_AZURE_VERSIONS})
+
+
+class TestAzureCloudProvider(unittest.TestCase):
+    """
+    Class used for testing of Azure cloud provider
+    """
+
+    def setUp(self):
+        """
+        Patch communication with metadata provider
+        """
+        requests_patcher = patch('cloud_what._base_provider.requests')
+        self.requests_mock = requests_patcher.start()
+        self.addCleanup(requests_patcher.stop)
+
+    def test_azure_cloud_provider_id(self):
+        """
+        Test of CLOUD_PROVIDER_ID
+        """
+        self.assertEqual(azure.AzureCloudProvider.CLOUD_PROVIDER_ID, "azure")
+        azure_detector = azure.AzureCloudProvider({})
+        self.assertEqual(azure_detector.CLOUD_PROVIDER_ID, "azure")
+
+    def test_azure_not_vm(self):
+        """
+        Test for the case, when the machine is host (not virtual machine)
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': False,
+            'dmi.bios.version': 'cool hardware company'
+        }
+        azure_detector = azure.AzureCloudProvider(facts)
+        is_vm = azure_detector.is_vm()
+        self.assertFalse(is_vm)
+
+    def test_azure_vm(self):
+        """
+        Test for the case, when the vm is running on Azure
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'hyperv',
+            'dmi.bios.version': '090008',
+            'dmi.chassis.asset_tag': '7783-7084-3265-9085-8269-3286-77'
+        }
+        azure_detector = azure.AzureCloudProvider(facts)
+        is_vm = azure_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_azure_vm = azure_detector.is_running_on_cloud()
+        self.assertTrue(is_azure_vm)
+
+    def test_vm_not_on_azure_cloud(self):
+        """
+        Test for the case, when the vm is not running on AWS
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'hyperv',
+            'dmi.bios.version': '090008',
+            'dmi.bios.vendor': 'Foo'
+        }
+        azure_detector = azure.AzureCloudProvider(facts)
+        is_vm = azure_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_azure_vm = azure_detector.is_running_on_cloud()
+        self.assertFalse(is_azure_vm)
+
+    def test_vm_without_dmi_bios_info(self):
+        """
+        Test for the case, when MS BIOS does not provide any useful information for our code
+        """
+        # We will mock facts using simple dictionary
+        facts = {}
+        azure_detector = azure.AzureCloudProvider(facts)
+        is_vm = azure_detector.is_vm()
+        self.assertFalse(is_vm)
+        is_azure_vm = azure_detector.is_running_on_cloud()
+        self.assertFalse(is_azure_vm)
+
+    def test_get_metadata_from_server(self):
+        """
+        Test getting metadata from server, when there is no cache
+        """
+        self.requests_mock.Request = Mock()
+        mock_result = Mock()
+        mock_result.status_code = 200
+        mock_result.text = AZURE_METADATA
+        mock_session = Mock()
+        mock_session.send = Mock(return_value=mock_result)
+        mock_session.prepare_request = Mock()
+        mock_session.hooks = {'response': []}
+        self.requests_mock.Session = Mock(return_value=mock_session)
+        azure_collector = azure.AzureCloudProvider({})
+        metadata = azure_collector.get_metadata()
+        self.requests_mock.Request.assert_called_once_with(
+            method="GET",
+            url=f"http://169.254.169.254/metadata/instance?api-version={azure.AzureCloudProvider.API_VERSION}",
+            headers={
+                'User-Agent': 'cloud-what/1.0',
+                "Metadata": "true"
+            }
+        )
+        mock_session.send.assert_called_once()
+        self.assertEqual(metadata, AZURE_METADATA)
+
+    def test_get_api_versions(self):
+        """
+        Test getting API versions
+        """
+        self.requests_mock.Request = Mock()
+        mock_result = Mock()
+        mock_result.status_code = 200
+        mock_result.text = AZURE_API_VERSIONS
+        mock_session = Mock()
+        mock_session.send = Mock(return_value=mock_result)
+        mock_session.prepare_request = Mock()
+        mock_session.hooks = {'response': []}
+        self.requests_mock.Session = Mock(return_value=mock_session)
+        azure_provider = azure.AzureCloudProvider({})
+        api_versions = azure_provider.get_api_versions()
+        self.requests_mock.Request.assert_called_once_with(
+            method="GET",
+            url="http://169.254.169.254/metadata/versions",
+            headers={
+                'User-Agent': 'cloud-what/1.0',
+                "Metadata": "true"
+            }
+        )
+        mock_session.send.assert_called_once()
+        self.assertEqual(api_versions, SUPPORTED_AZURE_VERSIONS)
+
+    def test_get_signature_from_server(self):
+        """
+        Test getting signature from server, when there is no cache file
+        """
+        self.requests_mock.Request = Mock()
+        mock_result = Mock()
+        mock_result.status_code = 200
+        mock_result.text = AZURE_SIGNATURE
+        mock_session = Mock()
+        mock_session.send = Mock(return_value=mock_result)
+        mock_session.prepare_request = Mock()
+        mock_session.hooks = {'response': []}
+        self.requests_mock.Session = Mock(return_value=mock_session)
+        azure_collector = azure.AzureCloudProvider({})
+        signature = azure_collector.get_signature()
+        self.requests_mock.Request.assert_called_once_with(
+            method="GET",
+            url=f"http://169.254.169.254/metadata/attested/document?api-version={azure.AzureCloudProvider.API_VERSION}",
+            headers={
+                'User-Agent': 'cloud-what/1.0',
+                "Metadata": "true"
+            }
+        )
+        mock_session.send.assert_called_once()
+        self.assertEqual(signature, AZURE_SIGNATURE)
+
+    @staticmethod
+    def mock_send_azure_IMDS(request, *args, **kwargs):
+        """
+        Mock Azure IMDS supporting only few API versions
+        """
+        supported_api_version = False
+        for api_version in SUPPORTED_AZURE_VERSIONS:
+            if request.url.endswith(api_version):
+                supported_api_version = True
+
+        mock_result = Mock()
+        if supported_api_version is False:
+            mock_result.status_code = 400
+            mock_result.text = '{ "error": "Bad request. api-version is invalid or was not specified in the request." }'
+        else:
+            mock_result.status_code = 200
+            if '/metadata/instance' in request.url:
+                mock_result.text = AZURE_SIGNATURE
+            elif '/metadata/attested/document' in request.url:
+                mock_result.text = AZURE_SIGNATURE
+            else:
+                mock_result.text = ''
+
+        return mock_result
+
+    @patch('cloud_what.providers.azure.AzureCloudProvider.get_api_versions')
+    def test_get_metadata_from_server_outdated_api_version(self, mock_get_api_versions):
+        """
+        Test getting metadata from server using outdated API version that is not supported
+        """
+        def _mock_prepare_request(mock_request, *args, **kwargs):
+            mock_prepared_request = Mock(spec=["method", "url", "headers"])
+            mock_prepared_request.method = mock_request.method
+            mock_prepared_request.url = mock_request.url
+            mock_prepared_request.headers = mock_request.headers
+            return mock_prepared_request
+
+        self.requests_mock.Request = Mock(wraps=requests.Request)
+        # We simple mock getting api versions, because this method is tested in another test method
+        mock_get_api_versions.return_value = SUPPORTED_AZURE_VERSIONS
+        mock_session = Mock()
+        mock_session.send = Mock(side_effect=self.mock_send_azure_IMDS)
+        mock_session.prepare_request = _mock_prepare_request
+        mock_session.hooks = {'response': []}
+        self.requests_mock.Session = Mock(return_value=mock_session)
+
+        azure_collector = azure.AzureCloudProvider({})
+        metadata = azure_collector.get_metadata()
+
+        request_calls = [
+            call(
+                method='GET',
+                headers={'User-Agent': 'cloud-what/1.0', 'Metadata': 'true'},
+                url=f'http://169.254.169.254/metadata/instance?api-version={azure.AzureCloudProvider.API_VERSION}'
+            ),
+            call(
+                method='GET',
+                headers={'User-Agent': 'cloud-what/1.0', 'Metadata': 'true'},
+                url=f'http://169.254.169.254/metadata/instance?api-version={SUPPORTED_AZURE_VERSIONS[-1]}'
+            )
+        ]
+        self.requests_mock.Request.assert_has_calls(calls=request_calls)
+        self.assertEqual(mock_session.send.call_count, 2)
+        self.assertIsNotNone(metadata)
+
+
+GCP_JWT_TOKEN = """eyJhbGciOiJSUzI1NiIsImtpZCI6IjZhOGJhNTY1MmE3MDQ0MTIxZDRmZWRhYzhmMTRkMTRjNTRlNDg5NWIiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL3N1YnNjcmlwdGlvbi5yaHNtLnJlZGhhdC5jb206NDQzL3N1YnNjcmlwdGlvbiIsImF6cCI6IjEwNDA3MDk1NTY4MjI5ODczNjE0OSIsImVtYWlsIjoiMTYxOTU4NDY1NjEzLWNvbXB1dGVAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZXhwIjoxNjE2NTk5ODIzLCJnb29nbGUiOnsiY29tcHV0ZV9lbmdpbmUiOnsiaW5zdGFuY2VfY3JlYXRpb25fdGltZXN0YW1wIjoxNjE2NTk1ODQ3LCJpbnN0YW5jZV9pZCI6IjI1ODkyMjExNDA2NzY3MTgwMjYiLCJpbnN0YW5jZV9uYW1lIjoiaW5zdGFuY2UtMSIsImxpY2Vuc2VfaWQiOlsiNTczMTAzNTA2NzI1NjkyNTI5OCJdLCJwcm9qZWN0X2lkIjoiZmFpci1raW5nZG9tLTMwODUxNCIsInByb2plY3RfbnVtYmVyIjoxNjE5NTg0NjU2MTMsInpvbmUiOiJ1cy1lYXN0MS1iIn19LCJpYXQiOjE2MTY1OTYyMjMsImlzcyI6Imh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbSIsInN1YiI6IjEwNDA3MDk1NTY4MjI5ODczNjE0OSJ9.XQKeqMAvsH2T2wsdN97jlm52DzLfix3DTMCu9QCuhSKLEk1xHYOYtvh5Yzn7j-tbZtV-siyPAfpGZO3Id87573OVGgohN3q7Exlf9CEIHa1-X7zLyiyIlyrnfQJ1aGHeH6y7gb_tWxHFLJRzhulfkfJxSDn5fEBSgBqbjzCr9unQgMkuzQ3uui2BbIbALmOpY6D-IT71mgMDZ_zm4G6q-Mh0nIMkDWhmQ8pa3RAVqqBMBYJninKLdCD8eQzIlDhtIzwmYGLrsJMktFF3pJFCqEFv1rKZy_OUyV4JOkOLtXbKnwxqmFTq-2SP0KtUWjDy1-U8GnVDptISjOf2O9FaLA
+"""
+
+GCP_JOSE_HEADER = '{"alg":"RS256","kid":"6a8ba5652a7044121d4fedac8f14d14c54e4895b","typ":"JWT"}'
+
+GCP_METADATA = '{"aud":"https://subscription.rhsm.redhat.com:443/subscription","azp":"104070955682298736149","email":"161958465613-compute@developer.gserviceaccount.com","email_verified":true,"exp":1616599823,"google":{"compute_engine":{"instance_creation_timestamp":1616595847,"instance_id":"2589221140676718026","instance_name":"instance-1","license_id":["5731035067256925298"],"project_id":"fair-kingdom-308514","project_number":161958465613,"zone":"us-east1-b"}},"iat":1616596223,"iss":"https://accounts.google.com","sub":"104070955682298736149"}'
+
+GCP_SIGNATURE = """XQKeqMAvsH2T2wsdN97jlm52DzLfix3DTMCu9QCuhSKLEk1xHYOYtvh5Yzn7j-tbZtV-siyPAfpGZO3Id87573OVGgohN3q7Exlf9CEIHa1-X7zLyiyIlyrnfQJ1aGHeH6y7gb_tWxHFLJRzhulfkfJxSDn5fEBSgBqbjzCr9unQgMkuzQ3uui2BbIbALmOpY6D-IT71mgMDZ_zm4G6q-Mh0nIMkDWhmQ8pa3RAVqqBMBYJninKLdCD8eQzIlDhtIzwmYGLrsJMktFF3pJFCqEFv1rKZy_OUyV4JOkOLtXbKnwxqmFTq-2SP0KtUWjDy1-U8GnVDptISjOf2O9FaLA
+==="""
+
+
+class TestGCPCloudProvider(unittest.TestCase):
+    """
+    Class used for testing detector of GCP
+    """
+
+    def setUp(self):
+        """
+        Patch communication with metadata provider
+        """
+        requests_patcher = patch('cloud_what._base_provider.requests')
+        self.requests_mock = requests_patcher.start()
+        self.addCleanup(requests_patcher.stop)
+
+    def test_gcp_cloud_provider_id(self):
+        """
+        Test of CLOUD_PROVIDER_ID
+        """
+        self.assertEqual(gcp.GCPCloudProvider.CLOUD_PROVIDER_ID, "gcp")
+        gcp_detector = gcp.GCPCloudProvider({})
+        self.assertEqual(gcp_detector.CLOUD_PROVIDER_ID, "gcp")
+
+    def test_gcp_not_vm(self):
+        """
+        Test for the case, when the machine is host (not virtual machine)
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': False,
+            'dmi.bios.version': 'cool hardware company'
+        }
+        gcp_detector = gcp.GCPCloudProvider(facts)
+        is_vm = gcp_detector.is_vm()
+        self.assertFalse(is_vm)
+
+    def test_gcp_vm(self):
+        """
+        Test for the case, when the vm is running on GCP
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.version': 'Google',
+            'dmi.bios.vendor': 'Google'
+        }
+        gcp_detector = gcp.GCPCloudProvider(facts)
+        is_vm = gcp_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_gcp_vm = gcp_detector.is_running_on_cloud()
+        self.assertTrue(is_gcp_vm)
+
+    def test_vm_not_on_gcp_cloud(self):
+        """
+        Test for the case, when the vm is not running on GCP
+        """
+        # We will mock facts using simple dictionary
+        facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.version': '1.0',
+            'dmi.bios.vendor': 'Foo'
+        }
+        gcp_detector = gcp.GCPCloudProvider(facts)
+        is_vm = gcp_detector.is_vm()
+        self.assertTrue(is_vm)
+        is_gcp_vm = gcp_detector.is_running_on_cloud()
+        self.assertFalse(is_gcp_vm)
+
+    def test_get_token(self):
+        """
+        Test getting GCP token, when default audience URL is used
+        """
+        self.requests_mock.Request = Mock()
+        mock_result = Mock()
+        mock_result.status_code = 200
+        mock_result.text = GCP_JWT_TOKEN
+        mock_session = Mock()
+        mock_session.send = Mock(return_value=mock_result)
+        mock_session.prepare_request = Mock()
+        mock_session.hooks = {'response': []}
+        self.requests_mock.Session = Mock(return_value=mock_session)
+
+        gcp_collector = gcp.GCPCloudProvider({})
+        gcp_collector._get_token_from_cache_file = Mock(return_value=None)
+        gcp_collector._write_token_to_cache_file = Mock(return_value=None)
+        token = gcp_collector.get_metadata()
+        self.requests_mock.Request.assert_called_once_with(
+            method="GET",
+            url='http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?'
+                'audience=https://subscription.rhsm.redhat.com:443/subscription&format=full',
+            headers={
+                'User-Agent': 'cloud-what/1.0',
+                'Metadata-Flavor': 'Google'
+            }
+        )
+        self.assertEqual(token, GCP_JWT_TOKEN)
+
+    def test_get_token_custom_audience(self):
+        """
+        Test getting GCP token, when custom audience URL is used (e.g. Satellite or stage is used)
+        """
+        self.requests_mock.Request = Mock()
+        mock_result = Mock()
+        mock_result.status_code = 200
+        mock_result.text = GCP_JWT_TOKEN
+        mock_session = Mock()
+        mock_session.send = Mock(return_value=mock_result)
+        mock_session.prepare_request = Mock()
+        mock_session.hooks = {'response': []}
+        self.requests_mock.Session = Mock(return_value=mock_session)
+        gcp_collector = gcp.GCPCloudProvider({}, audience_url="https://example.com:8443/rhsm")
+        gcp_collector._get_token_from_cache_file = Mock(return_value=None)
+        gcp_collector._write_token_to_cache_file = Mock(return_value=None)
+        token = gcp_collector.get_metadata()
+        self.requests_mock.Request.assert_called_once_with(
+            method="GET",
+            url='http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?'
+                'audience=https://example.com:8443/rhsm&format=full',
+            headers={
+                'User-Agent': 'cloud-what/1.0',
+                'Metadata-Flavor': 'Google'
+            }
+        )
+        mock_session.send.assert_called_once()
+        self.assertEqual(token, GCP_JWT_TOKEN)
+
+    def test_decode_jwt(self):
+        """
+        Test decoding of JWT token
+        """
+
+        gcp_collector = gcp.GCPCloudProvider({}, audience_url="https://subscription.rhsm.redhat.com:443/subscription")
+        jose_header_str, metadata_str, encoded_signature = gcp_collector.decode_jwt(GCP_JWT_TOKEN)
+
+        self.assertIsNotNone(jose_header_str)
+        self.assertIsNotNone(metadata_str)
+        self.assertIsNotNone(encoded_signature)
+
+        self.assertEqual(jose_header_str, GCP_JOSE_HEADER)
+        self.assertEqual(metadata_str, GCP_METADATA)
+        self.assertEqual(encoded_signature, GCP_SIGNATURE)
+
+        jose_header = json.loads(jose_header_str)
+        self.assertIn("typ", jose_header)
+        self.assertEqual(jose_header["typ"], "JWT")
+
+        metadata = json.loads(metadata_str)
+        self.assertIn("google", metadata)
+        self.assertIn("compute_engine", metadata["google"])
+        self.assertIn("instance_id", metadata["google"]["compute_engine"])
+        self.assertEqual("2589221140676718026", metadata["google"]["compute_engine"]["instance_id"])
+
+    def test_decoding_corrupted_jwt(self):
+        """
+        Test decoding of JWT token with wrong UTF-encoding
+        """
+
+        jwt_token = 'foobar.foobar.foobar'
+        gcp_collector = gcp.GCPCloudProvider({})
+
+        jose_header_str, metadata_str, encoded_signature = gcp_collector.decode_jwt(jwt_token)
+
+        self.assertIsNone(jose_header_str)
+        self.assertIsNone(metadata_str)
+
+    def test_decoding_jwt_wrong_section_number(self):
+        """
+        Test decoding of JWT token with wrong number of sections
+        """
+        # There are only two sections
+        jwt_token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjJ9'
+        gcp_collector = gcp.GCPCloudProvider({})
+
+        jose_header_str, metadata_str, encoded_signature = gcp_collector.decode_jwt(jwt_token)
+
+        self.assertIsNone(jose_header_str)
+        self.assertIsNone(metadata_str)
+
+
+class TestCloudProvider(unittest.TestCase):
+    """
+    Class for testing cloud_what.utils module
+    """
+    def setUp(self):
+        """
+        Set up two mocks that are used in all tests
+        """
+        host_collector_patcher = patch('cloud_what.provider.HostCollector')
+        self.host_collector_mock = host_collector_patcher.start()
+        self.host_fact_collector_instance = Mock()
+        self.host_collector_mock.return_value = self.host_fact_collector_instance
+        self.addCleanup(host_collector_patcher.stop)
+
+        # hardware_collector_patcher = patch('cloud_what.provider.HardwareCollector')
+        # self.hardware_collector_mock = hardware_collector_patcher.start()
+        # self.hw_fact_collector_instance = Mock()
+        # self.hardware_collector_mock.return_value = self.hw_fact_collector_instance
+        # self.addCleanup(hardware_collector_patcher.stop)
+
+        write_cache_patcher = patch('cloud_what.providers.aws.AWSCloudProvider._write_token_to_cache_file')
+        self.write_cache_mock = write_cache_patcher.start()
+        self.addCleanup(write_cache_patcher.stop)
+
+        self.requests_patcher = patch('cloud_what._base_provider.requests')
+        self.azure_requests_mock = self.requests_patcher.start()
+        self.addCleanup(self.requests_patcher.stop)
+
+    def test_detect_cloud_provider_aws(self):
+        """
+        Test the case, when detecting of aws works as expected
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.vendor': 'Amazon EC2'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['aws'])
+
+    def test_detect_cloud_provider_aws_heuristics(self):
+        """
+        Test the case, when detecting of aws does not work using strong signs, but it is necessary
+        to use heuristics method
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.vendor': 'AWS',
+            'dmi.bios.version': '1.0',
+            'dmi.system.manufacturer': 'Amazon'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['aws'])
+
+    def test_detect_cloud_provider_gcp(self):
+        """
+        Test the case, when detecting of gcp works as expected
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.vendor': 'Google',
+            'dmi.bios.version': 'Google'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['gcp'])
+
+    def test_detect_cloud_provider_gcp_heuristics(self):
+        """
+        Test the case, when detecting of gcp does not work using strong signs, but it is necessary
+        to use heuristics method
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.vendor': 'Foo Company',
+            'dmi.bios.version': '1.0',
+            'dmi.chassis.asset_tag': 'Google Cloud',
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['gcp'])
+
+    def test_detect_cloud_provider_azure(self):
+        """
+        Test the case, when detecting of azure works as expected
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'hyperv',
+            'dmi.bios.vendor': 'Foo company',
+            'dmi.bios.version': '1.0',
+            'dmi.chassis.asset_tag': '7783-7084-3265-9085-8269-3286-77'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['azure'])
+
+    def test_detect_cloud_provider_azure_heuristics(self):
+        """
+        Test the case, when detecting of azure does not work using strong signs, but it is necessary
+        to use heuristics method
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'hyperv',
+            'dmi.bios.vendor': 'Microsoft',
+            'dmi.bios.version': '1.0',
+            'dmi.system.manufacturer': 'Google',
+            'dmi.chassis.manufacturer': 'Amazon'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        detected_clouds = detect_cloud_provider()
+        self.assertEqual(detected_clouds, ['azure'])
+
+    def test_conclict_in_strong_signs(self):
+        """
+        Test the case, when cloud providers change strong signs and there is conflict (two providers
+        are detected using strong signs). In such case result using strong signs should be dropped
+        and heuristics should be used, because strong signs do not work with probability and original
+        order is influenced by the order of classes in 'constant' CLOUD_DETECTORS.
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.vendor': 'Google',
+            'dmi.bios.version': 'Amazon EC2',
+            'dmi.chassis.asset_tag': '7783-7084-3265-9085-8269-3286-77',
+            'dmi.chassis.manufacturer': 'Microsoft'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        detected_clouds = detect_cloud_provider()
+        detected_clouds.sort()
+        self.assertEqual(detected_clouds, ['aws', 'azure', 'gcp'])
+
+    def test_conclict_in_heuristics_detection(self):
+        """
+        Test the case, when cloud providers two cloud providers were
+        detected using heuristics with same probability.
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.system.manufacturer': 'Google',
+            'dmi.chassis.manufacturer': 'Amazon EC2',
+        }
+
+        aws_cloud_provider = aws.AWSCloudProvider(host_facts)
+        azure_cloud_provider = azure.AzureCloudProvider(host_facts)
+        gcp_cloud_provider = gcp.GCPCloudProvider(host_facts)
+
+        probability_aws = aws_cloud_provider.is_likely_running_on_cloud()
+        self.assertEqual(probability_aws, 0.6)
+        probability_azure = azure_cloud_provider.is_likely_running_on_cloud()
+        self.assertEqual(probability_azure, 0.0)
+        probability_gcp = gcp_cloud_provider.is_likely_running_on_cloud()
+        self.assertEqual(probability_gcp, 0.6)
+
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        detected_clouds = detect_cloud_provider()
+        detected_clouds.sort()
+        self.assertEqual(detected_clouds, ['aws', 'gcp'])
+
+    def test_get_cloud_provider(self):
+        """
+        Test getting instance of cloud provider
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'hyperv',
+            'dmi.bios.vendor': 'Microsoft',
+            'dmi.bios.version': '1.0',
+            'dmi.chassis.asset_tag': '7783-7084-3265-9085-8269-3286-77'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        cloud_provider = get_cloud_provider()
+        self.assertIsInstance(cloud_provider, azure.AzureCloudProvider)

--- a/test/cloud_what/test_cloud_what.py.orig
+++ b/test/cloud_what/test_cloud_what.py.orig
@@ -15,22 +15,30 @@
 #
 
 """
-Module for testing Python all modules from Python package rhsmlib.cloud
+Module for testing Python all modules from Python package cloud_what
 """
 
 import unittest
 from mock import patch, Mock, call
 import tempfile
 import time
-import base64
 import json
 
 import requests
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+=======
 
 from rhsmlib.cloud.providers import aws, azure, gcp
 from rhsmlib.cloud.provider import detect_cloud_provider, collect_cloud_info, get_cloud_provider
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
 
+from cloud_what.providers import aws, azure, gcp
+from cloud_what.provider import detect_cloud_provider, get_cloud_provider
 
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+
+=======
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
 def send_only_imds_v2_is_supported(request, *args, **kwargs):
     """
     Mock result, when we try to get metadata using GET method against
@@ -228,7 +236,11 @@ class TestAWSCloudProvider(unittest.TestCase):
         probability = aws_detector.is_likely_running_on_cloud()
         self.assertEqual(probability, 0.1)
 
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+    @patch('cloud_what._base_provider.requests.Session')
+=======
     @patch('rhsmlib.cloud._base_provider.requests.Session')
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
     def test_get_metadata_from_server_imds_v1(self, mock_session_class):
         """
         Test the case, when metadata are obtained from server using IMDSv1
@@ -247,7 +259,11 @@ class TestAWSCloudProvider(unittest.TestCase):
         metadata = aws_collector.get_metadata()
         self.assertEqual(metadata, AWS_METADATA)
 
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+    @patch('cloud_what._base_provider.requests.Session')
+=======
     @patch('rhsmlib.cloud._base_provider.requests.Session')
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
     def test_get_signature_from_server_imds_v1(self, mock_session_class):
         """
         Test the case, when metadata are obtained from server using IMDSv1
@@ -268,7 +284,11 @@ class TestAWSCloudProvider(unittest.TestCase):
         signature = '-----BEGIN PKCS7-----\n' + AWS_SIGNATURE + '\n-----END PKCS7-----'
         self.assertEqual(signature, test_signature)
 
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+    @patch('cloud_what._base_provider.requests.Session')
+=======
     @patch('rhsmlib.cloud._base_provider.requests.Session')
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
     def test_get_metadata_from_server_imds_v2(self, mock_session_class):
         """
         Test the case, when metadata are obtained from server using IMDSv2
@@ -292,7 +312,11 @@ class TestAWSCloudProvider(unittest.TestCase):
         metadata = aws_provider.get_metadata()
         self.assertEqual(metadata, AWS_METADATA)
 
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+    @patch('cloud_what._base_provider.requests.Session')
+=======
     @patch('rhsmlib.cloud._base_provider.requests.Session')
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
     def test_get_signature_from_server_imds_v2(self, mock_session_class):
         """
         Test the case, when signature is obtained from server using IMDSv2
@@ -544,7 +568,7 @@ class TestAzureCloudProvider(unittest.TestCase):
         """
         Patch communication with metadata provider
         """
-        requests_patcher = patch('rhsmlib.cloud._base_provider.requests')
+        requests_patcher = patch('cloud_what._base_provider.requests')
         self.requests_mock = requests_patcher.start()
         self.addCleanup(requests_patcher.stop)
 
@@ -634,7 +658,11 @@ class TestAzureCloudProvider(unittest.TestCase):
             method="GET",
             url=f"http://169.254.169.254/metadata/instance?api-version={azure.AzureCloudProvider.API_VERSION}",
             headers={
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+                'User-Agent': 'cloud-what/1.0',
+=======
                 'User-Agent': 'RHSM/1.0',
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
                 "Metadata": "true"
             }
         )
@@ -660,7 +688,11 @@ class TestAzureCloudProvider(unittest.TestCase):
             method="GET",
             url="http://169.254.169.254/metadata/versions",
             headers={
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+                'User-Agent': 'cloud-what/1.0',
+=======
                 'User-Agent': 'RHSM/1.0',
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
                 "Metadata": "true"
             }
         )
@@ -686,7 +718,11 @@ class TestAzureCloudProvider(unittest.TestCase):
             method="GET",
             url=f"http://169.254.169.254/metadata/attested/document?api-version={azure.AzureCloudProvider.API_VERSION}",
             headers={
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+                'User-Agent': 'cloud-what/1.0',
+=======
                 'User-Agent': 'RHSM/1.0',
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
                 "Metadata": "true"
             }
         )
@@ -718,7 +754,11 @@ class TestAzureCloudProvider(unittest.TestCase):
 
         return mock_result
 
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+    @patch('cloud_what.providers.azure.AzureCloudProvider.get_api_versions')
+=======
     @patch('rhsmlib.cloud.providers.azure.AzureCloudProvider.get_api_versions')
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
     def test_get_metadata_from_server_outdated_api_version(self, mock_get_api_versions):
         """
         Test getting metadata from server using outdated API version that is not supported
@@ -745,12 +785,20 @@ class TestAzureCloudProvider(unittest.TestCase):
         request_calls = [
             call(
                 method='GET',
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+                headers={'User-Agent': 'cloud-what/1.0', 'Metadata': 'true'},
+=======
                 headers={'User-Agent': 'RHSM/1.0', 'Metadata': 'true'},
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
                 url=f'http://169.254.169.254/metadata/instance?api-version={azure.AzureCloudProvider.API_VERSION}'
             ),
             call(
                 method='GET',
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+                headers={'User-Agent': 'cloud-what/1.0', 'Metadata': 'true'},
+=======
                 headers={'User-Agent': 'RHSM/1.0', 'Metadata': 'true'},
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
                 url=f'http://169.254.169.254/metadata/instance?api-version={SUPPORTED_AZURE_VERSIONS[-1]}'
             )
         ]
@@ -779,7 +827,7 @@ class TestGCPCloudProvider(unittest.TestCase):
         """
         Patch communication with metadata provider
         """
-        requests_patcher = patch('rhsmlib.cloud._base_provider.requests')
+        requests_patcher = patch('cloud_what._base_provider.requests')
         self.requests_mock = requests_patcher.start()
         self.addCleanup(requests_patcher.stop)
 
@@ -861,7 +909,11 @@ class TestGCPCloudProvider(unittest.TestCase):
             url='http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?'
                 'audience=https://subscription.rhsm.redhat.com:443/subscription&format=full',
             headers={
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+                'User-Agent': 'cloud-what/1.0',
+=======
                 'User-Agent': 'RHSM/1.0',
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
                 'Metadata-Flavor': 'Google'
             }
         )
@@ -889,7 +941,11 @@ class TestGCPCloudProvider(unittest.TestCase):
             url='http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?'
                 'audience=https://example.com:8443/rhsm&format=full',
             headers={
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+                'User-Agent': 'cloud-what/1.0',
+=======
                 'User-Agent': 'RHSM/1.0',
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
                 'Metadata-Flavor': 'Google'
             }
         )
@@ -951,29 +1007,37 @@ class TestGCPCloudProvider(unittest.TestCase):
 
 class TestCloudProvider(unittest.TestCase):
     """
-    Class for testing rhsmlib.cloud.utils module
+    Class for testing cloud_what.utils module
     """
     def setUp(self):
         """
         Set up two mocks that are used in all tests
         """
-        host_collector_patcher = patch('rhsmlib.cloud.provider.HostCollector')
+        host_collector_patcher = patch('cloud_what.provider.HostCollector')
         self.host_collector_mock = host_collector_patcher.start()
         self.host_fact_collector_instance = Mock()
         self.host_collector_mock.return_value = self.host_fact_collector_instance
         self.addCleanup(host_collector_patcher.stop)
 
-        hardware_collector_patcher = patch('rhsmlib.cloud.provider.HardwareCollector')
-        self.hardware_collector_mock = hardware_collector_patcher.start()
-        self.hw_fact_collector_instance = Mock()
-        self.hardware_collector_mock.return_value = self.hw_fact_collector_instance
-        self.addCleanup(hardware_collector_patcher.stop)
+        # hardware_collector_patcher = patch('cloud_what.provider.HardwareCollector')
+        # self.hardware_collector_mock = hardware_collector_patcher.start()
+        # self.hw_fact_collector_instance = Mock()
+        # self.hardware_collector_mock.return_value = self.hw_fact_collector_instance
+        # self.addCleanup(hardware_collector_patcher.stop)
 
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+        write_cache_patcher = patch('cloud_what.providers.aws.AWSCloudProvider._write_token_to_cache_file')
+        self.write_cache_mock = write_cache_patcher.start()
+        self.addCleanup(write_cache_patcher.stop)
+
+        self.requests_patcher = patch('cloud_what._base_provider.requests')
+=======
         write_cache_patcher = patch('rhsmlib.cloud.providers.aws.AWSCloudProvider._write_token_to_cache_file')
         self.write_cache_mock = write_cache_patcher.start()
         self.addCleanup(write_cache_patcher.stop)
 
         self.requests_patcher = patch('rhsmlib.cloud._base_provider.requests')
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
         self.azure_requests_mock = self.requests_patcher.start()
         self.addCleanup(self.requests_patcher.stop)
 
@@ -983,13 +1047,10 @@ class TestCloudProvider(unittest.TestCase):
         """
         host_facts = {
             'virt.is_guest': True,
-            'virt.host_type': 'kvm'
-        }
-        hw_facts = {
+            'virt.host_type': 'kvm',
             'dmi.bios.vendor': 'Amazon EC2'
         }
         self.host_fact_collector_instance.get_all.return_value = host_facts
-        self.hw_fact_collector_instance.get_all.return_value = hw_facts
         detected_clouds = detect_cloud_provider()
         self.assertEqual(detected_clouds, ['aws'])
 
@@ -1000,15 +1061,12 @@ class TestCloudProvider(unittest.TestCase):
         """
         host_facts = {
             'virt.is_guest': True,
-            'virt.host_type': 'kvm'
-        }
-        hw_facts = {
+            'virt.host_type': 'kvm',
             'dmi.bios.vendor': 'AWS',
             'dmi.bios.version': '1.0',
             'dmi.system.manufacturer': 'Amazon'
         }
         self.host_fact_collector_instance.get_all.return_value = host_facts
-        self.hw_fact_collector_instance.get_all.return_value = hw_facts
         detected_clouds = detect_cloud_provider()
         self.assertEqual(detected_clouds, ['aws'])
 
@@ -1018,14 +1076,11 @@ class TestCloudProvider(unittest.TestCase):
         """
         host_facts = {
             'virt.is_guest': True,
-            'virt.host_type': 'kvm'
-        }
-        hw_facts = {
+            'virt.host_type': 'kvm',
             'dmi.bios.vendor': 'Google',
             'dmi.bios.version': 'Google'
         }
         self.host_fact_collector_instance.get_all.return_value = host_facts
-        self.hw_fact_collector_instance.get_all.return_value = hw_facts
         detected_clouds = detect_cloud_provider()
         self.assertEqual(detected_clouds, ['gcp'])
 
@@ -1036,15 +1091,12 @@ class TestCloudProvider(unittest.TestCase):
         """
         host_facts = {
             'virt.is_guest': True,
-            'virt.host_type': 'kvm'
-        }
-        hw_facts = {
+            'virt.host_type': 'kvm',
             'dmi.bios.vendor': 'Foo Company',
             'dmi.bios.version': '1.0',
             'dmi.chassis.asset_tag': 'Google Cloud',
         }
         self.host_fact_collector_instance.get_all.return_value = host_facts
-        self.hw_fact_collector_instance.get_all.return_value = hw_facts
         detected_clouds = detect_cloud_provider()
         self.assertEqual(detected_clouds, ['gcp'])
 
@@ -1055,14 +1107,11 @@ class TestCloudProvider(unittest.TestCase):
         host_facts = {
             'virt.is_guest': True,
             'virt.host_type': 'hyperv',
-        }
-        hw_facts = {
             'dmi.bios.vendor': 'Foo company',
             'dmi.bios.version': '1.0',
             'dmi.chassis.asset_tag': '7783-7084-3265-9085-8269-3286-77'
         }
         self.host_fact_collector_instance.get_all.return_value = host_facts
-        self.hw_fact_collector_instance.get_all.return_value = hw_facts
         detected_clouds = detect_cloud_provider()
         self.assertEqual(detected_clouds, ['azure'])
 
@@ -1074,15 +1123,12 @@ class TestCloudProvider(unittest.TestCase):
         host_facts = {
             'virt.is_guest': True,
             'virt.host_type': 'hyperv',
-        }
-        hw_facts = {
             'dmi.bios.vendor': 'Microsoft',
             'dmi.bios.version': '1.0',
             'dmi.system.manufacturer': 'Google',
             'dmi.chassis.manufacturer': 'Amazon'
         }
         self.host_fact_collector_instance.get_all.return_value = host_facts
-        self.hw_fact_collector_instance.get_all.return_value = hw_facts
         detected_clouds = detect_cloud_provider()
         self.assertEqual(detected_clouds, ['azure'])
 
@@ -1096,15 +1142,12 @@ class TestCloudProvider(unittest.TestCase):
         host_facts = {
             'virt.is_guest': True,
             'virt.host_type': 'kvm',
-        }
-        hw_facts = {
             'dmi.bios.vendor': 'Google',
             'dmi.bios.version': 'Amazon EC2',
             'dmi.chassis.asset_tag': '7783-7084-3265-9085-8269-3286-77',
             'dmi.chassis.manufacturer': 'Microsoft'
         }
         self.host_fact_collector_instance.get_all.return_value = host_facts
-        self.hw_fact_collector_instance.get_all.return_value = hw_facts
         detected_clouds = detect_cloud_provider()
         detected_clouds.sort()
         self.assertEqual(detected_clouds, ['aws', 'azure', 'gcp'])
@@ -1117,16 +1160,13 @@ class TestCloudProvider(unittest.TestCase):
         host_facts = {
             'virt.is_guest': True,
             'virt.host_type': 'kvm',
-        }
-        hw_facts = {
             'dmi.system.manufacturer': 'Google',
             'dmi.chassis.manufacturer': 'Amazon EC2',
         }
-        facts = {**host_facts, **hw_facts}
 
-        aws_cloud_provider = aws.AWSCloudProvider(facts)
-        azure_cloud_provider = azure.AzureCloudProvider(facts)
-        gcp_cloud_provider = gcp.GCPCloudProvider(facts)
+        aws_cloud_provider = aws.AWSCloudProvider(host_facts)
+        azure_cloud_provider = azure.AzureCloudProvider(host_facts)
+        gcp_cloud_provider = gcp.GCPCloudProvider(host_facts)
 
         probability_aws = aws_cloud_provider.is_likely_running_on_cloud()
         self.assertEqual(probability_aws, 0.6)
@@ -1136,11 +1176,12 @@ class TestCloudProvider(unittest.TestCase):
         self.assertEqual(probability_gcp, 0.6)
 
         self.host_fact_collector_instance.get_all.return_value = host_facts
-        self.hw_fact_collector_instance.get_all.return_value = hw_facts
         detected_clouds = detect_cloud_provider()
         detected_clouds.sort()
         self.assertEqual(detected_clouds, ['aws', 'gcp'])
 
+<<<<<<< HEAD:test/cloud_what/test_cloud_what.py
+=======
     @patch('rhsmlib.cloud.providers.aws.requests.Session')
     def test_collect_cloud_info_one_cloud_provider_detected(self, mock_session_class):
         """
@@ -1216,6 +1257,7 @@ class TestCloudProvider(unittest.TestCase):
             '-----BEGIN PKCS7-----\n' + AWS_SIGNATURE + '\n-----END PKCS7-----'
         )
 
+>>>>>>> main:test/rhsmlib_test/test_cloud.py
     def test_get_cloud_provider(self):
         """
         Test getting instance of cloud provider
@@ -1223,13 +1265,10 @@ class TestCloudProvider(unittest.TestCase):
         host_facts = {
             'virt.is_guest': True,
             'virt.host_type': 'hyperv',
-        }
-        hw_facts = {
             'dmi.bios.vendor': 'Microsoft',
             'dmi.bios.version': '1.0',
             'dmi.chassis.asset_tag': '7783-7084-3265-9085-8269-3286-77'
         }
         self.host_fact_collector_instance.get_all.return_value = host_facts
-        self.hw_fact_collector_instance.get_all.return_value = hw_facts
         cloud_provider = get_cloud_provider()
         self.assertIsInstance(cloud_provider, azure.AzureCloudProvider)

--- a/test/rhsmlib_test/test_cloud_facts.py
+++ b/test/rhsmlib_test/test_cloud_facts.py
@@ -23,9 +23,124 @@ import requests
 
 from rhsmlib.facts import cloud_facts
 
-from .test_cloud import AWS_METADATA, AZURE_METADATA, GCP_JWT_TOKEN
-
 from subscription_manager import injection as inj
+
+AWS_METADATA = """
+{
+  "accountId" : "012345678900",
+  "architecture" : "x86_64",
+  "availabilityZone" : "eu-central-1b",
+  "billingProducts" : [ "bp-0124abcd", "bp-63a5400a" ],
+  "devpayProductCodes" : null,
+  "marketplaceProductCodes" : null,
+  "imageId" : "ami-0123456789abcdeff",
+  "instanceId" : "i-abcdef01234567890",
+  "instanceType" : "m5.large",
+  "kernelId" : null,
+  "pendingTime" : "2020-02-02T02:02:02Z",
+  "privateIp" : "12.34.56.78",
+  "ramdiskId" : null,
+  "region" : "eu-central-1",
+  "version" : "2017-09-30"
+}
+"""
+
+AZURE_METADATA = """
+{
+    "compute": {
+        "azEnvironment": "AzurePublicCloud",
+        "customData": "",
+        "location": "westeurope",
+        "name": "foo-bar",
+        "offer": "RHEL",
+        "osType": "Linux",
+        "placementGroupId": "",
+        "plan": {
+            "name": "",
+            "product": "",
+            "publisher": ""
+        },
+        "platformFaultDomain": "0",
+        "platformUpdateDomain": "0",
+        "provider": "Microsoft.Compute",
+        "publicKeys": [
+            {
+                "keyData": "ssh-rsa SOMEpublicSSHkey user@localhost.localdomain",
+                "path": "/home/user/.ssh/authorized_keys"
+            }
+        ],
+        "publisher": "RedHat",
+        "resourceGroupName": "foo-bar",
+        "resourceId": "/subscriptions/01234567-0123-0123-0123-012345679abc/resourceGroups/foo-bar/providers/Microsoft.Compute/virtualMachines/foo",
+        "sku": "8.1-ci",
+        "storageProfile": {
+            "dataDisks": [],
+            "imageReference": {
+                "id": "",
+                "offer": "RHEL",
+                "publisher": "RedHat",
+                "sku": "8.1-ci",
+                "version": "latest"
+            },
+            "osDisk": {
+                "caching": "ReadWrite",
+                "createOption": "FromImage",
+                "diskSizeGB": "64",
+                "encryptionSettings": {
+                    "enabled": "false"
+                },
+                "image": {
+                    "uri": ""
+                },
+                "managedDisk": {
+                    "id": "/subscriptions/01234567-0123-0123-0123-012345679abc/resourceGroups/FOO-BAR/providers/Microsoft.Compute/disks/foo_OsDisk_1_b21768daf38e48c6a0db7cff1f054b03",
+                    "storageAccountType": ""
+                },
+                "name": "FOO_OsDisk_1_b21768daf38e48c6a0db7cff1f054b03",
+                "osType": "Linux",
+                "vhd": {
+                    "uri": ""
+                },
+                "writeAcceleratorEnabled": "false"
+            }
+        },
+        "subscriptionId": "01234567-0123-0123-0123-012345679abc",
+        "tags": "",
+        "version": "8.1.2020042511",
+        "vmId": "12345678-1234-1234-1234-123456789abc",
+        "vmScaleSetName": "",
+        "vmSize": "Standard_D2s_v3",
+        "zone": ""
+    },
+    "network": {
+        "interface": [
+            {
+                "ipv4": {
+                    "ipAddress": [
+                        {
+                            "privateIpAddress": "172.16.2.5",
+                            "publicIpAddress": "1.2.3.4"
+                        }
+                    ],
+                    "subnet": [
+                        {
+                            "address": "172.16.2.0",
+                            "prefix": "24"
+                        }
+                    ]
+                },
+                "ipv6": {
+                    "ipAddress": []
+                },
+                "macAddress": "000D3A123456"
+            }
+        ]
+    }
+}
+"""
+
+GCP_JWT_TOKEN = """eyJhbGciOiJSUzI1NiIsImtpZCI6IjZhOGJhNTY1MmE3MDQ0MTIxZDRmZWRhYzhmMTRkMTRjNTRlNDg5NWIiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL3N1YnNjcmlwdGlvbi5yaHNtLnJlZGhhdC5jb206NDQzL3N1YnNjcmlwdGlvbiIsImF6cCI6IjEwNDA3MDk1NTY4MjI5ODczNjE0OSIsImVtYWlsIjoiMTYxOTU4NDY1NjEzLWNvbXB1dGVAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZXhwIjoxNjE2NTk5ODIzLCJnb29nbGUiOnsiY29tcHV0ZV9lbmdpbmUiOnsiaW5zdGFuY2VfY3JlYXRpb25fdGltZXN0YW1wIjoxNjE2NTk1ODQ3LCJpbnN0YW5jZV9pZCI6IjI1ODkyMjExNDA2NzY3MTgwMjYiLCJpbnN0YW5jZV9uYW1lIjoiaW5zdGFuY2UtMSIsImxpY2Vuc2VfaWQiOlsiNTczMTAzNTA2NzI1NjkyNTI5OCJdLCJwcm9qZWN0X2lkIjoiZmFpci1raW5nZG9tLTMwODUxNCIsInByb2plY3RfbnVtYmVyIjoxNjE5NTg0NjU2MTMsInpvbmUiOiJ1cy1lYXN0MS1iIn19LCJpYXQiOjE2MTY1OTYyMjMsImlzcyI6Imh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbSIsInN1YiI6IjEwNDA3MDk1NTY4MjI5ODczNjE0OSJ9.XQKeqMAvsH2T2wsdN97jlm52DzLfix3DTMCu9QCuhSKLEk1xHYOYtvh5Yzn7j-tbZtV-siyPAfpGZO3Id87573OVGgohN3q7Exlf9CEIHa1-X7zLyiyIlyrnfQJ1aGHeH6y7gb_tWxHFLJRzhulfkfJxSDn5fEBSgBqbjzCr9unQgMkuzQ3uui2BbIbALmOpY6D-IT71mgMDZ_zm4G6q-Mh0nIMkDWhmQ8pa3RAVqqBMBYJninKLdCD8eQzIlDhtIzwmYGLrsJMktFF3pJFCqEFv1rKZy_OUyV4JOkOLtXbKnwxqmFTq-2SP0KtUWjDy1-U8GnVDptISjOf2O9FaLA
+"""
 
 # The AWS instance ID has to be the same as "instance_id" in AWS_METADATA
 AWS_INSTANCE_ID = "i-abcdef01234567890"
@@ -48,11 +163,11 @@ class TestCloudCollector(unittest.TestCase):
         self.mock_facts = mock.Mock()
         inj.provide(inj.FACTS, self.mock_facts)
         # Azure and GCP
-        self.requests_patcher = patch('rhsmlib.cloud._base_provider.requests')
+        self.requests_patcher = patch('cloud_what._base_provider.requests')
         self.requests_mock = self.requests_patcher.start()
         self.addCleanup(self.requests_patcher.stop)
 
-    @patch('rhsmlib.cloud.providers.aws.requests.Session', name='test_get_aws_facts.mock_session_class')
+    @patch('cloud_what.providers.aws.requests.Session', name='test_get_aws_facts.mock_session_class')
     def test_get_aws_facts(self, mock_session_class):
         """
         Test getting AWS facts (instance ID, accountID and billingProducts)
@@ -90,7 +205,7 @@ class TestCloudCollector(unittest.TestCase):
         self.assertIn("aws_marketplace_product_codes", facts)
         self.assertEqual(facts["aws_marketplace_product_codes"], None)
 
-    @patch('rhsmlib.cloud.providers.aws.requests.Session', name='mock_session_class')
+    @patch('cloud_what.providers.aws.requests.Session', name='mock_session_class')
     def test_get_aws_facts_with_null_billing_products(self, mock_session_class):
         """
         Billing products could be null in some cases (not RHEL)
@@ -176,8 +291,8 @@ class TestCloudCollector(unittest.TestCase):
         self.assertIn("azure_offer", facts)
         self.assertEqual(facts["azure_offer"], AZURE_OFFER)
 
-    @patch('rhsmlib.cloud.providers.gcp.GCPCloudProvider._write_token_to_cache_file')
-    @patch('rhsmlib.cloud.providers.gcp.GCPCloudProvider._get_metadata_from_cache')
+    @patch('cloud_what.providers.gcp.GCPCloudProvider._write_token_to_cache_file')
+    @patch('cloud_what.providers.gcp.GCPCloudProvider._get_metadata_from_cache')
     def test_get_gcp_facts(self, mock_get_metadata_from_cache, mock_write_token_to_cache_file):
         """
         Test getting GCP instance ID from metadata provided by GCP cloud provider
@@ -206,7 +321,7 @@ class TestCloudCollector(unittest.TestCase):
         self.assertIn("gcp_instance_id", facts)
         self.assertEqual(facts["gcp_instance_id"], "2589221140676718026")
 
-    @patch('rhsmlib.cloud.providers.aws.requests.Session', name='mock_session_class')
+    @patch('cloud_what.providers.aws.requests.Session', name='mock_session_class')
     def test_get_not_aws_instance(self, mock_session_class):
         """
         Test that AWS instance ID is not included in facts, when VM is not running on the AWS public cloud
@@ -235,7 +350,7 @@ class TestCloudCollector(unittest.TestCase):
 
         self.assertNotIn("aws_instance_id", facts)
 
-    @patch('rhsmlib.cloud.providers.aws.requests.Session', name='mock_session_class')
+    @patch('cloud_what.providers.aws.requests.Session', name='mock_session_class')
     def test_get_bad_json(self, mock_session_class):
         """
         Test parsing some string that is not Json document
@@ -264,7 +379,7 @@ class TestCloudCollector(unittest.TestCase):
 
         self.assertNotIn("aws_instance_id", facts)
 
-    @patch('rhsmlib.cloud.providers.aws.requests.Session', name='mock_session_class')
+    @patch('cloud_what.providers.aws.requests.Session', name='mock_session_class')
     def test_get_timeout(self, mock_session_class):
         """
         Test ensures that exception is captured and does not impede
@@ -294,7 +409,7 @@ class TestCloudCollector(unittest.TestCase):
 
         self.assertNotIn("aws_instance_id", facts)
 
-    @patch('rhsmlib.cloud.providers.aws.requests.Session', name='mock_session_class')
+    @patch('cloud_what.providers.aws.requests.Session', name='mock_session_class')
     def test_get_http_error(self, mock_session_class):
         """
         test ensures that exception is captured and does not impede

--- a/test/test_auto_registration.py
+++ b/test/test_auto_registration.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+"""
+Module for testing automatic registration on public cloud
+"""
+
+import unittest
+import base64
+from mock import patch, Mock
+
+from subscription_manager.scripts.rhsmcertd_worker import _collect_cloud_info
+from .rhsmlib_test.test_cloud_facts import AWS_METADATA
+from cloud_what.providers import aws
+
+AWS_SIGNATURE = """ABCDEFGHIJKLMNOPQRSTVWXYZabcdefghijklmnopqrstvwxyz01234567899w0BBwGggCSABIIB
+73sKICAiYWNjb3VudElkIiA6ICI1NjcwMTQ3ODY4OTAiLAogICJhcmNoaXRlY3R1cmUiIDogIng4
+Nl82NCIsCiAgImF2YWlsYWJpbGl0eVpvbmUiIDogImV1LWNlbnRyYWwtMWIiLAogICJiaWxsaW5n
+UHJvZHVjdHMiIDogWyAiYnAtNmZhNTQwMDYiIF0sCiAgImRldnBheVByb2R1Y3RDb2RlcyIgOiBu
+73sKICAiYWNjb3VudElkIiA6ICI1NjcwMTQ3ODY4OTAiLAogICJhcmNoaXRlY3R1cmUiIDogIng4
+bWktMDgxNmFkNzYyOTc2YzM1ZGIiLAogICJpbnN0YW5jZUlkIiA6ICJpLTBkNTU0YzRmM2JhNWVl
+YTczIiwKICAiaW5zdGFuY2VUeXBlIiA6ICJtNS5sYXJnZSIsCiAgImtlcm5lbElkIiA6IG51bGws
+CiAgInBlbmRpbmdUaW1lIiA6ICIyMDIwLTA0LTI0VDE0OjU3OjQzWiIsCiAgInByaXZhdGVJcCIg
+OiAiMTcyLjMxLjExLjc4IiwKICAicmFtZGlza0lkIiA6IG51bGwsCiAgInJlZ2lvbiIgOiAiZXUt
+Y2VudHJhbC0xIiwKICAidmVyc2lvbiIgOiAiMjAxNy0wOS0zMCIKfQAAAAAAADGCAf8wggH7AgEB
+CiAgInBlbmRpbmdUaW1lIiA6ICIyMDIwLTA0LTI0VDE0OjU3OjQzWiIsCiAgInByaXZhdGVJcCIg
+YXR0bGUxIDAeBgNVBAoTF0FtYXpvbiBXZWIgU2VydmljZXMgTExDAgkAoP6/ot5H9aswDQYJYIZI
+AWUDBAIBBQCgaTAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3DQEJBTEPFw0yMDA5
+MDExNTMyNDhaMC8GCSqGSIb3DQEJBDEiBCCmizT0hDlJmxHtDBaEjql5ZPFaoKy6OSk7qBFREVRk
+iTANBgkqhkiG9w0BAQEFAASCAQAh//5+AaFAcgw/5SoglQ27kQKuThcJYa+QhC2aw4n1GvkvCmyi
+helVMxH33tB9tUei/mapSF3v8jUseRLEbcDVRHf6n6h14Qj2MxtgYanzUCDF8qECYbZ2uSy3JLEP
+iNsndm8nt7XcJC7NRoWJWAsly1VeXVIauA/l7uXmUarDQs5BhFYl7REX4htxg9mCibR6xqU5i8/D
+iTANBgkqhkiG9w0BAQEFAASCAQAh//5+AaFAcgw/5SoglQ27kQKuThcJYa+QhC2aw4n1GvkvCmyi
+tGbafapTj+6KnJAfP0sW7ZbzKclaCPHXQ37z9mc8vtCxEQmCbGL6sj2wtpi4rmRlAAAAAAAA"""
+
+AWS_TOKEN = "ABCDEFGHIJKLMNOPQRSTVWXYZabcdefghijklmnopqrstvwxyz0123=="
+
+
+def send_only_imds_v2_is_supported(request, *args, **kwargs):
+    """
+    Mock result, when we try to get metadata using GET method against
+    AWS metadata provider. This mock is for the case, when only IMDSv2
+    is supported by instance.
+    :param request: HTTP request
+    :return: Mock with result
+    """
+    mock_result = Mock()
+
+    if request.method == 'PUT':
+        if request.url == aws.AWSCloudProvider.CLOUD_PROVIDER_TOKEN_URL:
+            if 'X-aws-ec2-metadata-token-ttl-seconds' in request.headers:
+                mock_result.status_code = 200
+                mock_result.text = AWS_TOKEN
+            else:
+                mock_result.status_code = 400
+                mock_result.text = 'Error: TTL for token not specified'
+        else:
+            mock_result.status_code = 400
+            mock_result.text = 'Error: Invalid URL'
+    elif request.method == 'GET':
+        if 'X-aws-ec2-metadata-token' in request.headers.keys():
+            if request.headers['X-aws-ec2-metadata-token'] == AWS_TOKEN:
+                if request.url == aws.AWSCloudProvider.CLOUD_PROVIDER_METADATA_URL:
+                    mock_result.status_code = 200
+                    mock_result.text = AWS_METADATA
+                elif request.url == aws.AWSCloudProvider.CLOUD_PROVIDER_SIGNATURE_URL:
+                    mock_result.status_code = 200
+                    mock_result.text = AWS_SIGNATURE
+                else:
+                    mock_result.status_code = 400
+                    mock_result.text = 'Error: Invalid URL'
+            else:
+                mock_result.status_code = 400
+                mock_result.text = 'Error: Invalid metadata token provided'
+        else:
+            mock_result.status_code = 400
+            mock_result.text = 'Error: IMDSv1 is not supported on this instance'
+    else:
+        mock_result.status_code = 400
+        mock_result.text = 'Error: not supported request method'
+
+    return mock_result
+
+
+def mock_prepare_request(request):
+    return request
+
+
+class TestAutomaticRegistration(unittest.TestCase):
+    @patch('cloud_what.providers.aws.requests.Session')
+    def test_collect_cloud_info_one_cloud_provider_detected(self, mock_session_class):
+        """
+        Test the case, when we try to collect cloud info only for
+        one detected cloud provider
+        """
+        mock_session = Mock()
+        mock_session.send = send_only_imds_v2_is_supported
+        mock_session.prepare_request = Mock(side_effect=mock_prepare_request)
+        mock_session.hooks = {'response': []}
+        mock_session_class.return_value = mock_session
+
+        cloud_list = ['aws']
+        cloud_info = _collect_cloud_info(cloud_list, Mock())
+
+        self.assertIsNotNone(cloud_info)
+        self.assertTrue(len(cloud_info) > 0)
+        self.assertTrue('cloud_id' in cloud_info)
+        self.assertEqual(cloud_info['cloud_id'], 'aws')
+        # Test metadata
+        self.assertTrue('metadata' in cloud_info)
+        b64_metadata = cloud_info['metadata']
+        metadata = base64.b64decode(b64_metadata).decode('utf-8')
+        self.assertEqual(metadata, AWS_METADATA)
+        # Test signature
+        self.assertTrue('signature' in cloud_info)
+        b64_signature = cloud_info['signature']
+        signature = base64.b64decode(b64_signature).decode('utf-8')
+        self.assertEqual(
+            signature,
+            '-----BEGIN PKCS7-----\n' + AWS_SIGNATURE + '\n-----END PKCS7-----'
+        )
+
+    @patch('cloud_what.providers.aws.requests.Session')
+    def test_collect_cloud_info_more_cloud_providers_detected(self, mock_session_class):
+        """
+        Test the case, when we try to collect cloud info only for
+        more than one cloud providers, because more than one cloud
+        providers were detected
+        """
+        mock_session = Mock()
+        mock_session.send = send_only_imds_v2_is_supported
+        mock_session.prepare_request = Mock(side_effect=mock_prepare_request)
+        mock_session.hooks = {'response': []}
+        mock_session_class.return_value = mock_session
+
+        # More cloud providers detected
+        cloud_list = ['azure', 'aws']
+
+        cloud_info = _collect_cloud_info(cloud_list, Mock())
+
+        self.assertIsNotNone(cloud_info)
+        self.assertTrue(len(cloud_info) > 0)
+        self.assertTrue('cloud_id' in cloud_info)
+        self.assertEqual(cloud_info['cloud_id'], 'aws')
+        # Test metadata
+        self.assertTrue('metadata' in cloud_info)
+        b64_metadata = cloud_info['metadata']
+        metadata = base64.b64decode(b64_metadata).decode('utf-8')
+        self.assertEqual(metadata, AWS_METADATA)
+        # Test signature
+        self.assertTrue('signature' in cloud_info)
+        b64_signature = cloud_info['signature']
+        signature = base64.b64decode(b64_signature).decode('utf-8')
+        self.assertEqual(
+            signature,
+            '-----BEGIN PKCS7-----\n' + AWS_SIGNATURE + '\n-----END PKCS7-----'
+        )


### PR DESCRIPTION
* Card ID: ENT-3861
* Moved code from src/rhsmlibc/cloud to src/cloud_what
* Updated references to the package and modules in other
  code and unit tests
* Changed User-Agent in http headers to cloud-what/1.0
* Moved one RHSM specific method to rhsmcertd_worker.py
* Moved unit tests specific for cloud collector and
  cloud detector from test/rhsmlib_test/test_cloud.py
  to test/cloud_what/test_cloud_what.py. This file
  will be probably split into more files later.
* Moved unit tests related to automatic registration
  to own file
* Added method for setting audience for GCPCloudProvider
* Modified .spec file to create python3-cloud-what
  RPM package
* TODO: change default GCP audience ID to something
  more generic, when it will be necessary