### PR TITLE
1983144: More useful feedback on unknown argument

### DIFF
--- a/src/subscription_manager/cli_command/cli.py
+++ b/src/subscription_manager/cli_command/cli.py
@@ -26,7 +26,7 @@ import subscription_manager.injection as inj
 from rhsm.certificate import CertificateException
 from rhsm.connection import ProxyException
 from rhsm.https import ssl
-from rhsm.utils import ServerUrlParseError, remove_scheme
+from rhsm.utils import cmd_name, ServerUrlParseError, remove_scheme
 
 from rhsmlib.services import config
 
@@ -239,13 +239,15 @@ class CliCommand(AbstractCLICommand):
         if args is None:
             args = sys.argv[2:]
 
-        (self.options, self.args) = self.parser.parse_known_args(args)
+        (self.options, unknown_args) = self.parser.parse_known_args(args)
 
         # check for unparsed arguments
-        if self.args:
-            for arg in self.args:
-                print(_("cannot parse argument: {}").format(arg))
-            system_exit(os.EX_USAGE)
+        if unknown_args:
+            message: str = _("{prog}: error: no such option: {args}").format(
+                prog=cmd_name(sys.argv),
+                args=" ".join(unknown_args),
+            )
+            system_exit(os.EX_USAGE, message)
 
         if hasattr(self.options, "insecure") and self.options.insecure:
             conf["server"]["insecure"] = "1"

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -224,6 +224,18 @@ class TestCliCommand(SubManFixture):
             # 2 == no args given
             self.assertEqual(e.code, 2)
 
+    def test_unknown_args_cause_exit(self):
+        with Capture() as cap, patch.object(
+            sys, 'argv',
+            # test with some subcommand; sub-man prints help without it
+            ['subscription-manager', 'attach', '--foo', 'bar', 'baz'],
+        ):
+            try:
+                self.cc.main()
+            except SystemExit as e:
+                self.assertEqual(e.code, os.EX_USAGE)
+            self.assertEqual("subscription-manager: error: no such option: --foo bar baz\n", cap.err)
+
     def test_command_has_correlation_id(self):
         self.assertIsNotNone(self.cc.correlation_id)
 


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1983144
* Card ID: ENT-4233

When unknown subcommand or argument is supplied, an error message is
printed and sub-man exits. This commit changes the error message to be
the same as it was before we switched from optparse to argparse.