### PR TITLE
[1.28] 1922151: Use in-memory cache on AWS too

### DIFF
--- a/src/cloud_what/providers/aws.py
+++ b/src/cloud_what/providers/aws.py
@@ -210,10 +210,13 @@ class AWSCloudProvider(BaseCloudProvider):
         """
         log.debug(f'Trying to get AWS metadata from {self.CLOUD_PROVIDER_METADATA_URL} using IMDSv1')
 
-        return self._get_data_from_server(
+        self._cached_metadata = self._get_data_from_server(
             data_type='metadata',
             url=self.CLOUD_PROVIDER_METADATA_URL
         )
+        if self._cached_metadata is not None:
+            self._cached_metadata_ctime = time.time()
+        return self._cached_metadata
 
     def _get_metadata_from_server_imds_v2(self) -> Union[str, None]:
         """
@@ -231,11 +234,15 @@ class AWSCloudProvider(BaseCloudProvider):
             **self.HTTP_HEADERS
         }
 
-        return self._get_data_from_server(
+        self._cached_metadata = self._get_data_from_server(
             data_type='metadata',
             url=self.CLOUD_PROVIDER_METADATA_URL,
             headers=headers
         )
+
+        if self._cached_metadata is not None:
+            self._cached_metadata_ctime = time.time()
+        return self._cached_metadata
 
     def _get_metadata_from_server(self) -> Union[str, None]:
         """
@@ -323,11 +330,16 @@ class AWSCloudProvider(BaseCloudProvider):
         if signature is not None:
             signature = f'-----BEGIN PKCS7-----\n{signature}\n-----END PKCS7-----'
 
+        # Save signature in in-memory cache
+        if signature is not None:
+            self._cached_signature = signature
+            self._cached_signature_ctime = time.time()
+
         return signature
 
     def get_metadata(self) -> Union[str, None]:
         """
-        Try to get metadata from the cache file first. When the cache file is not available, then try to
+        Try to get metadata from the in-memory cache first. When the in-memory cache is not valid, then try to
         get metadata from server.
         :return: String with metadata or None
         """
@@ -335,7 +347,7 @@ class AWSCloudProvider(BaseCloudProvider):
 
     def get_signature(self) -> Union[str, None]:
         """
-        Try to get signature from the cache file first. When the cache file is not available, then try to
+        Try to get signature from the in-memory cache first. When the in-memory cache is not valid, then try to
         get signature from server.
         :return: String with metadata or None
         """

--- a/test/rhsmlib_test/test_cloud_facts.py
+++ b/test/rhsmlib_test/test_cloud_facts.py
@@ -23,6 +23,8 @@ import requests
 
 from rhsmlib.facts import cloud_facts
 
+from cloud_what.providers import aws, azure, gcp
+
 from subscription_manager import injection as inj
 
 AWS_METADATA = """
@@ -159,6 +161,12 @@ def mock_prepare_request(request):
 
 class TestCloudCollector(unittest.TestCase):
     def setUp(self):
+        aws.AWSCloudProvider._instance = None
+        aws.AWSCloudProvider._initialized = False
+        azure.AzureCloudProvider._instance = None
+        azure.AzureCloudProvider._initialized = False
+        gcp.GCPCloudProvider._instance = None
+        gcp.GCPCloudProvider._initialized = False
         super(TestCloudCollector, self).setUp()
         self.mock_facts = mock.Mock()
         inj.provide(inj.FACTS, self.mock_facts)

--- a/test/test_auto_registration.py
+++ b/test/test_auto_registration.py
@@ -24,7 +24,7 @@ from mock import patch, Mock
 
 from subscription_manager.scripts.rhsmcertd_worker import _collect_cloud_info
 from .rhsmlib_test.test_cloud_facts import AWS_METADATA
-from cloud_what.providers import aws
+from cloud_what.providers import aws, azure, gcp
 
 AWS_SIGNATURE = """ABCDEFGHIJKLMNOPQRSTVWXYZabcdefghijklmnopqrstvwxyz01234567899w0BBwGggCSABIIB
 73sKICAiYWNjb3VudElkIiA6ICI1NjcwMTQ3ODY4OTAiLAogICJhcmNoaXRlY3R1cmUiIDogIng4
@@ -100,6 +100,15 @@ def mock_prepare_request(request):
 
 
 class TestAutomaticRegistration(unittest.TestCase):
+
+    def setUp(self):
+        aws.AWSCloudProvider._instance = None
+        aws.AWSCloudProvider._initialized = False
+        azure.AzureCloudProvider._instance = None
+        azure.AzureCloudProvider._initialized = False
+        gcp.GCPCloudProvider._instance = None
+        gcp.GCPCloudProvider._initialized = False
+
     @patch('cloud_what.providers.aws.requests.Session')
     def test_collect_cloud_info_one_cloud_provider_detected(self, mock_session_class):
         """

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -218,6 +218,11 @@ class TestProfileManager(unittest.TestCase):
         mock_db.conf.substitutions = {'releasever': '1', 'basearch': 'x86_64'}
         dnf_mock.dnf.Base = Mock(return_value=mock_db)
 
+        provider_patcher = patch('rhsm.profile.provider')
+        provider_mock = provider_patcher.start()
+        provider_mock.get_cloud_provider = Mock(return_value=None)
+        self.addCleanup(provider_patcher.stop)
+
         self.current_profile = self._mock_pkg_profile(current_pkgs, repo_file_name, ENABLED_MODULES)
         self.profile_mgr = ProfileManager()
         self.profile_mgr.current_profile = self.current_profile


### PR DESCRIPTION
* Cherry-pick of d0b2bb31ad5efcc0a4a7ce78467c64e28c1adf34 to 1.28 branch
* Original PR: #2730 
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1922151#c5
* In-memory cache wasn't used properly
* All instances of BaseCloudProvider and subclasses are sinletons
  to be able to store in-memory cache easily. The code is not
  thread safe at this momement, because it is not necessary now.
  Making code thread safe will require more effort and it will
  be solved in different PR/commit.
* Fixed unit tests, because singleton is used
* Added unit test for singleton and using in-memory cache