### PR TITLE
[1.28] 1922151: Add /var/cache/cloud-what to python3-cloud-what RPM.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,6 +373,7 @@ install-files: dbus-install install-conf install-plugins install-post-boot insta
 	install -d $(DESTDIR)/var/spool/rhsm/debug
 	install -d $(DESTDIR)${RUN_DIR}/rhsm
 	install -d -m 750 $(DESTDIR)/var/lib/rhsm/{cache,facts,packages,repo_server_val}
+	install -d -m 750 $(DESTDIR)/var/cache/cloud-what
 
 	# Set up rhsmcertd daemon. Installation location depends on distro...
 	# if WITH_SYSTEMD == true: sles12, opensuse42, el7+, or fedora

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1322,6 +1322,7 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 
 %files -n python3-cloud-what
 %defattr(-,root,root,-)
+%attr(750,root,root) %dir %{_var}/cache/cloud-what
 %dir %{python_sitearch}/cloud_what
 %dir %{python_sitearch}/cloud_what/providers
 %{python_sitearch}/cloud_what/*


### PR DESCRIPTION
* Backport of 43dbd7bceef805ad0c6b8a48ba4001a7a2e3e80f to 1.28 branch
* Original PR: #2736
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1922151#c6
* The /var/cache/cloud-what should be part of python3-cloud-what
  RPM to be able to fix SELinux context.
* Permissions for /var/cache/cloud-what: 750 (root:root)
* It will be necessary to create another PR to fix SELinux context
  for this directory too, but it will be done in another PR
  against another repository:
    https://github.com/fedora-selinux/selinux-policy
* PR for selinux-policy here: https://github.com/fedora-selinux/selinux-policy/pull/836