### PR TITLE
1859569: Abort on invalid username/token argument in syspurpose subcommands

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -417,15 +417,19 @@ Lists the available addons system purpose values.
 
 .TP
 .B --username=USERNAME
-Gives the username for the account to use to connect to the organization account [Use with --list when unregistered].
+Gives the username for the account to use to connect to the organization account [Usable with --list on unregistered systems].
 
 .TP
 .B --password=PASSWORD
-Gives the user account password [Use with --list when unregistered].
+Gives the user account password [Usable with --list on unregistered systems].
 
 .TP
 .B --token=TOKEN
-Token to use when authorizing against the server [Use with --list when unregistered].
+Token to use when authorizing against the server [Usable with --list on unregistered systems].
+
+.TP
+.B --org=ORG
+Identifies the organization for which the addons apply [Usable with --list on unregistered systems].
 
 .TP
 .B --add=ADDON
@@ -438,10 +442,6 @@ Remove the addon from the list of requested addons.
 .TP
 .B --unset
 Removes all addons from the list of requested addons.
-
-.TP
-.B --org=ORG
-Identifies the organization for which the addons applies.
 
 
 .SS role options
@@ -461,15 +461,19 @@ Lists the available role system purpose values.
 
 .TP
 .B --username=USERNAME
-Gives the username for the account to use to connect to the organization account [Use with --list when unregistered].
+Gives the username for the account to use to connect to the organization account [Usable with --list on unregistered systems].
 
 .TP
 .B --password=PASSWORD
-Gives the user account password [Use with --list when unregistered].
+Gives the user account password [Usable with --list on unregistered systems].
 
 .TP
 .B --token=TOKEN
-Token to use when authorizing against the server [Use with --list when unregistered].
+Token to use when authorizing against the server [Usable with --list on unregistered systems].
+
+.TP
+.B --org=ORG
+Identifies the organization for which the role applies [Usable with --list on unregistered systems].
 
 .TP
 .B --set=ROLE
@@ -478,10 +482,6 @@ Role to apply to this system
 .TP
 .B --unset
 Removes any previously set role preference.
-
-.TP
-.B --org=ORG
-Identifies the organization for which the role applies.
 
 
 .SS service-level options
@@ -509,15 +509,15 @@ Lists the available service levels.
 
 .TP
 .B --username=USERNAME
-Gives the username for the account to use to connect to the organization account [Use with --list when unregistered].
+Gives the username for the account to use to connect to the organization account [Usable with --list on unregistered systems].
 
 .TP
 .B --password=PASSWORD
-Gives the user account password [Use with --list when unregistered].
+Gives the user account password [Usable with --list on unregistered systems].
 
 .TP
 .B --token=TOKEN
-Token to use when authorizing against the server [Use with --list when unregistered].
+Token to use when authorizing against the server [Usable with --list on unregistered systems].
 
 .TP
 .B --set=SERVICE_LEVEL
@@ -545,15 +545,19 @@ Lists the available usage system purpose values.
 
 .TP
 .B --username=USERNAME
-Gives the username for the account to use to connect to the organization account [Use with --list when unregistered].
+Gives the username for the account to use to connect to the organization account [Usable with --list on unregistered systems].
 
 .TP
 .B --password=PASSWORD
-Gives the user account password [Use with --list when unregistered].
+Gives the user account password [Usable with --list on unregistered systems].
 
 .TP
 .B --token=TOKEN
-Token to use when authorizing against the server [Use with --list when unregistered].
+Token to use when authorizing against the server [Usable with --list on unregistered systems].
+
+.TP
+.B --org=ORG
+Identifies the organization for which the usage applies [Usable with --list on unregistered systems].
 
 .TP
 .B --set=USAGE
@@ -562,10 +566,6 @@ Usage to apply to this system
 .TP
 .B --unset
 Removes any previously set usage preference.
-
-.TP
-.B --org=ORG
-Identifies the organization for which the usage applies.
 
 
 .SS IMPORT OPTIONS

--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -155,6 +155,17 @@ class AbstractSyspurposeCommand(CliCommand):
             else:
                 system_exit(ERR_NOT_REGISTERED_CODE, ERR_NOT_REGISTERED_MSG)
 
