### PR TITLE
connection: recognize proxy errors

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -766,6 +766,15 @@ class BaseRestLib(object):
                                             err))
                 raise
             except (socket.error, OSError) as err:
+                # If we get a ConnectionError here and we are using a proxy,
+                # then the issue was the connection to the proxy, not to the
+                # destination host.
+                if isinstance(err, ConnectionError) \
+                    and self.proxy_hostname and self.proxy_port:
+                    raise ProxyException("Unable to connect to: %s:%s %s "
+                                         % (normalized_host(self.proxy_hostname),
+                                            safe_int(self.proxy_port),
+                                            err))
                 code = httplib.PROXY_AUTHENTICATION_REQUIRED.value
                 if str(code) in str(err):
                     raise ProxyException(err)


### PR DESCRIPTION
In case the connection to the remote host fails and there is a proxy
server in use, assume it is a proxy error: errors from the actual
destination host are reported as `OSError`'s but not as `ConnectionError`'s
(as they rely error data coming from the established connection to the
proxy server).