### PR TITLE
1976225: read lscpu from its JSON output if available

### DIFF
--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -18,11 +18,13 @@ from __future__ import print_function, division, absolute_import
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+import json
 import logging
 import os
 import platform
 import re
 import socket
+import subprocess
 import sys
 
 from collections import defaultdict
@@ -567,7 +569,21 @@ class HardwareCollector(collector.FactsCollector):
         # # LANGUAGE trumps LC_ALL, LC_CTYPE, LANG. See rhbz#1225435, rhbz#1450210
         lscpu_env.update({'LANGUAGE': 'en_US.UTF-8'})
 
+        if self._check_lscpu_json(lscpu_env):
+            return self._parse_lscpu_json_output(lscpu_env)
+
         return self._parse_lscpu_human_readable_output(lscpu_env)
+
+    def _check_lscpu_json(self, lscpu_env):
+        lscpu_cmd = [self.LSCPU_CMD, '--help']
+
+        try:
+            output = subprocess.check_output(lscpu_cmd, env=lscpu_env)
+        except CalledProcessError as e:
+            log.warning('Failed to run \'lscpu --help\': %s', e)
+            return False
+
+        return b"--json" in output
 
     def _parse_lscpu_human_readable_output(self, lscpu_env):
         lscpu_info = {}
@@ -604,6 +620,66 @@ class HardwareCollector(collector.FactsCollector):
             log.warning('Error reading system CPU information: %s', e)
         if errors:
             log.debug('Errors while parsing lscpu output: %s', errors)
+
+        return lscpu_info
+
+    def _parse_lscpu_json_output(self, lscpu_env):
+        lscpu_cmd = [self.LSCPU_CMD, '--json']
+        if self.testing:
+            lscpu_cmd += ['-s', self.prefix]
+
+        try:
+            output = subprocess.check_output(lscpu_cmd, env=lscpu_env)
+        except CalledProcessError as e:
+            log.warning('Failed to run \'lscpu --json\': %s', e)
+            return {}
+
+        log.debug('Parsing lscpu JSON: %s', output)
+
+        try:
+            output_json = json.loads(output)
+        except json.JSONDecodeError as e:
+            log.warning('Failed to load the lscpu JSON: %s', e)
+            return {}
+
+        try:
+            main_object = output_json['lscpu']
+        except KeyError:
+            log.warning('Failed to load the lscpu JSON: missing \'lscpu\' '
+                        'root object')
+            return {}
+
+        lscpu_info = {}
+
+        def parse_item(obj):
+            try:
+                # get 'field' and 'data', considering them mandatory, and thus
+                # ignoring this element and all its children if they are
+                # missing; note that 'data' can be null, see later on
+                key = obj['field']
+                value = obj['data']
+            except KeyError:
+                log.warning('Failed to load the lscpu JSON: object lacks '
+                            'missing \'field\' and \'data\' fields: %s', obj)
+                return
+            # 'data' is null, which means the field is an "header"; ignore it
+            if value is not None:
+                if key.endswith(':'):
+                    key = key[:-1]
+                nkey = '.'.join(["lscpu", key.lower().strip().replace(" ", "_")])
+                lscpu_info[nkey] = value.strip()
+            try:
+                children = obj['children']
+                parse_list(children)
+            except KeyError:
+                # no 'children' field available, which is OK
+                pass
+
+        def parse_list(json_list):
+            for list_item in json_list:
+                parse_item(list_item)
+
+        parse_list(main_object)
 
         return lscpu_info
 

