### PR TITLE
ENT-4272: Remove Python 2 conditionals

### DIFF
--- a/src/plugins/dnf/subscription-manager.py
+++ b/src/plugins/dnf/subscription-manager.py
@@ -13,7 +13,6 @@
 #
 
 import os
-import six
 import logging
 
 from subscription_manager import injection as inj
@@ -30,10 +29,7 @@ from rhsm import config
 from dnfpluginscore import logger
 import dnf
 
-if six.PY3:
-    from configparser import ConfigParser
-else:
-    from ConfigParser import ConfigParser
+from configparser import ConfigParser
 
 expired_warning = _("""
 *** WARNING ***

--- a/src/rct/printing.py
+++ b/src/rct/printing.py
@@ -13,8 +13,6 @@
 #
 import signal
 
-import six
-
 from rhsm.certificate2 import EntitlementCertificate, ProductCertificate, IdentityCertificate
 from subscription_manager.i18n import ugettext as _
 
@@ -30,8 +28,6 @@ def xstr(value):
         return ''
     elif isinstance(value, list):
         return ", ".join([xstr(val) for val in value])
-    elif isinstance(value, six.text_type) and six.PY2:
-        return value.encode('utf-8')
     else:
         return str(value)
 

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -766,10 +766,7 @@ class BaseRestLib(object):
                                             err))
                 raise
             except (socket.error, OSError) as err:
-                if six.PY2:
-                    code = httplib.PROXY_AUTHENTICATION_REQUIRED
-                else:
-                    code = httplib.PROXY_AUTHENTICATION_REQUIRED.value
+                code = httplib.PROXY_AUTHENTICATION_REQUIRED.value
                 if str(code) in str(err):
                     raise ProxyException(err)
                 raise

--- a/src/rhsmlib/compat/subprocess_compat.py
+++ b/src/rhsmlib/compat/subprocess_compat.py
@@ -17,7 +17,6 @@
 
 import logging
 import subprocess
-import six
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +40,7 @@ def check_output_2_6(*args, **kwargs):
 
 def check_output_six(*args, **kwargs):
     output = subprocess.check_output(*args, **kwargs)
-    if six.PY3 and isinstance(output, bytes):
+    if isinstance(output, bytes):
         output = output.decode('utf-8')
     return output
 

--- a/src/rhsmlib/dbus/dbus_utils.py
+++ b/src/rhsmlib/dbus/dbus_utils.py
@@ -24,8 +24,6 @@ import xml.etree.ElementTree as Et
 import dbus
 import six
 
-PY2 = six.PY2
-
 log = logging.getLogger(__name__)
 
 
@@ -109,8 +107,6 @@ def dbus_to_python(obj, expected_type=None):
     elif isinstance(obj, dbus.Boolean):
         python_obj = bool(obj)
     elif isinstance(obj, dbus.String):
-        python_obj = obj.encode('utf-8') if PY2 else str(obj)
-    elif PY2 and isinstance(obj, dbus.UTF8String):  # Python3 has no UTF8String
         python_obj = str(obj)
     elif isinstance(obj, dbus.ObjectPath):
         python_obj = str(obj)

--- a/src/subscription_manager/cli.py
+++ b/src/subscription_manager/cli.py
@@ -15,8 +15,6 @@ import os
 import sys
 import logging
 
-import six
-
 from subscription_manager.printing_utils import columnize, echo_columnize_callback
 from subscription_manager.i18n_argparse import ArgumentParser
 from subscription_manager.utils import print_error
@@ -210,10 +208,7 @@ def system_exit(code, msgs=None):
             if isinstance(msg, Exception):
                 msg = "%s" % msg
 
-            if isinstance(msg, six.text_type) and six.PY2:
-                print_error(msg.encode("utf8"))
-            else:
-                print_error(msg)
+            print_error(msg)
 
     # Try to flush all outputs, see BZ: 1350402
     flush_stdout_stderr()

--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -18,8 +18,6 @@ from threading import local
 
 import os
 
-import six
-
 # Localization domain:
 APP = 'rhsm'
 # Directory where translations are deployed:
@@ -79,29 +77,17 @@ def configure_gettext():
 
 
 def ugettext(*args, **kwargs):
-    if six.PY2:
-        if hasattr(LOCALE, 'lang') and LOCALE.lang is not None:
-            return LOCALE.lang.ugettext(*args, **kwargs)
-        else:
-            return TRANSLATION.ugettext(*args, **kwargs)
+    if hasattr(LOCALE, 'lang') and LOCALE.lang is not None:
+        return LOCALE.lang.gettext(*args, **kwargs)
     else:
-        if hasattr(LOCALE, 'lang') and LOCALE.lang is not None:
-            return LOCALE.lang.gettext(*args, **kwargs)
-        else:
-            return TRANSLATION.gettext(*args, **kwargs)
+        return TRANSLATION.gettext(*args, **kwargs)
 
 
 def ungettext(*args, **kwargs):
-    if six.PY2:
-        if hasattr(LOCALE, 'lang') and LOCALE.lang is not None:
-            return LOCALE.lang.ungettext(*args, **kwargs)
-        else:
-            return TRANSLATION.ungettext(*args, **kwargs)
+    if hasattr(LOCALE, 'lang') and LOCALE.lang is not None:
+        return LOCALE.lang.ngettext(*args, **kwargs)
     else:
-        if hasattr(LOCALE, 'lang') and LOCALE.lang is not None:
-            return LOCALE.lang.ngettext(*args, **kwargs)
-        else:
-            return TRANSLATION.ngettext(*args, **kwargs)
+        return TRANSLATION.ngettext(*args, **kwargs)
 
 
 class Locale(object):

--- a/src/subscription_manager/identity.py
+++ b/src/subscription_manager/identity.py
@@ -16,7 +16,6 @@ import logging
 import os
 import errno
 import threading
-import six
 
 from rhsm.certificate import create_from_pem
 from rhsm.config import get_config_parser
@@ -141,10 +140,7 @@ class Identity(object):
             # existsAndValid did, so this is better.
             except (CertificateException, IOError) as err:
                 self.consumer = None
-                if six.PY2:
-                    err_msg = str(err).decode('utf-8')
-                else:
-                    err_msg = err
+                err_msg = err
                 msg = "Reload of consumer identity cert %s raised an exception with msg: %s" \
                     % (ConsumerIdentity.certpath(), err_msg)
                 if isinstance(err, IOError) and err.errno == errno.ENOENT:

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -16,10 +16,7 @@ import inspect
 import logging
 import os
 import six
-if six.PY2:
-    import imp
-else:
-    import importlib.util
+import importlib.util
 
 from iniparse import SafeConfigParser
 from iniparse.compat import NoSectionError, NoOptionError
@@ -937,16 +934,9 @@ class PluginManager(BasePluginManager):
         module_name = module_name.split(".py")[0]
 
         try:
-            if six.PY2:
-                fp, pathname, description = imp.find_module(module_name, [dir_path])
-                try:
-                    loaded_module = imp.load_module(module_name, fp, pathname, description)
-                finally:
-                    fp.close()
-            else:
-                spec = importlib.util.spec_from_file_location(module_name, module_file)
-                loaded_module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(loaded_module)
+            spec = importlib.util.spec_from_file_location(module_name, module_file)
+            loaded_module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(loaded_module)
         # we could catch BaseException too for system exit
         except Exception as e:
             log.exception(e)

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -27,7 +27,6 @@ import pkg_resources
 
 from six.moves import urllib
 from rhsm.https import ssl
-import six
 
 from subscription_manager.branding import get_branding
 from subscription_manager.certdirectory import Path
@@ -397,8 +396,6 @@ def is_true_value(test_string):
 
 def system_log(message, priority=syslog.LOG_NOTICE):
     syslog.openlog("subscription-manager")
-    if six.PY2:
-        message = message.encode("utf-8")
     syslog.syslog(priority, message)
 
 

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -31,10 +31,7 @@ from rhsmlib.services import config
 # use instead of the normal pid file based ActionLock
 from threading import RLock
 
-if six.PY2:
-    OPEN_FUNCTION = '__builtin__.open'
-else:
-    OPEN_FUNCTION = 'builtins.open'
+OPEN_FUNCTION = 'builtins.open'
 
 
 @contextmanager
@@ -75,10 +72,7 @@ def open_mock_many(file_content_map=None, **kwargs):
         try:
             rv, file_contents, content_out = file_content_map[path]
         except KeyError:
-            if six.PY2:
-                raise IOError(2, 'No such file or directory')
-            else:
-                raise OSError(2, 'No such file or directory')
+            raise OSError(2, 'No such file or directory')
 
         rv = rv.return_value
         rv.write = lambda x: content_out.write(x)

--- a/test/rhsmlib_test/test_insights.py
+++ b/test/rhsmlib_test/test_insights.py
@@ -20,7 +20,6 @@ from ..fixture import open_mock_many
 from rhsmlib.facts import insights
 from mock import patch
 import tempfile
-import six
 
 INSIGHT_FUTURE_UUID = "250878c1-a8a2-4c44-8a29-5736dc4094c7"
 INSIGHT_TEST_UUID = "2d05f031-d20c-40c9-9cee-2a1d7e823ab6"
@@ -32,10 +31,7 @@ class TestInsightsCollector(unittest.TestCase):
     def setUp(self):
         self.collector = insights.InsightsCollector()
         self.machine_id_fp = tempfile.NamedTemporaryFile()
-        if six.PY3:
-            self.machine_id_fp.write(bytes(INSIGHT_TEST_UUID, 'UTF-8'))
-        else:
-            self.machine_id_fp.write(INSIGHT_TEST_UUID)
+        self.machine_id_fp.write(bytes(INSIGHT_TEST_UUID, 'UTF-8'))
         self.machine_id_fp.flush()
 
     def tearDown(self):

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -8,8 +8,6 @@ import sys
 import socket
 import os
 
-import six
-
 from subscription_manager import syspurposelib
 from subscription_manager import managercli, managerlib
 from subscription_manager.injection import provide, \
@@ -388,10 +386,7 @@ class TestSystemExit(unittest.TestCase):
                 system_exit(1, msgs)
             except SystemExit:
                 pass
-        if six.PY2:
-            captured = cap.err.decode('utf-8')
-        else:
-            captured = cap.err
+        captured = cap.err
         self.assertEqual("%s\n" % msgs[0], captured)
 
     def test_msg_and_exception_str(self):


### PR DESCRIPTION
* Card ID: ENT-4272

In order to maintain compatibility between Python 2 and Python 3, the
six.PY2/six.PY3 variables were used to conditionally run a block of
code. Python 2 support has been dropped and they are no longer
necessary.