### PR TITLE
Fix redundant API traffics caused by upload profiles.

### DIFF
--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -228,7 +228,7 @@ def posttrans_hook(conduit):
     if '1' == cfg.get('rhsm', 'package_profile_on_trans'):
         conduit.info(3, "Updating package profile")
         package_profile_client = ProfileActionClient()
-        package_profile_client.update()
+        package_profile_client.profilelib._do_update(conduit=conduit)
     else:
         # do nothing
         return

--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -139,13 +139,15 @@ class EnabledRepos(object):
                 break
         return enabled_repos
 
-    def __init__(self, repo_file):
+    def __init__(self, repo_file, conduit=None):
         """
         :param path: A .repo file path used to filter the report.
         :type path: str
         """
         if dnf is not None:
             self.db = dnf.dnf.Base()
+        elif yum is not None and conduit:
+            self.yb = conduit._base
         elif yum is not None:
             self.yb = yum.YumBase()
 
@@ -191,8 +193,8 @@ class EnabledReposProfile(object):
     Collect information about enabled repositories
     """
 
-    def __init__(self, repo_file=REPOSITORY_PATH):
-        self._enabled_repos = EnabledRepos(repo_file)
+    def __init__(self, repo_file=REPOSITORY_PATH, conduit=None):
+        self._enabled_repos = EnabledRepos(repo_file, conduit=conduit)
 
     def __eq__(self, other):
         return self._enabled_repos.content == other._enabled_repos.content
@@ -345,7 +347,7 @@ class RPMProfile(object):
         return True
 
 
-def get_profile(profile_type):
+def get_profile(profile_type, conduit=None):
     """
     Returns an instance of a Profile object
     @param profile_type: profile type
@@ -354,7 +356,11 @@ def get_profile(profile_type):
     """
     if profile_type not in PROFILE_MAP:
         raise InvalidProfileType('Could not find profile for type [%s]', profile_type)
-    profile = PROFILE_MAP[profile_type]()
+
+    if profile_type == 'enabled_repos':
+        profile = PROFILE_MAP[profile_type](conduit=conduit)
+    else:
+        profile = PROFILE_MAP[profile_type]()
     return profile
 
 

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -421,6 +421,7 @@ class ProfileManager(CacheManager):
         self._current_profile = None
         self.report_package_profile = self.profile_reporting_enabled()
         self.identity = inj.require(inj.IDENTITY)
+        self.conduit = None
 
     def profile_reporting_enabled(self):
         # If profile reporting is disabled from the environment, that overrides the setting in the conf file
@@ -448,7 +449,7 @@ class ProfileManager(CacheManager):
     def current_profile(self):
         if not self._current_profile:
             rpm_profile = get_profile('rpm').collect()
-            enabled_repos = get_profile('enabled_repos').collect()
+            enabled_repos = get_profile('enabled_repos', conduit=self.conduit).collect()
             module_profile = get_profile('modulemd').collect()
             combined_profile = self._assembly_profile(rpm_profile, enabled_repos, module_profile)
             self._current_profile = combined_profile

--- a/src/subscription_manager/packageprofilelib.py
+++ b/src/subscription_manager/packageprofilelib.py
@@ -21,8 +21,8 @@ class PackageProfileActionInvoker(certlib.BaseActionInvoker):
     """Used by rhsmcertd to update the profile
     periodically.
     """
-    def _do_update(self):
-        action = PackageProfileActionCommand()
+    def _do_update(self, conduit=None):
+        action = PackageProfileActionCommand(conduit=conduit)
         return action.perform()
 
 
@@ -31,14 +31,16 @@ class PackageProfileActionCommand(object):
 
     Returns a PackageProfileActionReport.
     """
-    def __init__(self):
+    def __init__(self, conduit=None):
         self.report = PackageProfileActionReport()
         self.cp_provider = inj.require(inj.CP_PROVIDER)
         self.uep = self.cp_provider.get_consumer_auth_cp()
+        self.conduit = conduit
 
     def perform(self, force_upload=False):
         profile_mgr = inj.require(inj.PROFILE_MANAGER)
         consumer_identity = inj.require(inj.IDENTITY)
+        profile_mgr.conduit = self.conduit
         ret = profile_mgr.update_check(self.uep, consumer_identity.uuid, force=force_upload)
         self.report._status = ret
         return self.report


### PR DESCRIPTION
Pass the Yum conduit containing _base instance into the profile
lib so that subscription manager doesn't need to reload the
YumBase. Loading YumBase multiple times will unnecessary trigger
the postconfig hook and refresh the certificates. This causing
more API traffics to the server.