### PR TITLE
1995032: Use multiple environments

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -125,7 +125,7 @@ _subscription_manager_config()
 
 _subscription_manager_environments()
 {
-  local opts="--org --password --username --token
+  local opts="--org --password --username --token --set --list --list-enabled --list-disabled
               ${_subscription_manager_common_url_opts}
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
@@ -204,7 +204,7 @@ _subscription_manager_refresh()
 _subscription_manager_register()
 {
   local opts="--activationkey --auto-attach --autosubscribe --baseurl --consumerid
-              --environment --force --name --org --password --release
+              --environments --force --name --org --password --release
               --servicelevel --username --token
               ${_subscription_manager_common_url_opts}
               ${_subscription_manager_common_opts}"

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -258,8 +258,8 @@ Assigns the system to an organization. Infrastructures which are managed on-site
 meaning that there are multiple organizations within one customer unit. A system may be assigned manually to one of these organizations. When a system is registered with the Customer Portal, this is not required. When a system is registered with an on-premise application such as Subscription Asset Manager, this argument \fIis\fP required, unless there is only a single organization configured.
 
 .TP
-.B --environment=ENV
-Registers the system to an environment within an organization.
+.B --environments=ENV
+Registers the system to one or more environments within an organization. This is a comma-separated list and the order is maintained.
 
 .TP
 .B --release=VERSION
@@ -686,6 +686,22 @@ Token to use when authorizing against the server.
 .TP
 .B --org=ORG
 Identifies the organization for which to list the configured environments.
+
+.TP
+.B --list
+Lists all of the environments that have been configured for an organization.
+
+.TP
+.B --list-enabled
+Lists all of the environments that have been enabled for this consumer.
+
+.TP
+.B --list-disabled
+Lists all of the environments that have been configured for an organization but not for this consumer.
+
+.TP
+.B --set=SET
+Sets a list of one or more comma-separated environments for this consumer.
 
 
 .SS REPOS OPTIONS

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1071,7 +1071,7 @@ class UEPConnection(BaseConnection):
         )
 
     def registerConsumer(self, name="unknown", type="system", facts={},
-                         owner=None, environment=None, keys=None,
+                         owner=None, environments=None, keys=None,
                          installed_products=None, uuid=None, hypervisor_id=None,
                          content_tags=None, role=None, addons=None, service_level=None, usage=None,
                          jwt_token=None):
@@ -1100,15 +1100,18 @@ class UEPConnection(BaseConnection):
             params['usage'] = usage
         if service_level is not None:
             params['serviceLevel'] = service_level
+        if environments is not None:
+            env_list = []
+            for environment in environments.split(','):
+                env_list.append({"id": environment})
+            params['environments'] = env_list
 
         headers = {}
         if jwt_token:
             headers['Authorization'] = 'Bearer {jwt_token}'.format(jwt_token=jwt_token)
 
         url = "/consumers"
-        if environment:
-            url = "/environments/%s/consumers" % self.sanitize(environment)
-        elif owner:
+        if owner:
             query_param = urlencode({"owner": owner})
             url = "%s?%s" % (url, query_param)
             prepend = ""
@@ -1181,7 +1184,7 @@ class UEPConnection(BaseConnection):
     def updateConsumer(self, uuid, facts=None, installed_products=None,
                        guest_uuids=None, service_level=None, release=None,
                        autoheal=None, hypervisor_id=None, content_tags=None, role=None, addons=None,
-                       usage=None):
+                       usage=None, environments=None):
         """
         Update a consumer on the server.
 
@@ -1220,6 +1223,11 @@ class UEPConnection(BaseConnection):
                 params['addOns'] = [addons]
         if usage is not None:
             params['usage'] = usage
+        if environments is not None:
+            env_list = []
+            for environment in environments.split(','):
+                env_list.append({"id": environment})
+            params['environments'] = env_list
 
         # The server will reject a service level that is not available
         # in the consumer's organization, so no need to check if it's safe

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -31,7 +31,7 @@ class RegisterService(object):
         self.identity = inj.require(inj.IDENTITY)
         self.cp = cp
 
-    def register(self, org, activation_keys=None, environment=None, force=None, name=None, consumerid=None,
+    def register(self, org, activation_keys=None, environments=None, force=None, name=None, consumerid=None,
                  type=None, role=None, addons=None, service_level=None, usage=None, jwt_token=None, **kwargs):
         # We accept a kwargs argument so that the DBus object can pass the options dictionary it
         # receives transparently to the service via dictionary unpacking.  This strategy allows the
@@ -70,7 +70,7 @@ class RegisterService(object):
 
         options = {
             'activation_keys': activation_keys,
-            'environment': environment,
+            'environments': environments,
             'force': force,
             'name': name,
             'consumerid': consumerid,
@@ -79,7 +79,7 @@ class RegisterService(object):
         }
         self.validate_options(options)
 
-        environment = options['environment']
+        environments = options['environments']
         facts_dict = self.facts.get_facts()
 
         # Default to the hostname if no name is given
@@ -97,7 +97,7 @@ class RegisterService(object):
                 name=consumer_name,
                 facts=facts_dict,
                 owner=org,
-                environment=environment,
+                environments=environments,
                 keys=options.get('activation_keys'),
                 installed_products=self.installed_mgr.format_for_server(),
                 content_tags=self.installed_mgr.tags,
@@ -156,7 +156,7 @@ class RegisterService(object):
             elif options['consumerid']:
                 raise exceptions.ValidationError(_("Error: Activation keys can not be used with previously"
                                                    " registered IDs."))
-            elif options['environment']:
+            elif options['environments']:
                 raise exceptions.ValidationError(_("Error: Activation keys do not allow environments to be"
                                                    " specified."))
         elif options.get('jwt_token') is not None:

--- a/src/subscription_manager/cli_command/identity.py
+++ b/src/subscription_manager/cli_command/identity.py
@@ -29,6 +29,7 @@ from subscription_manager.cli_command.cli import handle_exception
 from subscription_manager.cli_command.user_pass import UserPassCommand
 from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
+from subscription_manager.i18n import ungettext
 from subscription_manager.utils import get_current_owner, get_supported_resources
 
 log = logging.getLogger(__name__)
@@ -86,12 +87,15 @@ class IdentityCommand(UserPassCommand):
                 supported_resources = get_supported_resources(self.cp, self.identity)
                 if 'environments' in supported_resources:
                     consumer = self.cp.getConsumer(consumerid)
-                    environment = consumer['environment']
-                    if environment:
-                        environment_name = environment['name']
+                    environments = consumer['environments']
+                    if environments:
+                        environment_name = (','.join([environment['name'] for environment in environments]))
                     else:
                         environment_name = _("None")
-                    print(_('environment name: {environment_name}').format(environment_name=environment_name))
+                        environments = []
+                    print(ungettext('environment name: {environment_name}',
+                                    'environment names: {environment_name}',
+                                    len(environments)).format(environment_name=environment_name))
             else:
                 if self.options.force:
                     # get an UEP with basic auth or keycloak auth

--- a/test/cli_command_test/test_register.py
+++ b/test/cli_command_test/test_register.py
@@ -41,7 +41,7 @@ class TestRegisterCommand(TestCliProxyCommand):
         self._test_exception(["--username", "bob", "--activationkey", "key"])
 
     def test_keys_and_environments(self):
-        self._test_exception(["--environment", "JarJar", "--activationkey", "Binks"])
+        self._test_exception(["--environments", "JarJar", "--activationkey", "Binks"])
 
     def test_env_and_org(self):
         self._test_no_exception(["--env", "env", "--org", "org"])

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -65,7 +65,7 @@ CONSUMER_CONTENT_JSON = '''{"hypervisorId": null,
         "facts": {}, "id": "ff808081550d997c015511b0406d1065",
         "uuid": "c1b8648c-6f0a-4aa5-b34e-b9e62c0e4364",
         "guestIds": null, "capabilities": null,
-        "environment": null, "installedProducts": null,
+        "environments": null, "installedProducts": null,
         "canActivate": false, "type": {"manifest": false,
         "id": "1000", "label": "system"}, "annotations": null,
         "username": "admin", "updated": "2016-06-02T15:16:51+0000",
@@ -187,13 +187,13 @@ class RegisterServiceTest(InjectionMockingTest):
         self.mock_cp.registerConsumer.return_value = expected_consumer
 
         register_service = register.RegisterService(self.mock_cp)
-        register_service.register("org", name="name", environment="environment")
+        register_service.register("org", name="name", environments="environment")
 
         self.mock_cp.registerConsumer.assert_called_once_with(
             name="name",
             facts={},
             owner="org",
-            environment="environment",
+            environments="environment",
             keys=None,
             installed_products=[],
             jwt_token=None,
@@ -263,13 +263,13 @@ class RegisterServiceTest(InjectionMockingTest):
 
         self.assertIsNotNone(org)
 
-        register_service.register(org, name="name", environment="environment")
+        register_service.register(org, name="name", environments="environment")
 
         self.mock_cp.registerConsumer.assert_called_once_with(
             name="name",
             facts={},
             owner="snowwhite",
-            environment="environment",
+            environments="environment",
             keys=None,
             installed_products=[],
             jwt_token=None,
@@ -308,7 +308,7 @@ class RegisterServiceTest(InjectionMockingTest):
             name="name",
             facts={},
             owner="org",
-            environment=None,
+            environments=None,
             keys=[1],
             installed_products=[],
             jwt_token=None,
@@ -353,10 +353,10 @@ class RegisterServiceTest(InjectionMockingTest):
         ]
         self.assertEqual(expected_plugin_calls, self.mock_pm.run.call_args_list)
 
-    def _build_options(self, activation_keys=None, environment=None, force=None, name=None, consumerid=None):
+    def _build_options(self, activation_keys=None, environments=None, force=None, name=None, consumerid=None):
         return {
             'activation_keys': activation_keys,
-            'environment': environment,
+            'environments': environments,
             'force': force,
             'name': name,
             'consumerid': consumerid
@@ -393,7 +393,7 @@ class RegisterServiceTest(InjectionMockingTest):
         self.mock_cp.registerConsumer.assert_called_once_with(
             addons=["addon1"],
             content_tags=[],
-            environment=None,
+            environments=None,
             facts={},
             installed_products=[],
             jwt_token=None,
@@ -425,7 +425,7 @@ class RegisterServiceTest(InjectionMockingTest):
         self.mock_cp.password = None
 
         self.mock_identity.is_valid.return_value = False
-        options = self._build_options(activation_keys=[1], environment='environment')
+        options = self._build_options(activation_keys=[1], environments='environment')
         with self.assertRaisesRegex(exceptions.ValidationError, r'.*do not allow environments.*'):
             register.RegisterService(self.mock_cp).validate_options(options)
 

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -472,7 +472,7 @@ class StubUEP(object):
 
     def updateConsumer(self, consumer, facts=None, installed_products=None,
                        guest_uuids=None, service_level=None, release=None, autoheal=None,
-                       content_tags=None, addons=None, role=None, usage=None):
+                       content_tags=None, addons=None, role=None, usage=None, environments=None):
         return consumer
 
     def setEnvironmentList(self, env_list):

--- a/test/test_environments.py
+++ b/test/test_environments.py
@@ -1,0 +1,98 @@
+#
+# Copyright (c) 2012 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+from unittest.mock import patch, Mock
+
+from subscription_manager.cli_command.environments import EnvironmentsCommand
+from .stubs import StubUEP
+from .fixture import SubManFixture, Capture
+
+
+class CliEnvironmentTests(SubManFixture):
+
+    def setUp(self):
+        super(CliEnvironmentTests, self).setUp()
+        get_supported_resources_patcher = patch('subscription_manager.cli_command.environments.get_supported_resources')
+        self.mock_get_resources = get_supported_resources_patcher.start()
+        self.mock_get_resources.return_value = ['environments']
+        self.addCleanup(self.mock_get_resources.stop)
+
+    def env_list(*args, **kwargs):
+        return [{"id": "1234", "name": "somename"},
+                {"id": "5678", "name": "othername"}]
+
+    def test_update_environments(self):
+        with patch('rhsm.connection.UEPConnection', new_callable=StubUEP) as mock_uep:
+            mock_identity = self._inject_mock_valid_consumer()
+            mock_uep.getEnvironmentList = self.env_list
+            mock_uep.has_capability = Mock(return_value=True)
+            mock_uep.updateConsumer = Mock()
+            self.stub_cp_provider.basic_auth_cp = mock_uep
+            cmd = EnvironmentsCommand()
+
+            serial1 = '1234'
+            cmd.main(['--set=somename', '--username', 'foo', '--password', 'bar'])
+            cmd.cp.updateConsumer.assert_called_once_with(mock_identity.uuid, environments=serial1)
+
+    def test_update_environments_multiple(self):
+        with patch('rhsm.connection.UEPConnection', new_callable=StubUEP) as mock_uep:
+            mock_identity = self._inject_mock_valid_consumer()
+            mock_uep.getEnvironmentList = self.env_list
+            mock_uep.has_capability = Mock(return_value=True)
+            mock_uep.updateConsumer = Mock()
+            self.stub_cp_provider.basic_auth_cp = mock_uep
+            cmd = EnvironmentsCommand()
+
+            serial1 = '1234,5678'
+            cmd.main(['--set=somename,othername', '--username', 'foo', '--password', 'bar'])
+            cmd.cp.updateConsumer.assert_called_once_with(mock_identity.uuid, environments=serial1)
+
+    def test_update_environments_repeated(self):
+        with patch('rhsm.connection.UEPConnection', new_callable=StubUEP) as mock_uep:
+            self._inject_mock_valid_consumer()
+            mock_uep.getEnvironmentList = self.env_list
+            mock_uep.has_capability = Mock(return_value=True)
+            mock_uep.updateConsumer = Mock()
+            self.stub_cp_provider.basic_auth_cp = mock_uep
+            cmd = EnvironmentsCommand()
+
+            with Capture(silent=True):
+                with self.assertRaises(SystemExit):
+                    cmd.main(['--set=somename,othername,somename', '--username', 'foo', '--password', 'bar'])
+
+    def test_update_environments_not_valid(self):
+        with patch('rhsm.connection.UEPConnection', new_callable=StubUEP) as mock_uep:
+            self._inject_mock_valid_consumer()
+            mock_uep.getEnvironmentList = self.env_list
+            mock_uep.has_capability = Mock(return_value=True)
+            mock_uep.updateConsumer = Mock()
+            self.stub_cp_provider.basic_auth_cp = mock_uep
+            cmd = EnvironmentsCommand()
+
+            with Capture(silent=True):
+                with self.assertRaises(SystemExit):
+                    cmd.main(['--set=somename,notagoodname', '--username', 'foo', '--password', 'bar'])
+
+    def test_update_indentity_not_valid(self):
+        with patch('rhsm.connection.UEPConnection', new_callable=StubUEP) as mock_uep:
+            self._inject_mock_invalid_consumer()
+            mock_uep.getEnvironmentList = self.env_list
+            mock_uep.has_capability = Mock(return_value=True)
+            mock_uep.updateConsumer = Mock()
+            self.stub_cp_provider.basic_auth_cp = mock_uep
+            cmd = EnvironmentsCommand()
+
+            with Capture(silent=True):
+                with self.assertRaises(SystemExit):
+                    cmd.main(['--set=somename', '--username', 'foo', '--password', 'bar'])


### PR DESCRIPTION
The client will now be able to send an ordered list of environments on registration.
Also, the ability to change the list after registration is added.

Smoke testing will need to wait until https://github.com/candlepin/candlepin/pull/3129 is completed