### PR TITLE
1975552: add '[SUBMODULE]' in syspurpose usage string

### DIFF
--- a/src/subscription_manager/cli_command/syspurpose.py
+++ b/src/subscription_manager/cli_command/syspurpose.py
@@ -93,6 +93,13 @@ class SyspurposeCommand(CliCommand):
             cmd = clazz(subparser)
             self.cli_commands[cmd.name] = cmd
 
+    def _get_usage(self):
+        """
+        Reimplemented from AbstractCLICommand to mention the optional submodule
+        in the usage string.
+        """
+        return _("%(prog)s {name} [SUBMODULE] [OPTIONS]").format(name=self.name)
+
     def _validate_options(self):
         """
         Validate provided options


### PR DESCRIPTION
Use a custom usage string for the 'syspurpose' command, so we can
mention that this command may take a submodule to use.