### PR TITLE
1973807: fix wording on error when listing syspurpose values

### DIFF
--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -350,22 +350,26 @@ class AbstractSyspurposeCommand(CliCommand):
 
     def list(self):
         valid_fields = self._get_valid_fields()
-        if len(valid_fields.get(self.attr, [])) > 0:
-            line = '+-------------------------------------------+'
-            print(line)
-            translated_string = _('Available {syspurpose_attr}').format(syspurpose_attr=self.attr)
-            # Print translated string (the length could be different) in the center of the line
-            line_len = len(line)
-            trans_str_len = len(translated_string)
-            empty_space_len = int((line_len - trans_str_len) / 2)
-            print(empty_space_len * ' ' + translated_string)
-            print(line)
-            # Print values
-            self._print_valid_values(valid_fields)
+        if self.attr in valid_fields:
+            if len(valid_fields[self.attr]) > 0:
+                line = '+-------------------------------------------+'
+                print(line)
+                translated_string = _('Available {syspurpose_attr}').format(syspurpose_attr=self.attr)
+                # Print translated string (the length could be different) in the center of the line
+                line_len = len(line)
+                trans_str_len = len(translated_string)
+                empty_space_len = int((line_len - trans_str_len) / 2)
+                print(empty_space_len * ' ' + translated_string)
+                print(line)
+                # Print values
+                self._print_valid_values(valid_fields)
+            else:
+                print(_('There are no available values for the system purpose "{syspurpose_attr}" '
+                        'from the available subscriptions in this '
+                        'organization.').format(syspurpose_attr=self.attr))
         else:
-            print(_('There are no available values for the system purpose "{syspurpose_attr}" '
-                    'from the available subscriptions in this '
-                    'organization.').format(syspurpose_attr=self.attr))
+            print(_('Unable to get the list of valid values for the system purpose '
+                    '"{syspurpose_attr}".').format(syspurpose_attr=self.attr))
 
     def sync(self):
         return syspurposelib.SyspurposeSyncActionCommand().perform(include_result=True)[1]


### PR DESCRIPTION
When listing syspurpose values, bring back the distinction between
"unavailable values" and "empty list of values" (reverting the part of
commit c71ee8d0a68e60081d6a87444f83f7fbcffd0c5f in
`AbstractSyspurposeCommand.list()`), so it is possible to keep different
diagnostic messages for them.

Also, improve the message for the error case, more in line with other
syspurpose-related messages.