### PR TITLE
1984133: repos: respect order of --enable & --disable

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -704,11 +704,15 @@ Lists all of the disabled repositories that are provided by the content service 
 
 .TP
 .B --enable=REPO_ID
-Enables the specified repository, which is made available by the content sources identified in the system subscriptions. To enable multiple repositories, use this argument multiple times. Wild cards * and ? are supported.
+Enables the specified repository, which is made available by the content sources identified in the system subscriptions. To enable multiple repositories, use this argument multiple times. Wild cards * and ? are supported. The repositories enabled by this option and disabled by
+.B --disable
+are processed in the same order they are specified.
 
 .TP
 .B --disable=REPO_ID
-Disables the specified repository, which is made available by the content sources identified in the system subscriptions. To disable multiple repositories, use this argument multiple times. Wild cards * and ? are supported.
+Disables the specified repository, which is made available by the content sources identified in the system subscriptions. To disable multiple repositories, use this argument multiple times. Wild cards * and ? are supported. The repositories disabled by this option and enabled by
+.B --enable
+are processed in the same order they are specified.
 
 
 .SS ORGS OPTIONS


### PR DESCRIPTION
With the old `optparse` implementation, there was a single callback to
fill `repo_actions` with the various values of the `--enable` & `--disable`
options, in the same order they were specified on the command line.
Commit eef1bb13f8924af9539f98330465c110f2df92b5 switched to `argparse`,
and switched to different destination lists for `--enable` & `--disable`,
mixing them back to a single list with first all the repos to enabled
and then all the repos to disable. As result, the order of intermixed
`--enable` & `--disable` was lost.

To revert back to the wanted behaviour, implement a custom
`argparse.Action` for `--enable` & `--disable` that appends all the actions to
the same list in the same order they were specified. This removes the
need for post-processing later on.

Also, explicitly document the ordered processing of `--enable` & `--disable`,
as it was not so far.

Card-ID: ENT-4146