### PR TITLE
[1.28] 2017795: Disallowed attaching pool in SCA mode:

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -270,7 +270,7 @@ This command has no options.
 .SS ATTACH OPTIONS
 The
 .B attach
-command applies a specific subscription to the system.
+command applies a specific subscription to the system. This command is not possible to use, when the content access mode of the organization to which the system is registered is simple content access mode.
 
 .TP
 .B --auto

--- a/src/rhsmlib/dbus/objects/attach.py
+++ b/src/rhsmlib/dbus/objects/attach.py
@@ -23,6 +23,7 @@ from rhsmlib.dbus import constants, base_object, util, dbus_utils
 from rhsmlib.services.attach import AttachService
 
 from subscription_manager.injectioninit import init_dep_injection
+from subscription_manager.utils import is_simple_content_access
 
 init_dep_injection()
 
@@ -55,6 +56,10 @@ class AttachDBusObject(base_object.BaseObject):
         Locale.set(locale)
 
         cp = self.build_uep(proxy_options, proxy_only=True)
+
+        if is_simple_content_access(uep=cp) is True:
+            raise dbus.DBusException('Auto-attaching is not allowed in simple content access mode')
+
         attach_service = AttachService(cp)
 
         try:
@@ -85,6 +90,10 @@ class AttachDBusObject(base_object.BaseObject):
             raise dbus.DBusException("Quantity must be a positive number.")
 
         cp = self.build_uep(proxy_options, proxy_only=True)
+
+        if is_simple_content_access(uep=cp) is True:
+            raise dbus.DBusException('Attaching of pool(s) is not allowed in simple content access mode')
+
         attach_service = AttachService(cp)
 
         try:

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -1025,8 +1025,22 @@ class ContentAccessModeCache(ConsumerCache):
         if uep is None:
             cp_provider = inj.require(inj.CP_PROVIDER)
             uep = cp_provider.get_consumer_auth_cp()
-        if hasattr(uep.conn, 'is_consumer_cert_key_valid') and uep.conn.is_consumer_cert_key_valid is True:
-            return False
+
+        if hasattr(uep.conn, 'is_consumer_cert_key_valid'):
+            if uep.conn.is_consumer_cert_key_valid is None:
+                log.debug(
+                    f'Cache file {self.CACHE_FILE} cannot be considered as valid, because no connection has not '
+                    'been created yet'
+                )
+                return True
+            elif uep.conn.is_consumer_cert_key_valid is True:
+                return False
+            else:
+                log.debug(
+                    f'Cache file {self.CACHE_FILE} cannot be considered as valid, because consumer certificate '
+                    'probably is not valid'
+                )
+                return True
         else:
             return True
 

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -1029,7 +1029,7 @@ class ContentAccessModeCache(ConsumerCache):
         if hasattr(uep.conn, 'is_consumer_cert_key_valid'):
             if uep.conn.is_consumer_cert_key_valid is None:
                 log.debug(
-                    f'Cache file {self.CACHE_FILE} cannot be considered as valid, because no connection has not '
+                    f'Cache file {self.CACHE_FILE} cannot be considered as valid, because no connection has '
                     'been created yet'
                 )
                 return True

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2249,11 +2249,14 @@ class AttachCommand(CliCommand):
         self.parser.add_argument("--quantity", dest="quantity", type=int,
             help=_("Number of subscriptions to attach. May not be used with an auto-attach."))
         self.parser.add_argument("--auto", action='store_true',
-            help=_("Automatically attach compatible subscriptions to this system. This is the default action."))
+            help=_("Automatically attach compatible subscriptions to this system. "
+                   "This is the default action."))
         self.parser.add_argument("--servicelevel", dest="service_level",
-                               help=_("Automatically attach only subscriptions matching the specified service level; only used with --auto"))
+                               help=_("Automatically attach only subscriptions matching the specified service level; "
+                                      "only used with --auto"))
         self.parser.add_argument("--file", dest="file",
-                                help=_("A file from which to read pool IDs. If a hyphen is provided, pool IDs will be read from stdin."))
+                                help=_("A file from which to read pool IDs. If a hyphen is provided, pool IDs will be "
+                                       "read from stdin."))
 
         # re bz #864207
         _("All installed products are covered by valid entitlements.")
