### PR TITLE
[1.28] Remove no arch from python3-cloud-what package

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -743,7 +743,6 @@ subscription-manager-initial-setup-addon, and subscription-manager-cockpit-plugi
 %package -n python3-cloud-what
 Summary: Python package for detection of public cloud provider
 License: GPLv2
-BuildArch: noarch
 Requires: python3-requests
 %ifnarch aarch64 ppc ppc64 ppc64le s390 s390x
 Requires:  %{py_package_prefix}-dmidecode %{?dmidecode_version}


### PR DESCRIPTION
* Original PR: #2700
* When building cloud-what for different architectures we specifically need to require python3-dmidecode on certain arches.
  This causes differences in the rpms built for different arches, which conflicts with the "noarch" BuildArch.
* This PR removes the "BuildArch: noarch" to allow the cloud-what package to build slightly differently depending on arch.