### PR TITLE
Remove Python 2 bits and pieces

### DIFF
--- a/build_ext/build_ext/i18n.py
+++ b/build_ext/build_ext/i18n.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/build_ext/build_ext/lint.py
+++ b/build_ext/build_ext/lint.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,
@@ -293,29 +290,6 @@ class GettextVisitor(AstVisitor):
                 return (node, "X302 string formatting within gettext function: _('%s' % foo) should be _('%s') % foo")
 
 
-class FutureVisitor(AstVisitor):
-    """Looks for files missing 'from __future__ import print_function, division, absolute_import`."""
-    codes = ['X400']
-
-    class ImportsVisitor(AstVisitor):
-        def visit_ImportFrom(self, node):
-            self.generic_visit(node)
-            if node.module != '__future__':
-                return False
-
-            expected = ['print_function', 'division', 'absolute_import']
-            found = [alias.name for alias in node.names]
-            self.results.append(expected == found)
-
-    def visit_Module(self, node):
-        self.generic_visit(node)
-        import_visitor = self.ImportsVisitor()
-        import_visitor.visit(node)
-        # Skip empty __init__ modules
-        if node.body and not any(import_visitor.results):
-            return (node, "X400 module does not contain the correct __futures__ import (tip: order matters)")
-
-
 class AstChecker(object):
     name = "SubscriptionManagerAstChecker"
     version = "1.0"
@@ -336,7 +310,6 @@ class AstChecker(object):
         self.visitors = [
             (GettextVisitor, {}),
             (DebugImportVisitor, {}),
-            (FutureVisitor, {}),
             (WidgetVisitor, {'defined_widgets': widgets}),
             (SignalVisitor, {'defined_handlers': handlers}),
         ]

