### PR TITLE
[1.28] 2026013: consider user-specified --org in any case

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1082,20 +1082,21 @@ class OrgCommand(UserPassCommand):
     @property
     def org(self):
         if not self._org:
-            owners = self.cp.getOwnerList(self.options.username)
-            if len(owners) == 1:
-                self._org = owners[0]['key']
-            elif self.options.org is None:
-                # Get a list of valid owners. Since no owner was specified,
-                # print a hint message showing available owners, before asking
-                # to enter one.
-                org_keys = [owner['key'] for owner in owners]
-                print(_(
-                    'Hint: User "{name}" is member of following organizations: {orgs}'
-                ).format(name=self.username, orgs=', '.join(org_keys)))
-                self._org = self._get_org(self.options.org)
-            else:
+            if self.options.org is not None:
                 self._org = self.options.org
+            else:
+                owners = self.cp.getOwnerList(self.options.username)
+                if len(owners) == 1:
+                    self._org = owners[0]['key']
+                else:
+                    # Get a list of valid owners. Since no owner was specified,
+                    # print a hint message showing available owners, before asking
+                    # to enter one.
+                    org_keys = [owner['key'] for owner in owners]
+                    print(_(
+                        'Hint: User "{name}" is member of following organizations: {orgs}'
+                    ).format(name=self.username, orgs=', '.join(org_keys)))
+                    self._org = self._get_org(self.options.org)
         return self._org
 
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1086,7 +1086,14 @@ class OrgCommand(UserPassCommand):
                 self._org = self.options.org
             else:
                 owners = self.cp.getOwnerList(self.options.username)
-                if len(owners) == 1:
+                if len(owners) == 0:
+                    system_exit(
+                        os.EX_DATAERR,
+                        _("Error: User {username} is not member of any organization.").format(
+                            username=self.options.username
+                        )
+                    )
+                elif len(owners) == 1:
                     self._org = owners[0]['key']
                 else:
                     # Get a list of valid owners. Since no owner was specified,

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1644,12 +1644,10 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
             super(ServiceLevelCommand, self).show()
 
     def list_service_levels(self):
-        org_key = self.options.org
-        if not org_key:
-            if self.is_registered():
-                org_key = self.cp.getOwner(self.identity.uuid)['key']
-            else:
-                org_key = self.org
+        if self.is_registered():
+            org_key = self.cp.getOwner(self.identity.uuid)['key']
+        else:
+            org_key = self.org
 
         try:
             slas = self.cp.getServiceLevelList(org_key)

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1085,12 +1085,14 @@ class OrgCommand(UserPassCommand):
             owners = self.cp.getOwnerList(self.options.username)
             if len(owners) == 1:
                 self._org = owners[0]['key']
-            else:
-                # Print list of owners to the console
+            elif self.options.org is None:
+                # Get a list of valid owners. Since no owner was specified,
+                # print a hint message showing available owners, before asking
+                # to enter one.
                 org_keys = [owner['key'] for owner in owners]
-                print(_('Hint: User "{name}" is member of following organizations: {orgs}').format(
-                    name=self.username, orgs=', '.join(org_keys)
-                ))
+                print(_(
+                    'Hint: User "{name}" is member of following organizations: {orgs}'
+                ).format(name=self.username, orgs=', '.join(org_keys)))
                 self._org = self._get_org(self.options.org)
         return self._org
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1094,6 +1094,8 @@ class OrgCommand(UserPassCommand):
                     'Hint: User "{name}" is member of following organizations: {orgs}'
                 ).format(name=self.username, orgs=', '.join(org_keys)))
                 self._org = self._get_org(self.options.org)
+            else:
+                self._org = self.options.org
         return self._org
 
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1086,6 +1086,11 @@ class OrgCommand(UserPassCommand):
             if len(owners) == 1:
                 self._org = owners[0]['key']
             else:
+                # Print list of owners to the console
+                org_keys = [owner['key'] for owner in owners]
+                print(_('Hint: User "{name}" is member of following organizations: {orgs}').format(
+                    name=self.username, orgs=', '.join(org_keys)
+                ))
                 self._org = self._get_org(self.options.org)
         return self._org
 

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -2325,6 +2325,11 @@ class TestRoleOrgCheckingCommand(SubManFixture):
         self.cc = managercli.RoleCommand()
         self.cc.is_registered = Mock(return_value=False)
 
+    def test_no_org(self):
+        self.set_orgs_for_stub_cp_provider([])
+        with self.assertRaises(InvalidOrg):
+            self.cc.main(self.common_args + ['--org', 'foo'])
+
     def test_single_org_same(self):
         self.set_orgs_for_stub_cp_provider(['org1'])
         self.cc.main(self.common_args + ['--org', 'org1'])

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -23,8 +23,9 @@ from subscription_manager import managercli, managerlib
 from subscription_manager.cache import ContentAccessCache, \
     ContentAccessModeCache
 from subscription_manager.entcertlib import CONTENT_ACCESS_CERT_TYPE
