### PR TITLE
[1.28.13] build: pin flake8 to < 4

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,6 +6,7 @@
 -e ./build_ext
 -e ./syspurpose
 
+flake8<4
 nose
 nose-capturestderr
 nose-randomly


### PR DESCRIPTION
flake8 4 drops flake8.main.setuptools_command, which we use in our lint
commands. Hence, for now pin it to any version lower than 4 to keep the
stylish test working again.

(cherry picked from commit cd96129eb154968f019594ce85af6c167e5eac01)

Backport of PR #2832 to 1.28.13.