### PR TITLE
ENT-4340: Resolve deprecation warnings

### DIFF
--- a/src/rhsmlib/facts/dmiinfo.py
+++ b/src/rhsmlib/facts/dmiinfo.py
@@ -125,5 +125,5 @@ class DmiFirmwareInfoCollector(collector.FactsCollector):
     def log_warnings(self, dmidecode):
         dmiwarnings = dmidecode.get_warnings()
         if dmiwarnings:
-            log.warn(_("Error reading system DMI information: {dmiwarnings}").format(dmiwarnings=dmiwarnings), exc_info=True)
+            log.warning(_("Error reading system DMI information: {dmiwarnings}").format(dmiwarnings=dmiwarnings), exc_info=True)
             dmidecode.clear_warnings()

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -242,7 +242,7 @@ class StatusCache(CacheManager):
                 log.error("Server unreachable, registered, but no cache exists.")
                 return None
 
-            log.warn("Unable to reach server, using cached status.")
+            log.warning("Unable to reach server, using cached status.")
             return self._read_cache()
         except connection.RestlibException as ex:
             # Indicates we may be talking to a very old candlepin server

--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -296,7 +296,7 @@ class EntCertUpdateAction(object):
                 self.report.rogue.append(cert)
             except OSError as er:
                 log.exception(er)
-                log.warn("Failed to delete cert")
+                log.warning("Failed to delete cert")
 
         # If we just deleted certs, we need to refresh the now stale
         # entitlement directory before we go to delete expired certs.

--- a/src/subscription_manager/healinglib.py
+++ b/src/subscription_manager/healinglib.py
@@ -74,7 +74,7 @@ class HealingUpdateAction(object):
         consumer = self.uep.getConsumer(uuid)
 
         if 'autoheal' not in consumer or not consumer['autoheal']:
-            log.warn("Auto-heal disabled on server, skipping.")
+            log.warning("Auto-heal disabled on server, skipping.")
             return 0
 
         try:
@@ -92,8 +92,7 @@ class HealingUpdateAction(object):
 
             cert_updater = entcertlib.EntCertActionInvoker()
             if not cs.is_valid():
