### PR TITLE
2003777: Show available organizations before asking for input

### DIFF
--- a/src/subscription_manager/cli_command/org.py
+++ b/src/subscription_manager/cli_command/org.py
@@ -51,5 +51,10 @@ class OrgCommand(UserPassCommand):
             if len(owners) == 1:
                 self._org = owners[0]['key']
             else:
+                # Print list of owners to the console
+                org_keys = [owner['key'] for owner in owners]
+                print(_('Hint: User "{name}" is member of following organizations: {orgs}').format(
+                    name=self.username, orgs=', '.join(org_keys)
+                ))
                 self._org = self._get_org(self.options.org)
         return self._org


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2003777
* Card ID: ENT-4316

If the user has more than one organization available and uses --list
to show one of system purposes they are asked to enter key of one of
their organizations.

Now, before they are prompted to enter the organization, a list of all
available organizations will be shown.

This functionality is already available in the 'register' command since
1ad8b33 (2020-02).