### PR TITLE
1980418: Add 'active' field to module stream profile

### DIFF
--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -95,7 +95,8 @@ ENABLED_MODULES = [
         "arch": "noarch",
         "profiles": ["default"],
         "installed_profiles": [],
-        "status": "enabled"
+        "status": "enabled",
+        "active": True
     },
     {
         "name": "flipper",
@@ -105,7 +106,8 @@ ENABLED_MODULES = [
         "arch": "x86_64",
         "profiles": ["default", "server"],
         "installed_profiles": ["server"],
-        "status": "unknown"
+        "status": "unknown",
+        "active": True
     }
 ]
 
@@ -448,7 +450,8 @@ class TestProfileManager(unittest.TestCase):
                 "arch": "noarch",
                 "profiles": ["default"],
                 "installed_profiles": [],
-                "status": "enabled"
+                "status": "enabled",
+                "active": True
             },
             {
                 "name": "duck",
@@ -458,7 +461,8 @@ class TestProfileManager(unittest.TestCase):
                 "arch": "noarch",
                 "profiles": ["default", "server"],
                 "installed_profiles": ["server"],
-                "status": "unknown"
+                "status": "unknown",
+                "active": True
             }
 
         ]
@@ -466,6 +470,48 @@ class TestProfileManager(unittest.TestCase):
         self.assertEqual(modules_input, ModulesProfile._uniquify(modules_input))
         # now test dup modules
         self.assertEqual(modules_input, ModulesProfile._uniquify(modules_input + [modules_input[0]]))
+
+    def test_module_md_uniquify_active_and_inactive(self):
+        modules_input = [
+            {
+                "name": "duck",
+                "stream": 0,
+                "version": "20180730233102",
+                "context": "deadbeef",
+                "arch": "noarch",
+                "profiles": ["default"],
+                "installed_profiles": [],
+                "status": "enabled",
+                "active": False
+            },
+            {
+                "name": "duck",
+                "stream": 0,
+                "version": "20180730233102",
+                "context": "deadbeef",
+                "arch": "noarch",
+                "profiles": ["default"],
+                "installed_profiles": [],
+                "status": "enabled",
+                "active": True
+            }
+        ]
+
+        expected_output = [
+            {
+                "name": "duck",
+                "stream": 0,
+                "version": "20180730233102",
+                "context": "deadbeef",
+                "arch": "noarch",
+                "profiles": ["default"],
+                "installed_profiles": [],
+                "status": "enabled",
+                "active": True
+            }
+        ]
+
+        self.assertEqual(expected_output, ModulesProfile._uniquify(modules_input))
 
     @staticmethod
     def _mock_pkg_profile(packages, repo_file, enabled_modules):


### PR DESCRIPTION
Katello has run into an issue where the package profile from sub-man includes inactive, but enabled module streams.  Here is the context:

A user enables the perl 5.26 module stream. It enables perl-IO-Socket-SSL as a dependent module stream.  In the background, with dnf, the system has 3 perl-IO-Socket-SSL modules streams enabled with the same name, stream, version, and arch, but different contexts. Only one is active, because only one actually belongs to the perl 5.26 module.  This is causing RPM applicability to break in Katello. Katello applicability is not considering that there could be multiple enabled module streams with the same NSVA but differing context.

I am not seeing the case where Katello needs to know about enabled and inactive module streams.  As such, to stop our applicability queries from getting more expensive, I'm adding an active flag here to the module profile.  Katello will check if the module is active and go from there.

I also had to add a change to `_uniquify()`.  For whatever reason, the dnf library is returning duplicate enabled module streams with the same NSVCA, but one being active and one being inactive.  To address this, I've made `_uniquify()` prefer active module streams if there are duplicates.

I'm also curious if sub-man even needs to carry these enabled+inactive modules in the package profile.  Does anyone use that information?  To me, an enabled module doesn't really seem enabled if it isn't active.  The user can't install rpms from the enabled+inactive modules, so are they really enabled from a logical standpoint?  Perhaps the info could be useful to check for sub-module-streams like the relationship between perl and perl-IO-Socket-SSL, but I'm not sure.