### PR TITLE
Fix Deb822 format implementation for Architectures field

### DIFF
--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -474,7 +474,7 @@ if HAS_DEB822:
             if apt_cont['arches'] is None:
                 apt_cont['arches'] = 'none'
             else:
-                arches_str = ", ".join(apt_cont['arches'])
+                arches_str = " ".join(apt_cont['arches'])
                 apt_cont['arches'] = arches_str
                 apt_cont['Architectures'] = arches_str
 

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -1017,8 +1017,8 @@ class AptRepoFileTest(unittest.TestCase):
         assert open("/etc/apt/sources.list.d/rhsm.sources").read() == "data"
         mock_file.assert_called_with("/etc/apt/sources.list.d/rhsm.sources")
         exp_params = {
-            'arches': 'amd64, i386',
-            'Architectures': 'amd64, i386',
+            'arches': 'amd64 i386',
+            'Architectures': 'amd64 i386',
             'URIs': 'https://example.site.org/',
             'sslclientcert': 'mypem.pem'
         }


### PR DESCRIPTION
* Switch comma-separated join to space-separated join
* Implement Deb822 format correctly (refer to [manpages](https://manpages.debian.org/stretch/apt/sources.list.5.en.html))