### PR TITLE
[1.28] 2023392: libdnf: respect environment CFLAGS

### DIFF
--- a/src/dnf-plugins/product-id/CMakeLists.txt
+++ b/src/dnf-plugins/product-id/CMakeLists.txt
@@ -34,7 +34,7 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif ()
 
 if (CMAKE_COMPILER_IS_GNUCC)
-    set (CMAKE_C_FLAGS "-Wall -fPIC -Wextra -pedantic -Wno-long-long -std=c99")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fPIC -Wextra -pedantic -Wno-long-long -std=c99")
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb -O0 --coverage")
     elseif( CMAKE_BUILD_TYPE STREQUAL "Release" )


### PR DESCRIPTION
Merely append our custom CFLAGS to the ones inherited by the
environment, otherwise the latter are lost.

Card ID: ENT-4516

(cherry picked from commit 2e9fe484d6c6d689170b3241f8ce46e60af9ca1f)

Backport of PR #2887 to 1.28.