### PR TITLE
[1.28] 2014646: fix rhn-migrate-classic-to-rhsm & its tests for argparse

### DIFF
--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -987,7 +987,7 @@ def main(args=None, five_to_six_script=False):
     if not args:
         args = sys.argv[1:]
 
-    (options, args) = parser.parse_args(args)
+    options = parser.parse_args(args)
     set_defaults(options, five_to_six_script)
     validate_options(options)
     MigrationEngine(options).main()


### PR DESCRIPTION
Adapt one leftover bit in rhn-migrate-classic-to-rhsm to the argparse
switch, so it hopefully works again.

Fix also its tests by switching them to argparse, with few caveats:
- ArgumentParser has no public "option_list" attribute: use a private
  attribute as shown in a CPython bug [1]
- ArgumentParser has no has_option(): implement an helper function using
  the aforementioned private attribute [1]

[1] https://bugs.python.org/issue23159

Card ID: ENT-4472