### PR TITLE
2023391: libdnf: respect environment CFLAGS

### DIFF
--- a/src/plugins/libdnf/CMakeLists.txt
+++ b/src/plugins/libdnf/CMakeLists.txt
@@ -34,7 +34,7 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif ()
 
 if (CMAKE_COMPILER_IS_GNUCC)
-    set (CMAKE_C_FLAGS "-Wall -fPIC -Wextra -pedantic -Wno-long-long -std=c99")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fPIC -Wextra -pedantic -Wno-long-long -std=c99")
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb -O0 --coverage")
     elseif( CMAKE_BUILD_TYPE STREQUAL "Release" )


### PR DESCRIPTION
Merely append our custom CFLAGS to the ones inherited by the
environment, otherwise the latter are lost.

Card ID: ENT-4516