### PR TITLE
Improvement of D-Bus Register() method

### DIFF
--- a/cockpit/src/subscriptions-client.js
+++ b/cockpit/src/subscriptions-client.js
@@ -330,10 +330,6 @@ client.registerSystem = (subscriptionDetails, update_progress) => {
                         'com.redhat.RHSM1.Register',
                         '/com/redhat/RHSM1/Register'
                     );
-                    const registration_options = {
-                        "enable_content": dbus_bool(subscriptionDetails.auto_attach)
-                    };
-                    console.log('registration_options:', registration_options);
                     if (subscriptionDetails.activation_keys) {
                         if (update_progress)
                             update_progress(_("Registering using activation key ..."), null);
@@ -343,7 +339,7 @@ client.registerSystem = (subscriptionDetails, update_progress) => {
                             [
                                 subscriptionDetails.org,
                                 subscriptionDetails.activation_keys.split(','),
-                                registration_options,
+                                {},
                                 connection_options,
                                 userLang
                             ]
@@ -353,6 +349,10 @@ client.registerSystem = (subscriptionDetails, update_progress) => {
                     }
                     else {
                         console.debug('registering using username and password');
+                        const registration_options = {
+                            "enable_content": dbus_bool(subscriptionDetails.auto_attach)
+                        };
+                        console.log('registration_options:', registration_options);
                         if (update_progress)
                             update_progress(_("Registering using username and password ..."), null);
                         let result = registerService.call(

--- a/src/rhsmlib/dbus/objects/config.py
+++ b/src/rhsmlib/dbus/objects/config.py
@@ -88,10 +88,12 @@ class ConfigDBusObject(base_object.BaseObject):
         # Try to temporary disable dir watcher, because 'self.config.persist()' writes configuration
         # file and it would trigger file system monitor callback function and saved values would be
         # read again. It can cause race conditions, when Set() is called multiple times
-        temporary_disable_dir_watcher()
+        Server.temporary_disable_dir_watchers({CONFIG_WATCHER})
 
         # Write new config value to configuration file
         self.config.persist()
+
+        Server.enable_dir_watchers({CONFIG_WATCHER})
 
         # When anything in logging section was just chnaged, then we have to re-initialize logger
         if logging_changed is True:
@@ -135,12 +137,14 @@ class ConfigDBusObject(base_object.BaseObject):
         # Try to temporary disable dir watcher, because 'self.config.persist()' writes configuration
         # file and it would trigger file system monitor callback function and saved values would be
         # read again. It can cause race conditions, when SetAll() is called multiple times
-        temporary_disable_dir_watcher()
+        Server.temporary_disable_dir_watchers({CONFIG_WATCHER})
 
         # Write new config value to configuration file
         self.config.persist()
 
-        # When anything in logging section was just chnaged, then we have to re-initialize logger
+        Server.enable_dir_watchers({CONFIG_WATCHER})
+
+        # When anything in logging section was just changed, then we have to re-initialize logger
         if logging_changed is True:
             parser = rhsm.config.get_config_parser()
             self.config = Config(parser)
@@ -215,14 +219,3 @@ class ConfigDBusObject(base_object.BaseObject):
             log.debug("Configuration file: %s reloaded: %s" % (parser.config_file, str(self.config)))
         else:
             log.warning("Unable to read configuration file: %s" % parser.config_file)
-
-
-def temporary_disable_dir_watcher():
-    """
-    This method temporary disables file system directory watcher for rhsm.conf
-    """
-
-    if Server.INSTANCE is not None:
-        server = Server.INSTANCE
-        dir_watcher = server.filesystem_watcher.dir_watches[CONFIG_WATCHER]
-        dir_watcher.temporary_disable()

--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -16,7 +16,6 @@ import logging
 import threading
 import dbus
 import dbus.service
-from typing import Union
 
 from rhsmlib.dbus import constants, exceptions, dbus_utils, base_object, server, util
 from rhsmlib.services.register import RegisterService

--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -31,42 +31,6 @@ from subscription_manager.entcertlib import EntCertActionInvoker
 log = logging.getLogger(__name__)
 
 
-def temporary_disable_dir_watchers(watcher_set: set = None) -> None:
-    """
-    This function temporary disables file system directory watchers
-    :param watcher_set: Set of watchers. If the watcher is None, then all watchers are disabled
-    :return: None
-    """
-    server_instance = server.Server.INSTANCE
-    if server_instance is None:
-        return
-
-    # Temporary disable watchers
-    for dir_watcher_id, dir_watcher in server_instance.filesystem_watcher.dir_watches.items():
-        # When watcher_set is not empty, then check if watcher_id is
-        # included in the set
-        if watcher_set is not None and dir_watcher_id not in watcher_set:
-            continue
-        log.debug(f'Disabling directory watcher: {dir_watcher_id}')
-        dir_watcher.temporary_disable()
-
-
-def enable_dir_watchers(watcher_set: set = None) -> None:
-    """
-    This function enables file system directory watchers
-    :param watcher_set: Set of watcher. If the watcher is None, then all watchers are enabled
-    :return: None
-    """
-    server_instance = server.Server.INSTANCE
-    if server_instance is None:
-        return
-    for dir_watcher_id, dir_watcher in server_instance.filesystem_watcher.dir_watches.items():
-        if watcher_set is not None and dir_watcher_id not in watcher_set:
-            continue
-        log.debug(f'Enabling directory watcher: {dir_watcher_id}')
-        dir_watcher.enable()
-
-
 class RegisterDBusObject(base_object.BaseObject):
     default_dbus_path = constants.REGISTER_DBUS_PATH
     interface_name = constants.REGISTER_INTERFACE
@@ -340,19 +304,12 @@ class DomainSocketRegisterDBusObject(base_object.BaseObject):
             # Remove 'enable_content' option, because it will not be proceed in register service
             enable_content = self._remove_enable_content_option(options)
 
-            # Temporary disable all watchers, because registering system will create some files
-            # and it would be useless to call related callbacks in this case
-            temporary_disable_dir_watchers()
-
             consumer = register_service.register(org, **options)
 
             # When consumer is created, then we can try to enabled content, when it was
             # requested in options.
             if enable_content is True:
                 self._enable_content(cp, consumer)
-
-            # We can enable watchers again
-            enable_dir_watchers()
 
             dbus_sender.reset_cmd_line()
 

--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -16,9 +16,12 @@ import logging
 import threading
 import dbus
 import dbus.service
+from typing import Union
 
 from rhsmlib.dbus import constants, exceptions, dbus_utils, base_object, server, util
 from rhsmlib.services.register import RegisterService
+from rhsmlib.services.attach import AttachService
+from rhsmlib.services.entitlement import EntitlementService
 from rhsmlib.client_info import DBusSender
 
 from subscription_manager.i18n import Locale
@@ -26,6 +29,42 @@ from subscription_manager.i18n import ugettext as _
 from subscription_manager.entcertlib import EntCertActionInvoker
 
 log = logging.getLogger(__name__)
+
+
+def temporary_disable_dir_watchers(watcher_set: set = None) -> None:
+    """
+    This function temporary disables file system directory watchers
+    :param watcher_set: Set of watchers. If the watcher is None, then all watchers are disabled
+    :return: None
+    """
+    server_instance = server.Server.INSTANCE
+    if server_instance is None:
+        return
+
+    # Temporary disable watchers
+    for dir_watcher_id, dir_watcher in server_instance.filesystem_watcher.dir_watches.items():
+        # When watcher_set is not empty, then check if watcher_id is
+        # included in the set
+        if watcher_set is not None and dir_watcher_id not in watcher_set:
+            continue
+        log.debug(f'Disabling directory watcher: {dir_watcher_id}')
+        dir_watcher.temporary_disable()
+
+
+def enable_dir_watchers(watcher_set: set = None) -> None:
+    """
+    This function enables file system directory watchers
+    :param watcher_set: Set of watcher. If the watcher is None, then all watchers are enabled
+    :return: None
+    """
+    server_instance = server.Server.INSTANCE
+    if server_instance is None:
+        return
+    for dir_watcher_id, dir_watcher in server_instance.filesystem_watcher.dir_watches.items():
+        if watcher_set is not None and dir_watcher_id not in watcher_set:
+            continue
+        log.debug(f'Enabling directory watcher: {dir_watcher_id}')
+        dir_watcher.enable()
 
 
 class RegisterDBusObject(base_object.BaseObject):
@@ -202,6 +241,31 @@ class DomainSocketRegisterDBusObject(base_object.BaseObject):
         # We return None here, because we cannot know what will be selected by user
         return None
 
+    def _enable_content(self, cp, consumer: dict) -> Union[dict, None]:
+        """
+        Try to enable content. Try to do auto-attach in non-SCA mode or try to do refresh SCA mode.
+        :param cp: Object representing connection to candlepin server
+        :param consumer: Dictionary representing consumer
+        :return: Dictionary with result of enablement of content or None
+        """
+        content_access_mode = consumer['owner']['contentAccessMode']
+
+        if content_access_mode == 'entitlement':
+            log.debug('Auto-attaching due to enable_content option')
+            attach_service = AttachService(cp)
+            return attach_service.attach_auto()
+        elif content_access_mode == 'org_environment':
+            log.debug('Refreshing due to enabled_content option and simple content access mode')
+            entitlement_service = EntitlementService(cp)
+            # TODO: try get anything useful from refresh result. It is not possible atm.
+            entitlement_service.refresh(remove_cache=False, force=False)
+            return None
+        else:
+            log.error(f"Unable to enable content due to unsupported content access mode: "
+                      f"{content_access_mode}")
+
+        return None
+
     @dbus.service.method(
         dbus_interface=constants.PRIVATE_REGISTER_INTERFACE,
         in_signature='sssa{sv}a{sv}s',
@@ -250,7 +314,35 @@ class DomainSocketRegisterDBusObject(base_object.BaseObject):
             if not org:
                 raise OrgNotSpecifiedException(username=connection_options['username'])
 
+            # Remove 'enable_content' option, because it will not be processed in register service
+            if 'enable_content' in options:
+                log.debug(
+                    f"Value and type of enable_content: '{options['enable_content']}' "
+                    f"({type(options['enable_content'])})"
+                )
+                enable_content = bool(options.pop('enable_content'))
+                log.debug(f"Value of converted enable_content: {enable_content}")
+            else:
+                enable_content = False
+
+            # Temporary disable all watchers, because registering system will create some files
+            # and it would be useless to call related callbacks in this case
+            temporary_disable_dir_watchers()
+
             consumer = register_service.register(org, **options)
+
+            # When consumer is created, then we can try to enabled content, when it was
+            # requested in options.
+            if enable_content is True:
+                enabled_content = self._enable_content(cp, consumer)
+                # When it was possible to enable content, then extend consumer
+                # with information about enabled content
+                if enabled_content is not None:
+                    consumer['enabledContent'] = enabled_content
+
+            # We can enable watchers again
+            enable_dir_watchers()
+
             dbus_sender.reset_cmd_line()
 
         return json.dumps(consumer)

--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -146,7 +146,10 @@ class Server(object):
             PRODUCT_WATCHER: products_dir_watch,
             SYSPURPOSE_WATCHER: syspurpose_dir_watch,
         })
-        self._thread = threading.Thread(target=self.filesystem_watcher.loop)
+        self._thread = threading.Thread(
+            target=self.filesystem_watcher.loop,
+            name='Thread-FileSystemWatcher',
+        )
         self._thread.start()
 
     def run(self, started_event=None, stopped_event=None):

--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -207,6 +207,42 @@ class Server(object):
         log.debug(f'Releasing Bus name: {self.bus_name}')
         self.bus.release_name(self.bus_name)
 
+    @classmethod
+    def temporary_disable_dir_watchers(cls, watcher_set: set = None) -> None:
+        """
+        This function temporary disables file system directory watchers
+        :param watcher_set: Set of watchers. If the watcher is None, then all watchers are disabled
+        :return: None
+        """
+        server_instance = cls.INSTANCE
+        if server_instance is None:
+            return
+
+        # Temporary disable watchers
+        for dir_watcher_id, dir_watcher in server_instance.filesystem_watcher.dir_watches.items():
+            # When watcher_set is not empty, then check if watcher_id is
+            # included in the set
+            if watcher_set is not None and dir_watcher_id not in watcher_set:
+                continue
+            log.debug(f'Disabling directory watcher: {dir_watcher_id}')
+            dir_watcher.temporary_disable()
+
+    @classmethod
+    def enable_dir_watchers(cls, watcher_set: set = None) -> None:
+        """
+        This function enables file system directory watchers
+        :param watcher_set: Set of watcher. If the watcher is None, then all watchers are enabled
+        :return: None
+        """
+        server_instance = cls.INSTANCE
+        if server_instance is None:
+            return
+        for dir_watcher_id, dir_watcher in server_instance.filesystem_watcher.dir_watches.items():
+            if watcher_set is not None and dir_watcher_id not in watcher_set:
+                continue
+            log.debug(f'Enabling directory watcher: {dir_watcher_id}')
+            dir_watcher.enable()
+
 
 class DomainSocketServer(object):
     """This class sets up a DBus server on a domain socket. That server can then be used to perform

--- a/src/rhsmlib/file_monitor.py
+++ b/src/rhsmlib/file_monitor.py
@@ -10,6 +10,7 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
+import threading
 
 from rhsm.config import get_config_parser
 from rhsmlib.services import config
@@ -165,7 +166,6 @@ class InotifyFilesystemWatcher(FilesystemWatcher):
             self.notifier.process_events()
             # We use timeout to keep checks reasonably fast while still timing out
             if self.notifier.check_events(self.TIMEOUT):
-                log.debug('Some i-notify event occured')
                 self.notifier.read_events()
 
             for dir_watch in self.dir_watches.values():
@@ -179,7 +179,10 @@ class InotifyFilesystemWatcher(FilesystemWatcher):
         default process function for pyinotify notifier
         :param event: pyinotify Event object, has path and mask of flags representing file modification
         """
-        log.debug('Some event occured: %s (%s)' % (event.path, event.pathname))
+        log.debug(
+            'Thread %s: Some event occurred: %s (%s)' %
+            (threading.current_thread().getName(), event.path, event.pathname)
+        )
 
         for dir_watch in self.dir_watches.values():
             # When watcher is temporary disabled, ten
@@ -302,6 +305,12 @@ class DirectoryWatch(object):
         log.debug('Temporary disabled watcher: %s for %d seconds' % (self.path, self.DISABLEMENT_TIMEOUT))
         self.temporary_disabled = True
         self._time_tmp_dis = time.time()
+
+    def enable(self):
+        """
+        Enable watcher
+        """
+        self.temporary_disabled = False
 
     def update_temporary_disabled_watcher(self):
         """

--- a/src/rhsmlib/services/attach.py
+++ b/src/rhsmlib/services/attach.py
@@ -23,8 +23,11 @@ class AttachService(object):
         self.identity = inj.require(inj.IDENTITY)
         self.cp = cp
 
-    def attach_auto(self, service_level):
+    def attach_auto(self, service_level=None):
 
+        # FIXME: First check if current service_level is the same as provided in
+        # argument and if not then try to set something new. Otherwise it is useless
+        # and it only cause unnecessary REST API call
         if service_level is not None:
             self.cp.updateConsumer(self.identity.uuid, service_level=service_level)
             log.debug("Service level set to: %s" % service_level)

--- a/src/rhsmlib/services/entitlement.py
+++ b/src/rhsmlib/services/entitlement.py
@@ -552,3 +552,27 @@ class EntitlementService(object):
         log.debug('Clearing in-memory cache of file %s' % status_cache.CACHE_FILE)
         status_cache.server_status = None
         sorter.load()
+
+    def refresh(self, remove_cache=False, force=False):
+        """
+        Try to refresh entitlement certificate(s) from candlepin server
+        :return: Report of EntCertActionInvoker
+        """
+
+        if remove_cache is True:
+            # remove content_access cache, ensuring we get it fresh
+            content_access = inj.require(inj.CONTENT_ACCESS_CACHE)
+            if content_access.exists():
+                content_access.remove()
+            # Also remove the content access mode cache to be sure we display
+            # SCA or regular mode correctly
+            content_access_mode = inj.require(inj.CONTENT_ACCESS_MODE_CACHE)
+            if content_access_mode.exists():
+                content_access_mode.delete_cache()
+
+        if force is True:
+            # Force a regen of the entitlement certs for this consumer
+            if not self.cp.regenEntitlementCertificates(self.identity.uuid, True):
+                log.debug("Warning: Unable to refresh entitlement certificates; service likely unavailable")
+
+        return self.entcertlib.update()

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -133,6 +133,26 @@ class RegisterService(object):
         # Save syspurpose attributes from consumer to cache file
         syspurposelib.write_syspurpose_cache(syspurpose_dict)
 
+        content_access_mode_cache = inj.require(inj.CONTENT_ACCESS_MODE_CACHE)
+
+        # Is information about content access mode included in consumer
+        if 'owner' not in consumer:
+            log.warning('Consumer does not contain any information about owner.')
+        elif 'contentAccessMode' in consumer['owner']:
+            log.debug('Saving content access mode from consumer object to cache file.')
+            # When we know content access mode from consumer, then write it to cache file
+            content_access_mode = consumer['owner']['contentAccessMode']
+            content_access_mode_cache.set_data(content_access_mode, self.identity)
+            content_access_mode_cache.write_cache()
+        else:
+            # If not, then we have to do another REST API call to get this information
+            # It will not be included in cache file. When cache file is empty, then
+            # it will trigger accessing REST API and saving result in cache file.
+            log.debug('Information about content access mode is not included in consumer')
+            content_access_mode = content_access_mode_cache.read_data()
+            # Add information about content access mode to consumer
+            consumer['owner']['contentAccessMode'] = content_access_mode
+
         return consumer
 
     def validate_options(self, options):

--- a/src/rhsmlib/services/syspurpose.py
+++ b/src/rhsmlib/services/syspurpose.py
@@ -63,8 +63,8 @@ class Syspurpose(object):
         :param syspurpose_values: Dictionary with system purpose values
         :return: Dictionary with local result
         """
+        Server.temporary_disable_dir_watchers({SYSPURPOSE_WATCHER})
         if self.identity.is_valid() and self.cp.has_capability("syspurpose"):
-            temporary_disable_dir_watcher()
             local_result = merge_syspurpose_values(
                 local=syspurpose_values,
                 uep=self.cp,
@@ -78,6 +78,7 @@ class Syspurpose(object):
             local_result = merge_syspurpose_values(local=syspurpose_values, remote={}, base={})
             write_syspurpose(local_result)
             result = local_result
+        Server.enable_dir_watchers({SYSPURPOSE_WATCHER})
 
         return result
 
@@ -102,14 +103,3 @@ class Syspurpose(object):
             'unknown': _('Unknown')
         }
         return status_map.get(status, status_map['unknown'])
-
-
-def temporary_disable_dir_watcher():
-    """
-    This method temporary disables file system directory watcher for syspurpose.json
-    """
-
-    if Server.INSTANCE is not None:
-        server = Server.INSTANCE
-        dir_watcher = server.filesystem_watcher.dir_watches[SYSPURPOSE_WATCHER]
-        dir_watcher.temporary_disable()

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -860,6 +860,19 @@ class ConsumerCache(CacheManager):
         """
         return False
 
+    def set_data(self, current_data, identity=None):
+        """
+        Set data into internal cache
+        :param current_data: data to set
+        :param identity: object of identity
+        :return: None
+        """
+
+        if identity is None:
+            identity = inj.require(inj.IDENTITY)
+
+        self.data = {identity.uuid: current_data}
+
     def read_data(self, uep=None, identity=None):
         """
         This function tries to get data from cache or server
@@ -923,8 +936,7 @@ class ConsumerCache(CacheManager):
                 raise rest_err
             else:
                 # Write data to cache
-                data = {identity.uuid: current_data}
-                self.data = data
+                self.set_data(current_data, identity)
                 self.write_cache(debug=True)
 
         return current_data

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -264,8 +264,9 @@ class StatusCache(CacheManager):
         the disk cache to the in-memory cache to avoid reading again.
         """
         if self.server_status is None:
-            log.debug('Trying to read status from %s file' % self.CACHE_FILE)
-            self.server_status = super(StatusCache, self)._read_cache()
+            if self._cache_exists():
+                log.debug('Trying to read status from %s file' % self.CACHE_FILE)
+                self.server_status = super(StatusCache, self)._read_cache()
         else:
             log.debug('Reading status from in-memory cache of %s file' % self.CACHE_FILE)
         return self.server_status
@@ -294,7 +295,9 @@ class StatusCache(CacheManager):
         """
 
         if self.server_status is None:
-            self.server_status = self.load_status(uep, uuid, on_date)
+            self.server_status = self._read_cache()
+            if self.server_status is None:
+                self.server_status = self.load_status(uep, uuid, on_date)
         else:
             log.debug('Reading status from in-memory cache of %s file' % self.CACHE_FILE)
         return self.server_status

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -720,34 +720,48 @@ class TestReleaseStatusCache(SubManFixture):
         self.release_cache._cache_exists = Mock(return_value=True)
         self.assertEqual(dummy_release, self.release_cache.read_status(uep, "SOMEUUID"))
 
-    def test_server_network_works_with_cache(self):
+    def test_server_not_needed_with_cache(self):
         uep = Mock()
         dummy_release = {'releaseVer': 'MockServer'}
         uep.getRelease = Mock(return_value=dummy_release)
 
         self.release_cache._cache_exists = Mock(return_value=True)
         self.release_cache._read_cache = Mock(return_value=dummy_release)
-        self.assertEqual(dummy_release, self.release_cache.read_status(uep, "SOMEUUID"))
-        self.assertEqual(1, self.release_cache.write_cache.call_count)
-        self.assertEqual(0, self.release_cache._read_cache.call_count)
-
-        self.assertEqual(dummy_release, self.release_cache.read_status(uep, "SOMEUUID"))
-        self.assertEqual(1, uep.getRelease.call_count)
+        release = self.release_cache.read_status(uep, "SOMEUUID")
+        self.assertEqual(dummy_release, release)
+        self.assertEqual(1, self.release_cache._read_cache.call_count)
+        self.assertEqual(0, uep.getRelease.call_count)
 
     def test_server_network_works_cache_caches(self):
         uep = Mock()
         dummy_release = {'releaseVer': 'MockServer'}
         uep.getRelease = Mock(return_value=dummy_release)
+        self.release_cache.write_cache = Mock()
 
+        # Mock that cache does not exist
         self.release_cache._cache_exists = Mock(return_value=False)
         self.release_cache.server_status = None
-        self.release_cache._read_cache = Mock(return_value=dummy_release)
-        self.assertEqual(dummy_release, self.release_cache.read_status(uep, "SOMEUUID"))
-        self.assertEqual(1, self.release_cache.write_cache.call_count)
-        self.assertEqual(0, self.release_cache._read_cache.call_count)
+        self.release_cache._read_cache = Mock(return_value=None)
 
+        # Try to read status
+        release = self.release_cache.read_status(uep, "SOMEUUID")
+
+        # Assert that status was read from server and result was written
+        # to cache file
+        self.assertEqual(dummy_release, release)
+        self.assertEqual(1, uep.getRelease.call_count)
+        self.assertEqual(1, self.release_cache.write_cache.call_count)
+        self.assertEqual(1, self.release_cache._read_cache.call_count)
+
+        # Mock that cache file exists now
         self.release_cache._cache_exists = Mock(return_value=True)
-        self.assertEqual(dummy_release, self.release_cache.read_status(uep, "SOMEUUID"))
+        self.release_cache._read_cache = Mock(return_value=dummy_release)
+
+        # Try to get release once again
+        release = self.release_cache.read_status(uep, "SOMEUUID")
+
+        # Assert that release was read from cache and not from server
+        self.assertEqual(dummy_release, release)
         self.assertEqual(1, self.release_cache.write_cache.call_count)
         self.assertEqual(1, uep.getRelease.call_count)
 


### PR DESCRIPTION
* Card ID: ENT-4410
* When consumer does not include information about
  content access mode, then another REST API call is made
  and this information is added to the dictionary
  containing information about current consumer
* The cache was quite useless, because it did not read cached
  information from file, but cached data were read only from
  in-memory cache
* Added refresh() method to entitlement service 
* When Register() method is called with enable_content
  option and this option is equal True, then auto-attach
  is called in non-SCA mode and refresh in SCA mode
* When D-Bus method Register() was called, then
  rhsm_service called almost 30 REST API calles
  due to i-notify. It was reduced to 4 calls
* Added support of enable_content to cockpit plugin.
* When D-Bus method RegisterWithActivationKeys() is used, then
  enable_content is ignored, because it auto-attach cannot be
  used together with activation keys
* Refactored code a little to be able to share code with
  Register() method
* Modified and extended unit tests