### PR TITLE
[1.28] connection: recognize proxy errors

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -765,6 +765,15 @@ class BaseRestLib(object):
                                             err))
                 raise
             except (socket.error, OSError) as err:
+                # If we get a ConnectionError here and we are using a proxy,
+                # then the issue was the connection to the proxy, not to the
+                # destination host.
+                if isinstance(err, ConnectionError) \
+                    and self.proxy_hostname and self.proxy_port:
+                    raise ProxyException("Unable to connect to: %s:%s %s "
+                                         % (normalized_host(self.proxy_hostname),
+                                            safe_int(self.proxy_port),
+                                            err))
                 if six.PY2:
                     code = httplib.PROXY_AUTHENTICATION_REQUIRED
                 else:


### PR DESCRIPTION
In case the connection to the remote host fails and there is a proxy
server in use, assume it is a proxy error: errors from the actual
destination host are reported as OSError's but not as ConnectionError's
(as they rely error data coming from the established connection to the
proxy server).

(cherry picked from commit 947e0712df7e8aa8d75b1674962d13c6e5969151)

Backport of PR #2874 to 1.28.