### PR TITLE
[1.28] 2021982: Fix syspurpose bash completion

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -270,7 +270,7 @@ _subscription_manager()
   # top-level commands and options
   opts="addons attach auto-attach clean config environments facts identity import list orgs
         repo-override plugins redeem refresh register release remove repos role service-level status
-        subscribe unregister unsubscribe usage version ${_subscription_manager_help_opts}"
+        subscribe syspurpose unregister unsubscribe usage version ${_subscription_manager_help_opts}"
 
   case "${first}" in
       addons|\


### PR DESCRIPTION
* Card ID: ENT-4512
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2021982

This commit adds 'syspurpose' to bash completion top level output.

This is essentially a backport of c3f4534.

Completion of syspurpose subcommands already works, as it has been done
as part of the main backport in 4e29138 (PR #2745).