### PR TITLE
[1.28] 1983074: Remove invalid log level

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -208,8 +208,8 @@ class RhsmConfigParser(SafeConfigParser):
         :param print_warning: print warning, when provided value is not valid
         :return: True, when value is valid. Otherwise return False
         """
-        valid = ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOSET']
-        if value not in valid:
+        valid = ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG']
+        if value not in valid + ["NOTSET"]:
             if print_warning is True:
                 print("Invalid Log Level: {lvl}, setting to INFO for this run.".format(lvl=value), file=sys.stderr)
                 print(


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1983074
* Card ID: ENT-4174

'NOSET' is not supported log level, and should not be included in the
list of possible log level values.