### PR TITLE
Switch away from `Thread.getName()`

### DIFF
--- a/src/rhsmlib/file_monitor.py
+++ b/src/rhsmlib/file_monitor.py
@@ -181,7 +181,7 @@ class InotifyFilesystemWatcher(FilesystemWatcher):
         """
         log.debug(
             'Thread %s: Some event occurred: %s (%s)' %
-            (threading.current_thread().getName(), event.path, event.pathname)
+            (threading.current_thread().name, event.path, event.pathname)
         )
 
         for dir_watch in self.dir_watches.values():


### PR DESCRIPTION
Thread has been providing a `name` property since at least Python 3.1;
considering that:
- subscription-manager requires Python 3.6
- `Thread.getName()` issues a `DeprecationWarning` since Python 3.10

then directly switch to the `name` property, which works the same.