### PR TITLE
Fixed one unused import of six

### DIFF
--- a/test/fixture.py
+++ b/test/fixture.py
@@ -3,7 +3,6 @@ import io
 import locale
 import os
 import pprint
-import six
 import sys
 import tempfile
 


### PR DESCRIPTION
* Caused by our effort of removing six (e.g. ENT-4272). One
  unused import of six leaked in due to solving conflicts.