### PR TITLE
ENT-4228: Always format restlib exceptions

### DIFF
--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -23,6 +23,7 @@ from rhsm.connection import ProxyException
 from subscription_manager import syspurposelib
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand, ERR_NOT_REGISTERED_CODE, ERR_NOT_REGISTERED_MSG
+from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ungettext, ugettext as _
 from subscription_manager.syspurposelib import get_syspurpose_valid_fields
 from subscription_manager.utils import friendly_join
@@ -410,7 +411,8 @@ class AbstractSyspurposeCommand(CliCommand):
             log.exception(err)
             if getattr(self.options, 'list', None):
                 log.error("Error: Unable to retrieve {attr} from server: {err}".format(attr=self.attr, err=err))
-                system_exit(os.EX_SOFTWARE, str(err))
+                mapped_message: str = ExceptionMapper().get_message(re)
+                system_exit(os.EX_SOFTWARE, mapped_message)
             else:
                 log.debug("Error: Unable to retrieve {attr} from server: {err}".format(attr=self.attr, err=err))
         except Exception as err:

--- a/src/subscription_manager/cli_command/cli.py
+++ b/src/subscription_manager/cli_command/cli.py
@@ -63,12 +63,8 @@ def handle_exception(msg, ex):
 
     exception_mapper = ExceptionMapper()
 
-    mapped_message = exception_mapper.get_message(ex)
-
-    if mapped_message:
-        system_exit(os.EX_SOFTWARE, mapped_message)
-    else:
-        system_exit(os.EX_SOFTWARE, ex)
+    mapped_message: str = exception_mapper.get_message(ex)
+    system_exit(os.EX_SOFTWARE, mapped_message)
 
 
 class CliCommand(AbstractCLICommand):

--- a/src/subscription_manager/cli_command/environments.py
+++ b/src/subscription_manager/cli_command/environments.py
@@ -23,6 +23,7 @@ from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import handle_exception
 from subscription_manager.cli_command.org import OrgCommand
 from subscription_manager.cli_command.list import ENVIRONMENT_LIST
+from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.printing_utils import columnize, echo_columnize_callback
 from subscription_manager.utils import get_supported_resources
@@ -71,6 +72,8 @@ class EnvironmentsCommand(OrgCommand):
         except connection.RestlibException as re:
             log.exception(re)
             log.error("Error: Unable to retrieve environment list from server: {re}".format(re=re))
-            system_exit(os.EX_SOFTWARE, str(re))
+
+            mapped_message: str = ExceptionMapper().get_message(re)
+            system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(_("Error: Unable to retrieve environment list from server"), e)

--- a/src/subscription_manager/cli_command/facts.py
+++ b/src/subscription_manager/cli_command/facts.py
@@ -22,6 +22,7 @@ import subscription_manager.injection as inj
 
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand
+from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
@@ -69,6 +70,8 @@ class FactsCommand(CliCommand):
                 raise ge
             except connection.RestlibException as re:
                 log.exception(re)
-                system_exit(os.EX_SOFTWARE, str(re))
+
+                mapped_message: str = ExceptionMapper().get_message(re)
+                system_exit(os.EX_SOFTWARE, mapped_message)
             log.debug("Succesfully updated the system facts.")
             print(_("Successfully updated the system facts."))

--- a/src/subscription_manager/cli_command/identity.py
+++ b/src/subscription_manager/cli_command/identity.py
@@ -27,6 +27,7 @@ from subscription_manager.branding import get_branding
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import handle_exception
 from subscription_manager.cli_command.user_pass import UserPassCommand
+from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.utils import get_current_owner, get_supported_resources
 
@@ -116,6 +117,8 @@ class IdentityCommand(UserPassCommand):
         except connection.RestlibException as re:
             log.exception(re)
             log.error("Error: Unable to generate a new identity for the system: {re}".format(re=re))
-            system_exit(os.EX_SOFTWARE, str(re))
+
+            mapped_message: str = ExceptionMapper().get_message(re)
+            system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(_("Error: Unable to generate a new identity for the system"), e)

--- a/src/subscription_manager/cli_command/owners.py
+++ b/src/subscription_manager/cli_command/owners.py
@@ -23,6 +23,7 @@ from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import handle_exception
 from subscription_manager.cli_command.list import ORG_LIST
 from subscription_manager.cli_command.user_pass import UserPassCommand
+from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.printing_utils import columnize, echo_columnize_callback
 
@@ -63,6 +64,8 @@ class OwnersCommand(UserPassCommand):
         except connection.RestlibException as re:
             log.exception(re)
             log.error("Error: Unable to retrieve org list from server: {re}".format(re=re))
