### PR TITLE
ENT-4274: Remove six.assert* methods

### DIFF
--- a/test/rhsm/unit/pathtree_tests.py
+++ b/test/rhsm/unit/pathtree_tests.py
@@ -14,7 +14,6 @@
 from collections import deque
 import os
 import unittest
-import six
 
 from rhsm.bitstream import GhettoBitStream
 from rhsm.huffman import HuffmanNode
@@ -107,7 +106,7 @@ class TestPathTree(unittest.TestCase):
             '/DPS_Satellite/Library/WF-RHEL-7-CV-2018_33-OS/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.3/os'
         ]
         # Assert the lists contain the same items regardless of order
-        six.assertCountEqual(self, expected, paths)
+        self.assertCountEqual(expected, paths)
 
     def test_match_path_listing(self):
         tree = {'foo': [{'path': [{'bar': [{PATH_END: None}]}]}]}

--- a/test/rhsmlib_test/test_attach.py
+++ b/test/rhsmlib_test/test_attach.py
@@ -13,7 +13,6 @@
 import dbus
 import json
 import mock
-import six
 
 from test.rhsmlib_test.base import DBusObjectTest, InjectionMockingTest
 
@@ -273,13 +272,13 @@ class TestAttachDBusObject(DBusObjectTest, InjectionMockingTest):
     def test_must_be_registered_pool(self):
         self.mock_identity.is_valid.return_value = False
         pool_method_args = [['x', 'y'], 1, {}, '']
-        with six.assertRaisesRegex(self, dbus.DBusException, r'requires the consumer to be registered.*'):
+        with self.assertRaisesRegex(dbus.DBusException, r'requires the consumer to be registered.*'):
             self.dbus_request(None, self.interface.PoolAttach, pool_method_args)
 
     def test_must_be_registered_auto(self):
         self.mock_identity.is_valid.return_value = False
         auto_method_args = ['service_level', {}, '']
-        with six.assertRaisesRegex(self, dbus.DBusException, r'requires the consumer to be registered.*'):
+        with self.assertRaisesRegex(dbus.DBusException, r'requires the consumer to be registered.*'):
             self.dbus_request(None, self.interface.AutoAttach, auto_method_args)
 
     def test_auto_attach(self):

--- a/test/rhsmlib_test/test_config.py
+++ b/test/rhsmlib_test/test_config.py
@@ -17,7 +17,6 @@ except ImportError:
     import unittest
 
 import dbus
-import six
 
 from rhsm.config import RhsmConfigParser, NoOptionError
 from rhsmlib.dbus import constants
@@ -231,5 +230,5 @@ class TestConfigDBusObject(DBusObjectTest, TestUtilsMixin):
     def test_set_section_fails(self):
         dbus_method_args = ['server', 'new', '']
 
-        with six.assertRaisesRegex(self, dbus.DBusException, r'Setting an entire section is not.*'):
+        with self.assertRaisesRegex(dbus.DBusException, r'Setting an entire section is not.*'):
             self.dbus_request(None, self.interface.Set, dbus_method_args)

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -18,7 +18,6 @@ import mock
 import json
 import dbus.connection
 import socket
-import six
 
 import subscription_manager.injection as inj
 
@@ -497,7 +496,7 @@ class DomainSocketRegisterDBusObjectTest(DBusObjectTest, InjectionMockingTest):
 
         def assertions(*args):
             result = args[0]
-            six.assertRegex(self, result, r'/run/dbus.*')
+            self.assertRegex(result, r'/run/dbus.*')
 
         self.dbus_request(assertions, self.interface.Start, dbus_method_args)
 
@@ -508,7 +507,7 @@ class DomainSocketRegisterDBusObjectTest(DBusObjectTest, InjectionMockingTest):
             # Assign the result as an attribute to this function.
             # See http://stackoverflow.com/a/27910553/6124862
             assertions.result = args[0]
-            six.assertRegex(self, assertions.result, r'/run/dbus.*')
+            self.assertRegex(assertions.result, r'/run/dbus.*')
 
         self.dbus_request(assertions, self.interface.Start, dbus_method_args)
 

--- a/test/rhsmlib_test/test_unregister.py
+++ b/test/rhsmlib_test/test_unregister.py
@@ -14,7 +14,6 @@
 
 import dbus
 import mock
-import six
 
 from test.rhsmlib_test.base import DBusObjectTest, InjectionMockingTest
 
@@ -88,5 +87,5 @@ class TestUnregisterDBusObject(DBusObjectTest, InjectionMockingTest):
     def test_must_be_registered_unregister(self):
         self.mock_identity.is_valid.return_value = False
         unregister_method_args = [{}, '']
-        with six.assertRaisesRegex(self, dbus.DBusException, r'requires the consumer to be registered.*'):
+        with self.assertRaisesRegex(dbus.DBusException, r'requires the consumer to be registered.*'):
             self.dbus_request(None, self.interface.Unregister, unregister_method_args)


### PR DESCRIPTION
* Card ID: ENT-4274

Six library was used to provide compatibility layer between Python 2
and Python 3. subscription-manager is Python 3 only, so these functions
can be simply replaced with their PY3 versions with no change of
behavior.