### PR TITLE
Change comments and variables to follow Conscious language initiative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Python setup.py doesn't cover all our bases.  Additionally, setuptools does not like
 # to install files outside of /usr (see http://stackoverflow.com/a/13476594/6124862).
 #
-# Therefore the Makefile performs the master build, but please keep the following guidelines
+# Therefore the Makefile performs the main build, but please keep the following guidelines
 # in mind when updating it:
 #
 # * If the file goes under /usr, put it in setup.py

--- a/cockpit/lib/packagekit.js
+++ b/cockpit/lib/packagekit.js
@@ -21,7 +21,7 @@ import cockpit from "cockpit";
 
 const _ = cockpit.gettext;
 
-// see https://github.com/hughsie/PackageKit/blob/master/lib/packagekit-glib2/pk-enum.h
+// see https://github.com/PackageKit/PackageKit/blob/main/lib/packagekit-glib2/pk-enum.h
 export const Enum = {
     EXIT_SUCCESS: 1,
     EXIT_FAILED: 2,

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -45,7 +45,7 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
+# The root toctree document.
 master_doc = 'index'
 
 # General information about the project.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -1,4 +1,4 @@
-.. subscription-manager documentation master file, created by
+.. subscription-manager documentation main file, created by
    sphinx-quickstart on Tue May 13 23:24:51 2014.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -34,7 +34,7 @@ proxy_user =
 # password for basic http proxy auth, if needed
 proxy_password =
 
-# host/domain suffix blacklist for proxy, if needed
+# host/domain suffix blocklist for proxy, if needed
 no_proxy =
 
 [rhsm]

--- a/integration-tests/run
+++ b/integration-tests/run
@@ -12,7 +12,7 @@
 # You need a couple of things installed for that.  At least Python 3,
 # a Chromium browser, and libvirtd.  See
 #
-#     https://github.com/cockpit-project/cockpit/blob/master/test/README.md
+#     https://github.com/cockpit-project/cockpit/blob/main/test/README.md
 #
 # for more information about the Cockpit integration test machinery.
 
@@ -55,7 +55,7 @@ $(VM_IMAGE): $(COCKPIT_TAR) $(SUBMAN_TAR) $(SMBEXT_TAR) bots
           -s ./integration-tests/vm.install
 
 # checkout Cockpit's bots for standard test VM images and API to launch them
-# must be from master, as only that has current and existing images; but testvm.py API is stable
+# must be from main, as only that has current and existing images; but testvm.py API is stable
 # support CI testing against a bots change
 bots:
 	git clone --quiet \

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -1479,7 +1479,7 @@ respects environment variables for proxy configuration, this should be avoided i
 .B rhsmcertd
 ) do not provide ways to modify their environments.
 
-Each option of the proxy configuration (hostname, port, host/domain pattern blacklist, username, password) is read independently, with precedence being command-line over configuration over environment, and then the resulting set of options is used to configure the proxy configuration.
+Each option of the proxy configuration (hostname, port, host/domain pattern blocklist, username, password) is read independently, with precedence being command-line over configuration over environment, and then the resulting set of options is used to configure the proxy configuration.
 
 For example,
 if the

--- a/pylintrc
+++ b/pylintrc
@@ -10,7 +10,7 @@
 # Profiled execution.
 profile=no
 
-# Add <file or directory> to the black list. It should be a base name, not a
+# Add <file or directory> to be skipped. It should be a base name, not a
 # path. You may set this option multiple times.
 ignore=CVS
 ignore=.#

--- a/scripts/checkcommits.sh
+++ b/scripts/checkcommits.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # run git-checkcommits against known branches and look
-# for commits that haven't been merged to master
+# for commits that haven't been merged to main
 # add a branch name to ".branches" file to have
 # it checked by the script
 #

--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -186,8 +186,8 @@ class ProductCertificateDirectory(CertificateDirectory):
 
     def get_provided_tags(self):
         """
-        Iterates all product certificates in the directory and extracts a master
-        set of all tags they provide.
+        Iterates all product certificates in the directory and extracts a set
+        of all tags they provide.
         """
         tags = set()
         for prod_cert in self.list_valid():

--- a/src/subscription_manager/cli_command/override.py
+++ b/src/subscription_manager/cli_command/override.py
@@ -117,7 +117,7 @@ class OverrideCommand(CliCommand):
                 results = overrides.add_overrides(self.identity.uuid, to_add)
             except connection.RestlibException as ex:
                 if ex.code == 400:
-                    # black listed overrides specified.
+                    # blocklisted overrides specified.
                     # Print message and return a less severe code.
                     system_exit(1, ex)
                 else:

