### PR TITLE
1859529: Remove proxy server test as it is unnecessary

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -27,7 +27,6 @@ from argparse import SUPPRESS
 import os
 import re
 import readline
-import socket
 import six.moves
 import sys
 import json
@@ -328,26 +327,6 @@ class CliCommand(AbstractCLICommand):
     def _get_logger(self):
         return logging.getLogger('rhsm-app.%s.%s' % (self.__module__, self.__class__.__name__))
 
-    def test_proxy_connection(self):
-        if not self.proxy_hostname and not conf["server"]["proxy_hostname"]:
-            return True
-        try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(10)
-            result = s.connect_ex((
-                self.proxy_hostname or conf["server"]["proxy_hostname"],
-                int(self.proxy_port or conf["server"]["proxy_port"] or rhsm.config.DEFAULT_PROXY_PORT)
-            ))
-        except Exception as e:
-            log.error("Attempted bad proxy: %s" % e)
-            return False
-        finally:
-            s.close()
-        if result:
-            return False
-        else:
-            return True
-
     def _request_validity_check(self):
         # Make sure the sorter is fresh (low footprint if it is)
         inj.require(inj.CERT_SORTER).force_cert_check()
@@ -544,10 +523,6 @@ class CliCommand(AbstractCLICommand):
 
             if config_changed:
                 try:
-                    # catch host/port issues; does not catch auth issues
-                    if not self.test_proxy_connection():
-                        system_exit(os.EX_UNAVAILABLE, _("Proxy connection failed, please check your settings."))
-
                     # this tries to actually connect to the server and ping it
                     if not is_valid_server_info(self.no_auth_cp):
                         system_exit(os.EX_UNAVAILABLE, _("Unable to reach the server at %s:%s%s") % (

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -276,13 +276,6 @@ class SubManFixture(unittest.TestCase):
         is_valid_server_mock = self.is_valid_server_patcher.start()
         is_valid_server_mock.return_value = True
 
-        # No tests should be trying to test the proxy connection
-        # so really, everything needs this mock. May need to be in __init__, or
-        # better, all test classes need to use SubManFixture
-        self.test_proxy_connection_patcher = patch("subscription_manager.managercli.CliCommand.test_proxy_connection")
-        test_proxy_connection_mock = self.test_proxy_connection_patcher.start()
-        test_proxy_connection_mock.return_value = True
-
         self.syncedstore_patcher = patch('subscription_manager.syspurposelib.SyncedStore')
         syncedstore_mock = self.syncedstore_patcher.start()
 

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -303,39 +303,6 @@ class TestCliCommand(SubManFixture):
             self.fail("Exception Raised")
 
 
-class TestProxyConnection(SubManFixture):
-    """
-    This class is used for testing test_proxy_connection from class CliCommand
-    """
-
-    def setUp(self):
-        super(TestProxyConnection, self).setUp()
-        # Temporary stop patcher of test_proxy_connection, because we need to test behavior of
-        # original function
-        self.test_proxy_connection_patcher.stop()
-
-    def tearDown(self):
-        # Start patcher again
-        self.test_proxy_connection_patcher.start()
-        super(TestProxyConnection, self).tearDown()
-
-    @patch('socket.socket')
-    def test_proxy_connection_hostname_and_port(self, sock):
-        """
-        Test functionality of test_proxy_connection()
-        """
-        sock_instance = sock.return_value
-        sock_instance.settimeout = MagicMock()
-        sock_instance.connect_ex = MagicMock(return_value=0)
-        sock_instance.close = MagicMock()
-
-        cli = managercli.CliCommand()
-        cli.test_proxy_connection()
-
-        # Expected values are from fake configuration file (see stub.py)
-        sock_instance.connect_ex.assert_called_once_with(('notaproxy.grimlock.usersys.redhat.com', 4567))
-
-
 class TestStatusCommand(SubManFixture):
     command_class = managercli.StatusCommand
 


### PR DESCRIPTION
The issue in the BZ is that the proxy is tested even if it is not needed. The test I removed was not taking the no_proxy value before determining if the test of the proxy server is useful.

Turns out that this test does not give us more information than we otherwise get, so it has been removed.