### PR TITLE
[1.24] Added support for marketplace ID on RHEL7.

### DIFF
--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -20,7 +20,6 @@ from __future__ import print_function, division, absolute_import
 import logging
 import json
 import socket
-import subscription_manager.injection as inj
 
 from rhsmlib.facts import collector
 from rhsm.https import httplib
@@ -28,14 +27,26 @@ from rhsm.https import httplib
 
 log = logging.getLogger(__name__)
 
-AWS_INSTANCE_URL = "169.254.169.254"
-AWS_INSTANCE_TIMEOUT = 5
+AWS_INSTANCE_IP = "169.254.169.254"
+AWS_INSTANCE_PATH = "/latest/dynamic/instance-identity/document"
+AWS_INSTANCE_TOKEN_PATH = "/latest/api/token"
+AWS_INSTANCE_TOKEN_TTL = 3600  # value is in seconds
+AWS_INSTANCE_TIMEOUT = 5  # value is in seconds
+
+AZURE_INSTANCE_IP = "169.254.169.254"
+AZURE_API_VERSION = "2021-02-01"
+AZURE_INSTANCE_PATH = "/metadata/instance?api-version=" + AZURE_API_VERSION
+AZURE_INSTANCE_TIMEOUT = 5  # value is in seconds
 
 
 class CloudFactsCollector(collector.FactsCollector):
     """
     Class used for collecting facts related to Cloud instances
     """
+
+    HEADERS = {
+        'User-Agent': 'RHSM/1.0',
+    }
 
     def __init__(self, arch=None, prefix=None, testing=None, collected_hw_info=None):
         super(CloudFactsCollector, self).__init__(
@@ -45,35 +56,214 @@ class CloudFactsCollector(collector.FactsCollector):
             collected_hw_info=collected_hw_info
         )
 
-        self.hardware_methods = [
-            self.get_aws_instance_id
-        ]
+        log.debug('Trying to detect public cloud')
 
-    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
-    def get_aws_instance_id(self):
-        values = {}
-        if not self._collected_hw_info['dmi.bios.version'].find('amazon') >= 0:
-            return ""
-        facts_cache = inj.require(inj.FACTS).read_cache_only() or {}
-        if 'aws_instance_id' in facts_cache:
-            return {'aws_instance_id': facts_cache['aws_instance_id']}
+        public_cloud = None
+        if self.is_aws() is True:
+            public_cloud = "aws"
+            self.hardware_methods = [
+                self.get_aws_facts
+            ]
 
+        if self.is_azure() is True:
+            public_cloud = "azure"
+            self.hardware_methods = [
+                self.get_azure_facts
+            ]
+
+        if public_cloud is not None:
+            log.debug('Detected public cloud: {public_cloud}'.format(public_cloud=public_cloud))
+
+    def is_aws(self):
+        """
+        Is the VM running on AWS
+        :return: True, when VM is running on AWS
+        """
+        hw_info = self._collected_hw_info
+
+        if 'dmi.bios.version' in hw_info and 'amazon' in hw_info['dmi.bios.version']:
+            return True
+
+        if 'dmi.bios.vendor' in hw_info and 'Amazon EC2' in hw_info['dmi.bios.vendor']:
+            return True
+
+        return False
+
+    def get_cloud_metadata(self, ip_addr, path, headers=None, timeout=5.0):
+        """
+        Try to get AWS metadata using only IMDSv1
+        :return: http response
+        """
+        conn = httplib.HTTPConnection(ip_addr, timeout=timeout)
+        if headers is None:
+            headers = self.HEADERS
+        conn.request('GET', path, headers=headers)
+        response = conn.getresponse()
+        return response
+
+    def get_aws_token(self, ip_addr, path, headers=None, timeout=5.0):
+        """
+        Try to get AWS token
+        :return: AWS token or None, when it wasn't possible to get AWS token
+        """
+        log.debug('Trying to get AWS IMDSv2 token')
+        token = None
+        conn = httplib.HTTPConnection(ip_addr, timeout=timeout)
+        if headers is None:
+            headers = self.HEADERS
         try:
-            conn = httplib.HTTPConnection(AWS_INSTANCE_URL, timeout=AWS_INSTANCE_TIMEOUT)
-            conn.request('GET', '/latest/dynamic/instance-identity/document')
+            conn.request('PUT', path, headers=headers)
             response = conn.getresponse()
