### PR TITLE
[1.28] 1971693: syspurpose: remove deprecation notices

### DIFF
--- a/syspurpose/man/syspurpose.8
+++ b/syspurpose/man/syspurpose.8
@@ -21,9 +21,6 @@ The \fIset\fP, \fIunset\fP, \fIadd\fP, and \fIremove\fP commands modify the
 local system purpose, and when possible will report the updated settings to the
 Red Hat subscription management entitlement server (Customer Portal or Satellite
 6).  The \fIshow\fP command displays the current system purpose.
-.PP
-The 'syspurpose' command is deprecated and will be removed in a future major release. 
-Please use the subscription-manager modules going forward.
 
 .SH COMMANDS
 .TP

--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -154,9 +154,7 @@ def setup_arg_parser():
     Sets up argument parsing for the syspurpose tool.
     :return: An argparse.ArgumentParser ready to use to parse_args
     """
-    parser = argparse.ArgumentParser(prog="syspurpose", description="System Syspurpose Management Tool",
-                                     epilog=_("The 'syspurpose' command is deprecated and will be removed in a future major release."
-                                                " Please use the subscription-manager modules going forward."))
+    parser = argparse.ArgumentParser(prog="syspurpose", description="System Syspurpose Management Tool")
 
     subparsers = parser.add_subparsers(help="sub-command help")
 
@@ -350,8 +348,6 @@ def main():
         print(_("WARNING: Setting syspurpose in containers has no effect.\n"
               "Please run syspurpose on the host.\n"))
 
-    print(_("The 'syspurpose' command is deprecated and will be removed in a future major release."
-        " Please use the subscription-manager modules going forward."), file=sys.stderr)
     try:
         from subscription_manager.identity import Identity
         from subscription_manager.cp_provider import CPProvider


### PR DESCRIPTION
We decided to avoid deprecating the old `syspurpose` executable until
the unified `syspurpose` command in subscription-manager is available.