### PR TITLE
2026320: fix format of 'If-Modified-Since' header

### DIFF
--- a/jenkins/python3-stylish-tests.sh
+++ b/jenkins/python3-stylish-tests.sh
@@ -8,7 +8,6 @@
 # needs polib installed, http://pypi.python.org/pypi/polib
 # probably will need coverage tools installed
 # needs mock  (easy_install mock)
-# needs PyXML installed
 # needs pyflakes insalled
 # if we haven't installed/ran subsctiption-manager (or installed it)
 #   we need to make /etc/pki/product and /etc/pki/entitlement

--- a/jenkins/python3-tests.sh
+++ b/jenkins/python3-tests.sh
@@ -1,7 +1,6 @@
 # needs polib installed, http://pypi.python.org/pypi/polib
 # probably will need coverage tools installed
 # needs python-rhsm
-# needs PyXML installed
 # if we haven't installed/ran subsctiption-manager (or installed it)
 #   we need to make /etc/pki/product and /etc/pki/entitlement
 

--- a/jenkins/stylish-tests.sh
+++ b/jenkins/stylish-tests.sh
@@ -8,7 +8,6 @@
 # needs polib installed, http://pypi.python.org/pypi/polib
 # probably will need coverage tools installed
 # needs mock  (easy_install mock)
-# needs PyXML installed
 # needs pyflakes insalled
 # if we haven't installed/ran subsctiption-manager (or installed it)
 #   we need to make /etc/pki/product and /etc/pki/entitlement

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -929,6 +929,13 @@ class BaseRestLib(object):
     def request_delete(self, method, params=None, headers=None):
         return self._request("DELETE", method, params, headers=headers)
 
+    @staticmethod
+    def _format_http_date(dt):
+        """
+        Format a datetime to HTTP-date as described by RFC 7231.
+        """
+        return formatdate(time.mktime(dt.timetuple()), usegmt=True)
+
 
 # FIXME: it would be nice if the ssl server connection stuff
 # was decomposed from the api handling parts
@@ -1430,7 +1437,7 @@ class UEPConnection(BaseConnection):
         method = "/consumers/%s/accessible_content" % consumerId
         headers = {}
         if if_modified_since:
-            timestamp = formatdate(time.mktime(if_modified_since.timetuple()), usegmt=True)
+            timestamp = BaseRestLib._format_http_date(if_modified_since)
             headers["If-Modified-Since"] = timestamp
         return self.conn.request_get(method, headers=headers)
 

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -28,7 +28,7 @@ import time
 import traceback
 import tempfile
 
-from email.utils import formatdate
+from email.utils import format_datetime
 
 from rhsm.https import httplib, ssl
 
@@ -934,7 +934,7 @@ class BaseRestLib(object):
         """
         Format a datetime to HTTP-date as described by RFC 7231.
         """
-        return formatdate(time.mktime(dt.timetuple()), usegmt=True)
+        return format_datetime(dt, usegmt=True)
 
 
 # FIXME: it would be nice if the ssl server connection stuff

--- a/src/subscription_manager/isodate.py
+++ b/src/subscription_manager/isodate.py
@@ -15,6 +15,7 @@
 #
 
 
+import datetime
 import dateutil.parser
 import logging
 
@@ -25,6 +26,13 @@ def _parse_date_dateutil(date):
     # see comment for _parse_date_pyxml
     try:
         dt = dateutil.parser.parse(date)
+        # the datetime.datetime objects returned by dateutil use the own
+        # dateutil.tz.tzutc object for UTC, rather than the datetime own;
+        # switch the tzinfo object of UTC dates to datetime.timezone.utc:
+        # this is done because classes in the standard Python library
+        # explicitly check for that object for UTC checks
+        if dt.tzinfo.tzname(dt) == 'UTC':
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
     except ValueError:
         log.warning("Date overflow: %s, using 9999-09-06 instead." % date)
         return dateutil.parser.parse("9999-09-06T00:00:00.000+0000")

--- a/src/subscription_manager/isodate.py
+++ b/src/subscription_manager/isodate.py
@@ -23,7 +23,6 @@ log = logging.getLogger(__name__)
 
 
 def _parse_date_dateutil(date):
-    # see comment for _parse_date_pyxml
     try:
         dt = dateutil.parser.parse(date)
         # the datetime.datetime objects returned by dateutil use the own

--- a/test/rhsm/unit/test_connection.py
+++ b/test/rhsm/unit/test_connection.py
@@ -11,7 +11,6 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import datetime
 import locale
 import unittest
 import shutil
@@ -25,7 +24,10 @@ from rhsm.connection import UEPConnection, Restlib, ConnectionException, Connect
     RemoteServerException, drift_check, ExpiredIdentityCertException, UnauthorizedException, \
     ForbiddenException, AuthenticationException, RateLimitExceededException, ContentConnection, NoValidEntitlement
 
-from mock import Mock, mock, patch
+from subscription_manager.cache import ContentAccessCache
+import subscription_manager.injection as inj
+
+from mock import Mock, mock, patch, mock_open
 from datetime import date
 from time import strftime, gmtime
 from rhsm import ourjson as json
@@ -914,6 +916,13 @@ class ExpiredIdentityCertTest(ExceptionTest):
 
 
 class DatetimeFormattingTests(unittest.TestCase):
+    MOCK_CONTENT = {
+        "lastUpdate": "2016-12-01T21:56:35+0000",
+        "contentListing": {"42": ["cert-part1", "cert-part2"]}
+    }
+
+    MOCK_OPEN_CACHE = mock_open(read_data=json.dumps(MOCK_CONTENT))
+
     def setUp(self):
         # NOTE: this won't actually work, idea for this suite of unit tests
         # is to mock the actual server responses and just test logic in the
