### PR TITLE
1974641: Fix tab completion with multiple optional commands

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -256,7 +256,16 @@ _subscription_manager()
   COMPREPLY=()
   first=${COMP_WORDS[1]}
   cur="${COMP_WORDS[COMP_CWORD]}"
-  prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  # Because the 'prev' may be optional argument like '--list', we iterate from the end
+  # until we find string that doesn't start with dash. That is the subcommand which
+  # should be used for completion.
+  i=1
+  prev="${COMP_WORDS[COMP_CWORD-$i]}"
+  while [[ $prev == -* ]]; do
+    i=$((i+1))
+    prev="${COMP_WORDS[COMP_CWORD-$i]}"
+  done
 
   # top-level commands and options
   opts="addons attach auto-attach clean config environments facts identity import list orgs


### PR DESCRIPTION
* Card ID: ENT-4013
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1974641

After the syspurpose was added as subcommand in 5406865 the 'prev'
variable was not always set correctly. For the first argument the
completion worked fine, but for the second (and further) the last
argument was picked up instead of the last subcommand.

This change iterates over the CLI arguments and uses the last word that
does not start with a dash, skipping all arguments and finding the last
subcommand.