### PR TITLE
ENT-4273: Drop usage of six.moves

### DIFF
--- a/debian-stuff/katello
+++ b/debian-stuff/katello
@@ -28,8 +28,8 @@ import sys
 import re
 import hashlib
 import requests
-from six.moves.urllib.parse import quote
-from six.moves.configparser import SafeConfigParser
+from urllib.parse import quote
+from configparser import SafeConfigParser
 
 
 class pkg_acquire_method:

--- a/src/plugins/zypper/services/rhsm
+++ b/src/plugins/zypper/services/rhsm
@@ -27,7 +27,7 @@ from subscription_manager.injectioninit import init_dep_injection
 from rhsm import connection, logutil
 from rhsm import config
 
-from six.moves.configparser import ConfigParser
+from configparser import ConfigParser
 
 reload(sys)
 sys.setdefaultencoding('UTF8')

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -32,8 +32,8 @@ from email.utils import formatdate
 
 from rhsm.https import httplib, ssl
 
-from six.moves.urllib.request import proxy_bypass
-from six.moves.urllib.parse import urlencode, quote, quote_plus
+from urllib.request import proxy_bypass
+from urllib.parse import urlencode, urlparse, quote, quote_plus
 
 from rhsm.config import get_config_parser
 from rhsm import ourjson as json
@@ -279,9 +279,9 @@ class KeycloakConnection(BaseConnection):
     """
 
     def __init__(self, realm, auth_url, resource, **kwargs):
-        host = six.moves.urllib.parse.urlparse(auth_url).hostname or ''
-        handler = six.moves.urllib.parse.urlparse(auth_url).path
-        ssl_port = six.moves.urllib.parse.urlparse(auth_url).port or 443
+        host = urlparse(auth_url).hostname or ''
+        handler = urlparse(auth_url).path
+        ssl_port = urlparse(auth_url).port or 443
         super(KeycloakConnection, self).__init__(host=host, ssl_port=ssl_port, handler=handler, **kwargs)
         self.realm = realm
         self.resource = resource
@@ -708,7 +708,7 @@ class BaseRestLib(object):
         if headers is not None and \
                 'Content-type' in headers and \
                 headers['Content-type'] == 'application/x-www-form-urlencoded':
-            body = six.moves.urllib.parse.urlencode(info).encode('utf-8')
+            body = urlencode(info).encode('utf-8')
         elif info is not None:
             body = json.dumps(info, default=json.encode)
         else:

--- a/src/rhsm/https.py
+++ b/src/rhsm/https.py
@@ -19,7 +19,7 @@ import logging
 import ssl as _ssl
 import sys
 
-import six.moves.http_client as _httplib
+import http.client as _httplib
 
 log = logging.getLogger(__name__)
 

--- a/src/rhsm/utils.py
+++ b/src/rhsm/utils.py
@@ -16,7 +16,7 @@ import os
 import re
 import sys
 
-import six.moves.urllib.parse
+import urllib.parse
 
 from rhsm.config import DEFAULT_PROXY_PORT
 
@@ -164,7 +164,7 @@ def parse_url(local_server_entry,
 
     # FIXME: need a try except here? docs
     # don't seem to indicate any expected exceptions
-    result = six.moves.urllib.parse.urlparse(good_url)
+    result = urllib.parse.urlparse(good_url)
     username = default_username
     password = default_password
 

--- a/src/rhsmlib/file_monitor.py
+++ b/src/rhsmlib/file_monitor.py
@@ -13,7 +13,7 @@
 
 from rhsm.config import get_config_parser
 from rhsmlib.services import config
-from six.moves import configparser
+import configparser
 import logging
 import os.path
 import fnmatch

--- a/src/subscription_manager/cli_command/org.py
+++ b/src/subscription_manager/cli_command/org.py
@@ -15,7 +15,6 @@
 # in this software or its documentation.
 #
 import readline
-import six.moves
 
 from subscription_manager.cli_command.user_pass import UserPassCommand
 from subscription_manager.i18n import ugettext as _
@@ -40,7 +39,7 @@ class OrgCommand(UserPassCommand):
     @staticmethod
     def _get_org(org):
         while not org:
-            org = six.moves.input(_("Organization: "))
+            org = input(_("Organization: "))
             readline.clear_history()
         return org
 

--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -17,7 +17,6 @@
 import logging
 import os
 import readline
-import six.moves
 
 import rhsm.connection as connection
 import subscription_manager.injection as inj
@@ -316,7 +315,7 @@ class RegisterCommand(UserPassCommand):
         """
         By breaking this code out, we can write cleaner tests
         """
-        environment = six.moves.input(_("Environment: ")).strip()
+        environment = input(_("Environment: ")).strip()
         readline.clear_history()
         return environment or self._prompt_for_environment()
 
@@ -390,6 +389,6 @@ class RegisterCommand(UserPassCommand):
         # Read the owner key from stdin
         owner_key = None
         while not owner_key:
-            owner_key = six.moves.input(_("Organization: "))
+            owner_key = input(_("Organization: "))
             readline.clear_history()
         return owner_key

--- a/src/subscription_manager/cli_command/user_pass.py
+++ b/src/subscription_manager/cli_command/user_pass.py
@@ -16,7 +16,6 @@
 #
 import getpass
 import readline
-import six.moves
 
 from subscription_manager.cli_command.cli import CliCommand
 from subscription_manager.i18n import ugettext as _
@@ -47,7 +46,7 @@ class UserPassCommand(CliCommand):
         not be prompted for.
         """
         while not username:
