### PR TITLE
[1.28] ENT-4228: Always format rhsmlib exceptions

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -220,12 +220,8 @@ def handle_exception(msg, ex):
 
     exception_mapper = ExceptionMapper()
 
-    mapped_message = exception_mapper.get_message(ex)
-
-    if mapped_message:
-        system_exit(os.EX_SOFTWARE, mapped_message)
-    else:
-        system_exit(os.EX_SOFTWARE, ex)
+    mapped_message: str = exception_mapper.get_message(ex)
+    system_exit(os.EX_SOFTWARE, mapped_message)
 
 
 def show_autosubscribe_output(uep, identity):

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -3233,7 +3233,8 @@ class OverrideCommand(CliCommand):
                 if ex.code == 400:
                     # black listed overrides specified.
                     # Print message and return a less severe code.
-                    system_exit(1, ex)
+                    mapped_message: str = ExceptionMapper().get_message(ex)
+                    system_exit(1, mapped_message)
                 else:
                     raise ex
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -939,7 +939,8 @@ class SyspurposeCommand(CliCommand):
             log.exception(re)
             if getattr(self.options, 'list', None):
                 log.error("Error: Unable to retrieve %s from server: %s" % (self.attr, err))
-                system_exit(os.EX_SOFTWARE, err.msg)
+                mapped_message: str = ExceptionMapper().get_message(err)
+                system_exit(os.EX_SOFTWARE, mapped_message)
             else:
                 log.debug("Error: Unable to retrieve %s from server: %s" % (self.attr, err))
         except Exception as err:
@@ -1116,7 +1117,8 @@ class RefreshCommand(CliCommand):
             print(_("All local data refreshed"))
         except connection.RestlibException as re:
             log.error(re)
-            system_exit(os.EX_SOFTWARE, re.msg)
+            mapped_message: str = ExceptionMapper().get_message(re)
+            system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(_("Unable to perform refresh due to the following exception: %s") % e, e)
 
@@ -1206,7 +1208,8 @@ class IdentityCommand(UserPassCommand):
         except connection.RestlibException as re:
             log.exception(re)
             log.error(u"Error: Unable to generate a new identity for the system: %s" % re)
-            system_exit(os.EX_SOFTWARE, re.msg)
+            mapped_message: str = ExceptionMapper().get_message(re)
+            system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(_("Error: Unable to generate a new identity for the system"), e)
 
@@ -1245,7 +1248,8 @@ class OwnersCommand(UserPassCommand):
         except connection.RestlibException as re:
             log.exception(re)
             log.error(u"Error: Unable to retrieve org list from server: %s" % re)
-            system_exit(os.EX_SOFTWARE, re.msg)
+            mapped_message: str = ExceptionMapper().get_message(re)
+            system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(_("Error: Unable to retrieve org list from server"), e)
 
@@ -1291,7 +1295,8 @@ class EnvironmentsCommand(OrgCommand):
         except connection.RestlibException as re:
             log.exception(re)
             log.error(u"Error: Unable to retrieve environment list from server: %s" % re)
-            system_exit(os.EX_SOFTWARE, re.msg)
+            mapped_message: str = ExceptionMapper().get_message(re)
+            system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(_("Error: Unable to retrieve environment list from server"), e)
 
@@ -1405,7 +1410,8 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
         except connection.RestlibException as re:
             log.exception(re)
             log.error(u"Error: Unable to retrieve service levels: %s" % re)
-            system_exit(os.EX_SOFTWARE, re.msg)
+            mapped_message: str = ExceptionMapper().get_message(re)
+            system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(_("Error: Unable to retrieve service levels."), e)
         else:
@@ -1427,7 +1433,8 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
             except connection.RestlibException as re_err:
                 log.exception(re_err)
                 log.error(u"Error: Unable to retrieve service levels: %s" % re_err)
