### PR TITLE
2003777: Only hint organizations if it's needed

### DIFF
--- a/src/subscription_manager/cli_command/org.py
+++ b/src/subscription_manager/cli_command/org.py
@@ -50,11 +50,13 @@ class OrgCommand(UserPassCommand):
             owners = self.cp.getOwnerList(self.options.username)
             if len(owners) == 1:
                 self._org = owners[0]['key']
-            else:
-                # Print list of owners to the console
+            elif self.options.org is None:
+                # Get a list of valid owners. Since no owner was specified,
+                # print a hint message showing available owners, before asking
+                # to enter one.
                 org_keys = [owner['key'] for owner in owners]
-                print(_('Hint: User "{name}" is member of following organizations: {orgs}').format(
-                    name=self.username, orgs=', '.join(org_keys)
-                ))
+                print(_(
+                    'Hint: User "{name}" is member of following organizations: {orgs}'
+                ).format(name=self.username, orgs=', '.join(org_keys)))
                 self._org = self._get_org(self.options.org)
         return self._org


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2003777
* Card ID: ENT-4411

Recent patch (#2796) added a hint message to the --org argument.
This follow-up update slightly changes the behavior, so the hint is only
 displayed when the user did not use the --org at all.

When they used it and it's valid, the hint is skipped and the syspurpose
subcommand is run as usual.

When they used it and it's invalid, the hint is skipped and formatted
RhsmlibException is printed saying that the organization could not be
found.

Now the behavior will be the same as it is in the register subcommand.