### PR TITLE
ENT-4379: Remove function make_utf8

### DIFF
--- a/src/syspurpose/files.py
+++ b/src/syspurpose/files.py
@@ -22,7 +22,7 @@ import os
 import errno
 import io
 
-from syspurpose.utils import create_dir, create_file, make_utf8, write_to_file_utf8
+from syspurpose.utils import create_dir, create_file, write_to_file_utf8
 from subscription_manager.i18n import ugettext as _
 
 # Constants for locations of the two system syspurpose files
@@ -127,8 +127,6 @@ class SyspurposeStore(object):
         :param value: The value to append to the list
         :return: None
         """
-        value = make_utf8(value)
-        key = make_utf8(key)
         try:
             current_value = self.contents[key]
             if current_value is not None and not isinstance(current_value, list):
@@ -153,8 +151,6 @@ class SyspurposeStore(object):
         :param value: The value to attempt to remove
         :return: True if the value was in the list, False if it was not
         """
-        value = make_utf8(value)
-        key = make_utf8(key)
         try:
             current_value = self.contents[key]
             if current_value is not None and not isinstance(current_value, list) and current_value == value:
@@ -175,8 +171,6 @@ class SyspurposeStore(object):
         :param key: The key to unset
         :return: boolean
         """
-        key = make_utf8(key)
-
         # Special handling is required for the SLA, since it deviates from the typical CP
         # empty => null semantics
         if key == 'service_level_agreement':
@@ -196,9 +190,7 @@ class SyspurposeStore(object):
         :param value: The value to set that parameter to
         :return: Whether any change was made
         """
-        value = make_utf8(value)
-        key = make_utf8(key)
-        org = make_utf8(self.contents.get(key, None))
+        org = self.contents.get(key, None)
         self.contents[key] = value
         return org != value or org is None
 
@@ -479,8 +471,6 @@ class SyncedStore(object):
         :param value: The value to append to the list
         :return: None
         """
-        value = make_utf8(value)
-        key = make_utf8(key)
         try:
             # When existing value was set using set() method, then the
             # existing valus is not list, but simple value. We have to convert
@@ -522,8 +512,6 @@ class SyncedStore(object):
         :param value: The value to attempt to remove
         :return: True if the value was in the list, False if it was not
         """
-        value = make_utf8(value)
-        key = make_utf8(key)
         try:
             current_values = self.local_contents[key]
             if current_values is not None and not isinstance(current_values, list) and current_values == value:
@@ -554,8 +542,6 @@ class SyncedStore(object):
         :param key: The key to unset
         :return: boolean
         """
-        key = make_utf8(key)
-
         # Special handling is required for the SLA, since it deviates from the typical CP
         # empty => null semantics
         if key == 'service_level_agreement':
@@ -586,9 +572,7 @@ class SyncedStore(object):
         :param value: The value to set that parameter to
         :return: Whether any change was made
         """
-        value = make_utf8(value)
-        key = make_utf8(key)
-        current_value = make_utf8(self.local_contents.get(key, None))
+        current_value = self.local_contents.get(key, None)
         self.local_contents[key] = value
 
         if current_value != value or current_value is None:

--- a/src/syspurpose/utils.py
+++ b/src/syspurpose/utils.py
@@ -64,21 +64,6 @@ def create_file(path, contents):
     return True
 
 
-def make_utf8(obj):
-    """
-    Transforms the provided string into unicode if it is not already
-
-    Previously there was a logic which converted the input.
-    Now the six.PY2 is never true and we can directly return the input.
-
-    It should be removed with other Python 2 utils.
-
-    :param obj: the string to decode
-    :return: the unicode format of the string
-    """
-    return obj
-
-
 def write_to_file_utf8(file, data):
     """
     Writes out the provided data to the specified file, with user-friendly indentation,
@@ -87,4 +72,4 @@ def write_to_file_utf8(file, data):
     :param data: The data to be written
     :return:
     """
-    file.write(make_utf8(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True)))
+    file.write(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True))

--- a/test/syspurpose/base.py
+++ b/test/syspurpose/base.py
@@ -144,22 +144,6 @@ class Capture(object):
         sys.stderr = self.stderr
 
 
-# utility functions from syspurpose.utils to help ensure data written to files is utf-8
-def make_utf8(obj):
-    """
-    Transforms the provided string into unicode if it is not already
-
-    Previously there was a logic which converted the input.
-    Now the six.PY2 is never true and we can directly return the input.
-
-    It should be removed with other Python 2 utils.
-
-    :param obj: the string to decode
-    :return: the unicode format of the string
-    """
-    return obj
-
-
 def write_to_file_utf8(file, data):
     """
     Writes out the provided data to the specified file, with user-friendly indentation,
@@ -168,4 +152,4 @@ def write_to_file_utf8(file, data):
     :param data: The data to be written
     :return:
     """
-    file.write(make_utf8(json.dumps(data, indent=2, ensure_ascii=False)))
+    file.write(json.dumps(data, indent=2, ensure_ascii=False))

--- a/test/syspurpose/test_syspurposefiles.py
+++ b/test/syspurpose/test_syspurposefiles.py
@@ -85,7 +85,7 @@ class SyspurposeStoreTests(SyspurposeTestBase):
             if file_contents and not isinstance(file_contents, str):
                 utils.write_to_file_utf8(f, file_contents)
             else:
-                f.write(utils.make_utf8(file_contents or ''))
+                f.write(file_contents or '')
             f.flush()
         self.assertTrue(os.path.exists(temp_dir), "Unable to create test file in temp dir")
 


### PR DESCRIPTION
* Card ID: ENT-4379

For a long time this function managed transparent conversion of Python 2
strings into UTF-8.

During Python 2/six removal efforts this function was simplified
to return the input, making it useless.