+        if self.is_registered() and (
+            getattr(self.options, "username", None) or
+            getattr(self.options, "password", None) or
+            getattr(self.options, "token", None) or
+            getattr(self.options, "org", None)
+        ):
+            system_exit(os.EX_USAGE, _(
+                "Error: --username, --password, --token and --org "
+                "can be used only on unregistered systems"
+            ))
+
     def _get_valid_fields(self):
         """
         Try to get valid fields from server

--- a/src/subscription_manager/cli_command/service_level.py
+++ b/src/subscription_manager/cli_command/service_level.py
@@ -82,6 +82,17 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
             else:
                 system_exit(ERR_NOT_REGISTERED_CODE, ERR_NOT_REGISTERED_MSG)
 
+        if self.is_registered() and (
+            getattr(self.options, "username", None) or
+            getattr(self.options, "password", None) or
+            getattr(self.options, "token", None) or
+            getattr(self.options, "org", None)
+        ):
+            system_exit(os.EX_USAGE, _(
+                "Error: --username, --password, --token and --org "
+                "can be used only on unregistered systems"
+            ))
+
     def _do_command(self):
         self._validate_options()
         try:

--- a/test/cli_command_test/test_role.py
+++ b/test/cli_command_test/test_role.py
@@ -48,13 +48,12 @@ class TestRoleCommand(TestCliProxyCommand):
         self.cc.cp.registered_consumer_info['role'] = None
         self.cc.cp._capabilities = ["syspurpose"]
 
-    def test_org_requires_list_good(self):
-        self.cc.main(["--org", "one", "--list"])
-
     def test_list_username_password_org(self):
+        self.cc.is_registered = Mock(return_value=False)
         self.cc.main(["--username", "admin", "--password", "secret", "--org", "one", "--list"])
 
     def test_list_username_password(self):
+        self.cc.is_registered = Mock(return_value=False)
         self.cc.main(["--username", "admin", "--password", "secret", "--list"])
 
     def test_list_only_username(self):
@@ -96,6 +95,70 @@ class TestRoleCommand(TestCliProxyCommand):
         self.cc.options.unset = True
         self.cc.options.to_add = False
         self.cc.options.to_remove = False
+        try:
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)
+
+    def test_username_on_registered_system(self):
+        """Argument --username cannot be used on registered system."""
+        self.cc.is_registered = Mock(return_value=True)
+        self.cc.options = Mock()
+        self.cc.options.set = None
+        self.cc.options.unset = None
+        self.cc.options.to_add = None
+        self.cc.options.to_remove = None
+        self.cc.options.show = None
+        self.cc.options.list = True
+        self.cc.options.username = "admin"
+        try:
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)
+
+    def test_password_on_registered_system(self):
+        """Argument --password cannot be used on registered system."""
+        self.cc.is_registered = Mock(return_value=True)
+        self.cc.options = Mock()
+        self.cc.options.set = None
+        self.cc.options.unset = None
+        self.cc.options.to_add = None
+        self.cc.options.to_remove = None
+        self.cc.options.show = None
+        self.cc.options.list = True
+        self.cc.options.password = "secret"
+        try:
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)
+
+    def test_token_on_registered_system(self):
+        """Argument --token cannot be used on registered system."""
+        self.cc.is_registered = Mock(return_value=True)
+        self.cc.options = Mock()
+        self.cc.options.set = None
+        self.cc.options.unset = None
+        self.cc.options.to_add = None
+        self.cc.options.to_remove = None
+        self.cc.options.show = None
+        self.cc.options.list = True
+        self.cc.options.token = "TOKEN"
+        try:
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)
+
+    def test_org_on_registered_system(self):
+        """Argument --org cannot be used on registered system."""
+        self.cc.is_registered = Mock(return_value=True)
+        self.cc.options = Mock()
+        self.cc.options.set = None
+        self.cc.options.unset = None
+        self.cc.options.to_add = None
+        self.cc.options.to_remove = None
+        self.cc.options.show = None
+        self.cc.options.list = True
+        self.cc.options.org = "organization"
         try:
             self.cc._validate_options()
         except SystemExit as e:

--- a/test/cli_command_test/test_service_level.py
+++ b/test/cli_command_test/test_service_level.py
@@ -54,6 +54,7 @@ class TestServiceLevelCommand(TestCliProxyCommand):
             self.assertEqual(e.code, os.EX_USAGE)
 
     def test_set_allows_list_good(self):
+        self.cc.is_registered = Mock(return_value=False)
         self.cc.main(["--set", "two", "--org", "test"])
         self.cc._validate_options()
 
@@ -109,3 +110,67 @@ class TestServiceLevelCommand(TestCliProxyCommand):
         self.cc.cp.updateConsumer.assert_has_calls(
             [call('fixture_identity_mock_uuid', service_level='JRJAR')]
         )
+
+    def test_username_on_registered_system(self):
+        """Argument --username cannot be used on registered system."""
+        self.cc.is_registered = Mock(return_value=True)
+        self.cc.options = Mock()
+        self.cc.options.set = None
+        self.cc.options.unset = None
+        self.cc.options.to_add = None
+        self.cc.options.to_remove = None
+        self.cc.options.show = None
+        self.cc.options.list = True
+        self.cc.options.username = "admin"
+        try:
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)
+
+    def test_password_on_registered_system(self):
+        """Argument --password cannot be used on registered system."""
+        self.cc.is_registered = Mock(return_value=True)
+        self.cc.options = Mock()
+        self.cc.options.set = None
+        self.cc.options.unset = None
+        self.cc.options.to_add = None
+        self.cc.options.to_remove = None
+        self.cc.options.show = None
+        self.cc.options.list = True
+        self.cc.options.password = "secret"
+        try:
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)
+
+    def test_token_on_registered_system(self):
+        """Argument --token cannot be used on registered system."""
+        self.cc.is_registered = Mock(return_value=True)
+        self.cc.options = Mock()
+        self.cc.options.set = None
+        self.cc.options.unset = None
+        self.cc.options.to_add = None
+        self.cc.options.to_remove = None
+        self.cc.options.show = None
+        self.cc.options.list = True
+        self.cc.options.token = "TOKEN"
+        try:
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)
+
+    def test_org_on_registered_system(self):
+        """Argument --org cannot be used on registered system."""
+        self.cc.is_registered = Mock(return_value=True)
+        self.cc.options = Mock()
+        self.cc.options.set = None
+        self.cc.options.unset = None
+        self.cc.options.to_add = None
+        self.cc.options.to_remove = None
+        self.cc.options.show = None
+        self.cc.options.list = True
+        self.cc.options.org = "organization"
+        try:
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)


### PR DESCRIPTION
* Card ID: ENT-2697
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1859569

- If the system is registered, abort if --username, --password, --token or --org are specified.
- In man page, the --org argument has been moved up so it is directly below other arguments usable on unregistered systems.
- For those arguments the description has been altered to clarify their meaning.