-                system_exit(os.EX_SOFTWARE, re_err.msg)
+                mapped_message: str = ExceptionMapper().get_message(re_err)
+                system_exit(os.EX_SOFTWARE, mapped_message)
             except ProxyException:
                 system_exit(os.EX_UNAVAILABLE, _("Proxy connection failed, please check your settings."))
 
@@ -1494,7 +1501,8 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
             if e.code == 404 and e.msg.find('/servicelevels') > 0:
                 system_exit(os.EX_UNAVAILABLE, _("Error: The service-level command is not supported by the server."))
             elif e.code == 404:
-                system_exit(os.EX_DATAERR, _(e.msg))
+                mapped_message: str = ExceptionMapper().get_message(e)
+                system_exit(os.EX_DATAERR, mapped_message)
             else:
                 raise e
 
@@ -1608,7 +1616,8 @@ class RegisterCommand(UserPassCommand):
             # set during service.register() call
             attach.AttachService(self.cp).attach_auto(service_level=None)
         except connection.RestlibException as rest_lib_err:
-            print_error(rest_lib_err.msg)
+            mapped_message: str = ExceptionMapper().get_message(rest_lib_err)
+            print_error(mapped_message)
         except Exception:
             log.exception("Auto-attach failed")
             raise
@@ -1702,7 +1711,8 @@ class RegisterCommand(UserPassCommand):
                 )
         except (connection.RestlibException, exceptions.ServiceError) as re:
             log.exception(re)
-            system_exit(os.EX_SOFTWARE, re)
+            mapped_message: str = ExceptionMapper().get_message(re)
+            system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(_("Error during registration: %s") % e, e)
         else:
@@ -2181,10 +2191,7 @@ class AttachCommand(CliCommand):
                             subscribed = True
                     except connection.RestlibException as re:
                         log.exception(re)
-
-                        exception_mapper = ExceptionMapper()
-                        mapped_message = exception_mapper.get_message(re)
-
+                        mapped_message: str = ExceptionMapper().get_message(re)
                         if re.code == 403:
                             print(mapped_message)  # already subscribed.
                         elif re.code == 400 or re.code == 404:
@@ -2384,7 +2391,8 @@ class RemoveCommand(CliCommand):
                 raise ge
             except connection.RestlibException as err:
                 log.error(err)
-                system_exit(os.EX_SOFTWARE, err.msg)
+                mapped_message: str = ExceptionMapper().get_message(err)
+                system_exit(os.EX_SOFTWARE, mapped_message)
             except Exception as e:
                 handle_exception(_("Unable to perform remove due to the following exception: %s") % e, e)
         else:
@@ -2474,7 +2482,8 @@ class FactsCommand(CliCommand):
                 raise ge
             except connection.RestlibException as re:
                 log.exception(re)
-                system_exit(os.EX_SOFTWARE, re.msg)
+                mapped_message: str = ExceptionMapper().get_message(re)
+                system_exit(os.EX_SOFTWARE, mapped_message)
             log.debug("Succesfully updated the system facts.")
             print(_("Successfully updated the system facts."))
 

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -41,7 +41,7 @@ class TestExceptionMapper(unittest.TestCase):
     def test_single_mapped_exception(self):
         expected_message = "Single Exception Message"
         mapper = ExceptionMapper()
-        mapper.message_map[RuntimeError] = (expected_message, mapper.format_default)
+        mapper.message_map[RuntimeError] = (expected_message, mapper.format_using_template)
 
         err = RuntimeError("Testing")
         self.assertEqual(expected_message, mapper.get_message(err))
@@ -49,7 +49,7 @@ class TestExceptionMapper(unittest.TestCase):
     def test_subclass_mapped_by_base_class(self):
         expected_message = "Single Exception Message"
         mapper = ExceptionMapper()
