### PR TITLE
hwprobe.py: Fix counting cores per cpu for Fujitsu A64FX CPU

### DIFF
--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -264,6 +264,25 @@ class HardwareCollector(collector.FactsCollector):
         # that field was empty
         return None
 
+    def is_a64fx(self):
+        if self.arch != "aarch64":
+            return False
+        try:
+            # MIDR_EL1 register shows the identifer of ARM64 CPU.
+            # MIDR_EL1 of A64FX is as follows:
+            # FX700:  0x00000000461f0010
+            # FX1000: 0x00000000460f0010
+            f = open("/sys/devices/system/cpu/cpu0/regs/identification/midr_el1", 'r')
+        except IOError:
+            return False
+
+        midr = f.read().rstrip('\n')
+        f.close()
+        if midr == "0x00000000461f0010" or midr == "0x00000000460f0010":
+            return True
+
+        return False
+
     # replace/add with getting CPU Totals for s390x
     def _parse_s390x_sysinfo_topology(self, cpu_count, sysinfo):
         # to quote lscpu.c:
@@ -445,7 +464,12 @@ class HardwareCollector(collector.FactsCollector):
         # but lscpu makes the same assumption
 
         threads_per_core = self.count_cpumask_entries(cpu_files[0], 'thread_siblings_list')
-        cores_per_cpu = self.count_cpumask_entries(cpu_files[0], 'core_siblings_list')
+        if self.is_a64fx():
+            # core_siblings_list of A64FX shows the cpu mask which is in a same CMG,
+            # not the socket. A64FX has always 4 CMGs on the socket.
+            cores_per_cpu = self.count_cpumask_entries(cpu_files[0], 'core_siblings_list') * 4
+        else:
+            cores_per_cpu = self.count_cpumask_entries(cpu_files[0], 'core_siblings_list')
 
         # if we find valid values in cpu/cpuN/topology/*siblings_list
         # sometimes it's not there, particularly on rhel5


### PR DESCRIPTION
subscription-manager facts command shows the wrong value of cpu.cpu_socket(s)
on the Fujitsu A64FX machine.

```
  # subscription-manager facts
  ...
  cpu.cpu_socket(s): 4
```

A64FX is one socket architecture, so it should be cpu.cpu_socket(s): 1.

subscription-manager gets the wrong value because it counts the cores per
cpu by using /sys/devices/system/cpu/cpuX/topology/core_siblings_list.
For A64FX, the sysfs file shows the cores mask which are in the
same CMG (Core Memory Group), not the core mask per socket.

A64FX has always 4 CMGs on the socket [1], so we can get the number
of cores by:

```
   count_cpumask_entries(, 'core_siblings_list') * 4CMGs
```

[1] :   [A64FX Microarchitecture Manual ](https://github.com/fujitsu/A64FX/blob/master/doc/A64FX_Microarchitecture_Manual_en_1.5.pdf)
     1.2. A64FX Processor Specification