### PR TITLE
1977452: typo in string format change

### DIFF
--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -325,7 +325,7 @@ class DumpManifestCommand(RCTManifestCommand):
             # IOError/OSError base class
             if e.errno == errno.EEXIST:
                 # useful error for file already exists
-                print(_('File {filename} exists. Use -f to force overwriting the file.').format(filename=e.filename))
+                print(_('File "{filename}" exists. Use -f to force overwriting the file.').format(filename=e.filename))
             else:
                 # generic error for everything else
                 print(_("Manifest could not be written:"))

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -280,7 +280,7 @@ class MigrationEngine(object):
             else:
                 msgs = [_("This system appears to already be registered to Red Hat Subscription Management.")]
                 msgs.append(_("Please visit https://access.redhat.com/management/consumers/{identity_uuid} to view the "
-                              " profile details.").format(identity_uuid=identity.uuid))
+                              "profile details.").format(identity_uuid=identity.uuid))
             system_exit(1, msgs)
 
         try:


### PR DESCRIPTION
Add quotes to a {filename} and remove an extra space.