### PR TITLE
ENT-4231: Use /proc/device-tree/ibm,partition-uuid as UUID on POWER LPARs

### DIFF
--- a/src/rhsmlib/facts/virt.py
+++ b/src/rhsmlib/facts/virt.py
@@ -117,11 +117,15 @@ class VirtUuidCollector(collector.FactsCollector):
         For ppc64/ppc64le systems running KVM or PowerKVM, the
         virt uuid is found in /proc/device-tree/vm,uuid.
 
+        For ppc64/ppc64le LPARs, the UUID is found in
+        /proc/device-tree/ibm,partition-uuid.
+
         (In contrast to use of DMI on x86_64).
         """
 
         uuid_paths = [
             f"{self.prefix}/proc/device-tree/vm,uuid",
+            f"{self.prefix}/proc/device-tree/ibm,partition-uuid",
         ]
 
         for uuid_path in uuid_paths:

--- a/test/rhsmlib_test/test_virt.py
+++ b/test/rhsmlib_test/test_virt.py
@@ -86,6 +86,16 @@ class VirtUuidCollectorTest(unittest.TestCase):
             uuid = collector._get_devicetree_uuid()
             self.assertEqual('123', uuid)
 
+    @patch("os.path.isfile")
+    def test_strips_null_byte_on_uuid_ibm_partition_uuid(self, mock_isfile):
+        def is_uuid_file(path):
+            return path.endswith('/ibm,partition-uuid')
+        mock_isfile.side_effect = is_uuid_file
+        with test.fixture.open_mock(content="123\0"):
+            collector = virt.VirtUuidCollector(arch='ppc64')
+            uuid = collector._get_devicetree_uuid()
+            self.assertEqual('123', uuid)
+
     def test_default_virt_uuid_physical(self):
         """Check that physical systems dont set an 'Unknown' virt.uuid."""
         collected = {


### PR DESCRIPTION
Refactor the POWER bits of `VirtUuidCollector`, and then try to read `/proc/device-tree/ibm,partition-uuid` as file for the UUID, typically found on LPARs.

Card ID: ENT-4231