--- a/test/rhsmlib_test/test_hwprobe.py
+++ b/test/rhsmlib_test/test_hwprobe.py
@@ -124,6 +124,19 @@ REDHAT_SUPPORT_PRODUCT_VERSION=42.0"""
 
 UPTIME = "1273.88 1133.34"
 
+LSCPU_HUMAN_READABLE_OUTPUT = """Architecture:                    x86_64
+CPU op-mode(s):                  32-bit, 64-bit
+Byte Order:                      Little Endian
+Address sizes:                   39 bits physical, 48 bits virtual
+"""
+
+LSCPU_HUMAN_READABLE_EXPECTED = {
+    'lscpu.architecture': 'x86_64',
+    'lscpu.cpu_op-mode(s)': '32-bit, 64-bit',
+    'lscpu.byte_order': 'Little Endian',
+    'lscpu.address_sizes': '39 bits physical, 48 bits virtual',
+}
+
 
 class TestParseRange(unittest.TestCase):
     def test_single(self):
@@ -823,3 +836,12 @@ class TestLscpu(unittest.TestCase):
         for key, value in facts.items():
             key.encode('ascii')
             value.encode('ascii')
+
+    @patch("rhsmlib.facts.hwprobe.compat_check_output")
+    @patch("os.access")
+    def test_mocked_human_output_parser(self, mock_access, mock_check_output):
+        mock_access.return_value = True
+        mock_check_output.return_value = LSCPU_HUMAN_READABLE_OUTPUT
+        hw_check = hwprobe.HardwareCollector()
+        facts = hw_check.get_ls_cpu_info()
+        self.assertEqual(LSCPU_HUMAN_READABLE_EXPECTED, facts)

--- a/test/rhsmlib_test/test_hwprobe.py
+++ b/test/rhsmlib_test/test_hwprobe.py
@@ -137,6 +137,106 @@ LSCPU_HUMAN_READABLE_EXPECTED = {
     'lscpu.address_sizes': '39 bits physical, 48 bits virtual',
 }
 
+LSCPU_JSON_OUTPUT = """
+{
+   "lscpu": [
+      {
+         "field": "Architecture:",
+         "data": "x86_64",
+         "children": [
+            {
+               "field": "CPU op-mode(s):",
+               "data": "32-bit, 64-bit"
+            },{
+               "field": "Address sizes:",
+               "data": "46 bits physical, 48 bits virtual"
+            },{
+               "field": "Byte Order:",
+               "data": "Little Endian"
+            }
+         ]
+      },{
+         "field": "Vendor ID:",
+         "data": "GenuineIntel",
+         "children": [
+            {
+               "field": "BIOS Vendor ID:",
+               "data": "Bochs"
+            },{
+               "field": "Model name:",
+               "data": "Intel Core Processor (Broadwell)",
+               "children": [
+                  {
+                     "field": "CPU family:",
+                     "data": "6"
+                  },{
+                     "field": "Model:",
+                     "data": "61"
+                  },{
+                     "field": "Thread(s) per core:",
+                     "data": "1"
+                  },{
+                     "field": "Core(s) per socket:",
+                     "data": "1"
+                  },{
+                     "field": "Socket(s):",
+                     "data": "1"
+                  },{
+                     "field": "Stepping:",
+                     "data": "2"
+                  },{
+                     "field": "BogoMIPS:",
+                     "data": "3999.99"
+                  },{
+                     "field": "Flags:",
+                     "data": "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl cpuid tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase bmi1 hle avx2 smep bmi2 erms invpcid rtm rdseed adx smap xsaveopt"
+                  }
+               ]
+            }
+         ]
+      },{
+         "field": "Virtualization features:",
+         "data": null,
+         "children": [
+            {
+               "field": "Hypervisor vendor:",
+               "data": "KVM"
+            },{
+               "field": "Virtualization type:",
+               "data": "full"
+            }
+         ]
+      }
+   ]
+}"""
+
+LSCPU_JSON_EXPECTED = {
+    'lscpu.architecture': 'x86_64',
+    'lscpu.cpu_op-mode(s)': '32-bit, 64-bit',
+    'lscpu.address_sizes': '46 bits physical, 48 bits virtual',
+    'lscpu.byte_order': 'Little Endian',
+    'lscpu.vendor_id': 'GenuineIntel',
+    'lscpu.bios_vendor_id': 'Bochs',
+    'lscpu.model_name': 'Intel Core Processor (Broadwell)',
+    'lscpu.cpu_family': '6',
+    'lscpu.model': '61',
+    'lscpu.thread(s)_per_core': '1',
+    'lscpu.core(s)_per_socket': '1',
+    'lscpu.socket(s)': '1',
+    'lscpu.stepping': '2',
+    'lscpu.bogomips': '3999.99',
+    'lscpu.flags': 'fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca '
+                   'cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx '
+                   'pdpe1gb rdtscp lm constant_tsc rep_good nopl cpuid '
+                   'tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 '
+                   'sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave '
+                   'avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch '
+                   'invpcid_single pti fsgsbase bmi1 hle avx2 smep bmi2 erms '
+                   'invpcid rtm rdseed adx smap xsaveopt',
+    'lscpu.hypervisor_vendor': 'KVM',
+    'lscpu.virtualization_type': 'full'
+}
+
 
 class TestParseRange(unittest.TestCase):
     def test_single(self):
@@ -838,10 +938,23 @@ class TestLscpu(unittest.TestCase):
             value.encode('ascii')
 
     @patch("rhsmlib.facts.hwprobe.compat_check_output")
+    @patch.object(hwprobe.HardwareCollector, "_check_lscpu_json")
     @patch("os.access")
-    def test_mocked_human_output_parser(self, mock_access, mock_check_output):
+    def test_mocked_human_output_parser(self, mock_access, mock_check_json, mock_check_output):
         mock_access.return_value = True
+        mock_check_json.return_value = False
         mock_check_output.return_value = LSCPU_HUMAN_READABLE_OUTPUT
         hw_check = hwprobe.HardwareCollector()
         facts = hw_check.get_ls_cpu_info()
         self.assertEqual(LSCPU_HUMAN_READABLE_EXPECTED, facts)
+
+    @patch("subprocess.check_output")
+    @patch.object(hwprobe.HardwareCollector, "_check_lscpu_json")
+    @patch("os.access")
+    def test_mocked_json_parser(self, mock_access, mock_check_json, mock_check_output):
+        mock_access.return_value = True
+        mock_check_json.return_value = True
+        mock_check_output.return_value = LSCPU_JSON_OUTPUT
+        hw_check = hwprobe.HardwareCollector()
+        facts = hw_check.get_ls_cpu_info()
+        self.assertEqual(LSCPU_JSON_EXPECTED, facts)


### PR DESCRIPTION
lscpu has a `-J`/`--json` option to output the data as JSON since util-linux 2.30. Since it is obviously meant for machine parsing, and the "human output" recently changed in ways that broke our simple parser, then switch to the JSON output.

Query lscpu to check whether it has a `--json` parameter; this is done scraping the `--help` text, which is not nice, however should do it; if `--json` is available, invoke lscpu that way, and parse the JSON output to populate the facts from it.

Card ID: ENT-4040