### PR TITLE
ENT-4278: Drop unittest2 imports

### DIFF
--- a/test/fixture.py
+++ b/test/fixture.py
@@ -6,10 +6,7 @@ import pprint
 import sys
 import tempfile
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 
 # just log py.warnings (and pygtk warnings in particular)

--- a/test/rhsmlib_test/base.py
+++ b/test/rhsmlib_test/base.py
@@ -13,10 +13,7 @@
 #
 from tempfile import NamedTemporaryFile
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import os
 import sys

--- a/test/rhsmlib_test/test_collector.py
+++ b/test/rhsmlib_test/test_collector.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import platform
 import mock

--- a/test/rhsmlib_test/test_config.py
+++ b/test/rhsmlib_test/test_config.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import dbus
 

--- a/test/rhsmlib_test/test_host_collector.py
+++ b/test/rhsmlib_test/test_host_collector.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import mock
 

--- a/test/rhsmlib_test/test_hwprobe.py
+++ b/test/rhsmlib_test/test_hwprobe.py
@@ -10,10 +10,7 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import io
 

--- a/test/rhsmlib_test/test_insights.py
+++ b/test/rhsmlib_test/test_insights.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from ..fixture import open_mock_many
 from rhsmlib.facts import insights

--- a/test/rhsmlib_test/test_kpatch.py
+++ b/test/rhsmlib_test/test_kpatch.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from mock import patch
 import tempfile

--- a/test/rhsmlib_test/test_service_wrapper.py
+++ b/test/rhsmlib_test/test_service_wrapper.py
@@ -10,10 +10,7 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import dbus
 import mock

--- a/test/rhsmlib_test/test_utils.py
+++ b/test/rhsmlib_test/test_utils.py
@@ -15,10 +15,7 @@
 Unit tests for module rhsmlib.utils.
 """
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import threading
 import time

--- a/test/rhsmlib_test/test_virt.py
+++ b/test/rhsmlib_test/test_virt.py
@@ -10,10 +10,7 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import test.fixture
 from mock import patch, MagicMock

--- a/test/test_branding.py
+++ b/test/test_branding.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from subscription_manager.branding import Branding
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -9,10 +9,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import os
 import logging

--- a/test/test_catcert_command.py
+++ b/test/test_catcert_command.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from . import certdata
 from .fixture import Capture, SubManFixture

--- a/test/test_certdirectory.py
+++ b/test/test_certdirectory.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import tempfile
 import os

--- a/test/test_certificate.py
+++ b/test/test_certificate.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from datetime import datetime, timedelta
 

--- a/test/test_cp_provider.py
+++ b/test/test_cp_provider.py
@@ -11,11 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from mock import patch
 

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -9,10 +9,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from subscription_manager.exceptions import ExceptionMapper
 from rhsm.connection import RestlibException

--- a/test/test_format_time.py
+++ b/test/test_format_time.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import locale
 

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -1,9 +1,6 @@
 from mock import patch
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import codecs
 import glob

--- a/test/test_isodate.py
+++ b/test/test_isodate.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import datetime
 import time

--- a/test/test_jsonwrapper.py
+++ b/test/test_jsonwrapper.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from .modelhelpers import create_pool, create_attribute_list
 from subscription_manager.jsonwrapper import PoolWrapper

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from subscription_manager import listing
 

--- a/test/test_lock.py
+++ b/test/test_lock.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import os
 import subprocess

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from datetime import datetime, timedelta
 import sys

--- a/test/test_managerlib.py
+++ b/test/test_managerlib.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from datetime import datetime, timedelta
 import os

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import os
 import mock

--- a/test/test_po_files.py
+++ b/test/test_po_files.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from . import fixture
 import six

--- a/test/test_productid.py
+++ b/test/test_productid.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import collections.abc
 import os

--- a/test/test_rct_cert_command.py
+++ b/test/test_rct_cert_command.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from mock import patch
 from rhsm.certificate import CertificateException

--- a/test/test_rct_manifest_command.py
+++ b/test/test_rct_manifest_command.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import errno
 import mock

--- a/test/test_reasons.py
+++ b/test/test_reasons.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from .stubs import StubEntitlementCertificate, StubProduct
 from mock import Mock

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -11,10 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import io
 import re


### PR DESCRIPTION
* Card ID: ENT-4278

Package unittest2 has been used to provide Python 3-like unittest
functionality in Python 2.x. subscription-manager is only supported on
Python 3 now, there is no need to keep unittest2 around anymore.

One occurence of 'unittest2' has been left untouched in 'test/rhsmlib_test/test_compat.py'. That file is being removed in currently open PR #2865, and this exclusion will prevent merge issues.