### PR TITLE
ENT-4213: Remove deprecated pep8 package

### DIFF
--- a/build_ext/build_ext/lint.py
+++ b/build_ext/build_ext/lint.py
@@ -25,11 +25,9 @@ from build_ext.utils import Utils, BaseCommand, memoize
 # These dependencies aren't available in build environments.  We won't need any
 # linting functionality there though, so just create a dummy class so we can proceed.
 try:
-    # These dependencies aren't available in build environments.  We won't need any
-    # linting functionality there though, so just create a dummy class so we can proceed.
-    import pep8
+    import pycodestyle
 except ImportError:
-    pep8 = None
+    pycodestyle = None
 
 try:
     import pkg_resources
@@ -403,7 +401,7 @@ def detect_overindent(logical_line, tokens, indent_level, hang_closing, indent_c
     """Flag lines that are overindented.  This includes lines that are indented solely to align
     vertically with an opening brace.  This rule allows continuation lines to be relatively
     indented up to 8 spaces and closes braces to be relatively indented up to 4 spaces.  Heavily
-    adapted from pep8's continued_indentation method
+    adapted from pycodestyle's continued_indentation method
 
     Okay: foo = my_func('hello',
               'world'
@@ -441,7 +439,7 @@ def detect_overindent(logical_line, tokens, indent_level, hang_closing, indent_c
         newline = row < start[0] - first_row
         if newline:
             row = start[0] - first_row
-            newline = not last_token_multiline and token_type not in pep8.NEWLINE
+            newline = not last_token_multiline and token_type not in pycodestyle.NEWLINE
 
         if newline:
             # this is the beginning of a continuation line.
@@ -450,7 +448,7 @@ def detect_overindent(logical_line, tokens, indent_level, hang_closing, indent_c
                 print("... " + line.rstrip())
 
             # record the initial indent.
-            rel_indent[row] = pep8.expand_indent(line) - indent_level
+            rel_indent[row] = pycodestyle.expand_indent(line) - indent_level
 
             # identify closing bracket
             close_bracket = (token_type == tokenize.OP and text in ']})')

--- a/build_ext/setup.py
+++ b/build_ext/setup.py
@@ -20,9 +20,7 @@ test_require = [
 ]
 
 install_requires = [
-    'pep8',
     'flake8',
-    'pyflakes',
     'lxml'
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,4 @@
 
-# ignore errors:
-# E501 is line too long
-# E12* are continuation line indention related
-# E713,E714 are 'not a in b' v 'a not in b' suggests
-#   Need to be removed when those are fixed.
-# E265 block comment should start with '#'
-# V250 and V260 comes from pyqver2 and indicate that the given line
-#   requires Python 2.5 or 2.6 and up.  Since we only support 2.6 and up,
-#   we don't care about these two errors.
-
-# TODO: Investigate if these are worthile and fix
-# E402 module level import not at top of file
-# E731 do not assign a lambda expression, use a def
-
-# TODO enable E198, E199, E122, E124, E121
-[pep8]
-ignore=E123,E125,E126,E127,E128,E129,E265,E402,E501,E713,E714,E731,E198,E199,E122,E124,E121,E131
-max-line-length=300
-
 [flake8]
 ignore=E123,E125,E126,E127,E128,E129,E265,E402,E501,E713,E714,E731,V250,V260,E198,E199,E122,E124,E121,E131,F403
 exclude=*certdata*,*manifestdata*


### PR DESCRIPTION
* Card ID: ENT-4213

Package pep8 has been renamed to pycodestyle in 2017.

pycodestyle is a dependency for flake8, this will not alter any linting
behavior.