### PR TITLE
Switch to shutil.which() & drop custom implementation

### DIFF
--- a/src/rhsm/utils.py
+++ b/src/rhsm/utils.py
@@ -64,29 +64,6 @@ class UnsupportedOperationException(Exception):
     pass
 
 
-def which(program):
-    """
-    Function returning path of program (it could be path to executable file or command)
-    :param program: string with command
-    :return: Path to command, when some executable exists in system. Otherwise it returns None.
-    """
-
-    def is_exe(_fpath):
-        return os.path.isfile(_fpath) and os.access(_fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-    return None
-
-
 def has_bad_scheme(url):
     """Check a url for an invalid or unuseful schema.
 

--- a/src/rhsmlib/facts/kpatch.py
+++ b/src/rhsmlib/facts/kpatch.py
@@ -14,9 +14,9 @@
 
 import logging
 import os
+import shutil
 
 from rhsmlib.facts import collector
-from rhsm.utils import which
 
 log = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ class KPatchCollector(collector.FactsCollector):
         Check if kpatch is installed
         :return: Return true, when kpatch CLI tool is installed. Otherwise return False
         """
-        return which('kpatch') is not None
+        return shutil.which('kpatch') is not None
 
     def _get_installed_live_kernel_patches(self):
         """

--- a/test/rhsm/unit/test_util.py
+++ b/test/rhsm/unit/test_util.py
@@ -5,7 +5,7 @@ from rhsm.utils import remove_scheme, get_env_proxy_info, \
     ServerUrlParseErrorEmpty, ServerUrlParseErrorNone, \
     ServerUrlParseErrorPort, ServerUrlParseErrorScheme, \
     ServerUrlParseErrorJustScheme, has_bad_scheme, has_good_scheme, \
-    parse_url, cmd_name, which
+    parse_url, cmd_name
 from rhsm.config import DEFAULT_PORT, DEFAULT_PREFIX, DEFAULT_HOSTNAME
 
 
@@ -413,23 +413,3 @@ class TestCmdName(unittest.TestCase):
     def test_virt_who(self):
         argv = ['/usr/share/virt-who/virtwho.py']
         self.assertEqual("virtwho.py", cmd_name(argv))
-
-
-class TestWhich(unittest.TestCase):
-    def test_which_python(self):
-        """Some python command just has to exist :-)"""
-        cmd_path = which('python')
-        self.assertIsNotNone(cmd_path)
-
-    def test_which_bin_sh(self):
-        """Assumed that Linux is used and some /bin/sh exist"""
-        cmd_path = which('/bin/sh')
-        self.assertIsNotNone(cmd_path)
-
-    def test_which_not_existing_command(self):
-        cmd_path = which('not-existing-command')
-        self.assertIsNone(cmd_path)
-
-    def test_which_not_existing_command_path(self):
-        cmd_path = which('/not/existing/command/path/not-existing-command')
-        self.assertIsNone(cmd_path)

--- a/test/rhsmlib_test/test_kpatch.py
+++ b/test/rhsmlib_test/test_kpatch.py
@@ -37,14 +37,14 @@ class TestKPatchCollector(unittest.TestCase):
         shutil.rmtree(self.DIRS_WITH_LOADED_MODULE[1])
         shutil.rmtree(self.DIR_WITH_INSTALLED_KPATCH_MODULES)
 
-    @patch('rhsmlib.facts.kpatch.which')
+    @patch('shutil.which')
     def test_kpatch_is_not_installed(self, which):
         which.return_value = None
         collector = kpatch.KPatchCollector()
         kpatch_facts = collector.get_all()
         self.assertEqual(kpatch_facts, {})
 
-    @patch('rhsmlib.facts.kpatch.which')
+    @patch('shutil.which')
     def test_get_kpatch_facts(self, which):
         which.return_value = '/usr/sbin/kpatch'
         collector = kpatch.KPatchCollector()


### PR DESCRIPTION
Python 3.3 provides `shutil.which()`; since our required Python version is 3.6, then:
- switch all the usages of our custom `which()` to `shutil.which()`
- drop the custom `which()` and the tests for it

There should be no behaviour change, as `shutil.which()` does the right thing.