### PR TITLE
2015173: chmod /etc/pki/entitlement/*.pem only when existing

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1064,7 +1064,7 @@ fi
 %endif
 
 # Make all entitlement certificates and keys files readable by group and other
-chmod go+r /etc/pki/entitlement/*.pem || true
+find /etc/pki/entitlement -mindepth 1 -maxdepth 1 -name '*.pem' | xargs --no-run-if-empty chmod go+r
 
 if [ -x /bin/dbus-send ] ; then
     dbus-send --system --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig > /dev/null 2>&1 || :


### PR DESCRIPTION
There are no `.pem` files in `/etc/pki/entitlement` in case a system is not
registered; in that case, the shell expansion will error out, producing
an error message (ignored) during upgrades.

Instead, find the files manually and run chmod on whatever was found;
this way there is no behaviour change (the permissions of `.pem` files
are properly set), there is no message in case of no certificates, and
(bonus) the errors from chmod are no more ignored.

Card ID: ENT-4473