### PR TITLE
2003777: Fix organizations hint in syspurpose commands

### DIFF
--- a/src/subscription_manager/cli_command/org.py
+++ b/src/subscription_manager/cli_command/org.py
@@ -58,4 +58,6 @@ class OrgCommand(UserPassCommand):
                     'Hint: User "{name}" is member of following organizations: {orgs}'
                 ).format(name=self.username, orgs=', '.join(org_keys)))
                 self._org = self._get_org(self.options.org)
+            else:
+                self._org = self.options.org
         return self._org


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2003777
* Card ID: ENT-4470

This is a follow-up commit for previous ones handling this BZ. When the
user didn't specify any org, they were correctly prompted to enter one.
When they did, the option was not saved and `None` was used instead,
resulting in an HTTP 404 error.

I do believe this is the final PR :)

Previous PRs:
- https://github.com/candlepin/subscription-manager/pull/2796
- https://github.com/candlepin/subscription-manager/pull/2819