+            output = response.read()
+            token = output.decode()
+        except Exception as err:
+            log.warning('Unable to get AWS token: {err}'.format(err=str(err)))
+        else:
+            log.debug('AWS token gathered')
+        return token
+
+    def get_aws_metadata(self):
+        """
+        Try to get AWS metadata using only IMDSv2, which is supported in all cases. Using of IMDSv1
+        can be forbidden by administrator of VM on AWS console.
+        :return: http response
+        """
+
+        # First try to get IMDSv2 token
+        headers = {
+            'X-aws-ec2-metadata-token-ttl-seconds': str(AWS_INSTANCE_TOKEN_TTL)
+        }
+        headers.update(self.HEADERS)
+        token = self.get_aws_token(
+            ip_addr=AWS_INSTANCE_IP,
+            path=AWS_INSTANCE_TOKEN_PATH,
+            headers=headers,
+            timeout=AWS_INSTANCE_TIMEOUT
+        )
+
+        # When token is gathered, then try to get metadata using IMDSv2
+        headers = {}
+        if token is not None:
+            headers = {
+                'X-aws-ec2-metadata-token': token
+            }
+        headers.update(self.HEADERS)
+        return self.get_cloud_metadata(
+            ip_addr=AWS_INSTANCE_IP,
+            path=AWS_INSTANCE_PATH,
+            headers=headers,
+            timeout=AWS_INSTANCE_TIMEOUT
+        )
+
+    def get_aws_facts(self):
+        """
+        Try to get facts from metadata returned by AWS IMDS server according this documentation:
+
+        https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
+
+        :return: dictionary containing AWS facts or empty dictionary, when it wasn't
+        possible to get information from IMDS server
+        """
+        log.debug('Trying to get AWS metadata')
+        facts = {}
+        try:
+            response = self.get_aws_metadata()
             output = response.read()
             values = self.parse_content(output)
         except (httplib.HTTPException, ValueError, socket.timeout) as e:
-            # any exception is logged by value is simply not added.
-            log.exception("Cannot retrieve AWS instance Id: %s" % e)
-        finally:
+            # Any exception is logged by value is simply not added.
+            log.exception("Cannot retrieve AWS metadata: %s" % e)
+        else:
+            log.debug('AWS metadata gathered')
             if 'instanceId' in values:
-                return {"aws_instance_id": values['instanceId']}
-            else:
-                return {}
+                facts["aws_instance_id"] = values['instanceId']
 
-    def parse_content(self, content):
+            if 'accountId' in values:
+                facts['aws_account_id'] = values['accountId']
+
+            # Note: There should be only two types of billing codes: bp-63a5400a and bp-6fa54006 in the list,
+            # when RHEL is used. When the subscription-manager is used by some other Linux distribution,
+            # then there could be different codes or it could be null
+            if 'billingProducts' in values:
+                billing_products = values['billingProducts']
+                if isinstance(billing_products, list):
+                    facts['aws_billing_products'] = " ".join(billing_products)
+                elif billing_products is None:
+                    facts['aws_billing_products'] = billing_products
+                else:
+                    log.debug('AWS metadata attribute billingProducts has to be list or null')
+
+            if 'marketplaceProductCodes' in values:
+                marketplace_product_codes = values['marketplaceProductCodes']
+                if isinstance(marketplace_product_codes, list):
+                    facts['aws_marketplace_product_codes'] = " ".join(marketplace_product_codes)
+                elif marketplace_product_codes is None:
+                    facts['aws_marketplace_product_codes'] = marketplace_product_codes
+                else:
+                    log.debug('AWS metadata attribute marketplaceProductCodes has to be list or null')
+
+        return facts
+
+    def is_azure(self):
+        """
+        Is VM running on Azure public cloud
+        :return:
+        """
+        hw_info = self._collected_hw_info
+
+        if 'dmi.chassis.asset_tag' in hw_info and \
+                hw_info['dmi.chassis.asset_tag'] == '7783-7084-3265-9085-8269-3286-77':
+            return True
+
+        return False
+
+    def get_azure_metadata(self):
+        """
+        Try to get AWS metadata using only IMDSv1
+        :return: http response
+        """
+        headers = {
+            "Metadata": "true",
+        }
+        headers.update(self.HEADERS)
+        return self.get_cloud_metadata(
+            ip_addr=AZURE_INSTANCE_IP,
+            path=AZURE_INSTANCE_PATH,
+            headers=headers,
+            timeout=AZURE_INSTANCE_TIMEOUT
+        )
+
+    def get_azure_facts(self):
+        """
+        Try to get Azure facts from IMDS server according this documentation:
+
+        https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service?tabs=linux#instance-metadata
+
+        :return: dictionary containing AWS facts or empty dictionary, when it wasn't
+        possible to get information from IMDS server
+        """
+        log.debug('Trying to get Azure metadata')
+        facts = {}
+        try:
+            response = self.get_azure_metadata()
+            output = response.read()
+            values = self.parse_content(output)
+        except (httplib.HTTPException, ValueError, socket.timeout) as e:
+            # Any exception is logged by value is simply not added.
+            log.exception("Cannot retrieve Azure metadata: %s" % e)
+        else:
+            log.debug('Azure metadata gathered')
+            if 'compute' in values:
+                if 'vmId' in values['compute']:
+                    facts["azure_instance_id"] = values['compute']['vmId']
+                if 'sku' in values['compute']:
+                    facts['azure_sku'] = values['compute']['sku']
+                if 'offer' in values['compute']:
+                    facts['azure_offer'] = values['compute']['offer']
+        return facts
+
+    @staticmethod
+    def parse_content(content):
         try:
             doc_values = json.loads(content)
             return doc_values


### PR DESCRIPTION
* Card ID: ENT-4106
* Backported support for marketplace ID to RHEL7
  - Azure is supported fully
  - AWS is supported using IMDSv1
* AWS do not use caching of AWS facts, because it could
  cause some issues, when VM is migrated
* Modified some unit tests