### PR TITLE
Only rpmlint our specfiles

### DIFF
--- a/build_ext/build_ext/lint.py
+++ b/build_ext/build_ext/lint.py
@@ -15,7 +15,8 @@ import ast
 from distutils.spawn import spawn
 
 from build_ext.utils import Utils, BaseCommand
-
+import os
+import subprocess
 # These dependencies aren't available in build environments.  We won't need any
 # linting functionality there though, so just create a dummy class so we can proceed.
 try:
@@ -64,8 +65,12 @@ class RpmLint(BaseCommand):
     description = "run rpmlint on spec files"
 
     def run(self):
-        for f in Utils.find_files_of_type('.', '*.spec'):
-            spawn(['rpmlint', '--file=rpmlint.config', f])
+        files = subprocess.run(['git', 'ls-files', '--full-name'],
+                               capture_output=True).stdout
+        files = files.decode().splitlines()
+        files = [x for x in files if x.endswith(".spec")]
+        for f in files:
+            spawn(['rpmlint', '--file=rpmlint.config', os.path.realpath(f)])
 
 
 class AstVisitor(object):


### PR DESCRIPTION
Prior to this it was possible in certain cases for our rpmlint check to be run against specfiles of the node_modules we install with our cockpit plugin.

This limits the files which are checked to those which git claims as tracked. This way we'll only ever rpmlint specfiles of our projects.