### PR TITLE
2020248: handle server-side consumer deletion in syspurpose commands

### DIFF
--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -386,7 +386,7 @@ class AbstractSyspurposeCommand(CliCommand):
                     '"{syspurpose_attr}".').format(syspurpose_attr=self.attr))
 
     def sync(self):
-        return syspurposelib.SyspurposeSyncActionCommand().perform(include_result=True)[1]
+        return syspurposelib.SyspurposeSyncActionCommand().perform(include_result=True, passthrough_gone=True)[1]
 
     def _do_command(self):
         self._validate_options()


### PR DESCRIPTION
`AbstractSyspurposeCommand` tries to synchronize the syspurpose status
from the server. If the customer no more exists,
`SyspurposeSyncActionCommand.perform()` gets a `GoneException`, caught by
the generic `ConnectionException` handler (as `GoneException` is a indirect
subclass of `ConnectionException`). In that case, an error status report
is returned, which is not what `AbstractSyspurposeCommand` expects.

Since `SyspurposeSyncActionCommand` is indirectly used in other contexts
(e.g. rhsmcertd) than the syspurpose CLI, tweak a bit its exception
handling: add a custom parameter to request the passthrough of
`GoneException`'s, so they can be propagated back. `CliCommand.main()`,
which invokes the requested CLI command, already handles `GoneException`,
giving the proper diagnostic.

Card ID: ENT-4505