### PR TITLE
build: pin flake8 to < 4

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,7 @@
 # immediately available.
 -e ./build_ext
 
+flake8<4
 pytest
 pytest-randomly
 pytest-timeout


### PR DESCRIPTION
flake8 4 drops `flake8.main.setuptools_command`, which we use in our lint
commands. Hence, for now pin it to any version lower than 4 to keep the
stylish test working again.