### PR TITLE
[1.28] Extended D-Bus API - syspurpose methods; ENT-2373

### DIFF
--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -32,13 +32,6 @@ import os
 log = logging.getLogger(__name__)
 
 try:
-    from syspurpose.sync import sync
-except ImportError:
-    def sync(uep, consumer_uuid, command=None, report=None):
-        log.debug("Syspurpose module unavailable, not syncing")
-        return read_syspurpose()
-
-try:
     from syspurpose.files import SyncedStore, USER_SYSPURPOSE, post_process_received_data, CACHED_SYSPURPOSE
 except ImportError:
     log.debug("Could not import from module syspurpose.")
@@ -166,20 +159,22 @@ def get_syspurpose_valid_fields(uep=None, identity=None):
     return valid_fields
 
 
-def merge_syspurpose_values(local=None, remote=None, base=None):
+def merge_syspurpose_values(local=None, remote=None, base=None, uep=None, consumer_uuid=None):
     """
     Try to do three-way merge of local, remote and base dictionaries.
     Note: when remote is None, then this method will call REST API.
     :param local: dictionary with local values
     :param remote: dictionary with remote values
     :param base: dictionary with cached values
+    :param uep: object representing connection to canlepin server
+    :param consumer_uuid: UUID of consumer
     :return: Dictionary with local result
     """
 
     if SyncedStore is None:
         return {}
 
-    synced_store = SyncedStore(uep=None)
+    synced_store = SyncedStore(uep=uep, consumer_uuid=consumer_uuid)
 
     if local is None:
         local = synced_store.get_local_contents()
@@ -276,7 +271,6 @@ class SyspurposeSyncActionCommand(object):
             store = SyncedStore(
                 uep=self.uep,
                 consumer_uuid=consumer_uuid,
-                report=self.report,
                 on_changed=self.report.record_change
             )
             result = store.sync()

--- a/syspurpose/test/syspurpose/test_utils.py
+++ b/syspurpose/test/syspurpose/test_utils.py
@@ -77,7 +77,7 @@ class UtilsTests(SyspurposeTestBase):
         self.assertTrue(os.path.exists(to_create))
 
         with io.open(to_create, 'r', encoding='utf-8') as fp:
-            actual_contents = json.load(fp, encoding='utf-8')
+            actual_contents = json.load(fp)
 
         self.assertDictEqual(actual_contents, test_data)
 


### PR DESCRIPTION
* Origin PR: #2354
  * One commit: 412d246b668bae3db0d89ea4983b8e4cf17432ba
* Card ID: ENT-4569
* Fixing following BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2028565
* Added D-Bus method GetValidFields(). Thus it is
  possible to get dictionary of valid attributes
  and values in client applications using
  D-Bus API.
* Added D-Bus method SetSyspurpose(). It is possible
  to set syspurpose value without need of calling
  syspurpose CLI tool
* Added one missing argument to GetSyspurposeStatus
* Fixed method get_owner_syspurpose_valid_fields in
  service.sypurpose module
* Disabled in-memory caching in SyncedStore, because there were
  only troubles with this in rhsm.service, because it runs
  for very long time.
* Removed report attribute from SyncedStore
* Added exception for three-way merge conflict
* Added many unit tests for syspurpose.files