### PR TITLE
[1.28] 2029384: Fix bash autocompletion

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -257,14 +257,14 @@ _subscription_manager()
   first=${COMP_WORDS[1]}
   cur="${COMP_WORDS[COMP_CWORD]}"
 
-  # Because the 'prev' may be optional argument like '--list', we iterate from the end
-  # until we find string that doesn't start with dash. That is the subcommand which
-  # should be used for completion.
-  i=1
-  prev="${COMP_WORDS[COMP_CWORD-$i]}"
-  while [[ $prev == -* ]]; do
-    i=$((i+1))
-    prev="${COMP_WORDS[COMP_CWORD-$i]}"
+  # Because the 'prev' may be optional argument like '--list', we iterate from the start
+  # until we find string that starts with a dash. The word before is the subcommand
+  # which should be used for completion.
+  for word in ${COMP_WORDS[@]}; do
+    if [[ $word == -* ]]; then
+      break;
+    fi
+    prev=$word
   done
 
   # top-level commands and options


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2029384
* Card ID: ENT-4568

Previous loop was searching for words from the end. Because some
arguments (--user) take a value, this would break.

Now, the words are searched from the beginning and the loop stops when
it encounters the first optional argument (starting with a dash).

This is a cherry-pick of 9cc980f.