### PR TITLE
Adding containers for development and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ src/plugins/libdnf/Makefile
 /integration-tests/common
 /test/images
 package-lock.json
-
+test_results/

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,87 @@
+FROM registry.fedoraproject.org/fedora:34
+
+MAINTAINER "Candlepin Team" <candlepin@redhat.com>
+# should be the UID of whatever user is running podman, change this with: podman build --build-arg UID="$(id -u)"
+ARG UID=1000
+ARG GIT_HASH=main
+ENV SMDEV_CONTAINER_OFF='True'
+
+RUN dnf -y update
+
+RUN dnf install -y \
+    cmake \
+    dbus-daemon \
+    dnf-utils \
+    gcc \
+    gettext \
+    git \
+    glibc-langpack-de \
+    glibc-langpack-en \
+    glibc-langpack-ja \
+    intltool \
+    json-c-devel \
+    libdnf-devel \
+    libnotify-devel \
+    make \
+    npm \
+    openssl \
+    openssl-devel \
+    procps-ng \
+    python3-coverage \
+    python3-dateutil \
+    python3-decorator \
+    python3-devel \
+    python3-ethtool \
+    python3-gobject-base \
+    python3-iniparse \
+    python3-inotify \
+    python3-librepo \
+    python3-mock \
+    python3-pip \
+    python3-polib \
+    python3-pytest \
+    python3-pytest-flake8 \
+    python3-pytest-forked \
+    python3-pytest-randomly \
+    python3-pytest-timeout \
+    python3-requests \
+    python3-rpm \
+    python3-simplejson \
+    python3-virtualenv \
+    redhat-rpm-config \
+    rpm-build \
+    rpmlint \
+    subscription-manager-rhsm-certificates \
+    sudo \
+    tito \
+    vim \
+    wget \
+    && dnf clean all
+
+RUN useradd -u ${UID} -m user && usermod -aG wheel user && \
+    chown -R user:user /home/user && \
+    echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN echo "export SMDEV_CONTAINER_OFF='True'" >> /root/.bashrc && \
+    echo "export SMDEV_CONTAINER_OFF='True'" >> /root/.zshrc
+
+RUN mkdir /build
+COPY requirements.txt dev-requirements.txt test-requirements.txt /build/
+COPY build_ext /build/build_ext
+WORKDIR /build
+RUN pip3 install -r dev-requirements.txt && \
+    git clone https://github.com/candlepin/subscription-manager.git && \
+    cd /build/subscription-manager && \
+    git config --add remote.origin.fetch +refs/pull/*/head:refs/remotes/origin/pr/* && \
+    git fetch && \
+    git checkout $GIT_HASH && \
+    dnf builddep -y ./subscription-manager.spec && \
+    python3 ./setup.py build && \
+    python3 ./setup.py build_ext --inplace
+
+RUN chown -R user:user /build
+USER user
+ENV DBUS_SESSION_BUS_ADDRESS='unix:path=/tmp/bus'
+RUN echo "export SMDEV_CONTAINER_OFF='True'" >> /home/user/.bashrc && \
+    echo "export SMDEV_CONTAINER_OFF='True'" >> /home/user/.zshrc
+WORKDIR /build/subscription-manager

--- a/README.containers.md
+++ b/README.containers.md
@@ -1,0 +1,55 @@
+Subscription Manager & Containers
+=================================
+
+This directory contains scripts and configuration files that are necessary for running
+subscription-manager in a containerized environment. This environment could be created
+using podman. Why do we care about running subscription-manager in a containerized
+environment? We believe that it could be useful for testing of subscription-manager.
+Running subscription-manager using podman could be more flexible for developers too.
+
+Requirements
+------------
+
+To create and use a containerized environment it is necessary to have following packages
+installed in the system:
+
+ * podman
+
+   $ sudo dnf install -y podman
+
+Create a containerized environment
+----------------------------------
+
+To create a containerized environment you can simply run following script:
+
+    $ podman build -f ./Containerfile --build-arg UID="$(id -u)" -t subman
+    $ podman run -it --rm -v /run/user/$UID/bus:/tmp/bus subman /bin/bash
+
+The above will create a clean sandbox in which to run tests reliably and
+test out subscription-manager.
+
+To do development locally and have the changes reflected locally (inside the con
+tainer) do the following run command from the base subscription-manager source
+directory:
+
+    $ podman run -t --rm -v /run/user/$UID/bus:/tmp/bus -v $PWD:/home/jenkins/subman:Z -w /home/jenkins/subman subman /bin/bash
+
+Reviewing PRs
+-------------
+
+Jenkins will build, tag, and push the PR test environment to
+quay.io/candlepin/subscription-manager:PR-XXXX where XXXX is the PR number.
+This is done as a regular part of the jenkins tests as each test is run in
+one of these containers.
+
+This means that for any PR which has had the jenkins tests complete
+(regardless of success or failure), you can run the following to reproduce
+the jenkins test results (for example if the unit tests failed):
+
+    $ git checkout origin pr/XXXX
+    $ podman run -it quay.io/candlepin/subscription-manager:PR-XXXX sh ./jenkins/unit.sh
+
+One can also run the following (for the unit tests or for any tests that jenkins
+runs) (the CHANGE_ID should be the PR number that you are reproducing):
+
+    $ CHANGE_ID=XXXX ./jenkins/run.sh ./jenkins/unit.sh

--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -39,4 +39,5 @@ podman run -t \
   sh "$2"
 
 RETVAL="$?"
+echo "Test script returned: $RETVAL"
 exit "$RETVAL"

--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -26,17 +26,32 @@ else
 fi
 
 echo "Using container name: $TAG"
-
-podman run -t \
-  -u $JUID:$JGID \
-  -v /run/user/$JUID/bus:/tmp/bus \
-  -w $WORKSPACE \
-  -v $WORKSPACE:$WORKSPACE:rw,z \
-  -v $WORKSPACE@tmp:$WORKSPACE@tmp:rw,z \
-  --name "$TAG" \
-  --rm \
-  quay.io/candlepin/subscription-manager:$GIT_HASH \
-  sh "$2"
+if [ -d $WORKSPACE@tmp ]; then
+    podman run -it \
+      -u $JUID:$JGID \
+      -v /run/user/$JUID/bus:/tmp/bus \
+      -w $WORKSPACE \
+      -v $WORKSPACE:$WORKSPACE:rw,z \
+      -v $WORKSPACE@tmp:$WORKSPACE@tmp:rw,z \
+      --name "$TAG" \
+      --rm \
+      --userns keep-id \
+      --group-add wheel \
+      quay.io/candlepin/subscription-manager:$GIT_HASH \
+      sh "$2"
+else
+    podman run -it \
+      -u $JUID:$JGID \
+      -v /run/user/$JUID/bus:/tmp/bus \
+      -w $WORKSPACE \
+      -v $WORKSPACE:$WORKSPACE:rw,z \
+      --name "$TAG" \
+      --rm \
+      --userns keep-id \
+      --group-add wheel \
+      quay.io/candlepin/subscription-manager:$GIT_HASH \
+      sh "$2"
+fi
 
 RETVAL="$?"
 echo "Test script returned: $RETVAL"

--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -x
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+# this will be set by the jenkins pipeline
+# GIT_HASH="$(git rev-parse HEAD)"
+JUID="$(id -u)"
+JGID="$(id -g)"
+WORKSPACE="${WORKSPACE:-$PROJECT_ROOT}"
+
+if (( $# != 2 )); then
+    >&2 cat << EOF
+    This script requires two arguments.
+
+    Usage: $0 [END_OF_TAG] [PATH_TO_SCRIPT_TO_RUN_IN_CONTAINER]
+    This script runs the subman container in a jenkins environment.
+EOF
+    exit 1
+fi
+
+# The CHANGE_ID environment variable is set by Jenkins for multibranch jobs.
+# It's value is generally the PR number. This is not set anywhere by our
+# bits (yet).  This TAG will be used to give the run a unique name.
+if [ -z "$CHANGE_ID" ]; then
+    TAG="latest-$1-$(git rev-parse --short HEAD)"
+else
+    TAG="PR-$CHANGE_ID-$1-$(git rev-parse --short HEAD)"
+fi
+
+echo "Using container name: $TAG"
+
+podman run -t \
+  -u $JUID:$JGID \
+  -v /run/user/$JUID/bus:/tmp/bus \
+  -w $WORKSPACE \
+  -v $WORKSPACE:$WORKSPACE:rw,z \
+  -v $WORKSPACE@tmp:$WORKSPACE@tmp:rw,z \
+  --name "$TAG" \
+  --rm \
+  quay.io/candlepin/subscription-manager:$GIT_HASH \
+  sh "$2"
+
+RETVAL="$?"
+exit "$RETVAL"

--- a/jenkins/stylish.sh
+++ b/jenkins/stylish.sh
@@ -15,6 +15,7 @@
 #   we need to make /etc/pki/product and /etc/pki/entitlement
 
 echo "GIT_COMMIT:" "${GIT_COMMIT}"
+WORKSPACE="$(git rev-parse --show-toplevel)"
 
 cd $WORKSPACE
 
@@ -39,5 +40,4 @@ pushd $WORKSPACE
 export PYTHONPATH="$PYTHON_RHSM"/src
 
 # make set-versions
-# capture exit status of 'make stylish' and not 'tee'
-( set -o pipefail; make stylish | tee stylish_results.txt )
+make stylish

--- a/jenkins/tito.sh
+++ b/jenkins/tito.sh
@@ -21,5 +21,4 @@ fi
 
 sudo yum-builddep subscription-manager.spec -y || true
 
-# Get exit status from 'tito' not 'tee'
-( set -o pipefail; tito build --output=tito/ --test --rpm | tee tito_results.txt )
+tito build --output=tito/ --test --rpm

--- a/jenkins/unit.sh
+++ b/jenkins/unit.sh
@@ -23,6 +23,7 @@ python3 setup.py build_ext --inplace
 
 # make sure we have a dbus session for the dbus tests
 dbus-run-session coverage run
-
+RETVAL="$?"
 coverage report
 coverage xml
+exit $RETVAL

--- a/scripts/build_and_push.sh
+++ b/scripts/build_and_push.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -x
+set -e
+if [ -z "$GIT_HASH" ]; then
+    TAG="$(git rev-parse HEAD)"
+else
+    TAG="$GIT_HASH"
+fi
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+
+pushd "$PROJECT_ROOT"
+podman build -f ./Containerfile --build-arg UID="$(id -u)" --build-arg GIT_HASH="pr/$CHANGE_ID" -t "quay.io/candlepin/subscription-manager:$TAG"
+podman push --creds "$QUAY_CREDS" "quay.io/candlepin/subscription-manager:$TAG"
+podman tag "quay.io/candlepin/subscription-manager:$TAG" "quay.io/candlepin/subscription-manager:PR-$CHANGE_ID"
+podman push --creds "$QUAY_CREDS" "quay.io/candlepin/subscription-manager:PR-$CHANGE_ID"
+popd


### PR DESCRIPTION
This adds fedora based toolbox containers and
updates the jenkinsfile of the project so that
tests can be run in a similar environment both
on jenkins nodes and locally.

This allows test failures to be reproduced more
easily. See the included readme updates for
details on the operation of the containers.

The containers can also be used for development
as well.

Allow toolbox create to pull images automatically