### PR TITLE
More SUSE compliance

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -74,7 +74,11 @@
 %global python_sitearch %python3_sitearch
 %global python_sitelib %python3_sitelib
 %global __python %__python3
+%if 0%{?suse_version}
+%global py_package_prefix python3
+%else
 %global py_package_prefix python%{python3_pkgversion}
+%endif
 %global rhsm_package_name %{py_package_prefix}-subscription-manager-rhsm
 %else
 %if 0%{?suse_version} >= 1500
@@ -246,7 +250,7 @@ Requires: dnf-plugin-subscription-manager = %{version}
 %endif
 
 %if 0%{?suse_version}
-Requires: python-gobject2, libzypp, zypp-plugin-python, python-zypp
+Requires: python-gobject2, libzypp, %{py_package_prefix}-zypp-plugin
 %else
 Requires:  usermode
 Requires: python3-gobject-base
@@ -273,7 +277,15 @@ Requires(preun): %{?suse_version:aaa_base} %{!?suse_version:chkconfig, initscrip
 
 Requires: python3-cloud-what = %{version}-%{release}
 
-BuildRequires: %{?suse_version:python-devel >= 2.6} %{!?suse_version:%{py_package_prefix}-devel}
+%if 0%{?suse_version}
+%if %{with python3}
+BuildRequires: %{py_package_prefix}-devel
+%else
+BuildRequires: python-devel >= 2.6
+%endif
+%else
+BuildRequires: %{py_package_prefix}-devel
+%endif
 BuildRequires: openssl-devel
 BuildRequires: gcc
 BuildRequires: %{py_package_prefix}-setuptools
@@ -688,8 +700,10 @@ install -m 644 %{_builddir}/%{buildsubdir}/etc-conf/redhat-uep.pem %{buildroot}/
 # fix timestamps on our byte compiled files so they match across arches
 find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 
+%if 0%{!?suse_version}
 %if %{with python3}
 %py_byte_compile %{__python3} %{buildroot}%{rhsm_plugins_dir}/
+%endif
 %endif
 
 # symlink services to /usr/sbin/ when building for SUSE distributions


### PR DESCRIPTION
* building on SUSE with python3 is now working
* Python3 subpackages are just prefixed with python3. No minor version
  suffix
* some python2 packages still named as "python" without 2 as suffix f.e.
  python-devel
* python3 bytecode is generated automatically on SUSE