### PR TITLE
cockpit CI: make it run on Fedora

### DIFF
--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -165,7 +165,8 @@ class SubscriptionsCase(MachineCase):
         # Wait for the web service to be accessible
         machine_python(self.machine, WAIT_SCRIPT, CANDLEPIN_URL)
 
-        m.write("/etc/insights-client/insights-client.conf",
+        if m.image.startswith('rhel-'):
+            m.write("/etc/insights-client/insights-client.conf",
 """
 [insights-client]
 gpg=False
@@ -438,7 +439,8 @@ class TestSubscriptionsPackages(SubscriptionsCase, PackageCase):
         m = self.machine
         b = self.browser
 
-        m.execute("pkcon remove -y insights-client")
+        if m.image.startswith('rhel-'):
+            m.execute("pkcon remove -y insights-client")
 
         self.createPackage("insights-client", "999", "1")
         self.enableRepo()

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -16,8 +16,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import functools
 import os
 import sys
+import unittest
 
 # import Cockpit's machinery for test VMs and its browser test API
 TEST_DIR = os.path.dirname(__file__)
@@ -107,6 +109,22 @@ def shell_escape(s):
 
 def machine_python(machine, script, arg=""):
     return machine.execute("python3 -c %s %s" % (shell_escape(script), shell_escape(arg)))
+
+
+def skipUnlessDistroFamily(distro, reason):
+    """
+    Skip the current test function with the specified [reason]
+    unless the distribution of the machine is part of the specified
+    family [distro] (i.e. it starts as "distro-").
+    """
+    def distro_wrapper(func):
+        @functools.wraps(func)
+        def wrapper(obj):
+            if not obj.machine.image.startswith(distro + '-'):
+                raise unittest.SkipTest(reason)
+            return func(obj)
+        return wrapper
+    return distro_wrapper
 
 
 class SubscriptionsCase(MachineCase):
@@ -310,6 +328,7 @@ class TestSubscriptions(SubscriptionsCase):
         self.browser.wait_in_text(".pf-c-empty-state__body", "current user isn't allowed to access system subscription")
         self.allow_journal_messages("junior is not in the sudoers file.  This incident will be reported.")
 
+    @skipUnlessDistroFamily("rhel", "Insights support is specific to RHEL")
     def testInsights(self):
         m = self.machine
         b = self.browser
@@ -362,6 +381,7 @@ class TestSubscriptions(SubscriptionsCase):
 
         b.wait_visible("button:contains('Not connected')")
 
+    @skipUnlessDistroFamily("rhel", "Insights support is specific to RHEL")
     def testSubAndInAndFail(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
The cockpit CI currently assumes a Red Hat system, and it already sort of works on Fedora. The only bits specific to RHEL are the ones related to Red Hat Insights, which is easy enough to limit to RHEL.

With these simple changes, the cockpit CI will successfully run also on Fedora.

Card ID: ENT-4475