### PR TITLE
ENT-4082: Fix flake8 error E265

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,9 +9,6 @@ ignore =
     # E125: continuation line with same indent as next logical line
     # wrong indentation of continuation lines
     E125,
-    # E265: block comment should start with '# '
-    # comments and commented code need a space after '#'
-    E265,
     # E501: line too long (* > 300 characters)
     # triggered by very long text string in tests
     E501,

--- a/example-plugins/dbus_event.py
+++ b/example-plugins/dbus_event.py
@@ -62,7 +62,6 @@ class DbusEventPlugin(SubManPlugin):
         # choose a name for ourselves on that bus
         self.bus_name = dbus.service.BusName("com.redhat.SubscriptionManager.PluginEvent", self.system_bus)
         self.dbus_object = SubManEventDbus(self.bus_name)
-        #self.called_as = None
 
     def _dbus_event(self, message, conduit):
         conduit.log.debug("sending dbus event: %s" % message)

--- a/src/rct/manifest_commands.py
+++ b/src/rct/manifest_commands.py
@@ -104,7 +104,7 @@ class ZipExtractAll(ZipFile):
         new_path = os.path.abspath(new_file)
         if not new_path.startswith(base_path):
             raise Exception(_('Manifest zip attempted to extract outside of the base directory.'))
-        #traces symlink to source, and checks that it is valid
+        # traces symlink to source, and checks that it is valid
         real_new_path = os.path.realpath(new_path)
         if real_new_path != new_path:
             self._is_secure(base, real_new_path)
@@ -254,7 +254,7 @@ class CatManifestCommand(RCTManifestCommand):
 
             entitlement_file = os.path.join("export", "entitlements", "%s.json" % data["id"])
             to_print.append((_("Entitlement File"), entitlement_file))
-            #Get the certificate to get the version
+            # Get the certificate to get the version
             serial = data["certificates"][0]["serial"]["id"]
 
             cert_file = os.path.join("export", "entitlement_certificates", "%s.pem" % serial)

--- a/src/rhsm/certificate.py
+++ b/src/rhsm/certificate.py
@@ -888,12 +888,10 @@ class OID(object):
 
         # Matching the end
         if not oid[0]:
-            #oid = OID(oid[1:])
             oid = oid[1:]
             parts = self.part[-len(oid):]
         # Matching the beginning
         elif not oid[-1]:
-            #oid = OID(oid[:-1])
             oid = oid[:-1]
             parts = self.part[:len(oid)]
         # Full on match