--- a/src/subscription_manager/cli_command/repos.py
+++ b/src/subscription_manager/cli_command/repos.py
@@ -144,9 +144,8 @@ class ReposCommand(CliCommand):
 
     def _set_repo_status(self, repos, repo_action_invoker, repo_actions):
         """
-        Given a list of repo actions (tuple of enable/disable and
-        repo ID), build the master list (without duplicates) to send to the
-        server.
+        Given a list of repo actions (tuple of enable/disable and repo ID),
+        build a list without duplicates to send to the server.
         """
         rc = 0
 

--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -36,8 +36,6 @@ LOCALE = local()
 LOCALE.language = None
 LOCALE.lang = None
 
-BLACKLISTED_LOCALES = ['turkish', 'tr_TR', 'tr_CY', 'ku_TR']
-
 log = logging.getLogger(__name__)
 
 
@@ -64,18 +62,6 @@ def configure_i18n():
             print('You are attempting to use a locale: "%s" that is not fully supported by this system.' % _locale)
         os.environ['LC_ALL'] = 'C.UTF-8'
         locale.setlocale(locale.LC_ALL, 'C.UTF-8')
-
-    # We have to set locale to C for blacklisted locales, because result of str.lower() and str.upper()
-    # methods is influenced by locale. E.g. character 'I' is not converted to 'i' by lower() for Turkish
-    # language, but it is converted to 'ı'. Character 'i' is converted to 'İ' by upper(). There other
-    # strange cases, when tr_TR
-    # See this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1703054#c10
-    if six.PY2 and current_locale is not None:
-        base_current_locale = current_locale.split('.')[0]
-        if base_current_locale in BLACKLISTED_LOCALES:
-            print("You are attempting to use forbidden locale: %s. Resetting to default locale." % current_locale)
-            os.environ['LC_ALL'] = 'C.UTF-8'
-            locale.setlocale(locale.LC_ALL, 'C.UTF-8')
 
     configure_gettext()
     # RHBZ 1642271  Don't set a None lang

--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -556,7 +556,7 @@ class ProductManager(object):
     def install_product_certs(self, product_certs):
         # collect info, then do the needful later, so we can hook
         # up a plugin in between and let it munge these lists, so a plugin
-        # could blacklist a product cert for example.
+        # could block a product cert for example.
         self.plugin_manager.run('pre_product_id_install', product_list=product_certs)
         # ProductCertDb.install()
         #  -> for each ProductCert:

--- a/test/rhsmlib_test/test_hwprobe.py
+++ b/test/rhsmlib_test/test_hwprobe.py
@@ -674,7 +674,7 @@ VARIANT_ID=server
     def test_get_slave_hwaddr_rr(self, MockOpen):
         MockOpen.return_value = six.StringIO(PROC_BONDING_RR)
         hw = hwprobe.HardwareCollector()
-        slave_hw = hw._get_slave_hwaddr("bond0", "eth0")
+        slave_hw = hw._get_permanent_hardware_address("bond0", "eth0")
         # note we .upper the result
         self.assertEqual("52:54:00:07:03:BA", slave_hw)
 
@@ -682,7 +682,7 @@ VARIANT_ID=server
     def test_get_slave_hwaddr_alb(self, MockOpen):
         MockOpen.return_value = six.StringIO(PROC_BONDING_ALB)
         hw = hwprobe.HardwareCollector()
-        slave_hw = hw._get_slave_hwaddr("bond0", "eth0")
+        slave_hw = hw._get_permanent_hardware_address("bond0", "eth0")
         # note we .upper the result
         self.assertEqual("52:54:00:07:03:BA", slave_hw)
 


### PR DESCRIPTION
* Card ID: ENT-3764

Following changes were made:
- blacklist -> blocklist, block
- master -> main
- master device, slave device -> bond device, permanent device

Additional notes:
- cockpit/lib/packagekit.js: PackageKit URL has been updated to main; their primary branch is no longer called master
- itegration-tests/run: Cockpit URL has been updated to main; their primary branch is no longer called master
- src/subscription_manager/i18l.py: BLACKLISTED_LOCALES and the 'if' was removed (see https://bugzilla.redhat.com/show_bug.cgi?id=1857214), it was not run anyway because it was only executed on Python 2.

Words that were not replaced:
- subscription-manager.spec: This file contains changelog, which is not subject to these changes.
- pylintrc: MASTER ini heading
- docs/sphinx/conf.py: 'master_doc' variable has been renamed to 'root_doc' in Sphinx 4.0 (released 2021-05-09). 'master_doc' is still an alias. Not changed because test-requirements.txt still specifies Sphinx>=1.8.5 for Python 3.
- src/dnf-plugins/product-id/README.md: Primary branches of linked projects are called 'master'.
- test/manifestdata.py, test/test_cert_sorter.py, test/rhsmlib_test/test_attach.py: 'master' is a value of 'subscriptionSubKey' key returned as 'pool' attribute from Candlepin server.