### PR TITLE
1995465: Do not use deprecated collections.MutableMapping

### DIFF
--- a/src/rhsmlib/facts/collection.py
+++ b/src/rhsmlib/facts/collection.py
@@ -13,14 +13,14 @@ from __future__ import print_function, division, absolute_import
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
 from datetime import datetime
-import collections
+import collections.abc
 import logging
 
 log = logging.getLogger(__name__)
 
 
 # TODO: Likely a bit much for this case
-class FactsDict(collections.MutableMapping):
+class FactsDict(collections.abc.MutableMapping):
     """A dict for facts that ignores items in 'graylist' on compares."""
 
     graylist = set(['cpu.cpu_mhz', 'lscpu.cpu_mhz'])

--- a/src/rhsmlib/services/config.py
+++ b/src/rhsmlib/services/config.py
@@ -14,11 +14,11 @@ from __future__ import print_function, division, absolute_import
 # in this software or its documentation.
 #
 import rhsm.config
-import collections
+import collections.abc
 import six
 
 
-class Config(collections.MutableMapping):
+class Config(collections.abc.MutableMapping):
     def __init__(self, parser=None, auto_persist=False):
         if parser:
             self._parser = parser
@@ -94,7 +94,7 @@ class Config(collections.MutableMapping):
         return "%s" % result
 
 
-class ConfigSection(collections.MutableMapping):
+class ConfigSection(collections.abc.MutableMapping):
     def __init__(self, wrapper, parser, section, auto_persist=False):
         self._wrapper = wrapper
         self._parser = parser

--- a/test/test_productid.py
+++ b/test/test_productid.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     import unittest
 
-import collections
+import collections.abc
 import os
 import shutil
 import tempfile
@@ -305,7 +305,7 @@ class TestProductDatabase(unittest.TestCase):
     def test_find_repos_old_format(self):
         self.pdb.populate_content({'product': 'repo'})
         repo = self.pdb.find_repos("product")
-        self.assertTrue(isinstance(repo, collections.Iterable))
+        self.assertTrue(isinstance(repo, collections.abc.Iterable))
         self.assertTrue("repo" in repo)
 
     def test_add_old_format(self):
@@ -319,10 +319,10 @@ class TestProductDatabase(unittest.TestCase):
         self.pdb.populate_content({'product1': 'repo1',
                                    'product2': ['repo2']})
         repo1 = self.pdb.find_repos("product1")
-        self.assertTrue(isinstance(repo1, collections.Iterable))
+        self.assertTrue(isinstance(repo1, collections.abc.Iterable))
         self.assertTrue("repo1" in repo1)
         repo2 = self.pdb.find_repos("product2")
-        self.assertTrue(isinstance(repo2, collections.Iterable))
+        self.assertTrue(isinstance(repo2, collections.abc.Iterable))
         self.assertTrue("repo2" in repo2)
 
     def test_add_mixed_old_and_new_format(self):
@@ -334,9 +334,9 @@ class TestProductDatabase(unittest.TestCase):
         product1_repos = self.pdb.find_repos('product1')
         product2_repos = self.pdb.find_repos('product2')
         product3_repos = self.pdb.find_repos('product3')
-        self.assertTrue(isinstance(product1_repos, collections.Iterable))
-        self.assertTrue(isinstance(product2_repos, collections.Iterable))
-        self.assertTrue(isinstance(product3_repos, collections.Iterable))
+        self.assertTrue(isinstance(product1_repos, collections.abc.Iterable))
+        self.assertTrue(isinstance(product2_repos, collections.abc.Iterable))
+        self.assertTrue(isinstance(product3_repos, collections.abc.Iterable))
         self.assertEqual(["product1-repo1", "product1-repo2"],
                          product1_repos)
         self.assertEqual(["product2-repo1", "product2-repo2"],


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1995465
* The `collections.MutableMapping` was deprecated in Python 3.3
  and new `collections.abc.MutableMapping` should be used.
  The old API will be completely removed in Python 3.10.
* Fixed another similar issue with `collections.Iterable`
  in unit tests