### PR TITLE
2024930: build: fix build on 'build' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,13 +134,13 @@ build-subpackages:
 # Install doesn't perform a build if it doesn't have too.  Best to clean out
 # any cruft so developers don't end up install old builds.
 ifeq ($(WITH_SUBMAN_GUI),true)
-    build: rhsmcertd rhsm-icon build-subpackages
-        EXCLUDE_PACKAGES:="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py clean --all
-        EXCLUDE_PACKAGES:="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py build --quiet --gtk-version=$(GTK_VERSION) --rpm-version=$(VERSION)
+build: rhsmcertd rhsm-icon build-subpackages
+	EXCLUDE_PACKAGES="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py clean --all
+	EXCLUDE_PACKAGES="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py build --quiet --gtk-version=$(GTK_VERSION) --rpm-version=$(VERSION)
 else
-    build: rhsmcertd build-subpackages
-        EXCLUDE_PACKAGES:="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py clean --all
-        EXCLUDE_PACKAGES:="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py build --quiet --gtk-version=$(GTK_VERSION) --rpm-version=$(VERSION)
+build: rhsmcertd build-subpackages
+	EXCLUDE_PACKAGES="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py clean --all
+	EXCLUDE_PACKAGES="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py build --quiet --gtk-version=$(GTK_VERSION) --rpm-version=$(VERSION)
 endif
 
 # we never "remake" this makefile, so add a target so


### PR DESCRIPTION
Due to spaces used to indent the commands, the "build" target
effectively did not run any command as part of it, with only its
"rhsmcertd" dependency being done.

Hence, properly use tabs for the make commands, and fix the syntax used
to pass $EXCLUDE_PACKAGES to the commands.

(cherry picked from commit 4ce9da718589d5e6662dee806b810b1bd6913334)

Backport PR #2889 to 1.28.