### PR TITLE
1979323: Cockpit - do not show red red icon in SCA mode

### DIFF
--- a/cockpit/src/index.js
+++ b/cockpit/src/index.js
@@ -142,6 +142,7 @@ function initStore(rootElement) {
                 syspurpose_status: subscriptionsClient.syspurposeStatus.status,
                 insights_available: subscriptionsClient.insightsAvailable,
                 autoAttach: subscriptionsClient.autoAttach,
+                org: subscriptionsClient.org,
                 dismissError: dismissStatusError,
                 register: openRegisterDialog,
                 unregister: unregisterSystem,

--- a/cockpit/src/subscriptions-client.js
+++ b/cockpit/src/subscriptions-client.js
@@ -48,6 +48,7 @@ client.subscriptionStatus = {
     status_msg: _('Unknown'),
     products: [],
     error: undefined,
+    org: undefined,
 };
 
 client.config = {
@@ -519,6 +520,11 @@ function requestSubscriptionStatusUpdate() {
             .catch(ex => statusUpdateFailed(ex));
 }
 
+function requestCurrentOrgUpdate() {
+    return client.getCurrentOrg()
+            .catch(ex => statusUpdateFailed(ex));
+}
+
 function requestSyspurposeStatusUpdate() {
     return client.getSyspurposeStatus()
             .catch(ex => statusUpdateFailed(ex));
@@ -563,6 +569,41 @@ client.getSubscriptionStatus = function() {
                 .then(() => {
                     getSubscriptionDetails();
                     needRender();
+                });
+    });
+    return dfd.promise();
+};
+
+/**
+ * Method for getting current organization (owner), when system is already
+ * registered. When calling D-Bus method GetOrg is successful, then store
+ * returned JSON document in client.org.
+ */
+client.getCurrentOrg = function () {
+    let dfd = cockpit.defer();
+    safeDBusCall(consumerService, () => {
+        console.debug('Trying to get current organization...');
+        consumerService.GetOrg(userLang)
+                .then(result => {
+                    let parsed;
+                    console.debug('Current organization:', result);
+                    try {
+                        client.org = JSON.parse(result);
+                        parsed = true;
+                    } catch (err) {
+                        console.error('Error: parsing JSON with organization', err.message);
+                        parsed = false;
+                    }
+                    if (parsed) {
+                        dfd.resolve();
+                        needRender();
+                    }
+                })
+                .catch(error => {
+                    client.subscriptionStatus.error = {
+                        'severity': parseErrorSeverity(error),
+                        'msg': parseErrorMessage(error)
+                    };
                 });
     });
     return dfd.promise();
@@ -703,6 +744,11 @@ client.init = () => {
     productsService.addEventListener("InstalledProductsChanged", requestSubscriptionStatusUpdate);
     consumerService.addEventListener("ConsumerChanged", requestSubscriptionStatusUpdate);
 
+    // When consumer changed (system was registered/unregistered, then it is necessary to
+    // get current organization)
+    consumerService.addEventListener("ConsumerChanged", requestCurrentOrgUpdate);
+    entitlementService.addEventListener("EntitlementChanged", requestCurrentOrgUpdate);
+
     configService.addEventListener("ConfigChanged", updateConfig);
     syspurposeService.addEventListener("SyspurposeChanged", requestSyspurposeUpdate);
 
@@ -713,6 +759,7 @@ client.init = () => {
     consumerService.addEventListener("ConsumerChanged", requestSyspurposeStatusUpdate);
 
     // get initial status
+    requestCurrentOrgUpdate();
     requestSubscriptionStatusUpdate();
     requestSyspurposeUpdate();
     requestSyspurposeStatusUpdate();

--- a/cockpit/src/subscriptions.scss
+++ b/cockpit/src/subscriptions.scss
@@ -29,6 +29,10 @@
     padding-right: 0.5rem;
 }
 
+.subscriptions-info {
+    cursor: pointer;
+}
+
 #register_dialog .modal-footer .alert{
     text-align: left;
     padding-left: 37px;


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1979323
* Cockpit plugin has changed little bit since the bug report
  was created. There is no red icon anymore, but red text
  "Not subscribed" was displayed in the header of installed
  product
* New method GetOrg is used for gathering information
  about current organization. We can get information about
  SCA mode from current ogranization (owner)
* When SCA mode is used, then just do not disaply any text
  about subscription in the header of installed product
* When SCA mode is used, then following attributes are not
  printed: Status, Starts and Ends
* When SCA mode is used, then Auto-attach button is not
  displayed at all.
* Organization name is printed in the Overview card, because
  we had to gather information about organization anyway.
  When no organization is not able to gather, then no
  organization is printed in the Overview card
* When Subscription is "Disabled", then popup with simple
  exaplanation of SCA mode can be displayed (after clicking
  on info icon). There is similar icon for system purpose
  status