### PR TITLE
[1.28] 1859157: Display better error message on incorrect --org

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -740,6 +740,8 @@ class AbstractSyspurposeCommand(CliCommand):
                 server_response = self.cp.getOwnerSyspurposeValidFields(org_key)
             except connection.RestlibException as rest_err:
                 log.warning("Unable to get list of valid fields using REST API: %s" % rest_err)
+                mapped_message: str = ExceptionMapper().get_message(rest_err)
+                system_exit(os.EX_SOFTWARE, mapped_message)
             except ProxyException:
                 system_exit(os.EX_UNAVAILABLE, _("Proxy connection failed, please check your settings."))
             else:


### PR DESCRIPTION
This is a backport of PR #2779.

* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1859157
* Card ID: ENT-2701

If the user has more than one organization the --org argument can be
used to specify one of them.

If the --org value was set to some invalid string, error message was
just a generic text that the list of valid values could not be obtained.

Now the proper message, returned by the server, is shown and EX_SOFTWARE
exit code is used.

(cherry picked from 65ff3d9ffae6af4cbf4a208cd5bb04468da1d41f)