### PR TITLE
1976324: Added cloud_what to log root namespaces

### DIFF
--- a/src/cloud_what/provider.py
+++ b/src/cloud_what/provider.py
@@ -207,6 +207,6 @@ if __name__ == '__main__':
     # Try to detect cloud provider using own detector
     from cloud_what.fact_collector import MiniHostCollector
     collector = MiniHostCollector()
-    facts = collector.get_all()
-    _detector_result = detect_cloud_provider(facts)
+    _facts = collector.get_all()
+    _detector_result = detect_cloud_provider(_facts)
     print(f'>>> debug <<< detector result (minimalistic): {_detector_result}')

--- a/src/rhsm/logutil.py
+++ b/src/rhsm/logutil.py
@@ -33,6 +33,7 @@ ROOT_NAMESPACES = ['subscription_manager',
                    'rhsm-app',
                    'rhsmlib',
                    'syspurpose',
+                   'cloud_what'
                    ]
 
 

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -44,6 +44,7 @@ class CloudFactsCollector(collector.FactsCollector):
 
         # Try to detect cloud provider
         self.cloud_provider = get_cloud_provider(self._collected_hw_info)
+
         if self.cloud_provider is not None:
             # Create dispatcher for supported cloud providers
             cloud_provider_dispatcher = {


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1976324
* Card ID: ENT-4066
* The cloud_what wasn't added to log root namespaces and for
  this reason cloud_what log messages were not printed to
  rhsm.log file. Error log messages were printed to stderr.
* Fixed some stylish issues in provider.py and cloud_facts.py