### PR TITLE
New D-Bus method GetOrg()

### DIFF
--- a/src/rhsmlib/dbus/objects/consumer.py
+++ b/src/rhsmlib/dbus/objects/consumer.py
@@ -21,12 +21,14 @@ It uses interface: com.redhat.RHSM1.Consumer and path:
 
 import dbus
 import logging
+import json
 
 from rhsmlib.dbus import constants, base_object, util, dbus_utils
 from rhsmlib.services.consumer import Consumer
 
 from subscription_manager.injectioninit import init_dep_injection
 from subscription_manager.i18n import Locale
+from subscription_manager.utils import get_current_owner
 
 init_dep_injection()
 
@@ -68,6 +70,26 @@ class ConsumerDBusObject(base_object.BaseObject):
             raise dbus.DBusException(str(err))
 
         return str(uuid)
+
+    @util.dbus_service_method(
+        constants.CONSUMER_INTERFACE,
+        in_signature='s',
+        out_signature='s')
+    @util.dbus_handle_sender
+    @util.dbus_handle_exceptions
+    def GetOrg(self, locale, sender=None):
+        """
+        D-Bus method for getting current organization (owner)
+        :param locale: string with locale
+        :param sender: not used
+        :return:
+        """
+        locale = dbus_utils.dbus_to_python(locale, expected_type=str)
+        Locale.set(locale)
+
+        org = get_current_owner()
+
+        return json.dumps(org)
 
     @util.dbus_service_signal(
         constants.CONSUMER_INTERFACE,


### PR DESCRIPTION
* Added new D-Bus method `GetOrg()` to interface
  `com.redhat.RHSM1.Consumer`
* It is possible to get current organization (owner), when system
  is already registered
* This method return string containing JSON document with information
  about current organization. Information provided in returned JSON
  document can be used for detection of SCA mode
* There is already method `GetOrgs()`, but it can be used for getting
  list of valid organizations for given user. It is necessary to
  provide username and password. Thus `GetOrg()` is intended for
  clients that are already registered.