### PR TITLE
[1.28] Fixed reporting of AWS cloud facts (null value)

### DIFF
--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -80,12 +80,23 @@ class CloudFactsCollector(collector.FactsCollector):
             # BTW: There should be only two types of billing codes: bp-63a5400a and bp-6fa54006 in the list,
             # when RHEL is used. When the subscription-manager is used by some other Linux distribution,
             # then there could be different codes or it could be null
-            if 'billingProducts' in values and values['billingProducts'] is not None:
+            if 'billingProducts' in values:
                 billing_products = values['billingProducts']
                 if isinstance(billing_products, list):
-                    facts['aws_billing_products'] = " ".join(values['billingProducts'])
+                    facts['aws_billing_products'] = " ".join(billing_products)
+                elif billing_products is None:
+                    facts['aws_billing_products'] = billing_products
                 else:
-                    log.debug('AWS metadata attribute billingProducts has to be list')
+                    log.debug('AWS metadata attribute billingProducts has to be list or null')
+
+            if 'marketplaceProductCodes' in values:
+                marketplace_product_codes = values['marketplaceProductCodes']
+                if isinstance(marketplace_product_codes, list):
+                    facts['aws_marketplace_product_codes'] = " ".join(marketplace_product_codes)
+                elif marketplace_product_codes is None:
+                    facts['aws_marketplace_product_codes'] = marketplace_product_codes
+                else:
+                    log.debug('AWS metadata attribute marketplaceProductCodes has to be list or null')
 
             return facts
 

--- a/test/rhsmlib_test/test_cloud_facts.py
+++ b/test/rhsmlib_test/test_cloud_facts.py
@@ -73,10 +73,13 @@ class TestCloudCollector(unittest.TestCase):
         self.assertEqual(facts["aws_account_id"], AWS_ACCOUNT_ID)
         self.assertIn("aws_billing_products", facts)
         self.assertEqual(facts["aws_billing_products"], AWS_BILLING_PRODUCTS)
+        self.assertIn("aws_marketplace_product_codes", facts)
+        self.assertIsNone(facts["aws_marketplace_product_codes"])
 
     def test_get_aws_facts_with_null_billing_products(self):
         """
-        Billing products could be null in some cases (not RHEL)
+        Billing products could be null in some cases (not RHEL systems
+        or systems installed from custom installation images)
         """
         self.collector = cloud_facts.CloudFactsCollector(
             collected_hw_info={
@@ -105,13 +108,18 @@ class TestCloudCollector(unittest.TestCase):
   "version" : "2017-09-30"
 }
         """
+
         self.aws_requests_mock.get = mock.Mock(return_value=mock_result)
         facts = self.collector.get_all()
+
         self.assertIn("aws_instance_id", facts)
         self.assertEqual(facts["aws_instance_id"], AWS_INSTANCE_ID)
         self.assertIn("aws_account_id", facts)
         self.assertEqual(facts["aws_account_id"], AWS_ACCOUNT_ID)
-        self.assertNotIn("aws_billing_products", facts)
+        self.assertIn("aws_billing_products", facts)
+        self.assertIsNone(facts["aws_billing_products"])
+        self.assertIn("aws_marketplace_product_codes", facts)
+        self.assertIsNone(facts["aws_marketplace_product_codes"])
 
     def test_get_azure_facts(self):
         """


### PR DESCRIPTION
* Original PR to main branch: #2655
  - Contains only one commit: 6dd156415d432d1e6e5034d9b4235fe845f4462b 
* When billingProducts is null, then None value is reported
* Forgot to add marketplaceProductCodes in facts
  - I don't have any system for testing with non-null
    value, but it should be list according AWS documentation:
    https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html
* Fixed and extended unit tests to cover new behavior