-            username = six.moves.input(_("Username: "))
+            username = input(_("Username: "))
             readline.clear_history()
         while not password:
             password = getpass.getpass(_("Password: "))

--- a/src/subscription_manager/plugin/ostree/action_invoker.py
+++ b/src/subscription_manager/plugin/ostree/action_invoker.py
@@ -14,7 +14,7 @@
 import logging
 
 # rhsm.conf->iniparse->configParser can raise ConfigParser exceptions
-from six.moves import configparser
+import configparser
 
 from subscription_manager import certlib
 from subscription_manager.model import find_content

--- a/src/subscription_manager/release.py
+++ b/src/subscription_manager/release.py
@@ -19,7 +19,7 @@ import logging
 import socket
 import six
 
-import six.moves.http_client
+import http.client
 from rhsm.https import ssl
 from rhsm.connection import NoValidEntitlement
 
@@ -152,7 +152,7 @@ class CdnReleaseVersionProvider(object):
                     cert_key_pairs=ent_cert_key_pairs
                 )
             except (socket.error,
-                    six.moves.http_client.HTTPException,
+                    http.client.HTTPException,
                     ssl.SSLError,
                     NoValidEntitlement) as e:
                 # content connection doesn't handle any exceptions

--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -31,8 +31,8 @@ except ImportError:
 
 from subscription_manager import utils
 from subscription_manager.certdirectory import Path
-from six.moves import configparser
-from six.moves.urllib.parse import parse_qs, urlparse, urlunparse, urlencode
+import configparser
+from urllib.parse import parse_qs, urlparse, urlunparse, urlencode
 
 from rhsm.config import get_config_parser
 

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -29,7 +29,7 @@ from subscription_manager.utils import get_supported_resources
 from rhsm.config import get_config_parser, in_container
 from rhsm import connection
 import six
-from six.moves import configparser
+import configparser
 
 # FIXME: local imports
 

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -25,7 +25,7 @@ import syslog
 import uuid
 import pkg_resources
 
-from six.moves import urllib
+import urllib
 from rhsm.https import ssl
 
 from subscription_manager.branding import get_branding

--- a/test/rhsmlib_test/base.py
+++ b/test/rhsmlib_test/base.py
@@ -31,7 +31,7 @@ import threading
 import time
 import six
 
-from six.moves import queue
+import queue
 from rhsmlib.dbus import constants, server
 from subscription_manager.identity import Identity
 

--- a/test/rhsmlib_test/test_file_monitor.py
+++ b/test/rhsmlib_test/test_file_monitor.py
@@ -12,7 +12,7 @@
 # in this software or its documentation.
 
 from rhsmlib import file_monitor
-from six.moves import configparser
+import configparser
 from mock import Mock, patch
 from test import fixture
 from threading import Thread

--- a/test/test_ostree_content_plugin.py
+++ b/test/test_ostree_content_plugin.py
@@ -9,7 +9,7 @@
 
 # test constructing from Content models
 # ignores wrong content type
-from six.moves import configparser
+import configparser
 
 import six
 import mock

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -13,7 +13,7 @@
 #
 
 import mock
-import six.moves.http_client
+import http.client
 import socket
 from rhsm.https import ssl
 from rhsm import certificate2
@@ -208,7 +208,7 @@ class TestCdnReleaseVerionProvider(fixture.SubManFixture):
         # mock content_connection so we can verify it's calls
         with mock.patch.object(cdn_rv_provider, 'content_connection') as mock_cc:
             mock_cc.get_versions.side_effect = \
-                six.moves.http_client.BadStatusLine("some bogus status")
+                http.client.BadStatusLine("some bogus status")
             releases = cdn_rv_provider.get_releases()
             self.assertEqual([], releases)
 

--- a/test/zypper_test/test_serviceplugin.py
+++ b/test/zypper_test/test_serviceplugin.py
@@ -1,4 +1,4 @@
-from six.moves import configparser
+import configparser
 from unittest import TestCase
 import os
 import subprocess


### PR DESCRIPTION
* Card ID: ENT-4273

Six was being used to migrate from Python 2 to Python 3, and six.moves
provided some objects and functions which changed between the Python
versions under unified API. As subscription-manager runs on Python 3,
the usage of six is unnecessary and can be removed.