### PR TITLE
build: try to reduce potential TOCTOU issues when creating destination directories

### DIFF
--- a/build_ext/build_ext/template.py
+++ b/build_ext/build_ext/template.py
@@ -49,8 +49,7 @@ class BuildTemplate(BaseCommand):
         template = string.Template(template_text)
 
         base_directory = os.path.dirname(dest)
-        if not os.path.exists(base_directory):
-            os.makedirs(base_directory)
+        os.makedirs(base_directory, exist_ok=True)
 
         with open(dest, 'w') as output:
             output_text = template.substitute(self.vars)

--- a/build_ext/build_ext/utils.py
+++ b/build_ext/build_ext/utils.py
@@ -72,11 +72,6 @@ class BaseCommand(cmd.Command):
 
 class Utils(object):
     @staticmethod
-    def create_dest_dir(dest):
-        if not os.path.exists(os.path.dirname(dest)):
-            os.makedirs(os.path.dirname(dest))
-
-    @staticmethod
     def run_if_new(src, dest, callback):
         src_mtime = os.stat(src)[8]
         try:
@@ -84,7 +79,7 @@ class Utils(object):
         except OSError:
             dest_mtime = 0
         if src_mtime > dest_mtime:
-            Utils.create_dest_dir(dest)
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
             callback(src, dest)
 
     @staticmethod

--- a/build_ext/build_ext/utils.py
+++ b/build_ext/build_ext/utils.py
@@ -78,13 +78,13 @@ class Utils(object):
 
     @staticmethod
     def run_if_new(src, dest, callback):
-        Utils.create_dest_dir(dest)
         src_mtime = os.stat(src)[8]
         try:
             dest_mtime = os.stat(dest)[8]
         except OSError:
             dest_mtime = 0
         if src_mtime > dest_mtime:
+            Utils.create_dest_dir(dest)
             callback(src, dest)
 
     @staticmethod


### PR DESCRIPTION
`run_if_new()` will run the callback when the destination file is either
missing or older than the source file, and these are the only cases when
we have to make sure the directory of the destination file exists; in
case the destination file already exists, then also its directory exists
already, and we can avoid even trying to ensure it exists.

Remove TOCTOU issues when creating directories during the build process:
directly use `exist_ok=True` for `os.makedirs()`, so there is no need to
check for the existance of directories just before, risking a potential
race between check and creation (which will fail with `EEXIST`).

Additional note: this might fix, or at least reduce a bit, the "File exists" errors when building translations.