### PR TITLE
[1.28] 1973731: fix wording on error when listing syspurpose values

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -882,22 +882,26 @@ class SyspurposeCommand(CliCommand):
 
     def list(self):
         valid_fields = self._get_valid_fields()
-        if len(valid_fields.get(self.attr, [])) > 0:
-            line = '+-------------------------------------------+'
-            print(line)
-            translated_string = _('Available {syspurpose_attr}').format(syspurpose_attr=self.attr)
-            # Print translated string (the length could be different) in the center of the line
-            line_len = len(line)
-            trans_str_len = len(translated_string)
-            empty_space_len = int((line_len - trans_str_len) / 2)
-            print(empty_space_len * ' ' + translated_string)
-            print(line)
-            # Print values
-            self._print_valid_values(valid_fields)
+        if self.attr in valid_fields:
+            if len(valid_fields[self.attr]) > 0:
+                line = '+-------------------------------------------+'
+                print(line)
+                translated_string = _('Available {syspurpose_attr}').format(syspurpose_attr=self.attr)
+                # Print translated string (the length could be different) in the center of the line
+                line_len = len(line)
+                trans_str_len = len(translated_string)
+                empty_space_len = int((line_len - trans_str_len) / 2)
+                print(empty_space_len * ' ' + translated_string)
+                print(line)
+                # Print values
+                self._print_valid_values(valid_fields)
+            else:
+                print(_('There are no available values for the system purpose "{syspurpose_attr}" '
+                        'from the available subscriptions in this '
+                        'organization.').format(syspurpose_attr=self.attr))
         else:
-            print(_('There are no available values for the system purpose "{syspurpose_attr}" '
-                    'from the available subscriptions in this '
-                    'organization.').format(syspurpose_attr=self.attr))
+            print(_('Unable to get the list of valid values for the system purpose '
+                    '"{syspurpose_attr}".').format(syspurpose_attr=self.attr))
 
     def sync(self):
         return syspurposelib.SyspurposeSyncActionCommand().perform(include_result=True)[1]


### PR DESCRIPTION
When listing syspurpose values, bring back the distinction between
"unavailable values" and "empty list of values" (reverting the part of
commit a69c86a89e4aa0d50281c99d823a2b6a7bb81798 in
`AbstractSyspurposeCommand.list()`), so it is possible to keep different
diagnostic messages for them.

Also, improve the message for the error case, more in line with other
syspurpose-related messages.

(cherry picked from commit fe9a8e8a1d1528d21c8dc2e9ed4361e9538a9adf)

Backport of #2684 to 1.28.