### PR TITLE
1922151: Use in-memory cache on AWS too

### DIFF
--- a/test/rhsmlib_test/test_cloud_facts.py
+++ b/test/rhsmlib_test/test_cloud_facts.py
@@ -23,6 +23,8 @@ import requests
 
 from rhsmlib.facts import cloud_facts
 
+from cloud_what.providers import aws, azure, gcp
+
 from subscription_manager import injection as inj
 
 AWS_METADATA = """
@@ -159,6 +161,12 @@ def mock_prepare_request(request):
 
 class TestCloudCollector(unittest.TestCase):
     def setUp(self):
+        aws.AWSCloudProvider._instance = None
+        aws.AWSCloudProvider._initialized = False
+        azure.AzureCloudProvider._instance = None
+        azure.AzureCloudProvider._initialized = False
+        gcp.GCPCloudProvider._instance = None
+        gcp.GCPCloudProvider._initialized = False
         super(TestCloudCollector, self).setUp()
         self.mock_facts = mock.Mock()
         inj.provide(inj.FACTS, self.mock_facts)

--- a/test/test_auto_registration.py
+++ b/test/test_auto_registration.py
@@ -24,7 +24,7 @@ from mock import patch, Mock
 
 from subscription_manager.scripts.rhsmcertd_worker import _collect_cloud_info
 from .rhsmlib_test.test_cloud_facts import AWS_METADATA
-from cloud_what.providers import aws
+from cloud_what.providers import aws, azure, gcp
 
 AWS_SIGNATURE = """ABCDEFGHIJKLMNOPQRSTVWXYZabcdefghijklmnopqrstvwxyz01234567899w0BBwGggCSABIIB
 73sKICAiYWNjb3VudElkIiA6ICI1NjcwMTQ3ODY4OTAiLAogICJhcmNoaXRlY3R1cmUiIDogIng4
@@ -100,6 +100,15 @@ def mock_prepare_request(request):
 
 
 class TestAutomaticRegistration(unittest.TestCase):
+
+    def setUp(self):
+        aws.AWSCloudProvider._instance = None
+        aws.AWSCloudProvider._initialized = False
+        azure.AzureCloudProvider._instance = None
+        azure.AzureCloudProvider._initialized = False
+        gcp.GCPCloudProvider._instance = None
+        gcp.GCPCloudProvider._initialized = False
+
     @patch('cloud_what.providers.aws.requests.Session')
     def test_collect_cloud_info_one_cloud_provider_detected(self, mock_session_class):
         """

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -217,6 +217,11 @@ class TestProfileManager(unittest.TestCase):
         mock_db.conf.substitutions = {'releasever': '1', 'basearch': 'x86_64'}
         dnf_mock.dnf.Base = Mock(return_value=mock_db)
 
+        provider_patcher = patch('rhsm.profile.provider')
+        provider_mock = provider_patcher.start()
+        provider_mock.get_cloud_provider = Mock(return_value=None)
+        self.addCleanup(provider_patcher.stop)
+
         self.current_profile = self._mock_pkg_profile(current_pkgs, repo_file_name, ENABLED_MODULES)
         self.profile_mgr = ProfileManager()
         self.profile_mgr.current_profile = self.current_profile


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1922151#c5
* In-memory cache wasn't used properly
* All instances of BaseCloudProvider and subclasses are sinletons
  to be able to store in-memory cache easily. The code is not
  thread safe at this momement, because it is not necessary now.
  Making code thread safe will require more effort and it will
  be solved in different PR/commit.
* Fixed unit tests, because singleton is used
* Added unit test for singleton and using in-memory cache