### PR TITLE
1876828: Try to suppress errors in stderr when not run as root

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -1499,6 +1499,16 @@ environment variable is set and the
 .B no_proxy
 configuration file option is set, then the value from the configuration file is the effective value.
 
+.SH LOG FILES
+Default log location of the
+.B subscription-manager
+is 
+.B /var/log/rhsm/rhsm.log.
+When the program is run under non-root user (e.g. as dnf plugin) the logs are written to
+.B $XDG_CACHE_HOME/rhsm/rhsm.log.
+
+If the directory isn't writable, the logs are printed to stderr.
+
 .SH FILES
 .IP
 * /etc/pki/consumer/*.pem
@@ -1510,6 +1520,8 @@ configuration file option is set, then the value from the configuration file is 
 * /etc/rhsm/rhsm.conf
 .IP
 * /etc/rhsm/facts/*.facts
+.IP
+* /var/log/rhsm/rhsm.log
 
 .SH AUTHORS
 Deon Lackey, <dlackey@redhat.com>, and Pradeep Kilambi, <pkilambi@redhat.com>


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1876828
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1890314
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1876841
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1947844
* Card ID: ENT-3051
* Card ID: ENT-3852

Before this change the only log location was /var/log/rhsm/rhsm.log. If the subscription-manager was run as non-root user (as dnf plugin, e.g. 'dnf list'), it sent several error messages to stderr, polluting the output.

Now the UID of the subman process is checked:
- If the program is run as root (UID 0), the log location is still /var/log/rhsm/rhsm.log.
- If the program is run as non-root (other UIDs), the log location is $XDG_CACHE_HOME/rhsm/rhsm.log (~/.cache/rhsm/rhsm.log in most cases).
- If the location is not writable, the errors will be sent to stderr as they were before this change.

This behavior is now mentioned in the man page.
/var/log/rhsm/rhsm.log has been added to the man page's FILES section.