### PR TITLE
[1.28] syspurpose: solve i18n issues

### DIFF
--- a/syspurpose/setup.py
+++ b/syspurpose/setup.py
@@ -68,7 +68,7 @@ cmdclass = {
     'install_data': install_data,
     'update_trans': i18n.UpdateTrans,
     'uniq_trans': i18n.UniqTrans,
-    'gettext': i18n.Gettext,
+    'gettext': i18n.GettextWithArgparse,
     'clean': utils.clean,
 }
 setup_requires = []

--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -154,7 +154,7 @@ def setup_arg_parser():
     Sets up argument parsing for the syspurpose tool.
     :return: An argparse.ArgumentParser ready to use to parse_args
     """
-    parser = argparse.ArgumentParser(prog="syspurpose", description="System Syspurpose Management Tool",
+    parser = argparse.ArgumentParser(prog="syspurpose", description=_("System Syspurpose Management Tool"),
                                      epilog=_("The 'syspurpose' command is deprecated and will be removed in a future major release."
                                                 " Please use the 'subscription-manager syspurpose' command going forward."))
 
@@ -162,15 +162,15 @@ def setup_arg_parser():
 
     # Arguments shared by subcommands
     add_options = argparse.ArgumentParser(add_help=False)
-    add_options.add_argument("values", help="The value(s) to add", nargs='+')
+    add_options.add_argument("values", help=_("The value(s) to add"), nargs='+')
     add_options.set_defaults(func=add_command, requires_sync=True)
 
     remove_options = argparse.ArgumentParser(add_help=False)
-    remove_options.add_argument("values", help="The value(s) to remove", nargs='+')
+    remove_options.add_argument("values", help=_("The value(s) to remove"), nargs='+')
     remove_options.set_defaults(func=remove_command, requires_sync=True)
 
     set_options = argparse.ArgumentParser(add_help=False)
-    set_options.add_argument("value", help="The value to set", action="store")
+    set_options.add_argument("value", help=_("The value to set"), action="store")
     set_options.set_defaults(func=set_command, requires_sync=True)
 
     unset_options = argparse.ArgumentParser(add_help=False)

--- a/syspurpose/src/syspurpose/cli.py
+++ b/syspurpose/src/syspurpose/cli.py
@@ -422,4 +422,4 @@ def check_result(syspurposestore, expectation, success_msg, command, attr):
             ))
         )
     else:
-        print(_(success_msg))
+        print(success_msg)


### PR DESCRIPTION
Hopefully solve the issues related to the i18n of the `syspurpose` tool:
- extract also the messages of the Python `argparse` module, as Python does not have own translations; sub-man already does the same
- translate few UI strings that were not already translatable
- remove a redundant `_()` call

There will be a followup PR to update the translation catalogs in the `subscription-manager-1.28` branch.

Card ID: ENT-4494
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2013162 (this PR alone cannot fix it completely)