-from subscription_manager.injection import provide, \
-        CERT_SORTER, PROD_DIR, CONTENT_ACCESS_CACHE, CONTENT_ACCESS_MODE_CACHE
+from subscription_manager.injection import provide, require, \
+        CERT_SORTER, PROD_DIR, CONTENT_ACCESS_CACHE, CONTENT_ACCESS_MODE_CACHE, \
+        CP_PROVIDER
 from rhsmlib.services.products import InstalledProducts
 from subscription_manager.managercli import AVAILABLE_SUBS_MATCH_COLUMNS
 from subscription_manager.printing_utils import format_name, columnize, \
@@ -2260,6 +2261,87 @@ class TestRoleCommand(TestCliProxyCommand):
             self.cc._validate_options()
         except SystemExit as e:
             self.assertEqual(e.code, os.EX_USAGE)
+
+
+class InvalidOrg(Exception):
+    """
+    Small Exception to be used in TestRoleOrgCheckingCommand; it will be
+    passed through handle_exception().
+    """
+    def __init__(self, org_key):
+        self.org_key = org_key
+
+
+class OrgCheckingStubUEP(StubUEP):
+    """
+    An improved StubUEP that returns a specific list of valid organizations,
+    and raises InvalidOrg in getOwnerSyspurposeValidFields() in case the
+    requested organization is not one of the allowed ones. This will allow us
+    to check which AbstractSyspurposeCommand._get_valid_fields() is actually
+    passing to UEP.
+    The extra implementation on top of StubUEP is the minimal one to check
+    AbstractSyspurposeCommand in TestRoleOrgCheckingCommand.
+    """
+    def __init__(self, allowed_orgs):
+        super(OrgCheckingStubUEP, self).__init__()
+        self.allowed_orgs = allowed_orgs
+
+    def getOwnerList(self, username):
+        return [{'key': org} for org in self.allowed_orgs]
+
+    def getOwnerSyspurposeValidFields(self, org_key):
+        if org_key not in self.allowed_orgs:
+            raise InvalidOrg(org_key)
+        return super(OrgCheckingStubUEP, self).getOwnerSyspurposeValidFields(org_key)
+
+
+class TestRoleOrgCheckingCommand(SubManFixture):
+    common_args = ['--list', '--username', 'test', '--password', 'test']
+
+    def do_reraise(self, *args, **kwargs):
+        # handle_exception() was called with (msg, ex); we need to reraise
+        # 'ex', effectively bypassing handle_exception()
+        if len(args) >= 2:
+            raise args[1] from None
+
+    def set_orgs_for_stub_cp_provider(self, orgs):
+        cp_provider = require(CP_PROVIDER)
+        cp_provider.consumer_auth_cp = OrgCheckingStubUEP(orgs)
+        cp_provider.basic_auth_cp = OrgCheckingStubUEP(orgs)
+        cp_provider.no_auth_cp = OrgCheckingStubUEP(orgs)
+
+    def setUp(self):
+        synced_store_patch = patch('subscription_manager.syspurposelib.SyncedStore')
+        self.synced_store_mock = synced_store_patch.start()
+        self.addCleanup(self.synced_store_mock)
+        syspurpose_patch = patch('syspurpose.files.SyncedStore')
+        sp_patch = syspurpose_patch.start()
+        self.addCleanup(sp_patch.stop)
+        handle_exception_patch = patch('subscription_manager.managercli.handle_exception')
+        self.handle_exception_mock = handle_exception_patch.start()
+        self.handle_exception_mock.side_effect = self.do_reraise
+        self.addCleanup(self.handle_exception_mock)
+        super(TestRoleOrgCheckingCommand, self).setUp()
+        self.cc = managercli.RoleCommand()
+        self.cc.is_registered = Mock(return_value=False)
+
+    def test_single_org_same(self):
+        self.set_orgs_for_stub_cp_provider(['org1'])
+        self.cc.main(self.common_args + ['--org', 'org1'])
+
+    def test_single_org_different(self):
+        self.set_orgs_for_stub_cp_provider(['org1'])
+        with self.assertRaises(InvalidOrg):
+            self.cc.main(self.common_args + ['--org', 'foo'])
+
+    def test_multiple_orgs_same(self):
+        self.set_orgs_for_stub_cp_provider(['org1', 'org2'])
+        self.cc.main(self.common_args + ['--org', 'org1'])
+
+    def test_multiple_orgs_different(self):
+        self.set_orgs_for_stub_cp_provider(['org1', 'org2'])
+        with self.assertRaises(InvalidOrg):
+            self.cc.main(self.common_args + ['--org', 'foo'])
 
 
 class TestVersionCommand(TestCliCommand):


### PR DESCRIPTION
Right now, commands that can take `--org` ignore its value in case the
user belongs to only a single organization; this means that wrong values
passed by the user are ignored in that case, unlike what happens in case
the user belongs to more than one organization.

As a way to unify the behaviour in all the cases, always accept the
`--org` specified by the user, trying the automatic setting or the user
query otherwise.
    
This also saves one call to the server in case `--org` is specified.

Remove also an useless check in the service-level implementation.

Card ID: ENT-4560

Backport of PR #2905 to 1.28.