### PR TITLE
Add 'syspurpose' to list of commands in manpage

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -119,11 +119,14 @@ has specific options available for each command, depending on what operation is 
 20. status
 
 .IP
-21. deprecated commands: addons, role, service-level, subscribe, unsubscribe, usage, and activate
+21. syspurpose
 
 .IP
 22. repo-override
 
+.RE
+
+Following commands were deprecated: addons, role, service-level, subscribe, unsubscribe, usage, and activate
 
 .SS COMMON OPTIONS
 .TP


### PR DESCRIPTION
* Card ID: ENT-4150

Syspurpose was added as subscription-manager subcommand in 5406865.
Sections describing its subcommands were altered to match the update,
but 'syspurpose' itself was not added to the list of subcommands.