@@ -2268,7 +2271,10 @@ class AttachCommand(CliCommand):
                 self.options.pool.append(pool)
 
     def _short_description(self):
-        return _("Attach a specified subscription to the registered system")
+        return _(
+            "Attach a specified subscription to the registered system, when system does not use "
+            "Simple Content Access mode"
+        )
 
     def _command_name(self):
         return "attach"
@@ -2304,6 +2310,20 @@ class AttachCommand(CliCommand):
             else:
                 system_exit(os.EX_DATAERR, _("Error: The file \"%s\" does not exist or cannot be read.") % self.options.file)
 
+    def _print_ignore_attach_message(self):
+        """
+        Print message about ignoring attach request
+        :return: None
+        """
+        owner = get_current_owner(self.cp, self.identity)
+        owner_id = owner['key']
+        print(
+            _(
+                'Ignoring request to attach. '
+                'It is disabled for org "{owner_id}" because of the content access mode setting.'
+            ).format(owner_id=owner_id)
+        )
+
     def _do_command(self):
         """
         Executes the command.
@@ -2317,10 +2337,13 @@ class AttachCommand(CliCommand):
 
         # Do not try to do auto-attach, when simple content access mode is used
         # BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1826300
-        if self.auto_attach is True:
-            if is_simple_content_access(uep=self.cp, identity=self.identity):
+        #
+        if is_simple_content_access(uep=self.cp, identity=self.identity):
+            if self.auto_attach is True:
                 self._print_ignore_auto_attach_mesage()
-                return 0
+            else:
+                self._print_ignore_attach_message()
+            return 0
 
         installed_products_num = 0
         return_code = 0

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -170,7 +170,6 @@ def is_simple_content_access(uep=None, identity=None, owner=None):
     This function has three optional arguments that can be reused for getting required information.
     :param uep: connection to candlepin server
     :param identity: reference on current identity
-    :param owner: reference on current owner
     :return: True, when current owner uses contentAccesMode equal to org_environment. False otherwise.
     """
 

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1627,6 +1627,34 @@ class TestAttachCommand(TestCliProxyCommand):
         else:
             self.fail("No Exception Raised")
 
+    @patch('subscription_manager.managercli.is_simple_content_access')
+    def test_auto_attach_sca_mode(self, mock_is_simple_content_access):
+        """
+        Test the case, when SCA mode is used. Auto-attach is not possible in this case
+        """
+        mock_is_simple_content_access.return_value = True
+        try:
+            self.cc.main("--auto")
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)
+        else:
+            self.fail("No Exception Raised")
+
+    @patch('subscription_manager.managercli.is_simple_content_access')
+    def test_attach_sca_mode(self, mock_is_simple_content_access):
+        """
+        Test the case, when SCA mode is used. Attaching of pool is not possible in this case
+        """
+        mock_is_simple_content_access.return_value = True
+        try:
+            self.cc.main("--pool 123456789")
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)
+        else:
+            self.fail("No Exception Raised")
+
 
 # Test Attach and Subscribe are the same
 class TestSubscribeCommand(TestAttachCommand):


### PR DESCRIPTION
* Card ID: ENT-4594
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2017795
* Manual attaching of pool using --pool CLI option is not
  allowed now. When user tries to attach any pool in SCA
  mode, then info message is printedn and subscription-manager
  is terminated
* Added two unit tests for auto-attach ins SCA mode and
  manual attach
* Added more debug prints for cache used by function
  is_simple_content_access(), because I considered using
  this method, when --help is used, but calling
  subscription-manager attach --help would cause calling
  one REST API endpoint
* Updated manual page about subscription-manager

Backport of PR #2890 to 1.28.