-                log.warn("Found invalid entitlements for today: %s" %
-                         today)
+                log.warning("Found invalid entitlements for today: %s" % today)
                 self.plugin_manager.run("pre_auto_attach", consumer_uuid=uuid)
                 ents = self.uep.bind(uuid, today)
                 self.plugin_manager.run("post_auto_attach", consumer_uuid=uuid,
@@ -110,10 +109,9 @@ class HealingUpdateAction(object):
                     # Edge case here, not even sure this can happen as we
                     # should have a compliant until date if we're valid
                     # today, but just in case:
-                    log.warn("Got valid status from server but no valid until date.")
+                    log.warning("Got valid status from server but no valid until date.")
                 elif tomorrow > cs.compliant_until:
-                    log.warn("Entitlements will be invalid by tomorrow: %s" %
-                             tomorrow)
+                    log.warning("Entitlements will be invalid by tomorrow: %s" % tomorrow)
                     self.plugin_manager.run("pre_auto_attach", consumer_uuid=uuid)
                     ents = self.uep.bind(uuid, tomorrow)
                     self.plugin_manager.run("post_auto_attach", consumer_uuid=uuid,

--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -72,7 +72,6 @@ def configure_gettext():
     """
     gettext.bindtextdomain(APP, DIR)
     gettext.textdomain(APP)
-    gettext.bind_textdomain_codeset(APP, 'UTF-8')
     locale.bind_textdomain_codeset(APP, 'UTF-8')
 
 

--- a/src/subscription_manager/validity.py
+++ b/src/subscription_manager/validity.py
@@ -65,7 +65,7 @@ class ValidProductDateRangeCalculator(object):
                                  parse_date(prod['endDate']))
             else:
                 # If startDate / endDate not supported
-                log.warn("Server does not support product date ranges.")
+                log.warning("Server does not support product date ranges.")
                 return None
 
         # At this point, we haven't found the installed product that was

--- a/test/rhsmlib_test/test_entitlement.py
+++ b/test/rhsmlib_test/test_entitlement.py
@@ -178,13 +178,13 @@ class TestEntitlementService(InjectionMockingTest):
     def test_only_accepts_correct_pool_subsets(self):
         service = EntitlementService()
         options = self._build_options(pool_subsets=['foo'])
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*invalid listing type.*'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*invalid listing type.*'):
             service.validate_options(options)
 
     def test_show_all_requires_available(self):
         service = EntitlementService()
         options = self._build_options(pool_subsets=['installed'], show_all=True)
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*only applicable with --available'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*only applicable with --available'):
             service.validate_options(options)
         options['pool_subsets'].append('available')
         service.validate_options(options)
@@ -193,7 +193,7 @@ class TestEntitlementService(InjectionMockingTest):
         service = EntitlementService()
         on_date = datetime.date.today().strftime('%Y-%m-%d')
         options = self._build_options(pool_subsets=['installed', 'consumed'], on_date=on_date)
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*only applicable with --available'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*only applicable with --available'):
             service.validate_options(options)
         options['pool_subsets'].append('available')
         service.validate_options(options)
@@ -201,7 +201,7 @@ class TestEntitlementService(InjectionMockingTest):
     def test_service_level_requires_consumed_or_available(self):
         service = EntitlementService()
         options = self._build_options(pool_subsets=['installed'], service_level='foo')
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*only applicable with --available'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*only applicable with --available'):
             service.validate_options(options)
         options['pool_subsets'].append('available')
         service.validate_options(options)
@@ -209,7 +209,7 @@ class TestEntitlementService(InjectionMockingTest):
     def test_match_installed_requires_available(self):
         service = EntitlementService()
         options = self._build_options(pool_subsets=['installed', 'consumed'], match_installed=True)
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*only applicable with --available'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*only applicable with --available'):
             service.validate_options(options)
         options['pool_subsets'].append('available')
         service.validate_options(options)
@@ -217,7 +217,7 @@ class TestEntitlementService(InjectionMockingTest):
     def test_no_overlap_requires_available(self):
         service = EntitlementService()
         options = self._build_options(pool_subsets=['installed', 'consumed'], no_overlap=True)
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*only applicable with --available'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*only applicable with --available'):
             service.validate_options(options)
         options['pool_subsets'].append('available')
         service.validate_options(options)
@@ -225,7 +225,7 @@ class TestEntitlementService(InjectionMockingTest):
     def test_pool_only_requires_consumed_or_available(self):
         service = EntitlementService()
         options = self._build_options(pool_subsets=['installed'], pool_only=True)
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*only applicable with --available'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*only applicable with --available'):
             service.validate_options(options)
         options['pool_subsets'].append('available')
         service.validate_options(options)
@@ -234,7 +234,7 @@ class TestEntitlementService(InjectionMockingTest):
         service = EntitlementService()
         self.mock_identity.is_valid.return_value = False
         options = self._build_options(pool_subsets=['available'])
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*not registered.*'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*not registered.*'):
             service.validate_options(options)
 
     @mock.patch('rhsmlib.services.entitlement.managerlib')

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -365,7 +365,7 @@ class RegisterServiceTest(InjectionMockingTest):
     def test_fails_when_previously_registered(self):
         self.mock_identity.is_valid.return_value = True
 
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*system is already registered.*'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*system is already registered.*'):
             register.RegisterService(self.mock_cp).validate_options(self._build_options())
 
     def test_allows_force(self):
@@ -417,7 +417,7 @@ class RegisterServiceTest(InjectionMockingTest):
     def test_does_not_allow_basic_auth_with_activation_keys(self):
         self.mock_identity.is_valid.return_value = False
         options = self._build_options(activation_keys=[1])
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*do not require user credentials.*'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*do not require user credentials.*'):
             register.RegisterService(self.mock_cp).validate_options(options)
 
     def test_does_not_allow_environment_with_activation_keys(self):
@@ -426,7 +426,7 @@ class RegisterServiceTest(InjectionMockingTest):
 
         self.mock_identity.is_valid.return_value = False
         options = self._build_options(activation_keys=[1], environment='environment')
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*do not allow environments.*'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*do not allow environments.*'):
             register.RegisterService(self.mock_cp).validate_options(options)
 
     def test_does_not_allow_environment_with_consumerid(self):
@@ -435,7 +435,7 @@ class RegisterServiceTest(InjectionMockingTest):
 
         self.mock_identity.is_valid.return_value = False
         options = self._build_options(activation_keys=[1], consumerid='consumerid')
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*previously registered.*'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*previously registered.*'):
             register.RegisterService(self.mock_cp).validate_options(options)
 
     def test_requires_basic_auth_for_normal_registration(self):
@@ -444,7 +444,7 @@ class RegisterServiceTest(InjectionMockingTest):
 
         self.mock_identity.is_valid.return_value = False
         options = self._build_options(consumerid='consumerid')
-        with self.assertRaisesRegexp(exceptions.ValidationError, r'.*Missing username.*'):
+        with self.assertRaisesRegex(exceptions.ValidationError, r'.*Missing username.*'):
             register.RegisterService(self.mock_cp).validate_options(options)
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -993,8 +993,8 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
         mopen.side_effect = new_open
         res = get_process_names()
         res = list(res)
-        self.assertEquals(res, [fake_process_name],
-                          "Expected a list containing '%s', Actual: %s" % (fake_process_name, res))
+        self.assertEqual(res, [fake_process_name],
+                         "Expected a list containing '%s', Actual: %s" % (fake_process_name, res))
 
     def test_get_process_names_ioerror(self):
         """
@@ -1017,4 +1017,4 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
         mopen.side_effect = new_open
         res = get_process_names()
         res = list(res)
-        self.assertEquals(res, [fake_process_name], "Expected an empty list, Actual: %s" % res)
+        self.assertEqual(res, [fake_process_name], "Expected an empty list, Actual: %s" % res)


### PR DESCRIPTION
* Card ID: ENT-4340

This commit resolves some of the deprecation warnings that are being
emitted by parts of subscription-manager code. They can be seen, for
example, when 'pytest' is run.

Following changes have been made:

- 'assertRaisesRegex()' instead of 'assertRaisesRegexp()',
- 'assertEqual()' instead of 'assertEquals()',
- 'warning()' instead of 'warn()',
- 'bind_textdomain_codeset() is being removed.

The 'bind_textdomain_codeset' has been deprecated since Python 3.8 and
is being removed in Python 3.10. It only affects calls to 'l'-prefixed
functions of gettext ('lgettext()') which are not used in the code base.