### PR TITLE
[1.28] 2020284: handle server-side consumer deletion in syspurpose commands

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -920,7 +920,7 @@ class AbstractSyspurposeCommand(CliCommand):
                     '"{syspurpose_attr}".').format(syspurpose_attr=self.attr))
 
     def sync(self):
-        return syspurposelib.SyspurposeSyncActionCommand().perform(include_result=True)[1]
+        return syspurposelib.SyspurposeSyncActionCommand().perform(include_result=True, passthrough_gone=True)[1]
 
     def _do_command(self):
         self._validate_options()

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -22,7 +22,7 @@ This module is an interface to syspurpose's SyncedStore class from subscription-
 It contains methods for accessing/manipulating the local syspurpose.json metadata file through SyncedStore.
 """
 
-from rhsm.connection import ConnectionException
+from rhsm.connection import ConnectionException, GoneException
 from subscription_manager import certlib
 from subscription_manager import injection as inj
 
@@ -264,7 +264,7 @@ class SyspurposeSyncActionCommand(object):
         self.cp_provider = inj.require(inj.CP_PROVIDER)
         self.uep = self.cp_provider.get_consumer_auth_cp()
 
-    def perform(self, include_result=False):
+    def perform(self, include_result=False, passthrough_gone=False):
         """
         Perform the action that this Command represents.
         :return:
@@ -281,6 +281,11 @@ class SyspurposeSyncActionCommand(object):
             )
             result = store.sync()
         except ConnectionException as e:
+            # In case the error is GoneException (i.e. the consumer no more
+            # exists), then reraise it only if GoneException is handled in
+            # its own way rather than checking SyspurposeSyncActionReport.
+            if isinstance(e, GoneException) and passthrough_gone:
+                raise
             self.report._exceptions.append('Unable to sync syspurpose with server: %s' % str(e))
             self.report._status = 'Failed to sync system purpose'
         self.report._updates = "\n\t\t ".join(self.report._updates)


### PR DESCRIPTION
`AbstractSyspurposeCommand` tries to synchronize the syspurpose status
from the server. If the customer no more exists,
`SyspurposeSyncActionCommand.perform()` gets a `GoneException`, caught by
the generic `ConnectionException` handler (as `GoneException` is a indirect
subclass of `ConnectionException`). In that case, an error status report
is returned, which is not what `AbstractSyspurposeCommand` expects.

Since `SyspurposeSyncActionCommand` is indirectly used in other contexts
(e.g. rhsmcertd) than the syspurpose CLI, tweak a bit its exception
handling: add a custom parameter to request the passthrough of
`GoneException`'s, so they can be propagated back. `CliCommand.main()`,
which invokes the requested CLI command, already handles `GoneException`,
giving the proper diagnostic.

(cherry picked from commit 23258fcb724fae68617dc65e2bbdcefe07dea07f)

Card ID: ENT-4505

Backport of PR #2873 to 1.28.