@@ -924,12 +933,23 @@ class DatetimeFormattingTests(unittest.TestCase):
     def tearDown(self):
         locale.resetlocale()
 
+    @patch('subscription_manager.cache.open', MOCK_OPEN_CACHE)
     def test_date_formatted_properly_with_japanese_locale(self):
         locale.setlocale(locale.LC_ALL, 'ja_JP.UTF8')
-        expected_headers = {
-            'If-Modified-Since': 'Fri, 13 Feb 2009 23:31:30 GMT'
-        }
-        timestamp = 1234567890
+        cp_provider = Mock()
+        cp_provider.get_consumer_auth_cp = Mock(return_value=self.cp)
+        identity = Mock(uuid='bob')
+        inj.provide(inj.IDENTITY, identity, singleton=True)
+        inj.provide(inj.CP_PROVIDER, cp_provider)
+        cache = ContentAccessCache()
+        cache.cp_provider = cp_provider
+        cache.identity = identity
+        mock_exists = Mock(return_value=True)
         self.cp.conn = Mock()
-        self.cp.getAccessibleContent(consumerId='bob', if_modified_since=datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc))
+        self.cp.conn.request_get = Mock(return_value=self.MOCK_CONTENT)
+        expected_headers = {
+            'If-Modified-Since': 'Thu, 01 Dec 2016 21:56:35 GMT'
+        }
+        with patch('os.path.exists', mock_exists):
+            cache.check_for_update()
         self.cp.conn.request_get.assert_called_with('/consumers/bob/accessible_content', headers=expected_headers)

--- a/test/rhsm/unit/test_connection.py
+++ b/test/rhsm/unit/test_connection.py
@@ -931,5 +931,5 @@ class DatetimeFormattingTests(unittest.TestCase):
         }
         timestamp = 1234567890
         self.cp.conn = Mock()
-        self.cp.getAccessibleContent(consumerId='bob', if_modified_since=datetime.datetime.fromtimestamp(timestamp))
+        self.cp.getAccessibleContent(consumerId='bob', if_modified_since=datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc))
         self.cp.conn.request_get.assert_called_with('/consumers/bob/accessible_content', headers=expected_headers)

--- a/test/test_isodate.py
+++ b/test/test_isodate.py
@@ -66,8 +66,8 @@ class TestParseDate(unittest.TestCase):
         # sample date from json response from server
         server_date = "2012-04-10T00:00:00.000+0000"
         dt = isodate.parse_date(server_date)
-        # no dst
-        self.assertEqual(datetime.timedelta(seconds=0), dt.tzinfo.dst(dt))
+        # it's a datetime.timezone.utc object, not a dateutil one
+        self.assertEqual(datetime.timezone.utc, dt.tzinfo)
         # it's a utc date, no offset
         self.assertEqual(datetime.timedelta(seconds=0), dt.tzinfo.utcoffset(dt))
 

--- a/test/test_isodate.py
+++ b/test/test_isodate.py
@@ -19,8 +19,6 @@ from subscription_manager import isodate
 from dateutil.tz import tzlocal
 
 
-# two classes for this, one that sets up for dateutil, one for
-# for pyxml
 class TestParseDate(unittest.TestCase):
 
     def _test_local_tz(self):
@@ -92,25 +90,17 @@ class TestParseDate(unittest.TestCase):
         if isodate.parse_date_impl_name == 'dateutil':
             self._dateutil_overflow(parsed)
         else:
-            self._pyxml_overflow(parsed)
+            self.fail(f"unsupported parse_date_impl_name: {isodate.parse_date_impl_name}")
 
     def test_10000_bug(self):
         # dateutil is okay up to 9999, so we just return
         # 9999-9-6 after that since that's what datetime/dateutil do
-        # on RHEL5, y10k breaks pyxml with a value error
+        # on RHEL5
         parsed = isodate.parse_date("10000-09-06T00:00:00.000+0000")
         if isodate.parse_date_impl_name == 'dateutil':
             self._dateutil_overflow(parsed)
         else:
-            self._pyxml_overflow(parsed)
+            self.fail(f"unsupported parse_date_impl_name: {isodate.parse_date_impl_name}")
 
     def _dateutil_overflow(self, parsed):
         self.assertEqual(9999, parsed.year)
-
-    # Simulated a 32-bit date overflow, date should have been
-    # replaced by one that does not overflow:
-    def _pyxml_overflow(self, parsed):
-        # the expected result here is different for 32bit or 64 bit
-        # platforms, so except either
-        if (parsed.year != 2038) and (parsed.year != 9999):
-            self.fail("parsed year should be 2038 on 32bit, or 9999 on 64bit")


### PR DESCRIPTION
The current way of formatting the datetime for the `If-Modified-Since` header does a couple of roundtrips that discard information on timezone, leading to convering an UTC timestamp back to the local time.

As a way to fix this:
- fix the `datetime.datetime` objects returned by `dateutil.parser.parse()`: they have dateutil timezone objects, which are not properly recognized by the Python standard library; hence, switch UTC timezone objects with standard `datetime.timezone.utc`
- use `email.utils.format_datetime()`, available since Python 3.3, that does the right thing with `datetime.datetime` objects

Also, since they got in my way when debugging and digging into the history, drop the useless leftovers of PyXML, which was dropped more than 7 years ago. Hopefully there should be less confusion in `isodate` & its tests.

Card ID: ENT-4538