### PR TITLE
Version our obsoletes of syspurpose and the container plugin

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -309,7 +309,7 @@ Obsoletes: subscription-manager-initial-setup-addon <= %{version}-%{release}
 Obsoletes: rhsm-gtk <= %{version}-%{release}
 
 %if !%{use_container_plugin}
-Obsoletes: subscription-manager-plugin-container
+Obsoletes: subscription-manager-plugin-container <= %{version}
 %endif
 
 %if %{use_dnf}
@@ -323,7 +323,7 @@ Obsoletes: dnf-plugin-subscription-manager < 1.29.0
 %endif
 %endif
 
-Obsoletes: %{py_package_prefix}-syspurpose
+Obsoletes: %{py_package_prefix}-syspurpose <= %{version}
 
 %description
 The Subscription Manager package provides programs and libraries to allow users


### PR DESCRIPTION
Prior we had unversioned obsoletes in our spec file. On more recent version of rpmlint etc this is considered an error rather than a warning. This can cause our tests to fail depending on the version of the rpm tooling used.

This PR adds a version to our obsoletes which should work for all prior versions and which will pass the new more strict rpm tooling.