### PR TITLE
1999048: [1.28] Fixed partially subscribed product in Cockpit plugin

### DIFF
--- a/cockpit/src/subscriptions-client.js
+++ b/cockpit/src/subscriptions-client.js
@@ -96,6 +96,7 @@ function parseProducts(text) {
             'version': product[2],
             'arch': product[3],
             'status': product[4],
+            'status_details': product[5],
             'starts': product[6],
             'ends': product[7]
         };

--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -97,20 +97,35 @@ class InstalledProducts extends React.Component {
         }
 
         let entries = this.props.products.map(function (itm) {
-            let subscribed;
+            let status_color;
             let status_text;
+            let label_status_text;
             let start_date_text;
             let end_date_text;
             let body;
             let columns;
 
             if (itm.status === 'subscribed') {
-                subscribed = true;
-                status_text = _("Subscribed");
-
+                status_color = "green";
+                label_status_text = _("Subscribed");
+                status_text = label_status_text;
+            } else if (itm.status === 'partially_subscribed') {
+                status_color = "orange";
+                label_status_text = _("Partially subscribed");
+                status_text = cockpit.format(
+                    _("Partially subscribed ($0)"), itm.status_details.join(',')
+                );
+            } else if (itm.status === 'not_subscribed') {
+                status_color = "red";
+                label_status_text = _("Not subscribed");
+                status_text = cockpit.format(
+                    _("Not subscribed ($0)"), itm.status_details.join(',')
+                );
             } else {
-                subscribed = false;
-                status_text = _("Not subscribed (Not supported by a valid subscription)");
+                console.debug('Other state:', itm.status);
+                status_color = "red";
+                label_status_text = _("Unknown status");
+                status_text = label_status_text;
             }
 
             if (itm.starts.length === 0) {
@@ -145,7 +160,7 @@ class InstalledProducts extends React.Component {
                             </SplitItem>
                             <SplitItem>
                                 <Label
-                                    color={subscribed ? "green" : "red"}>{subscribed ? _("Subscribed") : _("Not subscribed")}</Label>
+                                    color={status_color}>{label_status_text}</Label>
                             </SplitItem>
                         </Split>),
                         header: true,

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -166,7 +166,16 @@ password=foobar
         m.spawn("/var/tmp/mock-insights", "mock-insights")
 
     def wait_subscription(self, product, is_subscribed):
-        self.browser.wait_text("tr[data-row-id='%s'] .pf-c-label" % product["name"], "Subscribed" if is_subscribed else "Not subscribed")
+        if is_subscribed is True:
+            self.browser.wait_text(
+                "tr[data-row-id='%s'] .pf-c-label" % product["name"],
+                "Subscribed"
+            )
+        elif is_subscribed is False:
+            self.browser.wait_text_not(
+                "tr[data-row-id='%s'] .pf-c-label" % product["name"],
+                "Subscribed"
+            )
 
 
 class TestSubscriptions(SubscriptionsCase):


### PR DESCRIPTION
* Backport of #2893
  * Commit: e1ffd3f6f5327861783eba74f91ebba8acb9ac50
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1999048
* Card ID: ENT-4288
* D-Bus method works as expected, but cockpit plugin just
  ignored some information provided by this method
* Cockpit card with "Installed products" displays information
  about partially subscribed products correctly with orange
  text
* Information about status details is also not lost and all
  reasons for partially or not subscribed products are
  displayed in cockpit plugin too
* Fixed cockpit integration tests