### PR TITLE
Newer versions of the rpm tooling expect __python defined

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -63,6 +63,7 @@
 %global py_package_prefix python%{python3_pkgversion}
 %global rhsm_package_name %{py_package_prefix}-subscription-manager-rhsm
 %else
+%global __python %__python2
 %global py_package_prefix python
 %global rhsm_package_name subscription-manager-rhsm
 %endif


### PR DESCRIPTION
This ensures the global __python is defined in either the python2
or the python3 case.