--- a/build_ext/build_ext/template.py
+++ b/build_ext/build_ext/template.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/build_ext/build_ext/utils.py
+++ b/build_ext/build_ext/utils.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/debian-stuff/katello
+++ b/debian-stuff/katello
@@ -24,8 +24,6 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 
-from __future__ import print_function
-
 import sys
 import re
 import hashlib

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -47,8 +47,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'subscription-manager'
-copyright = u'2014, Adrian Likins'
+project = 'subscription-manager'
+copyright = '2014, Adrian Likins'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -200,8 +200,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    ('index', 'subscription-manager.tex', u'subscription-manager Documentation',
-     u'Adrian Likins', 'manual'),
+    ('index', 'subscription-manager.tex', 'subscription-manager Documentation',
+     'Adrian Likins', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -230,8 +230,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'subscription-manager', u'subscription-manager Documentation',
-     [u'Adrian Likins'], 1)
+    ('index', 'subscription-manager', 'subscription-manager Documentation',
+     ['Adrian Likins'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -244,8 +244,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    ('index', 'subscription-manager', u'subscription-manager Documentation',
-     u'Adrian Likins', 'subscription-manager', 'One line description of project.',
+    ('index', 'subscription-manager', 'subscription-manager Documentation',
+     'Adrian Likins', 'subscription-manager', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # subscription-manager documentation build configuration file, created by
 # sphinx-quickstart on Tue May 13 23:24:51 2014.
 #

--- a/example-plugins/all_slots.py
+++ b/example-plugins/all_slots.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2013 Red Hat, Inc.
 #

--- a/example-plugins/dbus_event.py
+++ b/example-plugins/dbus_event.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/example-plugins/facts.py
+++ b/example-plugins/facts.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/example-plugins/product_install.py
+++ b/example-plugins/product_install.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/example-plugins/register_consumer.py
+++ b/example-plugins/register_consumer.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/example-plugins/subscribe.py
+++ b/example-plugins/subscribe.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -1,6 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2016 Red Hat, Inc.

--- a/scripts/gen_test_en_po.py
+++ b/scripts/gen_test_en_po.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 
-from __future__ import print_function, division, absolute_import
-
 import polib
 import sys
 

--- a/scripts/just_strings.py
+++ b/scripts/just_strings.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 
-from __future__ import print_function, division, absolute_import
-
 # dump out the msg keys by themselves, newline seperated
 #
 # require's polib from https://bitbucket.org/izi/polib/wiki/Home

--- a/scripts/untranslated.py
+++ b/scripts/untranslated.py
@@ -1,6 +1,4 @@
 #!/usr/bin/python
-from __future__ import print_function, division, absolute_import
-
 # sort of kind of a translation lint
 #
 # require's polib from https://bitbucket.org/izi/polib/wiki/Home

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function, division, absolute_import
 
 #
 # Copyright (c) 2014 Red Hat, Inc.

--- a/src/cloud_what/README.md
+++ b/src/cloud_what/README.md
@@ -11,8 +11,6 @@ Example: you want to add support for Foo Cloud Provider. You will create package
 folder `providers`. Content of `fcp.py` will look like this:
 
 ```python
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2021 Foo Company
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/cloud_what/_base_provider.py
+++ b/src/cloud_what/_base_provider.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2020 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/cloud_what/fact_collector.py
+++ b/src/cloud_what/fact_collector.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2021 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/cloud_what/provider.py
+++ b/src/cloud_what/provider.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2020 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/cloud_what/providers/aws.py
+++ b/src/cloud_what/providers/aws.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2020 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/cloud_what/providers/azure.py
+++ b/src/cloud_what/providers/azure.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2020 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/cloud_what/providers/gcp.py
+++ b/src/cloud_what/providers/gcp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2020 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/cloud_what/setup.py
+++ b/src/cloud_what/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2021 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/content_plugins/container_content.py
+++ b/src/content_plugins/container_content.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2014 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/content_plugins/ostree_content.py
+++ b/src/content_plugins/ostree_content.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/plugins/dnf/product-id.py
+++ b/src/plugins/dnf/product-id.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2015 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/plugins/dnf/subscription-manager.py
+++ b/src/plugins/dnf/subscription-manager.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2015 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/plugins/dnf/upload-profile.py
+++ b/src/plugins/dnf/upload-profile.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2015 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rct/cert_commands.py
+++ b/src/rct/cert_commands.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rct/cli.py
+++ b/src/rct/cli.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rct/commands.py
+++ b/src/rct/commands.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rct/printing.py
+++ b/src/rct/printing.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rct/version.py
+++ b/src/rct/version.py
@@ -1,4 +1,2 @@
-from __future__ import print_function, division, absolute_import
-
 # The values in this file are populated by setup.py build
 rpm_version = "RPM_VERSION"

--- a/src/rhsm/bitstream.py
+++ b/src/rhsm/bitstream.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsm/certificate.py
+++ b/src/rhsm/certificate.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # This module has been originally modified and enhanced from Red Hat Update
 # Agent's config module.
 #

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # A proxy interface to initiate and interact with candlepin.
 #
 # Copyright (c) 2010 - 2012 Red Hat, Inc.

--- a/src/rhsm/https.py
+++ b/src/rhsm/https.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # A wrapper that provides httplib and ssl using the standard libs,
 # checking for the required parts of them.
 #

--- a/src/rhsm/huffman.py
+++ b/src/rhsm/huffman.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsm/logutil.py
+++ b/src/rhsm/logutil.py
@@ -25,8 +25,8 @@ USER_LOGFILE_DIR = os.path.join(
 )
 USER_LOGFILE_PATH = os.path.join(USER_LOGFILE_DIR, "rhsm.log")
 
-LOG_FORMAT = u'%(asctime)s [%(levelname)s] %(cmd_name)s:%(process)d:' \
-             u'%(threadName)s @%(filename)s:%(lineno)d - %(message)s'
+LOG_FORMAT = '%(asctime)s [%(levelname)s] %(cmd_name)s:%(process)d:' \
+             '%(threadName)s @%(filename)s:%(lineno)d - %(message)s'
 
 _rhsm_log_handler = None
 _subman_debug_handler = None
@@ -125,7 +125,7 @@ class PyWarningsLoggingFilter(object):
         self.name = name
 
     def filter(self, record):
-        record.msg = u'%s %s' % (self.label, record.msg)
+        record.msg = '%s %s' % (self.label, record.msg)
         return True
 
 

--- a/src/rhsm/logutil.py
+++ b/src/rhsm/logutil.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2005-2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsm/ourjson.py
+++ b/src/rhsm/ourjson.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsm/pathtree.py
+++ b/src/rhsm/pathtree.py
@@ -1,7 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-# from __future__ import unicode_literals FIXME see if necessary
-
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2011 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/src/rhsm/utils.py
+++ b/src/rhsm/utils.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsm_debug/cli.py
+++ b/src/rhsm_debug/cli.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsm_debug/debug_commands.py
+++ b/src/rhsm_debug/debug_commands.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/__init__.py
+++ b/src/rhsmlib/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/candlepin/api.py
+++ b/src/rhsmlib/candlepin/api.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/client_info.py
+++ b/src/rhsmlib/client_info.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/compat/__init__.py
+++ b/src/rhsmlib/compat/__init__.py
@@ -1,3 +1,1 @@
-from __future__ import print_function, division, absolute_import
-
 from rhsmlib.compat.subprocess_compat import check_output  # NOQA

--- a/src/rhsmlib/compat/subprocess_compat.py
+++ b/src/rhsmlib/compat/subprocess_compat.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2010-2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/base_object.py
+++ b/src/rhsmlib/dbus/base_object.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/constants.py
+++ b/src/rhsmlib/dbus/constants.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/dbus_utils.py
+++ b/src/rhsmlib/dbus/dbus_utils.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (C) 2011,2012 Red Hat, Inc.
 #

--- a/src/rhsmlib/dbus/dbus_utils.py
+++ b/src/rhsmlib/dbus/dbus_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2011,2012 Red Hat, Inc.
 #
 # Authors:

--- a/src/rhsmlib/dbus/exceptions.py
+++ b/src/rhsmlib/dbus/exceptions.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/facts/__init__.py
+++ b/src/rhsmlib/dbus/facts/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 from rhsmlib.dbus.facts.base import HostFacts  # noqa: F401
 from rhsmlib.dbus.facts.client import FactsClient, FactsClientAuthenticationError  # noqa: F401
 from rhsmlib.dbus.facts.constants import FACTS_DBUS_NAME, FACTS_DBUS_INTERFACE, FACTS_DBUS_PATH  # noqa: F401

--- a/src/rhsmlib/dbus/facts/base.py
+++ b/src/rhsmlib/dbus/facts/base.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/facts/client.py
+++ b/src/rhsmlib/dbus/facts/client.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2010-2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/facts/constants.py
+++ b/src/rhsmlib/dbus/facts/constants.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/objects/__init__.py
+++ b/src/rhsmlib/dbus/objects/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/objects/attach.py
+++ b/src/rhsmlib/dbus/objects/attach.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/objects/config.py
+++ b/src/rhsmlib/dbus/objects/config.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/objects/consumer.py
+++ b/src/rhsmlib/dbus/objects/consumer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/objects/entitlement.py
+++ b/src/rhsmlib/dbus/objects/entitlement.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/objects/main.py
+++ b/src/rhsmlib/dbus/objects/main.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/objects/products.py
+++ b/src/rhsmlib/dbus/objects/products.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/objects/syspurpose.py
+++ b/src/rhsmlib/dbus/objects/syspurpose.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/objects/unregister.py
+++ b/src/rhsmlib/dbus/objects/unregister.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/service_wrapper.py
+++ b/src/rhsmlib/dbus/service_wrapper.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/dbus/util.py
+++ b/src/rhsmlib/dbus/util.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/facts/all.py
+++ b/src/rhsmlib/facts/all.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/src/rhsmlib/facts/cleanup.py
+++ b/src/rhsmlib/facts/cleanup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-#
 # Copyright (c) 2019 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2019 Red Hat, Inc.
 #

--- a/src/rhsmlib/facts/collection.py
+++ b/src/rhsmlib/facts/collection.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/src/rhsmlib/facts/collector.py
+++ b/src/rhsmlib/facts/collector.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/facts/cpuinfo.py
+++ b/src/rhsmlib/facts/cpuinfo.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Read and parse /proc/cpuinfo
 #
 # Copyright (c) 2015 Red Hat, Inc.

--- a/src/rhsmlib/facts/custom.py
+++ b/src/rhsmlib/facts/custom.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/facts/dmiinfo.py
+++ b/src/rhsmlib/facts/dmiinfo.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2010-2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/facts/firmware_info.py
+++ b/src/rhsmlib/facts/firmware_info.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Get the right platform specific provider or a null provider
 #
 # Copyright (c) 2010-2016 Red Hat, Inc.

--- a/src/rhsmlib/facts/host_collector.py
+++ b/src/rhsmlib/facts/host_collector.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Module to probe Hardware info from the system
 #
 # Copyright (c) 2010 Red Hat, Inc.

--- a/src/rhsmlib/facts/insights.py
+++ b/src/rhsmlib/facts/insights.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-#
 # Copyright (c) 2019 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/facts/insights.py
+++ b/src/rhsmlib/facts/insights.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2019 Red Hat, Inc.
 #

--- a/src/rhsmlib/facts/kpatch.py
+++ b/src/rhsmlib/facts/kpatch.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-#
 # Copyright (c) 2019 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/facts/kpatch.py
+++ b/src/rhsmlib/facts/kpatch.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2019 Red Hat, Inc.
 #

--- a/src/rhsmlib/facts/pkg_arches.py
+++ b/src/rhsmlib/facts/pkg_arches.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2020 ATIX AG
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/facts/virt.py
+++ b/src/rhsmlib/facts/virt.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Probe hardware info that requires root
 #
 # Copyright (c) 2010-2016 Red Hat, Inc.

--- a/src/rhsmlib/file_monitor.py
+++ b/src/rhsmlib/file_monitor.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/services/attach.py
+++ b/src/rhsmlib/services/attach.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/services/config.py
+++ b/src/rhsmlib/services/config.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/services/consumer.py
+++ b/src/rhsmlib/services/consumer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/services/entitlement.py
+++ b/src/rhsmlib/services/entitlement.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/services/exceptions.py
+++ b/src/rhsmlib/services/exceptions.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/services/products.py
+++ b/src/rhsmlib/services/products.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/services/syspurpose.py
+++ b/src/rhsmlib/services/syspurpose.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/services/unregister.py
+++ b/src/rhsmlib/services/unregister.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/rhsmlib/utils.py
+++ b/src/rhsmlib/utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/__init__.py
+++ b/src/subscription_manager/__init__.py
@@ -1,3 +1,1 @@
-from __future__ import print_function, division, absolute_import
-
 __test__ = None

--- a/src/subscription_manager/action_client.py
+++ b/src/subscription_manager/action_client.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2010 Red Hat, Inc.
 #

--- a/src/subscription_manager/api/__init__.py
+++ b/src/subscription_manager/api/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2015 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/src/subscription_manager/api/repos.py
+++ b/src/subscription_manager/api/repos.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2015 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/src/subscription_manager/async_utils.py
+++ b/src/subscription_manager/async_utils.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Async wrapper module for managerlib methods, with glib integration
 #
 # Copyright (c) 2010 Red Hat, Inc.

--- a/src/subscription_manager/base_action_client.py
+++ b/src/subscription_manager/base_action_client.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2014 Red Hat, Inc.
 #
 #

--- a/src/subscription_manager/base_plugin.py
+++ b/src/subscription_manager/base_plugin.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/branding/__init__.py
+++ b/src/subscription_manager/branding/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # branding - default localizable strings that can be overridden for app branding
 #
 # Copyright (c) 2011 Red Hat, Inc.

--- a/src/subscription_manager/branding/redhat_branding.py
+++ b/src/subscription_manager/branding/redhat_branding.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 from subscription_manager.i18n import ugettext as _
 
 

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # Authors: Jeff Ortel <jortel@redhat.com>

--- a/src/subscription_manager/certlib.py
+++ b/src/subscription_manager/certlib.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import logging
 
 from subscription_manager import injection as inj

--- a/src/subscription_manager/cli.py
+++ b/src/subscription_manager/cli.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/cli_command/redeem.py
+++ b/src/subscription_manager/cli_command/redeem.py
@@ -71,8 +71,8 @@ class RedeemCommand(CliCommand):
             if 200 <= e.code <= 210:
                 system_exit(0, e)
             else:
-                handle_exception(u"Unable to redeem: {e}".format(e=e), e)
+                handle_exception("Unable to redeem: {e}".format(e=e), e)
         except Exception as e:
-            handle_exception(u"Unable to redeem: {e}".format(e=e), e)
+            handle_exception("Unable to redeem: {e}".format(e=e), e)
 
         self._request_validity_check()

--- a/src/subscription_manager/cli_command/service_level.py
+++ b/src/subscription_manager/cli_command/service_level.py
@@ -110,7 +110,7 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
                 self.cp = self.cp_provider.get_consumer_auth_cp()
         except connection.RestlibException as re:
             log.exception(re)
-            log.error(u"Error: Unable to retrieve service levels: {re}".format(re=re))
+            log.error("Error: Unable to retrieve service levels: {re}".format(re=re))
 
             mapped_message: str = ExceptionMapper().get_message(re)
             system_exit(os.EX_SOFTWARE, mapped_message)
@@ -134,7 +134,7 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
                 raise ge
             except connection.RestlibException as re_err:
                 log.exception(re_err)
-                log.error(u"Error: Unable to retrieve service levels: {err}".format(err=re_err))
+                log.error("Error: Unable to retrieve service levels: {err}".format(err=re_err))
 
                 mapped_message: str = ExceptionMapper().get_message(re_err)
                 system_exit(os.EX_SOFTWARE, mapped_message)

--- a/src/subscription_manager/content_action_client.py
+++ b/src/subscription_manager/content_action_client.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2014 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/cp_provider.py
+++ b/src/subscription_manager/cp_provider.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/cpuinfo.py
+++ b/src/subscription_manager/cpuinfo.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Read and parse /proc/cpuinfo
 #
 # Copyright (c) 2015 Red Hat, Inc.

--- a/src/subscription_manager/dbus_interface.py
+++ b/src/subscription_manager/dbus_interface.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/entbranding.py
+++ b/src/subscription_manager/entbranding.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 #

--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2014 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 #

--- a/src/subscription_manager/factlib.py
+++ b/src/subscription_manager/factlib.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # Authors: Adrian Likins <alikins@redhat.com>

--- a/src/subscription_manager/facts.py
+++ b/src/subscription_manager/facts.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/src/subscription_manager/healinglib.py
+++ b/src/subscription_manager/healinglib.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/i18n_argparse.py
+++ b/src/subscription_manager/i18n_argparse.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Make argparse friendlier to i18n/l10n
 #
 # Copyright (c) 2010 Red Hat, Inc.

--- a/src/subscription_manager/identity.py
+++ b/src/subscription_manager/identity.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/identitycertlib.py
+++ b/src/subscription_manager/identitycertlib.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/injection.py
+++ b/src/subscription_manager/injection.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/injectioninit.py
+++ b/src/subscription_manager/injectioninit.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/installedproductslib.py
+++ b/src/subscription_manager/installedproductslib.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/src/subscription_manager/isodate.py
+++ b/src/subscription_manager/isodate.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # find a reasonable iso8601 date parser
 #
 # Copyright (c) 2013 Red Hat, Inc.

--- a/src/subscription_manager/jsonwrapper.py
+++ b/src/subscription_manager/jsonwrapper.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/listing.py
+++ b/src/subscription_manager/listing.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/lock.py
+++ b/src/subscription_manager/lock.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # Authors: Jeff Ortel <jortel@redhat.com>

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Subscription manager command line utility.
 #
 # Copyright (c) 2010 Red Hat, Inc.

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, division, absolute_import
-
 #
 # Subscription manager command line utility.
 #

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # common calls to get product and entitlemnt info for gui/tui
 #
 # Copyright (c) 2010 Red Hat, Inc.

--- a/src/subscription_manager/model/__init__.py
+++ b/src/subscription_manager/model/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2014 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/model/ent_cert.py
+++ b/src/subscription_manager/model/ent_cert.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2014 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/overrides.py
+++ b/src/subscription_manager/overrides.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 #

--- a/src/subscription_manager/packageprofilelib.py
+++ b/src/subscription_manager/packageprofilelib.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/src/subscription_manager/plugin/container/__init__.py
+++ b/src/subscription_manager/plugin/container/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2014 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/plugin/ostree/action_invoker.py
+++ b/src/subscription_manager/plugin/ostree/action_invoker.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2014 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/plugin/ostree/config.py
+++ b/src/subscription_manager/plugin/ostree/config.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2014 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/plugin/ostree/model.py
+++ b/src/subscription_manager/plugin/ostree/model.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2014 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/printing_utils.py
+++ b/src/subscription_manager/printing_utils.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2014 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # Authors: Jeff Ortel <jortel@redhat.com>

--- a/src/subscription_manager/reasons.py
+++ b/src/subscription_manager/reasons.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/release.py
+++ b/src/subscription_manager/release.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Subscription manager command line utility. This script is a modified version of
 # cp_client.py from candlepin scripts
 #

--- a/src/subscription_manager/release.py
+++ b/src/subscription_manager/release.py
@@ -178,7 +178,7 @@ class CdnReleaseVersionProvider(object):
         listing_parts = content_url.split('$releasever', 1)
         listing_base = listing_parts[0]
         # FIXME: cleanup paths ("//"'s, etc)
-        return u"%s/listing" % listing_base  # FIXME(khowell): ensure that my changes here don't break earlier fix
+        return "%s/listing" % listing_base  # FIXME(khowell): ensure that my changes here don't break earlier fix
 
     # require tags provided by installed products?
 

--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -1,7 +1,4 @@
-#
 # -*- coding: utf-8 -*-#
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2010 Red Hat, Inc.
 # Copyright (c) 2017 ATIX AG
 #

--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-#
 # Copyright (c) 2010 Red Hat, Inc.
 # Copyright (c) 2017 ATIX AG
 #

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # Authors: Jeff Ortel <jortel@redhat.com>

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -600,7 +600,7 @@ class RepoUpdateActionCommand(object):
 @six.python_2_unicode_compatible
 class RepoActionReport(ActionReport):
     """Report class for reporting yum repo updates."""
-    name = u"Repo Updates"
+    name = "Repo Updates"
 
     def __init__(self):
         super(RepoActionReport, self).__init__()
@@ -615,20 +615,19 @@ class RepoActionReport(ActionReport):
     def format_repos_info(self, repos, formatter):
         indent = '    '
         if not repos:
-            return u'%s<NONE>' % indent
+            return '%s<NONE>' % indent
 
         r = []
         for repo in repos:
-            r.append(u"%s%s" % (indent, formatter(repo)))
-        return u'\n'.join(r)
+            r.append("%s%s" % (indent, formatter(repo)))
+        return '\n'.join(r)
 
     def repo_format(self, repo):
-        msg = u"[id:%s %s]" % (repo.id,
-                               repo['name'])
+        msg = "[id:%s %s]" % (repo.id, repo['name'])
         return msg.encode('utf8')
 
     def section_format(self, section):
-        return u"[%s]" % section
+        return "[%s]" % section
 
     def format_repos(self, repos):
         return self.format_repos_info(repos, self.repo_format)
@@ -646,4 +645,4 @@ class RepoActionReport(ActionReport):
         s.append(_('Deleted'))
         # deleted are former repo sections, but they are the same type
         s.append(self.format_sections(self.repo_deleted))
-        return u'\n'.join(s)
+        return '\n'.join(s)

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -1,7 +1,4 @@
-#
 # -*- coding: utf-8 -*-#
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # Authors: Jeff Ortel <jortel@redhat.com>

--- a/src/subscription_manager/rhelentbranding.py
+++ b/src/subscription_manager/rhelentbranding.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 #

--- a/src/subscription_manager/rhelproduct.py
+++ b/src/subscription_manager/rhelproduct.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2014 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/scripts/package_profile_upload.py
+++ b/src/subscription_manager/scripts/package_profile_upload.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/scripts/rct.py
+++ b/src/subscription_manager/scripts/rct.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #

--- a/src/subscription_manager/scripts/rct.py
+++ b/src/subscription_manager/scripts/rct.py
@@ -13,7 +13,7 @@
 #
 
 # hack to allow bytes/strings to be interpolated w/ unicode values (gettext gives us bytes)
-# Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
+# Without this, for example, "Формат: %s\n" % "foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
 import sys
 

--- a/src/subscription_manager/scripts/rct.py
+++ b/src/subscription_manager/scripts/rct.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-#
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/scripts/rhsm_debug.py
+++ b/src/subscription_manager/scripts/rhsm_debug.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #

--- a/src/subscription_manager/scripts/rhsm_debug.py
+++ b/src/subscription_manager/scripts/rhsm_debug.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-#
 # Copyright (c) 2010 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/scripts/rhsm_debug.py
+++ b/src/subscription_manager/scripts/rhsm_debug.py
@@ -13,7 +13,7 @@
 #
 
 # hack to allow bytes/strings to be interpolated w/ unicode values (gettext gives us bytes)
-# Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
+# Without this, for example, "Формат: %s\n" % "foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
 import sys
 import os

--- a/src/subscription_manager/scripts/rhsm_facts_service.py
+++ b/src/subscription_manager/scripts/rhsm_facts_service.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/scripts/rhsm_service.py
+++ b/src/subscription_manager/scripts/rhsm_service.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-#
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/scripts/rhsm_service.py
+++ b/src/subscription_manager/scripts/rhsm_service.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2016 Red Hat, Inc.
 #

--- a/src/subscription_manager/scripts/rhsm_service.py
+++ b/src/subscription_manager/scripts/rhsm_service.py
@@ -19,7 +19,7 @@ log = logging.getLogger('')
 log.setLevel(logging.INFO)
 
 # hack to allow bytes/strings to be interpolated w/ unicode values (gettext gives us bytes)
-# Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
+# Without this, for example, "Формат: %s\n" % "foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
 import sys
 

--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-# ^ is to prevent selinux denials trying to load modules from unintended
-#   paths. See https://bugzilla.redhat.com/show_bug.cgi?id=1136163
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # ^ is to prevent selinux denials trying to load modules from unintended
 #   paths. See https://bugzilla.redhat.com/show_bug.cgi?id=1136163
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2012 Red Hat, Inc.
 #

--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -13,7 +13,7 @@
 #
 
 # hack to allow bytes/strings to be interpolated w/ unicode values (gettext gives us bytes)
-# Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
+# Without this, for example, "Формат: %s\n" % "foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
 import sys
 

--- a/src/subscription_manager/scripts/subscription_manager.py
+++ b/src/subscription_manager/scripts/subscription_manager.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 #
 # wrapper for subscription Manager commandline tool.
 #

--- a/src/subscription_manager/scripts/subscription_manager.py
+++ b/src/subscription_manager/scripts/subscription_manager.py
@@ -17,7 +17,7 @@
 #
 
 # hack to allow bytes/strings to be interpolated w/ unicode values (gettext gives us bytes)
-# Without this, for example, "Формат: %s\n" % u"foobar" will fail with UnicodeDecodeError
+# Without this, for example, "Формат: %s\n" % "foobar" will fail with UnicodeDecodeError
 # See http://stackoverflow.com/a/29832646/6124862 for more details
 import sys
 import os

--- a/src/subscription_manager/scripts/subscription_manager.py
+++ b/src/subscription_manager/scripts/subscription_manager.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-#
 # wrapper for subscription Manager commandline tool.
 #
 # Copyright (c) 2010 Red Hat, Inc.

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2018 Red Hat, Inc.
 #

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-#
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/unicode_width.py
+++ b/src/subscription_manager/unicode_width.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 # Copyright (c) 2010 Ville Skyttä
 # Copyright (c) 2009 Tim Lauridsen

--- a/src/subscription_manager/unicode_width.py
+++ b/src/subscription_manager/unicode_width.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2013 Red Hat, Inc.
 # Copyright (c) 2010 Ville Skyttä

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -446,7 +446,7 @@ class ProductCertificateFilter(CertificateFilter):
             '?': '.',
         }
 
-        expression = u"""
+        expression = """
             ((?:                # A captured, non-capture group :)
                 [^*?\\\\]*        # Character literals and other uninteresting junk (greedy)
                 (?:\\\\.?)*       # Anything escaped with a backslash, or just a trailing backslash

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/validity.py
+++ b/src/subscription_manager/validity.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/subscription_manager/version.py
+++ b/src/subscription_manager/version.py
@@ -1,4 +1,2 @@
-from __future__ import print_function, division, absolute_import
-
 # The values in this file are populated by setup.py build
 rpm_version = "RPM_VERSION"

--- a/src/syspurpose/files.py
+++ b/src/syspurpose/files.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/syspurpose/files.py
+++ b/src/syspurpose/files.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-#
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/syspurpose/utils.py
+++ b/src/syspurpose/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/src/syspurpose/utils.py
+++ b/src/syspurpose/utils.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-#
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import os
 import pathlib
 import sys

--- a/test/certdata.py
+++ b/test/certdata.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/cli_command_test/test_addons.py
+++ b/test/cli_command_test/test_addons.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import json
 import sys
 from contextlib import ExitStack

--- a/test/cli_command_test/test_attach.py
+++ b/test/cli_command_test/test_attach.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import contextlib
 import os
 import sys

--- a/test/cli_command_test/test_clean.py
+++ b/test/cli_command_test/test_clean.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..test_managercli import TestCliCommand
 from subscription_manager import managercli
 

--- a/test/cli_command_test/test_config.py
+++ b/test/cli_command_test/test_config.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import sys
 
 from rhsmlib.services import config

--- a/test/cli_command_test/test_environments.py
+++ b/test/cli_command_test/test_environments.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..test_managercli import TestCliProxyCommand
 from subscription_manager import managercli
 

--- a/test/cli_command_test/test_facts.py
+++ b/test/cli_command_test/test_facts.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..test_managercli import TestCliProxyCommand
 from subscription_manager import managercli
 

--- a/test/cli_command_test/test_identity.py
+++ b/test/cli_command_test/test_identity.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..test_managercli import TestCliProxyCommand
 from subscription_manager import managercli
 

--- a/test/cli_command_test/test_import_cert.py
+++ b/test/cli_command_test/test_import_cert.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 

--- a/test/cli_command_test/test_list.py
+++ b/test/cli_command_test/test_list.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 

--- a/test/cli_command_test/test_list.py
+++ b/test/cli_command_test/test_list.py
@@ -429,8 +429,8 @@ class TestListCommand(TestCliProxyCommand):
         product = StubProduct("product1")
         ent_cert = StubEntitlementCertificate(product)
         ent_cert.order.usage = "Development"
-        ent_cert.order.roles = [u"SP Server", u"SP Starter"]
-        ent_cert.order.addons = [u"ADDON1", u"ADDON2"]
+        ent_cert.order.roles = ["SP Server", "SP Starter"]
+        ent_cert.order.addons = ["ADDON1", "ADDON2"]
         ent_cert.version = MagicMock()
         ent_cert.version.major = 3
         ent_cert.version.minor = 4

--- a/test/cli_command_test/test_override.py
+++ b/test/cli_command_test/test_override.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 import sys
 

--- a/test/cli_command_test/test_owners.py
+++ b/test/cli_command_test/test_owners.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..test_managercli import TestCliProxyCommand
 from subscription_manager import managercli
 

--- a/test/cli_command_test/test_plugins.py
+++ b/test/cli_command_test/test_plugins.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..test_managercli import TestCliCommand
 from subscription_manager import managercli
 

--- a/test/cli_command_test/test_redeem.py
+++ b/test/cli_command_test/test_redeem.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..test_managercli import TestCliProxyCommand
 from subscription_manager import managercli
 

--- a/test/cli_command_test/test_refresh.py
+++ b/test/cli_command_test/test_refresh.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..fixture import SubManFixture
 from ..test_managercli import TestCliProxyCommand
 from mock import Mock

--- a/test/cli_command_test/test_register.py
+++ b/test/cli_command_test/test_register.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import sys
 
 from ..test_managercli import TestCliProxyCommand

--- a/test/cli_command_test/test_release.py
+++ b/test/cli_command_test/test_release.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..test_managercli import TestCliProxyCommand
 from subscription_manager import managercli
 from subscription_manager.cli_command import release

--- a/test/cli_command_test/test_remove.py
+++ b/test/cli_command_test/test_remove.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 
 from ..test_managercli import TestCliProxyCommand

--- a/test/cli_command_test/test_repos.py
+++ b/test/cli_command_test/test_repos.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 import sys
 

--- a/test/cli_command_test/test_role.py
+++ b/test/cli_command_test/test_role.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 
 from ..test_managercli import TestCliProxyCommand

--- a/test/cli_command_test/test_service_level.py
+++ b/test/cli_command_test/test_service_level.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import shutil
 import tempfile

--- a/test/cli_command_test/test_status.py
+++ b/test/cli_command_test/test_status.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from subscription_manager import managercli
 
 from ..stubs import StubConsumerIdentity, StubUEP

--- a/test/cli_command_test/test_unregister.py
+++ b/test/cli_command_test/test_unregister.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..test_managercli import TestCliProxyCommand
 from subscription_manager import managercli
 

--- a/test/cli_command_test/test_version.py
+++ b/test/cli_command_test/test_version.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..test_managercli import TestCliCommand
 from subscription_manager import managercli
 

--- a/test/cloud_what/test_cloud_what.py
+++ b/test/cloud_what/test_cloud_what.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2020 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import difflib
 import locale
 import os

--- a/test/manifestdata.py
+++ b/test/manifestdata.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 correct_manifest_output = """
 +-------------------------------------------+
 \tManifest

--- a/test/modelhelpers.py
+++ b/test/modelhelpers.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/plugins/config_plugin.py
+++ b/test/plugins/config_plugin.py
@@ -1,7 +1,5 @@
 #! /usr/bin/python
 
-from __future__ import print_function, division, absolute_import
-
 from subscription_manager.base_plugin import SubManPlugin
 
 requires_api_version = "1.0"

--- a/test/plugins/disabled_plugin.py
+++ b/test/plugins/disabled_plugin.py
@@ -1,6 +1,4 @@
 #! /usr/bin/python
-from __future__ import print_function, division, absolute_import
-
 from subscription_manager.base_plugin import SubManPlugin
 
 requires_api_version = "1.0"

--- a/test/plugins/dummy_plugin.py
+++ b/test/plugins/dummy_plugin.py
@@ -1,6 +1,4 @@
 #! /usr/bin/python
-from __future__ import print_function, division, absolute_import
-
 from subscription_manager.base_plugin import SubManPlugin
 
 requires_api_version = "1.0"

--- a/test/plugins/dummy_plugin_2.py
+++ b/test/plugins/dummy_plugin_2.py
@@ -1,6 +1,4 @@
 #! /usr/bin/python
-from __future__ import print_function, division, absolute_import
-
 from subscription_manager.base_plugin import SubManPlugin
 
 requires_api_version = "1.0"

--- a/test/plugins/dummy_plugin_3.py
+++ b/test/plugins/dummy_plugin_3.py
@@ -1,6 +1,4 @@
 #! /usr/bin/python
-from __future__ import print_function, division, absolute_import
-
 from subscription_manager.base_plugin import SubManPlugin
 
 requires_api_version = "1.0"

--- a/test/plugins/no_api_version.py
+++ b/test/plugins/no_api_version.py
@@ -1,6 +1,4 @@
 #! /usr/bin/python
-from __future__ import print_function, division, absolute_import
-
 from subscription_manager.base_plugin import SubManPlugin
 
 

--- a/test/plugins/old_api_version.py
+++ b/test/plugins/old_api_version.py
@@ -1,7 +1,5 @@
 #! /usr/bin/python
 
-from __future__ import print_function, division, absolute_import
-
 from subscription_manager.base_plugin import SubManPlugin
 
 requires_api_version = "0.0"

--- a/test/rhsm/functional/connection_tests.py
+++ b/test/rhsm/functional/connection_tests.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2011 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsm/functional/profile_tests.py
+++ b/test/rhsm/functional/profile_tests.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2011 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/test/rhsm/unit/bitstream_tests.py
+++ b/test/rhsm/unit/bitstream_tests.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsm/unit/certdata.py
+++ b/test/rhsm/unit/certdata.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsm/unit/certificate2_tests.py
+++ b/test/rhsm/unit/certificate2_tests.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsm/unit/certificate_tests.py
+++ b/test/rhsm/unit/certificate_tests.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2011 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsm/unit/config_tests.py
+++ b/test/rhsm/unit/config_tests.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2011 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsm/unit/connection_tests.py
+++ b/test/rhsm/unit/connection_tests.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2011 - 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsm/unit/connection_tests.py
+++ b/test/rhsm/unit/connection_tests.py
@@ -535,7 +535,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
 
     def test_200_json(self):
         # no exceptions
-        content = u'{"something": "whatever"}'
+        content = '{"something": "whatever"}'
         self.vr("200", content)
 
     # 202 ACCEPTED
@@ -546,7 +546,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
         self.vr("202", None)
 
     def test_202_json(self):
-        content = u'{"something": "whatever"}'
+        content = '{"something": "whatever"}'
         self.vr("202", content)
 
     # 204 NO CONTENT
@@ -587,7 +587,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
             self.fail("Should have raised UnauthorizedException")
 
     def test_401_invalid_json(self):
-        content = u'{this is not json</> dfsdf"" '
+        content = '{this is not json</> dfsdf"" '
         try:
             self.vr("401", content)
         except UnauthorizedException as e:
@@ -602,7 +602,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
     @patch("rhsm.connection.json.loads")
     def test_401_json_exception(self, mock_json_loads):
         mock_json_loads.side_effect = Exception
-        content = u'{"errors": ["Forbidden message"]}'
+        content = '{"errors": ["Forbidden message"]}'
         try:
             self.vr("401", content)
         except UnauthorizedException as e:
@@ -615,7 +615,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
             self.fail("Should have raised UnauthorizedException")
 
     def test_403_valid(self):
-        content = u'{"errors": ["Forbidden message"]}'
+        content = '{"errors": ["Forbidden message"]}'
         try:
             self.vr("403", content)
         except RestlibException as e:
@@ -637,7 +637,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
             self.fail("Should have raised ForbiddenException")
 
     def test_401_valid(self):
-        content = u'{"errors": ["Unauthorized message"]}'
+        content = '{"errors": ["Unauthorized message"]}'
         try:
             self.vr("401", content)
         except RestlibException as e:
@@ -657,7 +657,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
             self.fails("Should have raise RemoteServerException")
 
     def test_404_valid_but_irrelevant_json(self):
-        content = u'{"something": "whatever"}'
+        content = '{"something": "whatever"}'
         try:
             self.vr("404", content)
         except RestlibException as e:
@@ -667,7 +667,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
             self.fails("Should have raised a RemoteServerException")
 
     def test_404_valid_body_old_style(self):
-        content = u'{"displayMessage": "not found"}'
+        content = '{"displayMessage": "not found"}'
         try:
             self.vr("404", content)
         except RestlibException as e:
@@ -679,7 +679,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
             self.fail("RestlibException expected")
 
     def test_404_valid_body(self):
-        content = u'{"errors": ["not found", "still not found"]}'
+        content = '{"errors": ["not found", "still not found"]}'
         try:
             self.vr("404", content)
         except RestlibException as e:
@@ -700,7 +700,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
             self.fail("RemoteServerException expected")
 
     def test_410_body(self):
-        content = u'{"displayMessage": "foo", "deletedId": "12345"}'
+        content = '{"displayMessage": "foo", "deletedId": "12345"}'
         # self.assertRaises(GoneException, self.vr, "410", content)
         try:
             self.vr("410", content)
@@ -720,7 +720,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
             self.fail("Should have raised a RateLimitExceededException")
 
     def test_429_body(self):
-        content = u'{"errors": ["TooFast"]}'
+        content = '{"errors": ["TooFast"]}'
         headers = {'retry-after': 20}
         try:
             self.vr("429", content, headers)
@@ -748,7 +748,7 @@ class RestlibTests(unittest.TestCase):
 
     def test_json_uft8_encoding(self):
         # A unicode string containing JSON
-        test_json = u"""
+        test_json = """
             {
                 "firstName": "John",
                 "message": "こんにちは世界",
@@ -762,9 +762,9 @@ class RestlibTests(unittest.TestCase):
             }
         """
         data = json.loads(test_json)
-        self.assertTrue(isinstance(data["message"], type(u"")))
+        self.assertTrue(isinstance(data["message"], type("")))
         # Access a value deep in the structure to make sure we recursed down.
-        self.assertTrue(isinstance(data["phoneNumbers"][0][0]["type"], type(u"")))
+        self.assertTrue(isinstance(data["phoneNumbers"][0][0]["type"], type("")))
 
 
 # see #830767 and #842885 for examples of why this is
@@ -778,9 +778,9 @@ class ExceptionTest(unittest.TestCase):
         # FIXME: validate results are strings, unicode, etc
         # but just looking for exceptions atm
         # - no assertIsInstance on 2.4/2.6
-        self.assertTrue(isinstance("%s" % e, str) or isinstance("%s" % e, type(u"")))
-        self.assertTrue(isinstance("%s" % str(e), str) or isinstance("%s" % str(e), type(u"")))
-        self.assertTrue(isinstance("%s" % repr(e), str) or isinstance("%s" % repr(e), type(u"")))
+        self.assertTrue(isinstance("%s" % e, str) or isinstance("%s" % e, type("")))
+        self.assertTrue(isinstance("%s" % str(e), str) or isinstance("%s" % str(e), type("")))
+        self.assertTrue(isinstance("%s" % repr(e), str) or isinstance("%s" % repr(e), type("")))
 
     def _create_exception(self, *args, **kwargs):
         return self.exception(args, kwargs)

--- a/test/rhsm/unit/connection_tests.py
+++ b/test/rhsm/unit/connection_tests.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2011 - 2012 Red Hat, Inc.
 #

--- a/test/rhsm/unit/huffman_tests.py
+++ b/test/rhsm/unit/huffman_tests.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsm/unit/json_tests.py
+++ b/test/rhsm/unit/json_tests.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2015 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsm/unit/oid_tests.py
+++ b/test/rhsm/unit/oid_tests.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 from rhsm.certificate import OID

--- a/test/rhsm/unit/pathtree_tests.py
+++ b/test/rhsm/unit/pathtree_tests.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsm/unit/util_tests.py
+++ b/test/rhsm/unit/util_tests.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 from mock import patch

--- a/test/rhsm_display.py
+++ b/test/rhsm_display.py
@@ -1,6 +1,4 @@
 #!/usr/bin/python
-from __future__ import print_function, division, absolute_import
-
 
 # if we are going to use a display, check to
 # see if we set RHSM_DISPLAY and set DISPLAY

--- a/test/rhsmlib_test/base.py
+++ b/test/rhsmlib_test/base.py
@@ -1,6 +1,4 @@
 #! /usr/bin/env python
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2011 Red Hat, Inc.
 #

--- a/test/rhsmlib_test/test_attach.py
+++ b/test/rhsmlib_test/test_attach.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_cloud_facts.py
+++ b/test/rhsmlib_test/test_cloud_facts.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_collector.py
+++ b/test/rhsmlib_test/test_collector.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_compat.py
+++ b/test/rhsmlib_test/test_compat.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_config.py
+++ b/test/rhsmlib_test/test_config.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_consumer.py
+++ b/test/rhsmlib_test/test_consumer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_entitlement.py
+++ b/test/rhsmlib_test/test_entitlement.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_facts.py
+++ b/test/rhsmlib_test/test_facts.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_file_monitor.py
+++ b/test/rhsmlib_test/test_file_monitor.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_host_collector.py
+++ b/test/rhsmlib_test/test_host_collector.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_hwprobe.py
+++ b/test/rhsmlib_test/test_hwprobe.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_import_class.py
+++ b/test/rhsmlib_test/test_import_class.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_insights.py
+++ b/test/rhsmlib_test/test_insights.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_kpatch.py
+++ b/test/rhsmlib_test/test_kpatch.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2020 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_products.py
+++ b/test/rhsmlib_test/test_products.py
@@ -243,20 +243,20 @@ class TestProductService(InjectionMockingTest):
 
         expected_result = [
             (
-                u'Red Hat Enterprise Linux Server',
+                'Red Hat Enterprise Linux Server',
                 '69',
-                u'7.4',
-                u'x86_64',
+                '7.4',
+                'x86_64',
                 'subscribed',
                 [],
                 '{d.day}.{d.month}.{d.year}'.format(d=START_DATE),
                 '{d.day}.{d.month}.{d.year}'.format(d=END_DATE)
             ),
             (
-                u'Red Hat Enterprise Linux Server - Extended Update Support',
+                'Red Hat Enterprise Linux Server - Extended Update Support',
                 '70',
-                u'7.2',
-                u'x86_64',
+                '7.2',
+                'x86_64',
                 'subscribed',
                 [],
                 '{d.day}.{d.month}.{d.year}'.format(d=START_DATE),
@@ -294,10 +294,10 @@ class TestProductService(InjectionMockingTest):
 
         expected_result = [
             (
-                u'Red Hat Enterprise Linux Server - Extended Update Support',
+                'Red Hat Enterprise Linux Server - Extended Update Support',
                 '70',
-                u'7.2',
-                u'x86_64',
+                '7.2',
+                'x86_64',
                 'subscribed',
                 [],
                 '{d.day}.{d.month}.{d.year}'.format(d=START_DATE),
@@ -344,20 +344,20 @@ class TestProductsDBusObject(DBusObjectTest, InjectionMockingTest):
     def test_list_installed_products_without_filter(self):
         expected_result = [
             (
-                u'Red Hat Enterprise Linux Server',
+                'Red Hat Enterprise Linux Server',
                 '69',
-                u'7.4',
-                u'x86_64',
+                '7.4',
+                'x86_64',
                 'subscribed',
                 [],
                 START_DATE.strftime("%Y-%m-%d"),
                 END_DATE.strftime("%Y-%m-%d")
             ),
             (
-                u'Red Hat Enterprise Linux Server - Extended Update Support',
+                'Red Hat Enterprise Linux Server - Extended Update Support',
                 '70',
-                u'7.2',
-                u'x86_64',
+                '7.2',
+                'x86_64',
                 'subscribed',
                 [],
                 START_DATE.strftime("%Y-%m-%d"),

--- a/test/rhsmlib_test/test_products.py
+++ b/test/rhsmlib_test/test_products.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_service_wrapper.py
+++ b/test/rhsmlib_test/test_service_wrapper.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_unregister.py
+++ b/test/rhsmlib_test/test_unregister.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_utils.py
+++ b/test/rhsmlib_test/test_utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/rhsmlib_test/test_virt.py
+++ b/test/rhsmlib_test/test_virt.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/syspurpose/base.py
+++ b/test/syspurpose/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/syspurpose/base.py
+++ b/test/syspurpose/base.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-#
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/syspurpose/test_syspurposefiles.py
+++ b/test/syspurpose/test_syspurposefiles.py
@@ -63,7 +63,7 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         The SyspurposeStore.read_file method should return True if the file with unicode content was successfully read.
         """
         temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
-        test_data = {'key1': u'Νίκος', 'key2': [u'value_with_ř']}
+        test_data = {'key1': 'Νίκος', 'key2': ['value_with_ř']}
         with io.open(temp_dir, 'w', encoding='utf-8') as f:
             utils.write_to_file_utf8(f, test_data)
 
@@ -189,7 +189,7 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         in the store.
         """
         temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
-        test_data = {u'ονόματα': [u'Νίκος']}
+        test_data = {'ονόματα': ['Νίκος']}
         with io.open(temp_dir, 'w', encoding='utf-8') as f:
             utils.write_to_file_utf8(f, test_data)
 
@@ -198,8 +198,8 @@ class SyspurposeStoreTests(SyspurposeTestBase):
 
         # Add to an already seen existing key
         res = self.assertRaisesNothing(syspurpose_store.add, 'ονόματα', 'Κώστας')
-        self.assertIn(u'ονόματα', syspurpose_store.contents)
-        self.assertEqual(syspurpose_store.contents[u'ονόματα'], [u'Νίκος', u'Κώστας'])
+        self.assertIn('ονόματα', syspurpose_store.contents)
+        self.assertEqual(syspurpose_store.contents['ονόματα'], ['Νίκος', 'Κώστας'])
         self.assertTrue(res, "The add method should return true when the store has changed")
 
     def test_add_does_not_duplicate_existing_value(self):
@@ -267,7 +267,7 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         in the store.
         """
         temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
-        test_data = {u'ονόματα': [u'Νίκος', u'Κώστας']}
+        test_data = {'ονόματα': ['Νίκος', 'Κώστας']}
         with io.open(temp_dir, 'w', encoding='utf-8') as f:
             utils.write_to_file_utf8(f, test_data)
 
@@ -276,8 +276,8 @@ class SyspurposeStoreTests(SyspurposeTestBase):
 
         # Remove from an already seen existing key
         res = self.assertRaisesNothing(syspurpose_store.remove, 'ονόματα', 'Κώστας')
-        self.assertIn(u'ονόματα', syspurpose_store.contents)
-        self.assertEqual(syspurpose_store.contents[u'ονόματα'], [u'Νίκος'])
+        self.assertIn('ονόματα', syspurpose_store.contents)
+        self.assertEqual(syspurpose_store.contents['ονόματα'], ['Νίκος'])
         self.assertTrue(res, "The add method should return true when the store has changed")
 
     def test_unset(self):
@@ -306,7 +306,7 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         in the store.
         """
         temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
-        test_data = {u'ονόματα': [u'Νίκος']}
+        test_data = {'ονόματα': ['Νίκος']}
         with io.open(temp_dir, 'w', encoding='utf-8') as f:
             utils.write_to_file_utf8(f, test_data)
 
@@ -316,12 +316,12 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         res = self.assertRaisesNothing(syspurpose_store.unset, "ονόματα")
         # We expect a value of true from this method when the store was changed
         self.assertTrue(res, "The unset method should return true when the store has changed")
-        self.assertNotIn(u'ονόματα', syspurpose_store.contents, msg="Expected the key to no longer be present")
+        self.assertNotIn('ονόματα', syspurpose_store.contents, msg="Expected the key to no longer be present")
 
         res = self.assertRaisesNothing(syspurpose_store.unset, 'άκυρο_κλειδί')
         # We expect falsey values when the store was not modified
         self.assertFalse(res, "The unset method should return false when the store has not changed")
-        self.assertNotIn(u'άκυρο_κλειδί', syspurpose_store.contents, msg="The key passed to unset, has been added to the store")
+        self.assertNotIn('άκυρο_κλειδί', syspurpose_store.contents, msg="The key passed to unset, has been added to the store")
 
     def test_unset_sla(self):
         """
@@ -373,7 +373,7 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         Verify the operation of the set method of SyspurposeStore when using unicode strings
         """
         temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
-        test_data = {u'ονόματα': u'Νίκος'}
+        test_data = {'ονόματα': 'Νίκος'}
 
         syspurpose_store = self.assertRaisesNothing(files.SyspurposeStore, temp_dir)
         syspurpose_store.contents = dict(**test_data)
@@ -381,20 +381,20 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         # Check the behaviour of manipulating an existing key with an identical value (no update)
         res = self.assertRaisesNothing(syspurpose_store.set, 'ονόματα', 'Νίκος')
         self.assertFalse(res, "When a value is not actually changed, set should return false")
-        self.assertIn(u'ονόματα', syspurpose_store.contents)
-        self.assertEqual(syspurpose_store.contents[u'ονόματα'], u'Νίκος')
+        self.assertIn('ονόματα', syspurpose_store.contents)
+        self.assertEqual(syspurpose_store.contents['ονόματα'], 'Νίκος')
 
         # Modify existing item
         res = self.assertRaisesNothing(syspurpose_store.set, 'ονόματα', 'Κώστας')
         self.assertTrue(res, "When an item is set to a new value, set should return true")
-        self.assertIn(u'ονόματα', syspurpose_store.contents)
-        self.assertEqual(syspurpose_store.contents[u'ονόματα'], u'Κώστας')
+        self.assertIn('ονόματα', syspurpose_store.contents)
+        self.assertEqual(syspurpose_store.contents['ονόματα'], 'Κώστας')
 
         # Add new item set to a new value
         res = self.assertRaisesNothing(syspurpose_store.set, 'καινούργιο', 'Άλεξανδρος')
         self.assertTrue(res, "When an item is set to a new value, set should return true")
-        self.assertIn(u'καινούργιο', syspurpose_store.contents)
-        self.assertEqual(syspurpose_store.contents[u'καινούργιο'], u'Άλεξανδρος')
+        self.assertIn('καινούργιο', syspurpose_store.contents)
+        self.assertEqual(syspurpose_store.contents['καινούργιο'], 'Άλεξανδρος')
 
     def test_write(self):
         """
@@ -417,7 +417,7 @@ class SyspurposeStoreTests(SyspurposeTestBase):
         Verify that the SyspurposeStore can write changes that include unicode strings to the expected file.
         """
         temp_dir = os.path.join(self._mktmp(), 'syspurpose_file.json')
-        test_data = {u'όνομα': u'Νίκος'}
+        test_data = {'όνομα': 'Νίκος'}
         syspurpose_store = self.assertRaisesNothing(files.SyspurposeStore, temp_dir)
         syspurpose_store.contents = dict(**test_data)
 
@@ -455,7 +455,7 @@ class TestSyncedStore(SyspurposeTestBase):
         "role": None,
         "usage": None,
         "addOns": [],
-        "serviceLevel": u""
+        "serviceLevel": ""
     }
 
     def setUp(self):
@@ -817,21 +817,21 @@ class TestSyncedStore(SyspurposeTestBase):
 
     def test_values_not_known_server_side_are_left_alone(self):
         cache_contents = {
-            u'role': u'initial_role',
-            u'usage': u'initial_usage',
-            u'service_level_agreement': u'',
-            u'addons': []
+            'role': 'initial_role',
+            'usage': 'initial_usage',
+            'service_level_agreement': '',
+            'addons': []
         }
         local_contents = {
-            u'role': cache_contents[u'role'],
-            u'usage': cache_contents[u'usage'],
-            u'made_up_key': u'arbitrary_value'  # this key was added and is not known
+            'role': cache_contents['role'],
+            'usage': cache_contents['usage'],
+            'made_up_key': 'arbitrary_value'  # this key was added and is not known
         }
         remote_contents = {
-            u'role': u'remote_role',
-            u'usage': u'',  # Usage has been reset on the server side, should be removed locally
-            u'serviceLevel': u'',
-            u'addOns': []
+            'role': 'remote_role',
+            'usage': '',  # Usage has been reset on the server side, should be removed locally
+            'serviceLevel': '',
+            'addOns': []
         }
 
         self.uep.getConsumer.return_value = remote_contents
@@ -849,15 +849,15 @@ class TestSyncedStore(SyspurposeTestBase):
         cache_result = json.load(io.open(self.cache_syspurpose_file, 'r'))
 
         expected_local = {
-            u'role': remote_contents['role'],
-            u'made_up_key': local_contents['made_up_key']
+            'role': remote_contents['role'],
+            'made_up_key': local_contents['made_up_key']
         }
         expected_cache = {
-            u'role': remote_contents['role'],
-            u'usage': remote_contents['usage'],
-            u'made_up_key': local_contents['made_up_key'],
-            u'addons': [],
-            u'service_level_agreement': u''
+            'role': remote_contents['role'],
+            'usage': remote_contents['usage'],
+            'made_up_key': local_contents['made_up_key'],
+            'addons': [],
+            'service_level_agreement': ''
         }
 
         self.assert_equal_dict(expected_local, local_result)
@@ -865,19 +865,19 @@ class TestSyncedStore(SyspurposeTestBase):
 
     def test_same_values_not_synced_with_server(self):
         cache_contents = {
-            u'role': u'initial_role',
-            u'usage': u'initial_usage',
-            u'service_level_agreement': u'initial_sla'
+            'role': 'initial_role',
+            'usage': 'initial_usage',
+            'service_level_agreement': 'initial_sla'
         }
         local_contents = {
-            u'role': u'initial_role',
-            u'usage': u'initial_usage',
-            u'service_level_agreement': u'initial_sla'
+            'role': 'initial_role',
+            'usage': 'initial_usage',
+            'service_level_agreement': 'initial_sla'
         }
         remote_contents = {
-            u'role': u'initial_role',
-            u'usage': u'initial_usage',
-            u'serviceLevel': u'initial_sla'
+            'role': 'initial_role',
+            'usage': 'initial_usage',
+            'serviceLevel': 'initial_sla'
         }
 
         self.uep.getConsumer.return_value = remote_contents
@@ -897,15 +897,15 @@ class TestSyncedStore(SyspurposeTestBase):
         cache_result = json.load(io.open(self.cache_syspurpose_file, 'r'))
 
         expected_local = {
-            u'role': u'initial_role',
-            u'usage': u'initial_usage',
-            u'service_level_agreement': u'initial_sla'
+            'role': 'initial_role',
+            'usage': 'initial_usage',
+            'service_level_agreement': 'initial_sla'
         }
         expected_cache = {
-            u'role': u'initial_role',
-            u'usage': u'initial_usage',
-            u'service_level_agreement': u'initial_sla',
-            u'addons': None
+            'role': 'initial_role',
+            'usage': 'initial_usage',
+            'service_level_agreement': 'initial_sla',
+            'addons': None
         }
 
         self.assert_equal_dict(expected_cache, cache_result)
@@ -915,7 +915,7 @@ class TestSyncedStore(SyspurposeTestBase):
         # This is how we detect if we have syspurpose support
         self.uep.has_capability = mock.Mock(side_effect=lambda x: x in [])
 
-        write_to_file_utf8(io.open(self.local_syspurpose_file, 'w'), {u'role': u'initial'})
+        write_to_file_utf8(io.open(self.local_syspurpose_file, 'w'), {'role': 'initial'})
         write_to_file_utf8(io.open(self.cache_syspurpose_file, 'w'), {})
 
         synced_store = SyncedStore(self.uep, consumer_uuid="something")
@@ -923,7 +923,7 @@ class TestSyncedStore(SyspurposeTestBase):
         remote_content = synced_store.get_remote_contents()
         self.assertEqual(remote_content, {})
 
-        self.assertRaisesNothing(synced_store.set, u'role', u'new_role')
+        self.assertRaisesNothing(synced_store.set, 'role', 'new_role')
         result = self.assertRaisesNothing(synced_store.sync)
 
         self.assertTrue(isinstance(result, SyncResult))
@@ -933,30 +933,30 @@ class TestSyncedStore(SyspurposeTestBase):
 
         # The cache should not be updated at all
         self.assert_equal_dict({}, cache_result)
-        self.assert_equal_dict({u'role': u'new_role'}, local_result)
+        self.assert_equal_dict({'role': 'new_role'}, local_result)
 
         self.uep.updateConsumer.assert_not_called()
 
     def test_server_setting_unsupported_value(self):
-        write_to_file_utf8(io.open(self.local_syspurpose_file, 'w'), {u'role': u''})
+        write_to_file_utf8(io.open(self.local_syspurpose_file, 'w'), {'role': ''})
         write_to_file_utf8(io.open(self.cache_syspurpose_file, 'w'), {})
 
         synced_store = SyncedStore(self.uep, consumer_uuid="something", use_valid_fields=True)
 
         with Capture() as captured:
-            synced_store.set(u'role', u'new_role')
+            synced_store.set('role', 'new_role')
             self.assertTrue('Warning: Provided value "new_role" is not included in the list of valid values for attribute role' in captured.out)
             self.assertTrue("SP Starter" in captured.out)
             self.assertTrue("SP Server" in captured.out)
 
     def test_server_setting_unsupported_key(self):
-        write_to_file_utf8(io.open(self.local_syspurpose_file, 'w'), {u'role': u''})
+        write_to_file_utf8(io.open(self.local_syspurpose_file, 'w'), {'role': ''})
         write_to_file_utf8(io.open(self.cache_syspurpose_file, 'w'), {})
 
         synced_store = SyncedStore(self.uep, consumer_uuid="something", use_valid_fields=True)
 
         with Capture() as captured:
-            synced_store.set(u'foo', u'bar')
+            synced_store.set('foo', 'bar')
             self.assertTrue('Warning: Provided key "foo" is not included in the list of valid keys' in captured.out)
             self.assertTrue("addons" in captured.out)
             self.assertTrue("usage" in captured.out)
@@ -969,7 +969,7 @@ class TestSyncedStore(SyspurposeTestBase):
         # values
 
         self.uep.has_capability = mock.Mock(side_effect=lambda x: x in [])
-        write_to_file_utf8(io.open(self.local_syspurpose_file, 'w'), {u'role': u'initial'})
+        write_to_file_utf8(io.open(self.local_syspurpose_file, 'w'), {'role': 'initial'})
         write_to_file_utf8(io.open(self.cache_syspurpose_file, 'w'), {})
 
         synced_store = SyncedStore(self.uep, consumer_uuid="something")
@@ -980,7 +980,7 @@ class TestSyncedStore(SyspurposeTestBase):
         local_result = json.load(io.open(self.local_syspurpose_file, 'r'))
         cache_result = json.load(io.open(self.cache_syspurpose_file, 'r'))
 
-        self.assert_equal_dict({u'role': u'initial'}, local_result)
+        self.assert_equal_dict({'role': 'initial'}, local_result)
         self.assert_equal_dict({}, cache_result)
 
         # Now the "fake" upgrade
@@ -997,27 +997,27 @@ class TestSyncedStore(SyspurposeTestBase):
         cache_result = json.load(io.open(self.cache_syspurpose_file, 'r'))
 
         expected_cache = {
-            u'role': u'initial',  # This was set locally before and should still be
-            u'usage': self.default_remote_values['usage'],
-            u'service_level_agreement': self.default_remote_values['serviceLevel'],
-            u'addons': self.default_remote_values['addOns']
+            'role': 'initial',  # This was set locally before and should still be
+            'usage': self.default_remote_values['usage'],
+            'service_level_agreement': self.default_remote_values['serviceLevel'],
+            'addons': self.default_remote_values['addOns']
         }
 
-        self.assert_equal_dict({u'role': u'initial'}, local_result)
+        self.assert_equal_dict({'role': 'initial'}, local_result)
         self.assert_equal_dict(expected_cache, cache_result)
 
     def test_user_deletes_syspurpose_file(self):
         cache_contents = {
-            u'role': u'initial_role',
-            u'usage': u'initial_usage',
-            u'service_level_agreement': u'',
-            u'addons': []
+            'role': 'initial_role',
+            'usage': 'initial_usage',
+            'service_level_agreement': '',
+            'addons': []
         }
         remote_contents = {
-            u'role': u'initial_role',
-            u'usage': u'initial_usage',
-            u'serviceLevel': u'',
-            u'addOns': []
+            'role': 'initial_role',
+            'usage': 'initial_usage',
+            'serviceLevel': '',
+            'addOns': []
         }
         consumer_uuid = "something"
         self.uep.getConsumer.return_value = remote_contents
@@ -1028,8 +1028,8 @@ class TestSyncedStore(SyspurposeTestBase):
         synced_store = SyncedStore(self.uep, consumer_uuid=consumer_uuid)
         self.assertRaisesNothing(synced_store.sync)
 
-        expected_cache = {u'service_level_agreement': u'',
-                          u'addons': []}
+        expected_cache = {'service_level_agreement': '',
+                          'addons': []}
         expected_local = {}
 
         local_result = json.load(io.open(self.local_syspurpose_file, 'r'))
@@ -1038,9 +1038,9 @@ class TestSyncedStore(SyspurposeTestBase):
         self.assert_equal_dict(expected_local, local_result)
         self.assert_equal_dict(expected_cache, cache_result)
         self.uep.updateConsumer.assert_called_once_with(consumer_uuid,
-                                                        role=u"",
-                                                        usage=u"",
-                                                        service_level=u"",
+                                                        role="",
+                                                        usage="",
+                                                        service_level="",
                                                         addons=[])
 
     def test_read_file_non_existent_directory(self):

--- a/test/syspurpose/test_syspurposefiles.py
+++ b/test/syspurpose/test_syspurposefiles.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/syspurpose/test_syspurposefiles.py
+++ b/test/syspurpose/test_syspurposefiles.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-#
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/syspurpose/test_utils.py
+++ b/test/syspurpose/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/syspurpose/test_utils.py
+++ b/test/syspurpose/test_utils.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-#
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2015 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/test/test_async_utils.py
+++ b/test/test_async_utils.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_auto_registration.py
+++ b/test/test_auto_registration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2020 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_branding.py
+++ b/test/test_branding.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-#
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -423,16 +423,15 @@ class TestProfileManager(unittest.TestCase):
         json_str = json.dumps(data)  # to json
         data = json.loads(json_str)  # and back to an object
         for attr in ['name', 'version', 'release', 'arch', 'vendor']:
-            self.assertEqual(u'\ufffd', data[attr])
+            self.assertEqual('\ufffd', data[attr])
 
     def test_package_json_as_unicode_type(self):
-        # note that the data type at time of writing is bytes, so this is just defensive coding
-        package = Package(name=u'Björk', version=u'Björk', release=u'Björk', arch=u'Björk', vendor=u'Björk')
+        package = Package(name='Björk', version='Björk', release='Björk', arch='Björk', vendor='Björk')
         data = package.to_dict()
         json_str = json.dumps(data)  # to json
         data = json.loads(json_str)  # and back to an object
         for attr in ['name', 'version', 'release', 'arch', 'vendor']:
-            self.assertEqual(u'Björk', data[attr])
+            self.assertEqual('Björk', data[attr])
 
     def test_package_json_missing_attributes(self):
         package = Package(name=None, version=None, release=None, arch=None, vendor=None)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2011 Red Hat, Inc.
 #

--- a/test/test_catcert_command.py
+++ b/test/test_catcert_command.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_cert_sorter.py
+++ b/test/test_cert_sorter.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_certdirectory.py
+++ b/test/test_certdirectory.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_certificate.py
+++ b/test/test_certificate.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_certlib.py
+++ b/test/test_certlib.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_certmgr.py
+++ b/test/test_certmgr.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_completion.py
+++ b/test/test_completion.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_container_content_plugin.py
+++ b/test/test_container_content_plugin.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2014 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/test/test_cp_provider.py
+++ b/test/test_cp_provider.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_cpuinfo.py
+++ b/test/test_cpuinfo.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import os
 import logging
 log = logging.getLogger("rhsm-app.unittests." + __name__)

--- a/test/test_dnf_content_plugin.py
+++ b/test/test_dnf_content_plugin.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 import imp
 import os
 import types

--- a/test/test_dnf_content_plugin.py
+++ b/test/test_dnf_content_plugin.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import imp
 import os
 import types

--- a/test/test_entbranding.py
+++ b/test/test_entbranding.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import mock
 
 from . import fixture

--- a/test/test_entcertlib.py
+++ b/test/test_entcertlib.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-#
 
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2012 Red Hat, Inc.
 #

--- a/test/test_entcertlib.py
+++ b/test/test_entcertlib.py
@@ -42,8 +42,8 @@ class TestingUpdateAction(entcertlib.EntCertUpdateAction):
 class TestEntCertUpdateReport(fixture.SubManFixture):
     def test(self):
         r = entcertlib.EntCertUpdateReport()
-        r.expected = u'12312'
-        r.valid = [u'2342∰']
+        r.expected = '12312'
+        r.valid = ['2342∰']
         r.added.append(self._stub_cert())
         r.rogue.append(self._stub_cert())
 
@@ -56,8 +56,8 @@ class TestEntCertUpdateReport(fixture.SubManFixture):
             '%s' % r
 
     def _stub_cert(self):
-        stub_ent_cert = StubEntitlementCertificate(StubProduct(u"ஒரு அற்புதமான இயங்கு"))
-        stub_ent_cert.order.name = u'一些秩序'
+        stub_ent_cert = StubEntitlementCertificate(StubProduct("ஒரு அற்புதமான இயங்கு"))
+        stub_ent_cert.order.name = '一些秩序'
         return stub_ent_cert
 
 

--- a/test/test_entcertlib.py
+++ b/test/test_entcertlib.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-#
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/test/test_factlib.py
+++ b/test/test_factlib.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/test/test_facts.py
+++ b/test/test_facts.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import tempfile
 import shutil
 from mock import patch

--- a/test/test_format_time.py
+++ b/test/test_format_time.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 try:
     import unittest2 as unittest
 except ImportError:

--- a/test/test_format_time.py
+++ b/test/test_format_time.py
@@ -22,7 +22,7 @@ class TestFormatTime(unittest.TestCase):
 
     @patch('subscription_manager.managerlib.tzlocal')
     def test_system_dst(self, mock_tz):
-        mock_tz.return_value = tzstr(u'EST5EDT')
+        mock_tz.return_value = tzstr('EST5EDT')
         test = datetime(2014, 12, 21, 4, 59, 0, tzinfo=tzutc())
         self.assertEqual(managerlib.format_date(test), '12/20/2014')
         self.assertEqual(managerlib.format_iso8601_date(test), '2014-12-21')
@@ -63,7 +63,7 @@ class TestFormatTime(unittest.TestCase):
 
     @patch('subscription_manager.managerlib.tzlocal')
     def test_system_est(self, mock_tz):
-        mock_tz.return_value = tzstr(u'EST5EDT')
+        mock_tz.return_value = tzstr('EST5EDT')
         test = datetime(2014, 12, 21, 4, 59, 0, tzinfo=tzutc())
         self.assertEqual(managerlib.format_date(test), '12/20/2014')
         self.assertEqual(managerlib.format_iso8601_date(test), '2014-12-21')

--- a/test/test_healinglib.py
+++ b/test/test_healinglib.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 from mock import patch
 
 try:

--- a/test/test_identitycertlib.py
+++ b/test/test_identitycertlib.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public

--- a/test/test_isodate.py
+++ b/test/test_isodate.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010-2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_jsonwrapper.py
+++ b/test/test_jsonwrapper.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_lock.py
+++ b/test/test_lock.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 try:
     import unittest2 as unittest
 except ImportError:

--- a/test/test_logutil.py
+++ b/test/test_logutil.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import logging
 
 import mock

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -382,7 +382,7 @@ class TestSystemExit(unittest.TestCase):
         self.assertEqual("%s\n\n" % msgs[0], cap.err)
 
     def test_msg_unicode(self):
-        msgs = [u"\u2620 \u2603 \u203D"]
+        msgs = ["\u2620 \u2603 \u203D"]
         with Capture() as cap:
             try:
                 system_exit(1, msgs)
@@ -392,7 +392,7 @@ class TestSystemExit(unittest.TestCase):
             captured = cap.err.decode('utf-8')
         else:
             captured = cap.err
-        self.assertEqual(u"%s\n" % msgs[0], captured)
+        self.assertEqual("%s\n" % msgs[0], captured)
 
     def test_msg_and_exception_str(self):
         class StrException(Exception):

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, division, absolute_import
-
 try:
     import unittest2 as unittest
 except ImportError:

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 try:
     import unittest2 as unittest
 except ImportError:

--- a/test/test_managerlib.py
+++ b/test/test_managerlib.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import mock
 
 from . import fixture

--- a/test/test_model_ent_cert.py
+++ b/test/test_model_ent_cert.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import mock
 
 from . import fixture

--- a/test/test_ostree_content_plugin.py
+++ b/test/test_ostree_content_plugin.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 # import subman fixture
 # override plugin manager with one that provides
 #  the ostree content plugin

--- a/test/test_ostree_content_plugin.py
+++ b/test/test_ostree_content_plugin.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # import subman fixture
 # override plugin manager with one that provides
 #  the ostree content plugin

--- a/test/test_overrideslib.py
+++ b/test/test_overrideslib.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .fixture import SubManFixture
 from subscription_manager.overrides import Overrides, Override
 

--- a/test/test_overrideslib.py
+++ b/test/test_overrideslib.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, division, absolute_import
-
 from .fixture import SubManFixture
 from subscription_manager.overrides import Overrides, Override
 

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_po_files.py
+++ b/test/test_po_files.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 try:
     import unittest2 as unittest
 except ImportError:

--- a/test/test_po_files.py
+++ b/test/test_po_files.py
@@ -59,7 +59,7 @@ class TestUnicodeGettext(TestLocale):
     def test_ja_not_serial(self):
         with fixture.locale_context('ja_JP.UTF-8'):
             msg = _("'%s' is not a valid serial number") % "123123"
-            six.text_type(to_unicode_or_bust(msg)) + u'\n'
+            six.text_type(to_unicode_or_bust(msg)) + '\n'
 
     def test_system_exit(self):
         with fixture.locale_context('ja_JP.UTF-8'):

--- a/test/test_printing_utils.py
+++ b/test/test_printing_utils.py
@@ -165,12 +165,12 @@ class TestColumnize(unittest.TestCase):
 
     @patch('subscription_manager.printing_utils.get_terminal_width')
     def test_columnize_multibyte(self, term_width_mock):
-        multibyte_str = u"このシステム用に"
+        multibyte_str = "このシステム用に"
         term_width_mock.return_value = 40
         result = columnize([multibyte_str], echo_columnize_callback, multibyte_str)
-        expected = u"このシステム用に このシステム用に"
+        expected = "このシステム用に このシステム用に"
         self.assertEqual(result, expected)
         term_width_mock.return_value = 14
         result = columnize([multibyte_str], echo_columnize_callback, multibyte_str)
-        expected = u"このシ\nステム\n用に   このシ\n       ステム\n       用に"
+        expected = "このシ\nステム\n用に   このシ\n       ステム\n       用に"
         self.assertEqual(result, expected)

--- a/test/test_printing_utils.py
+++ b/test/test_printing_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import unittest
 
 from subscription_manager.cli_command.list import AVAILABLE_SUBS_MATCH_COLUMNS

--- a/test/test_productid.py
+++ b/test/test_productid.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 try:
     import unittest2 as unittest
 except ImportError:

--- a/test/test_rct_cert_command.py
+++ b/test/test_rct_cert_command.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_rct_manifest_command.py
+++ b/test/test_rct_manifest_command.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_reasons.py
+++ b/test/test_reasons.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -322,10 +322,10 @@ class TestReleaseIsCorrectRhel(fixture.SubManFixture):
         content_url = \
             "/content/dist/rhel/server/6/$releasever/$basearch/os/"
         listing_path = self.cdn_rv_provider._build_listing_path(content_url)
-        self.assertEqual(listing_path, u"/content/dist/rhel/server/6//listing")
+        self.assertEqual(listing_path, "/content/dist/rhel/server/6//listing")
 
         # /content/beta/rhel/server/6/$releasever/$basearch/optional/os
         content_url = \
             "/content/beta/rhel/server/6/$releasever/$basearch/optional/os"
         listing_path = self.cdn_rv_provider._build_listing_path(content_url)
-        self.assertEqual(listing_path, u"/content/beta/rhel/server/6//listing")
+        self.assertEqual(listing_path, "/content/beta/rhel/server/6//listing")

--- a/test/test_remove.py
+++ b/test/test_remove.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -174,12 +174,12 @@ class RepoTests(unittest.TestCase):
         self.assertEqual(repo_id, repo.id)
 
     def test_valid_unicode_just_ascii_label_for_id(self):
-        repo_id = u'valid-label'
+        repo_id = 'valid-label'
         repo = Repo(repo_id)
         self.assertEqual(repo_id, repo.id)
 
     def test_invalid_unicode_label_for_id(self):
-        repo_id = u'valid-不明-label'
+        repo_id = 'valid-不明-label'
         repo = Repo(repo_id)
         expected = 'valid----label'
         self.assertEqual(expected, repo.id)
@@ -238,11 +238,11 @@ class RepoTests(unittest.TestCase):
 class RepoActionReportTests(fixture.SubManFixture):
     def test(self):
         report = repolib.RepoActionReport()
-        repo = self._repo(u'a-unicode-content-label', u'A unicode repo name')
+        repo = self._repo('a-unicode-content-label', 'A unicode repo name')
         report.repo_updates.append(repo)
         report.repo_added.append(repo)
-        deleted_section = u'einige-repo-name'
-        deleted_section_2 = u'一些回購名稱'
+        deleted_section = 'einige-repo-name'
+        deleted_section_2 = '一些回購名稱'
         report.repo_deleted = [deleted_section, deleted_section_2]
 
         str(report)

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-#
-
-#
 # Copyright (c) 2010, 2011 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-#
 
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2010, 2011 Red Hat, Inc.
 #

--- a/test/test_rhelproduct.py
+++ b/test/test_rhelproduct.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 from . import stubs
 
 from subscription_manager import rhelproduct

--- a/test/test_rhsm_debug_command.py
+++ b/test/test_rhsm_debug_command.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_statcert_command.py
+++ b/test/test_statcert_command.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_syspurposestore_interface.py
+++ b/test/test_syspurposestore_interface.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division, absolute_import
-
 #
 # Copyright (c) 2018 Red Hat, Inc.
 #

--- a/test/test_syspurposestore_interface.py
+++ b/test/test_syspurposestore_interface.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-#
 # Copyright (c) 2018 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_unregistration.py
+++ b/test/test_unregistration.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2012 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -559,7 +559,7 @@ class TestFriendlyJoin(fixture.SubManFixture):
         self.assertTrue(res in ["One and Two", "Two and One"])
 
         self.assertEqual("1, 2, 3, 4, 5, 6, and fish",
-                         friendly_join([1, 2, u"3", 4, "5", 6, "fish"]))
+                         friendly_join([1, 2, "3", 4, "5", 6, "fish"]))
 
 
 class TestTrueValue(fixture.SubManFixture):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import os
 import random
 from . import fixture

--- a/test/test_validity.py
+++ b/test/test_validity.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-#
 # Copyright (c) 2010 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,

--- a/test/zypper_test/test_serviceplugin.py
+++ b/test/zypper_test/test_serviceplugin.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 from six.moves import configparser
 from unittest import TestCase
 import os


### PR DESCRIPTION
* Card ID: ENT-4277: Drop `__future__` imports
* Card ID: ENT-4326: Drop `# -*- coding` comment
* Card ID: ENT-4302: Remove "u" prefix from strings

None of the changes should alter behaviour in any way. They have been used in past to ensure Python 2 - Python 3 compatibility.