### PR TITLE
[1.28] Fix redundant API calls to Candlepin

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -422,6 +422,7 @@ class ProfileManager(CacheManager):
         # we're sure we actually need the data.
         self._current_profile = None
         self.report_package_profile = self.profile_reporting_enabled()
+        self.identity = inj.require(inj.IDENTITY)
 
     def profile_reporting_enabled(self):
         # If profile reporting is disabled from the environment, that overrides the setting in the conf file
@@ -472,7 +473,7 @@ class ProfileManager(CacheManager):
         """
 
         # If the server doesn't support packages, don't try to send the profile:
-        supported_resources = get_supported_resources()
+        supported_resources = get_supported_resources(uep=None, identity=self.identity)
         if PACKAGES_RESOURCE not in supported_resources:
             log.warning("Server does not support packages, skipping profile upload.")
             return 0
@@ -705,6 +706,7 @@ class ContentAccessCache(object):
         return os.remove(self.CACHE_FILE)
 
     def check_for_update(self):
+        data = None
         if self.exists():
             try:
                 data = json.loads(self.read())
@@ -717,7 +719,14 @@ class ContentAccessCache(object):
                 last_update = None
         else:
             last_update = None
-        return self._query_for_update(if_modified_since=last_update)
+
+        response = self._query_for_update(if_modified_since=last_update)
+        # Candlepin 4 bug 2010251. if_modified_since is not reliable so
+        # we double checks whether or not the sca certificate is changed.
+        if data is not None and data == response:
+            log.debug("Content access certificate is up-to-date.")
+            return None
+        return response
 
     @staticmethod
     def update_cert(cert, data):

--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -122,6 +122,7 @@ class EntCertUpdateAction(object):
             log.error('Cannot modify subscriptions while disconnected')
             raise Disconnected()
 
+        cert_changed = False
         missing_serials = self._find_missing_serials(local, expected)
         rogue_serials = self._find_rogue_serials(local, expected)
 
@@ -131,14 +132,31 @@ class EntCertUpdateAction(object):
         log.info('certs updated:\n%s', self.report)
         self.syslog_results()
 
-        if missing_serials or rogue_serials:
+        # We call EntCertlibActionInvoker.update() solo from
+        # the 'attach' cli instead of an ActionClient. So
+        # we need to refresh the ent_dir object before calling
+        # content updating actions.
+        self.ent_dir.refresh()
 
-            # We call EntCertlibActionInvoker.update() solo from
-            # the 'attach' cli instead of an ActionClient. So
-            # we need to refresh the ent_dir object before calling
-            # content updating actions.
-            self.ent_dir.refresh()
-            self.content_access_hook()
+        if missing_serials or rogue_serials:
+            cert_changed = True
+
+        if self.uep.has_capability(CONTENT_ACCESS_CERT_CAPABILITY):
+            content_access_certs = self._find_content_access_certs()
+            if len(content_access_certs) > 0:
+                # This addresses BZs: 1448855, 1450862
+                obsolete_certs = []
+                for cont_access_cert in content_access_certs:
+                    if cont_access_cert.serial not in expected:
+                        obsolete_certs.append(cont_access_cert)
+                if len(obsolete_certs) > 0:
+                    log.info('Deleting obsolete content access certificate')
+                    self.delete(obsolete_certs)
+            update_data = self.content_access_hook()
+            if update_data is not None:
+                cert_changed = True
+
+        if cert_changed:
             self.repo_hook()
 
             # NOTE: Since we have the yum repos defined here now
@@ -148,24 +166,6 @@ class EntCertUpdateAction(object):
 
             # reload certs and update branding
             self.branding_hook()
-
-        if self.uep.has_capability(CONTENT_ACCESS_CERT_CAPABILITY):
-            content_access_certs = self._find_content_access_certs()
-            update_data = None
-            if len(content_access_certs) > 0:
-                # This addresses BZs: 1448855, 1450862
-                obsolete_certs = []
-                for cont_access_cert in content_access_certs:
-                    if cont_access_cert.serial not in expected:
-                        obsolete_certs.append(cont_access_cert)
-                log.info('Deleting obsolete content access certificate')
-                self.delete(obsolete_certs)
-                update_data = self.content_access_cache.check_for_update()
-                for content_access_cert in content_access_certs:
-                    self.content_access_cache.update_cert(content_access_cert, update_data)
-            if update_data is not None:
-                self.ent_dir.refresh()
-                self.repo_hook()
 
         # if we want the full report, we can get it, but
         # this makes CertLib.update() have same sig as reset
@@ -197,6 +197,7 @@ class EntCertUpdateAction(object):
             self.content_access_cache.remove()
         if update_data is not None:
             self.ent_dir.refresh()
+        return update_data
 
     def branding_hook(self):
         """Update branding info based on entitlement cert changes."""
@@ -248,7 +249,9 @@ class EntCertUpdateAction(object):
         # grace period
         # XXX since we don't use grace period, this might not be needed
         self.ent_dir.refresh()
-        for valid in self.ent_dir.list():
+        ent_certs = self.ent_dir.list() + self.ent_dir.list_with_content_access()
+        ent_certs = list(set(ent_certs))
+        for valid in ent_certs:
             sn = valid.serial
             self.report.valid.append(sn)
             local[sn] = valid


### PR DESCRIPTION
* Cherry-pick PR. Original PR: #2820
  * Cherry-picked commit: 3567c93fb08ace29198bbeea6b0124af051ff6bd
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2014052
* Card ID: ENT-4469

In SCA enabled mode, Subscription manager and Yum are sending
redundant API calls (/accessible_content) to fetch the SCA
certificate from Candlepin and refresh the redhat.repo file
everytime unnecessarily which is also causing redundant
API calls (/content_overrides and /release) to the Candlepin.
Servers such as Satellite may encounter unnecessarily high
traffic loads when a lot of hosts are registering or patching
concurrently. This patch fixed the issue.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2010137