### PR TITLE
1924338: [1.28] list prints no status and dates in SCA mode

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -105,6 +105,13 @@ INSTALLED_PRODUCT_STATUS = [
     _("Ends:")
 ]
 
+INSTALLED_PRODUCT_STATUS_SCA = [
+    _("Product Name:"),
+    _("Product ID:"),
+    _("Version:"),
+    _("Arch:")
+]
+
 AVAILABLE_SUBS_LIST = [
     _("Subscription Name:"),
     _("Provides:"),
@@ -3186,9 +3193,33 @@ class ListCommand(CliCommand):
 
                 for product in installed_products:
                     status = STATUS_MAP[product[4]]
-                    print(columnize(INSTALLED_PRODUCT_STATUS, none_wrap_columnize_callback,
-                                    product[0], product[1], product[2], product[3],
-                                    status, product[5], product[6], product[7]) + "\n")
+                    if is_simple_content_access(self.cp, self.identity):
+                        print(
+                            columnize(
+                                INSTALLED_PRODUCT_STATUS_SCA,
+                                none_wrap_columnize_callback,
+                                product[0],  # Name
+                                product[1],  # ID
+                                product[2],  # Version
+                                product[3]   # Arch
+                            ) + "\n"
+                        )
+                    else:
+                        status = STATUS_MAP[product[4]]
+                        print(
+                            columnize(
+                                INSTALLED_PRODUCT_STATUS,
+                                none_wrap_columnize_callback,
+                                product[0],  # Name
+                                product[1],  # ID
+                                product[2],  # Version
+                                product[3],  # Arch
+                                status,      # Status
+                                product[5],  # Status details
+                                product[6],  # Start
+                                product[7]   # End
+                            ) + "\n"
+                        )
             else:
                 if self.options.filter_string:
                     print(_("No installed products were found matching the expression \"%s\".") % self.options.filter_string)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1924338
* PR for main branch: #2776
* Backported this change for 1.28 branch. Simple cherry-pick of 9c3823c75e91b5d75b300332d5a4e129f68ba653 was not possible, because there were only conflicts.
* Card ID: ENT-4058
* When SCA mode is enabled, then do not print: "Status",
  "Status Details", Start date and End date, because it only
  confused users
* Added two unit tests