--- a/src/rhsm/utils.py
+++ b/src/rhsm/utils.py
@@ -162,12 +162,11 @@ def parse_url(local_server_entry,
     if not good_url:
         good_url = "https://%s" % local_server_entry
 
-    #FIXME: need a try except here? docs
+    # FIXME: need a try except here? docs
     # don't seem to indicate any expected exceptions
     result = six.moves.urllib.parse.urlparse(good_url)
     username = default_username
     password = default_password
-    #netloc = result[1].split(":")
 
     # to support username and password, let's split on @
     # since the format will be username:password@hostname:port

--- a/src/rhsmlib/dbus/dbus_utils.py
+++ b/src/rhsmlib/dbus/dbus_utils.py
@@ -129,7 +129,6 @@ def dbus_to_python(obj, expected_type=None):
     elif isinstance(obj, dbus.Struct):
         python_obj = tuple([dbus_to_python(x) for x in obj])
     elif isinstance(obj, dbus.Dictionary):
-        #python_obj = {dbus_to_python(k): dbus_to_python(v) for k, v in obj.items()}
         python_obj = dict([dbus_to_python(k), dbus_to_python(v)] for k, v in list(obj.items()))
     elif isinstance(obj, bool) or \
         isinstance(obj, str) or isinstance(obj, bytes) or \

--- a/src/rhsmlib/facts/cleanup.py
+++ b/src/rhsmlib/facts/cleanup.py
@@ -29,7 +29,7 @@ class CleanupCollector(collector.FactsCollector):
 
     def explain_lack_of_virt_uuid(self):
         # No virt.uuid equiv is available for guests on these hypervisors
-        #virt_is_guest = self._collected_hw_info['virt.is_guest']
+        # virt_is_guest = self._collected_hw_info['virt.is_guest']
         if not self._is_a_virt_host_type_with_virt_uuids():
             log.debug("we don't sell virt uuids here")
 

--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -972,8 +972,6 @@ if __name__ == '__main__':
         value_0 = int(hw_dict.get(cpu_item[0], -1))
         value_1 = int(hw_dict.get(cpu_item[1], -1))
 
-        #print "%s/%s: %s %s" % (cpu_item[0], cpu_item[1], value_0, value_1)
-
         if value_0 != value_1 and ((value_0 != -1) and (value_1 != -1)):
             failed_list.append((cpu_item[0], cpu_item[1], value_0, value_1))
 

--- a/src/subscription_manager/i18n_argparse.py
+++ b/src/subscription_manager/i18n_argparse.py
@@ -47,6 +47,6 @@ class ArgumentParser(_ArgumentParser):
         prints command usage, then the error string, and exits.
         """
         self.print_usage(sys.stderr)
-        #translators: arg 1 is the program name, arg 2 is the error message
+        # translators: arg 1 is the program name, arg 2 is the error message
         print((_("{prog}: error: {msg}")).format(prog=self.prog, msg=msg))
         self.exit(2)

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -489,7 +489,7 @@ class PluginHookRunner(object):
             raise
 
 
-#NOTE: need to be super paranoid here about existing of cfg variables
+# NOTE: need to be super paranoid here about existing of cfg variables
 # BasePluginManager with our default config info
 class BasePluginManager(object):
     """Finds, load, and provides acccess to subscription-manager plugins."""

--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -547,7 +547,7 @@ class ProductManager(object):
         products_installed = self.install_product_certs(products_to_install)
         products_updated = self.update_product_certs(products_to_update)
 
-        #FIXME: nothing uses the return value here
+        # FIXME: nothing uses the return value here
         return (products_installed, products_updated)
 
     def install_product_certs(self, product_certs):

--- a/test/cli_command_test/test_release.py
+++ b/test/cli_command_test/test_release.py
@@ -18,7 +18,7 @@ class TestReleaseCommand(TestCliProxyCommand):
             self._orig_do_command()
 
             # FIXME: too many stubs atm to make this meaningful
-            #self.assertEquals(proxy_host, self.cc.cp_provider.content_connection.proxy_hostname)
+            # self.assertEquals(proxy_host, self.cc.cp_provider.content_connection.proxy_hostname)
 
             self.assertEqual(proxy_url, self.cc.options.proxy_url)
             self.assertEqual(type(proxy_url), type(self.cc.options.proxy_url))

--- a/test/modelhelpers.py
+++ b/test/modelhelpers.py
@@ -29,7 +29,7 @@ except ImportError:
     import md5
 
 
-#grumble, no hashblib on 2.4 and
+# grumble, no hashblib on 2.4 and
 # md5 is deprecated on 2.6
 def md5sum(buf):
     if isinstance(buf, six.text_type):

--- a/test/rhsm/unit/pathtree_tests.py
+++ b/test/rhsm/unit/pathtree_tests.py
@@ -160,7 +160,7 @@ class TestPathTree(unittest.TestCase):
         trees = [tree1, tree2, tree3, tree4]
         data = open(DATA, 'rb').read()
         pt = PathTree(data)
-        #just swap out the pre-cooked data with out with
+        # just swap out the pre-cooked data with out with
         for tree in trees:
             pt.path_tree = tree
             self.assertTrue(pt.match_path('/foo/path/bar'))

--- a/test/rhsmlib_test/test_hwprobe.py
+++ b/test/rhsmlib_test/test_hwprobe.py
@@ -870,7 +870,7 @@ VARIANT_ID=server
         def count_cpumask(cpu, field):
             vals = {
                 'thread_siblings_list': 1,
-                #'core_siblings_list': 2,
+                # 'core_siblings_list': 2,
                 'core_siblings_list': 2000,
                 'book_siblings_list': None
             }
@@ -902,7 +902,7 @@ VARIANT_ID=server
         def count_cpumask(cpu, field):
             vals = {
                 'thread_siblings_list': 1,
-                #'core_siblings_list': 2,
+                # 'core_siblings_list': 2,
                 'core_siblings_list': 4,
                 'book_siblings_list': None
             }

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -123,9 +123,9 @@ def stubInitConfig():
     return StubConfig()
 
 
-# create a global CFG object,then replace it with our own that candlepin
+# create a global CFG object, then replace it with our own that candlepin
 # read from a stringio
-#config.get_config_parser(config_file="test/rhsm.conf")
+# config.get_config_parser(config_file="test/rhsm.conf")
 config.CFG = StubConfig()
 
 # we are not actually reading test/rhsm.conf, it's just a placeholder

--- a/test/test_branding.py
+++ b/test/test_branding.py
@@ -17,7 +17,6 @@ except ImportError:
     import unittest
 
 from subscription_manager.branding import Branding
-#from subscription_manager.managerlib import configure_i18n
 
 
 class TestBranding(object):

--- a/test/test_certlib.py
+++ b/test/test_certlib.py
@@ -19,7 +19,6 @@ from . import fixture
 
 
 from subscription_manager import certlib
-#from subscription_manager import injection as inj
 
 
 class TestLocker(fixture.SubManFixture):

--- a/test/test_certmgr.py
+++ b/test/test_certmgr.py
@@ -66,8 +66,8 @@ class ActionClientTestBase(SubManFixture):
     def setUp(self):
         SubManFixture.setUp(self)
         # we have to have a reference to the patchers
-        #self.patcher2 = mock.patch.object(entcertlib.EntCertUpdateAction, '_get_consumer_id')
-        #self.entcertlib_updateaction_getconsumerid = self.patcher2.start()
+        # self.patcher2 = mock.patch.object(entcertlib.EntCertUpdateAction, '_get_consumer_id')
+        # self.entcertlib_updateaction_getconsumerid = self.patcher2.start()
 
         self.patcher3 = mock.patch.object(repolib.RepoUpdateActionCommand, 'perform')
         self.repolib_updateaction_perform = self.patcher3.start()
@@ -258,7 +258,7 @@ class TestActionClient(ActionClientTestBase):
 
         report = actionclient.entcertlib.report
         # the expired certs should be delete/rogue and expired
-        #report = self.update_action_syslog_mock.call_args[0][0]
+        # report = self.update_action_syslog_mock.call_args[0][0]
         self.assertTrue(self.stub_ent1 in report.rogue)
 
     @mock.patch.object(entcertlib.EntitlementCertBundleInstaller, 'build_cert')

--- a/test/test_facts.py
+++ b/test/test_facts.py
@@ -145,7 +145,7 @@ class TestFacts(fixture.SubManFixture):
         self.assertEqual(cached_facts["test.attr"], "blippy2")
 
     def test_facts_last_update(self):
-        #FIXME: verify the date is correct
+        # FIXME: verify the date is correct
         self.f.get_last_update()
 
     @patch('subscription_manager.facts.Facts.get_facts',

--- a/test/test_identitycertlib.py
+++ b/test/test_identitycertlib.py
@@ -77,8 +77,8 @@ class TestIdentityUpdateAction(fixture.SubManFixture):
     @mock.patch("subscription_manager.managerlib.persist_consumer_cert")
     def test_idcertlib_noops_when_serialnum_is_same(self, mock_persist):
         id_update_action = identitycertlib.IdentityUpdateAction()
-        #certlib.ConsumerIdentity = stubs.StubConsumerIdentity
-        #certlib.ConsumerIdentity.getSerialNumber = getSerialNumber
+        # certlib.ConsumerIdentity = stubs.StubConsumerIdentity
+        # certlib.ConsumerIdentity.getSerialNumber = getSerialNumber
 
         inj.provide(inj.IDENTITY, InvalidIdentity())
 

--- a/test/test_managerlib.py
+++ b/test/test_managerlib.py
@@ -36,9 +36,9 @@ from mock import Mock, patch
 cfg = rhsm.config.get_config_parser()
 ENT_CONFIG_DIR = cfg.get('rhsm', 'entitlementCertDir')
 
-#[-]*BEGIN [\w\ ]*[-]* - Find all begin lines
-#[-]*BEGIN[\w\ ]*[-]*|[-]*END[\w\ ]*[-]* - Find all BEGIN END lines
-#(?P<start>[-]*BEGIN[\w\ ]*[-]*)(?P<content>[^-]*)(?P<end>[-]*END[\w\ ]*[-]*)
+# [-]*BEGIN [\w\ ]*[-]* - Find all begin lines
+# [-]*BEGIN[\w\ ]*[-]*|[-]*END[\w\ ]*[-]* - Find all BEGIN END lines
+# (?P<start>[-]*BEGIN[\w\ ]*[-]*)(?P<content>[^-]*)(?P<end>[-]*END[\w\ ]*[-]*)
 
 EXPECTED_CERT_CONTENT = """-----BEGIN CERTIFICATE-----
 MIIJwTCCCSqgAwIBAgIIRW4yerC04nIwDQYJKoZIhvcNAQEFBQAwNDETMBEGA1UE

--- a/test/test_ostree_content_plugin.py
+++ b/test/test_ostree_content_plugin.py
@@ -349,7 +349,7 @@ last_key = blippy
         self.assertTrue(len(updates.new.remotes))
         self.assertTrue(isinstance(updates.new.remotes[0], model.OstreeRemote))
         self.assertEqual(updates.new.remotes[0].url, mock_content.url)
-        #self.assertEquals(updates.new.remotes[0].name, mock_content.name)
+        # self.assertEquals(updates.new.remotes[0].name, mock_content.name)
         self.assertEqual(updates.new.remotes[0].gpg_verify, True)
 
 

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -23,6 +23,8 @@ import six
 from subscription_manager import plugins
 from subscription_manager import base_plugin
 
+from test import subman_marker_functional
+
 
 # SubManPlugin
 # plugin_key
@@ -785,7 +787,7 @@ class TestPluginManagerReporting(unittest.TestCase):
         self.assertEqual(10, len(self.manager.get_slots()))
 
 
-#functional
+@subman_marker_functional
 class TestPluginManagerRun(unittest.TestCase):
     def setUp(self):
         self.module_dir = os.path.join(os.path.dirname(__file__), "plugins")

--- a/test/test_po_files.py
+++ b/test/test_po_files.py
@@ -21,7 +21,7 @@ class TestLocale(unittest.TestCase):
     test_locales = [
         # as_IN is kind of busted in RHEL6, and seemingly
         # very busted in 14
-        #"as_IN",   # Assamese
+        # "as_IN",   # Assamese
         "bn_IN",  # Bengali
         "de_DE",  # German
         "es_ES",  # Spanish
@@ -37,11 +37,11 @@ class TestLocale(unittest.TestCase):
         "or_IN",  # Oriya
         "pa_IN",  # Punjabi
         # "ne_IN",  # Nepali
-        #"se_IN", # Sinhala
-        #"br_IN", # Maithili
+        # "se_IN", # Sinhala
+        # "br_IN", # Maithili
         "pt_BR",  # Portugese
         "ru_RU",  # Russian
-        #"si_LK",   # Sri Lankan
+        # "si_LK",   # Sri Lankan
         "ta_IN",  # Tamil
         "te_IN",  # telgu
         "zh_CN",  # Chinese Simplified

--- a/test/test_productid.py
+++ b/test/test_productid.py
@@ -447,7 +447,7 @@ class TestProductManager(SubManFixture):
         enabled = [(cert, 'rhel-6-server')]
         active = set(['rhel-6-server'])
 
-        #self.prod_repo_map = {'69': 'rhel-6-server'}
+        # self.prod_repo_map = {'69': 'rhel-6-server'}
         self.prod_repo_map = {}
         self.prod_db_mock.find_repos = Mock(side_effect=self.find_repos_side_effect)
 
@@ -860,8 +860,8 @@ class TestProductManager(SubManFixture):
         self.assertFalse(cert.delete.called)
         self.assertFalse(self.prod_db_mock.delete.called)
 
-#TODO: test update_installed with a installed product cert, enabled, but not active
-#       because the packages were installed from anaconda
+# TODO: test update_installed with a installed product cert, enabled, but not active
+# because the packages were installed from anaconda
 
     def test_update_removed_no_packages_no_repos_no_active_no_certs(self):
         self.prod_mgr.update_removed(set([]))
@@ -1166,7 +1166,7 @@ class TestProductManager(SubManFixture):
 
         desktop_cert = self._create_desktop_cert()
         workstation_cert = self._create_workstation_cert()
-        #self.prod_dir.certs.append(workstation_cert)
+        # self.prod_dir.certs.append(workstation_cert)
 
         self.prod_repo_map = {}
         self.prod_db_mock.find_repos = Mock(side_effect=self.find_repos_side_effect)

--- a/test/test_rct_manifest_command.py
+++ b/test/test_rct_manifest_command.py
@@ -98,7 +98,7 @@ class RCTManifestCommandTests(SubManFixture):
         mancommand = DumpManifestCommand()
         mancommand.args = [_build_valid_manifest()]
 
-        #This makes sure there is a 'None' at 'self.options.destination'
+        # This makes sure there is a 'None' at 'self.options.destination'
         mancommand.options = mancommand
         mancommand.destination = None
         mancommand.overwrite_files = False
@@ -113,7 +113,7 @@ class RCTManifestCommandTests(SubManFixture):
         mancommand = DumpManifestCommand()
         mancommand.args = [_build_valid_manifest()]
 
-        #This makes sure the temp directory is referenced at 'self.options.destination'
+        # This makes sure the temp directory is referenced at 'self.options.destination'
         mancommand.options = mancommand
         mancommand.destination = new_directory
         mancommand.overwrite_files = False
@@ -127,7 +127,7 @@ class RCTManifestCommandTests(SubManFixture):
         mancommand = DumpManifestCommand()
         mancommand.args = [_build_valid_manifest()]
 
-        #This makes sure the temp directory is referenced at 'self.options.destination'
+        # This makes sure the temp directory is referenced at 'self.options.destination'
         mancommand.options = mancommand
         mancommand.destination = new_directory
         mancommand.overwrite_files = True
@@ -143,7 +143,7 @@ class RCTManifestCommandTests(SubManFixture):
         mancommand = DumpManifestCommand()
         mancommand.args = [_build_valid_manifest()]
 
-        #This makes sure the temp directory is referenced at 'self.options.destination'
+        # This makes sure the temp directory is referenced at 'self.options.destination'
         mancommand.options = mancommand
         mancommand.destination = new_directory
         mancommand.overwrite_files = True
@@ -160,7 +160,7 @@ class RCTManifestCommandTests(SubManFixture):
         mancommand = DumpManifestCommand()
         mancommand.args = [_build_valid_manifest()]
 
-        #This makes sure the temp directory is referenced at 'self.options.destination'
+        # This makes sure the temp directory is referenced at 'self.options.destination'
         mancommand.options = mancommand
         mancommand.destination = new_directory
         mancommand.overwrite_files = True

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -756,8 +756,8 @@ class TidyWriterTests(unittest.TestCase):
 
 class YumReleaseverSourceTest(fixture.SubManFixture):
     def test_init(self):
-        #inj.provide(inj.RELEASE_STATUS_CACHE, Mock())
-        #override_cache_mock = inj.require(inj.OVERRIDE_STATUS_CACHE)
+        # inj.provide(inj.RELEASE_STATUS_CACHE, Mock())
+        # override_cache_mock = inj.require(inj.OVERRIDE_STATUS_CACHE)
 
         release_source = YumReleaseverSource()
         self.assertEqual(release_source._expansion, None)

--- a/test/test_validity.py
+++ b/test/test_validity.py
@@ -94,8 +94,8 @@ class ValidProductDateRangeCalculatorTests(SubManFixture):
             self.assertTrue(self.calculator.calculate(pid) is None)
 
     def test_product_with_status(self):
-        #"startDate" : "2013-02-26T00:00:00.000+0000",
-        #"endDate" : "2014-02-26T00:00:00.000+0000"
+        # "startDate" : "2013-02-26T00:00:00.000+0000",
+        # "endDate" : "2014-02-26T00:00:00.000+0000"
         date_range = self.calculator.calculate(INST_PID_1)
         self.assertEqual(datetime(2013, 2, 26, 0, 0, 0, 0, GMT()), date_range.begin())
         self.assertEqual(datetime(2014, 2, 26, 0, 0, 0, 0, GMT()), date_range.end())


### PR DESCRIPTION
* Card ID: ENT-4082

E265: Block comment should start with '#'

Following files contained commented-out code that has not been changed
in a long time:
- src/rhsm/certificate.py: 22c26cc (2013-01)
- src/rhsm/utils.py: e7f88c6 (2013-12)
- src/rhsmlib/dbus/dbus_utils.py: 2aa48ef (2017-01)
- example-plugins/dbus_event.py: e706c53 (2014-02)

Commented-out code violating E265 have not been removed in test files,
only the spacing has been fixed. It should be investigated separately
why the lines are commented out.