### PR TITLE
2026316: Do not delete cache of content_access during refresh

### DIFF
--- a/src/subscription_manager/cli_command/refresh.py
+++ b/src/subscription_manager/cli_command/refresh.py
@@ -39,10 +39,6 @@ class RefreshCommand(CliCommand):
     def _do_command(self):
         self.assert_should_be_registered()
         try:
-            # remove content_access cache, ensuring we get it fresh
-            content_access = inj.require(inj.CONTENT_ACCESS_CACHE)
-            if content_access.exists():
-                content_access.remove()
             # Also remove the content access mode cache to be sure we display
             # SCA or regular mode correctly
             content_access_mode = inj.require(inj.CONTENT_ACCESS_MODE_CACHE)

--- a/test/cli_command_test/test_refresh.py
+++ b/test/cli_command_test/test_refresh.py
@@ -33,8 +33,12 @@ class TestRefreshCommandWithDoCommand(SubManFixture):
         mock_content_access_mode_cache = Mock(spec=ContentAccessModeCache)
         mock_content_access_mode_cache.return_value.exists.return_value = True
         provide(CONTENT_ACCESS_MODE_CACHE, mock_content_access_mode_cache)
+
         self.cc.main([])
-        mock_content_access_cache.return_value.remove.assert_called_once()
-        mock_content_access_mode_cache.return_value.delete_cache.assert_called_once()
-        mock_content_access_cache.return_value.exists.assert_called_once()
+
+        # This cache should not be deleted to be able to use HTTP header 'If-Modified-Since'
+        mock_content_access_cache.return_value.remove.assert_not_called()
+        # Cache about content access mode should be deleted, because content access mode
+        # can be changed from SCA to entitlement and vice versa
         mock_content_access_mode_cache.return_value.exists.assert_called_once()
+        mock_content_access_mode_cache.return_value.delete_cache.assert_called_once()


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2026316
* Card ID: ENT-4537
* It is safe to not delete this cache file, when If-Modified-Since
  HTTP header is used
* It wasn't necessary to modify repos command
* Modified one unit test to cover this case