### PR TITLE
Do not ship initial-setup in CentOS

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -93,6 +93,11 @@
 %global use_inotify 0
 %endif
 
+# Do not ship initial-setup in CentOS
+%if %{defined centos}
+%global use_initial_setup 0
+%endif
+
 %if (%{use_subman_gui} || %{use_initial_setup} || %{use_firstboot})
 %global use_rhsm_gtk 1
 %else


### PR DESCRIPTION
The CentOS team currently applies manual debranding to remove the initial-setup-gui supplements from the initial-setup-addon subpackage.  After discussing this with @ptoscano, we agreed it made more sense to just disable the initial-setup-addon subpackage entirely when built for CentOS.