-        mapper.message_map[RuntimeError] = (expected_message, mapper.format_default)
+        mapper.message_map[RuntimeError] = (expected_message, mapper.format_using_template)
 
         err = MyRuntimeError("Testing base class")
         self.assertEqual(expected_message, mapper.get_message(err))
@@ -57,9 +57,9 @@ class TestExceptionMapper(unittest.TestCase):
     def test_subclass_preferred_over_base_class(self):
         expected_message = "Subclass Exception Message"
         mapper = ExceptionMapper()
-        mapper.message_map[RuntimeError] = ("RuntimeError message", mapper.format_default)
-        mapper.message_map[MyRuntimeErrorBase] = ("MyRuntimeErrorBase message", mapper.format_default)
-        mapper.message_map[MyRuntimeError] = (expected_message, mapper.format_default)
+        mapper.message_map[RuntimeError] = ("RuntimeError message", mapper.format_using_template)
+        mapper.message_map[MyRuntimeErrorBase] = ("MyRuntimeErrorBase message", mapper.format_using_template)
+        mapper.message_map[MyRuntimeError] = (expected_message, mapper.format_using_template)
 
         err = MyRuntimeError("Logged Only")
         self.assertEqual(expected_message, mapper.get_message(err))
@@ -67,9 +67,9 @@ class TestExceptionMapper(unittest.TestCase):
     def test_can_map_middle_sub_class(self):
         expected_message = "MyRuntimeErrorBase message"
         mapper = ExceptionMapper()
-        mapper.message_map[RuntimeError] = ("RuntimeError message", mapper.format_default)
-        mapper.message_map[MyRuntimeErrorBase] = (expected_message, mapper.format_default)
-        mapper.message_map[MyRuntimeError] = ("MyRuntimeError message", mapper.format_default)
+        mapper.message_map[RuntimeError] = ("RuntimeError message", mapper.format_using_template)
+        mapper.message_map[MyRuntimeErrorBase] = (expected_message, mapper.format_using_template)
+        mapper.message_map[MyRuntimeError] = ("MyRuntimeError message", mapper.format_using_template)
 
         err = MyRuntimeErrorBase("Logged Only")
         self.assertEqual(expected_message, mapper.get_message(err))
@@ -78,7 +78,7 @@ class TestExceptionMapper(unittest.TestCase):
         mapper = ExceptionMapper()
         expected_message = "RuntimeError message"
 
-        mapper.message_map[RuntimeError] = (expected_message, mapper.format_default)
+        mapper.message_map[RuntimeError] = (expected_message, mapper.format_using_template)
         err = MyRuntimeError("Logged Only")
         self.assertEqual(expected_message, mapper.get_message(err))
 
@@ -89,14 +89,17 @@ class TestExceptionMapper(unittest.TestCase):
         err = RestlibException(404, expected_message)
         self.assertEqual(f"{expected_message} (HTTP error code 404: Not Found)", mapper.get_message(err))
 
-    def test_returns_none_when_no_mapped_exception_present(self):
+    def test_return_str_when_no_mapped_exception(self):
+        expected_message = "Expected message"
         mapper = ExceptionMapper()
-        self.assertEqual(None, mapper.get_message(RuntimeError()))
+
+        err = RuntimeError(expected_message)
+        self.assertEqual(expected_message, mapper.get_message(err))
 
     def test_can_support_old_style_classes(self):
         expected_message = "Old style class"
         mapper = ExceptionMapper()
-        mapper.message_map[OldStyleClass] = (expected_message, mapper.format_default)
+        mapper.message_map[OldStyleClass] = (expected_message, mapper.format_using_template)
 
         err = OldStyleClass()
         self.assertEqual(expected_message, mapper.get_message(err))


### PR DESCRIPTION
* Card ID: ENT-4228

This is a backport into RHEL 8.

Following ENT-4114 this change formats the rest of rhsmlib exceptions
with ExceptionMapper. It ensures that the exceptions have unified
format of "Message from candlepin. (HTTP error code XXX: YYY)".