-            system_exit(os.EX_SOFTWARE, str(re))
+
+            mapped_message: str = ExceptionMapper().get_message(re)
+            system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(_("Error: Unable to retrieve org list from server"), e)

--- a/src/subscription_manager/cli_command/refresh.py
+++ b/src/subscription_manager/cli_command/refresh.py
@@ -22,6 +22,7 @@ import subscription_manager.injection as inj
 
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand, handle_exception
+from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
@@ -61,7 +62,9 @@ class RefreshCommand(CliCommand):
             print(_("All local data refreshed"))
         except connection.RestlibException as re:
             log.error(re)
-            system_exit(os.EX_SOFTWARE, str(re))
+
+            mapped_message: str = ExceptionMapper().get_message(re)
+            system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(_("Unable to perform refresh due to the following exception: {e}").format(e=e), e)
 

--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -37,6 +37,7 @@ from subscription_manager.cli_command.cli import handle_exception, conf
 from subscription_manager.cli_command.list import show_autosubscribe_output
 from subscription_manager.cli_command.user_pass import UserPassCommand
 from subscription_manager.entcertlib import CONTENT_ACCESS_CERT_CAPABILITY
+from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.utils import restart_virt_who, print_error, get_supported_resources, \
     is_simple_content_access
@@ -141,7 +142,8 @@ class RegisterCommand(UserPassCommand):
             # set during service.register() call
             attach.AttachService(self.cp).attach_auto(service_level=None)
         except connection.RestlibException as rest_lib_err:
-            print_error(rest_lib_err.msg)
+            mapped_message: str = ExceptionMapper().get_message(rest_lib_err)
+            print_error(mapped_message)
         except Exception:
             log.exception("Auto-attach failed")
             raise
@@ -235,7 +237,9 @@ class RegisterCommand(UserPassCommand):
                 )
         except (connection.RestlibException, exceptions.ServiceError) as re:
             log.exception(re)
-            system_exit(os.EX_SOFTWARE, re)
+
+            mapped_message: str = ExceptionMapper().get_message(re)
+            system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(_("Error during registration: {e}").format(e=e), e)
         else:

--- a/src/subscription_manager/cli_command/remove.py
+++ b/src/subscription_manager/cli_command/remove.py
@@ -23,6 +23,7 @@ from rhsmlib.services import entitlement
 
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand, handle_exception
+from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ungettext, ugettext as _
 from subscription_manager.utils import unique_list_items
 
@@ -138,7 +139,9 @@ class RemoveCommand(CliCommand):
                 raise ge
             except connection.RestlibException as err:
                 log.error(err)
-                system_exit(os.EX_SOFTWARE, str(err))
+
+                mapped_message: str = ExceptionMapper().get_message(err)
+                system_exit(os.EX_SOFTWARE, mapped_message)
             except Exception as e:
                 handle_exception(_("Unable to perform remove due to the following exception: {e}").format(e=e), e)
         else:

--- a/src/subscription_manager/cli_command/service_level.py
+++ b/src/subscription_manager/cli_command/service_level.py
@@ -26,6 +26,7 @@ from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.abstract_syspurpose import AbstractSyspurposeCommand
 from subscription_manager.cli_command.cli import ERR_NOT_REGISTERED_CODE, ERR_NOT_REGISTERED_MSG, handle_exception
 from subscription_manager.cli_command.org import OrgCommand
+from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 
 from syspurpose.files import SyncedStore
@@ -110,7 +111,9 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
         except connection.RestlibException as re:
             log.exception(re)
             log.error(u"Error: Unable to retrieve service levels: {re}".format(re=re))
-            system_exit(os.EX_SOFTWARE, str(re))
+
+            mapped_message: str = ExceptionMapper().get_message(re)
+            system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(_("Error: Unable to retrieve service levels."), e)
         else:
@@ -132,7 +135,9 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
             except connection.RestlibException as re_err:
                 log.exception(re_err)
                 log.error(u"Error: Unable to retrieve service levels: {err}".format(err=re_err))
-                system_exit(os.EX_SOFTWARE, str(re_err))
+
+                mapped_message: str = ExceptionMapper().get_message(re_err)
+                system_exit(os.EX_SOFTWARE, mapped_message)
             except ProxyException:
                 system_exit(os.EX_UNAVAILABLE, _("Proxy connection failed, please check your settings."))
 
@@ -202,6 +207,7 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
             if e.code == 404 and e.msg.find('/servicelevels') > 0:
                 system_exit(os.EX_UNAVAILABLE, _("Error: The service-level command is not supported by the server."))
             elif e.code == 404:
-                system_exit(os.EX_DATAERR, _(str(e)))
+                mapped_message: str = ExceptionMapper().get_message(e)
+                system_exit(os.EX_DATAERR, mapped_message)
             else:
                 raise e

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -41,7 +41,7 @@ class TestExceptionMapper(unittest.TestCase):
     def test_single_mapped_exception(self):
         expected_message = "Single Exception Message"
         mapper = ExceptionMapper()
