### PR TITLE
ENT-4168: Unify description of --org argument in syspurpose subcommands

### DIFF
--- a/src/subscription_manager/cli_command/org.py
+++ b/src/subscription_manager/cli_command/org.py
@@ -29,7 +29,7 @@ class OrgCommand(UserPassCommand):
         super(OrgCommand, self).__init__(name, shortdesc, primary)
         self._org = None
         if not hasattr(self, "_org_help_text"):
-            self._org_help_text = _("specify organization")
+            self._org_help_text = _("specify an organization")
         self.parser.add_argument(
             "--org",
             dest="org",

--- a/src/subscription_manager/cli_command/service_level.py
+++ b/src/subscription_manager/cli_command/service_level.py
@@ -38,8 +38,6 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
     def __init__(self, subparser=None):
 
         shortdesc = _("Show or modify the system purpose service-level setting")
-        self._org_help_text = _(
-            "specify an organization when listing available service levels using the organization key, only used with --list")
         super(ServiceLevelCommand, self).__init__(
             "service-level",
             subparser,

--- a/src/subscription_manager/cli_command/usage.py
+++ b/src/subscription_manager/cli_command/usage.py
@@ -23,7 +23,6 @@ class UsageCommand(AbstractSyspurposeCommand, OrgCommand):
 
     def __init__(self, subparser=None):
         shortdesc = _("Show or modify the system purpose usage setting")
-        self._org_help_text = _("use set and unset to define the value for this field")
         super(UsageCommand, self).__init__(
             "usage",
             subparser,


### PR DESCRIPTION
* Card ID: ENT-4168

Before this change 'service-level' and 'usage' contained their own
description of the shared '--org' argument.