### PR TITLE
1976240: Improve HTTP code/message reporting in error strings

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -314,9 +314,12 @@ class RestlibException(ConnectionException):
         self.msg = msg or ""
         self.headers = headers or {}
 
+    @property
+    def title(self):
+        return httplib.responses.get(self.code, "Unknown")
+
     def __str__(self):
-        error_title = httplib.responses.get(self.code, "Unknown")
-        return "HTTP error (%s - %s): %s" % (self.code, error_title, self.msg)
+        return f"HTTP error ({self.code} - {self.title}): {self.msg}"
 
 
 class GoneException(RestlibException):

--- a/src/subscription_manager/cli_command/attach.py
+++ b/src/subscription_manager/cli_command/attach.py
@@ -28,6 +28,7 @@ from subscription_manager.action_client import ProfileActionClient, ActionClient
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand, handle_exception
 from subscription_manager.cli_command.list import show_autosubscribe_output
+from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.packageprofilelib import PackageProfileActionInvoker
 from subscription_manager.syspurposelib import save_sla_to_syspurpose_metadata
@@ -159,12 +160,16 @@ class AttachCommand(CliCommand):
                             subscribed = True
                     except connection.RestlibException as re:
                         log.exception(re)
+
+                        exception_mapper = ExceptionMapper()
+                        mapped_message = exception_mapper.get_message(re)
+
                         if re.code == 403:
-                            print(str(re))  # already subscribed.
+                            print(mapped_message)  # already subscribed.
                         elif re.code == 400 or re.code == 404:
-                            print(str(re))  # no such pool.
+                            print(mapped_message)  # no such pool.
                         else:
-                            system_exit(os.EX_SOFTWARE, str(re))  # some other error.. don't try again
+                            system_exit(os.EX_SOFTWARE, mapped_message)  # some other error.. don't try again
                 if not subscribed:
                     return_code = 1
             # must be auto

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -25,7 +25,6 @@ from subscription_manager.cp_provider import TokenAuthUnsupportedException
 from subscription_manager.entcertlib import Disconnected
 
 from subscription_manager.i18n import ugettext as _
-from subscription_manager.printing_utils import to_unicode_or_bust
 
 SOCKET_MESSAGE = _('Network error, unable to connect to server. Please see /var/log/rhsm/rhsm.log for more information.')
 NETWORK_MESSAGE = _('Network error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information.')
@@ -45,9 +44,9 @@ PERROR_SCHEME_MESSAGE = _("Server URL has an invalid scheme. http:// and https:/
 RATE_LIMIT_MESSAGE = _("The server rate limit has been exceeded, please try again later.")
 RATE_LIMIT_EXPIRATION = _("The server rate limit has been exceeded, please try again later. (Expires in %s seconds)")
 
-# TRANSLATORS: example: "HTTP error code 500: Error on the server" (the portion after the colon will
-# originate on the server)
-RESTLIB_MESSAGE = _(u"HTTP error code %s: %s")
+# TRANSLATORS: example: "You don't have permission to perform this action (HTTP error code 403: Forbidden)"
+# (the part before the opening bracket originates on the server)
+RESTLIB_MESSAGE = _("{message} (HTTP error code {code}: {title})")
 
 
 class ExceptionMapper(object):
@@ -87,7 +86,11 @@ class ExceptionMapper(object):
         return message_template % ssl_error
 
     def format_restlib_exception(self, restlib_exception, message_template):
-        return message_template % (restlib_exception.code, to_unicode_or_bust(restlib_exception.msg))
+        return message_template.format(
+            message=restlib_exception.msg,
+            code=restlib_exception.code,
+            title=restlib_exception.title
+        )
 
     def format_rate_limit_exception(self, rate_limit_exception, _):
         if rate_limit_exception.retry_after is not None:

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -87,7 +87,7 @@ class TestExceptionMapper(unittest.TestCase):
         mapper = ExceptionMapper()
 
         err = RestlibException(404, expected_message)
-        self.assertEqual("HTTP error code 404: %s" % expected_message, mapper.get_message(err))
+        self.assertEqual(f"{expected_message} (HTTP error code 404: Not Found)", mapper.get_message(err))
 
     def test_returns_none_when_no_mapped_exception_present(self):
         mapper = ExceptionMapper()


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1976240
* Card ID: ENT-3914

The error message in the attach command prints error code and a message
received from the server.

Instead of relying on internal RestlibException string representation
a less scary/more friendly format is used, by placing the error message
before the error code. It's also being translated with ExceptionMapper.

One property has been added to the RestlibException to prevent duplicate
code.