-        mapper.message_map[RuntimeError] = (expected_message, mapper.format_default)
+        mapper.message_map[RuntimeError] = (expected_message, mapper.format_using_template)
 
         err = RuntimeError("Testing")
         self.assertEqual(expected_message, mapper.get_message(err))
@@ -49,7 +49,7 @@ class TestExceptionMapper(unittest.TestCase):
     def test_subclass_mapped_by_base_class(self):
         expected_message = "Single Exception Message"
         mapper = ExceptionMapper()
-        mapper.message_map[RuntimeError] = (expected_message, mapper.format_default)
+        mapper.message_map[RuntimeError] = (expected_message, mapper.format_using_template)
 
         err = MyRuntimeError("Testing base class")
         self.assertEqual(expected_message, mapper.get_message(err))
@@ -57,9 +57,9 @@ class TestExceptionMapper(unittest.TestCase):
     def test_subclass_preferred_over_base_class(self):
         expected_message = "Subclass Exception Message"
         mapper = ExceptionMapper()
-        mapper.message_map[RuntimeError] = ("RuntimeError message", mapper.format_default)
-        mapper.message_map[MyRuntimeErrorBase] = ("MyRuntimeErrorBase message", mapper.format_default)
-        mapper.message_map[MyRuntimeError] = (expected_message, mapper.format_default)
+        mapper.message_map[RuntimeError] = ("RuntimeError message", mapper.format_using_template)
+        mapper.message_map[MyRuntimeErrorBase] = ("MyRuntimeErrorBase message", mapper.format_using_template)
+        mapper.message_map[MyRuntimeError] = (expected_message, mapper.format_using_template)
 
         err = MyRuntimeError("Logged Only")
         self.assertEqual(expected_message, mapper.get_message(err))
@@ -67,9 +67,9 @@ class TestExceptionMapper(unittest.TestCase):
     def test_can_map_middle_sub_class(self):
         expected_message = "MyRuntimeErrorBase message"
         mapper = ExceptionMapper()
-        mapper.message_map[RuntimeError] = ("RuntimeError message", mapper.format_default)
-        mapper.message_map[MyRuntimeErrorBase] = (expected_message, mapper.format_default)
-        mapper.message_map[MyRuntimeError] = ("MyRuntimeError message", mapper.format_default)
+        mapper.message_map[RuntimeError] = ("RuntimeError message", mapper.format_using_template)
+        mapper.message_map[MyRuntimeErrorBase] = (expected_message, mapper.format_using_template)
+        mapper.message_map[MyRuntimeError] = ("MyRuntimeError message", mapper.format_using_template)
 
         err = MyRuntimeErrorBase("Logged Only")
         self.assertEqual(expected_message, mapper.get_message(err))
@@ -78,7 +78,7 @@ class TestExceptionMapper(unittest.TestCase):
         mapper = ExceptionMapper()
         expected_message = "RuntimeError message"
 
-        mapper.message_map[RuntimeError] = (expected_message, mapper.format_default)
+        mapper.message_map[RuntimeError] = (expected_message, mapper.format_using_template)
         err = MyRuntimeError("Logged Only")
         self.assertEqual(expected_message, mapper.get_message(err))
 
@@ -89,14 +89,17 @@ class TestExceptionMapper(unittest.TestCase):
         err = RestlibException(404, expected_message)
         self.assertEqual(f"{expected_message} (HTTP error code 404: Not Found)", mapper.get_message(err))
 
-    def test_returns_none_when_no_mapped_exception_present(self):
+    def test_return_str_when_no_mapped_exception(self):
+        expected_message = "Expected message"
         mapper = ExceptionMapper()
-        self.assertEqual(None, mapper.get_message(RuntimeError()))
+
+        err = RuntimeError(expected_message)
+        self.assertEqual(expected_message, mapper.get_message(err))
 
     def test_can_support_old_style_classes(self):
         expected_message = "Old style class"
         mapper = ExceptionMapper()
-        mapper.message_map[OldStyleClass] = (expected_message, mapper.format_default)
+        mapper.message_map[OldStyleClass] = (expected_message, mapper.format_using_template)
 
         err = OldStyleClass()
         self.assertEqual(expected_message, mapper.get_message(err))


### PR DESCRIPTION
* Card ID: ENT-4228

Following PR #2706 (ab97ef6, ENT-3914) this change formats the rest of
rhsmlib exceptions with ExceptionMapper. It ensures that the exceptions
have unified format of "Message from candlepin. (HTTP error code XXX: YYY)".