### PR TITLE
2024929: build: fix build on 'build' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,8 @@ STYLEFILES=$(PYFILES) $(BIN_FILES)
 .DEFAULT_GOAL := build
 
 build: rhsmcertd
-    EXCLUDE_PACKAGES:="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py clean --all
-    EXCLUDE_PACKAGES:="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py build --quiet --rpm-version=$(VERSION)
+	EXCLUDE_PACKAGES="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py clean --all
+	EXCLUDE_PACKAGES="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py build --quiet --rpm-version=$(VERSION)
 
 # we never "remake" this makefile, so add a target so
 # we stop searching for implicit rules on how to remake it


### PR DESCRIPTION
Due to spaces used to indent the commands, the "build" target
effectively did not run any command as part of it, with only its
"rhsmcertd" dependency being done.

Hence, properly use tabs for the make commands, and fix the syntax used
to pass $EXCLUDE_PACKAGES to the commands.