### PR TITLE
ENT-4588: Switch away from six iterators

### DIFF
--- a/src/rhsm/bitstream.py
+++ b/src/rhsm/bitstream.py
@@ -10,12 +10,10 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-import six
-
 from collections import deque
 
 
-class GhettoBitStream(six.Iterator):
+class GhettoBitStream:
     """
     Accepts binary data and makes it available as a stream of bits or one byte
     at a time. Python does not provide a built-in way to read a stream of bits,

--- a/src/rhsm/pathtree.py
+++ b/src/rhsm/pathtree.py
@@ -13,7 +13,6 @@
 
 import itertools
 import zlib
-import six
 
 from rhsm.bitstream import GhettoBitStream
 from rhsm.huffman import HuffmanNode
@@ -105,7 +104,7 @@ class PathTree(object):
         if isinstance(tree, dict):
             tree = [tree]
         for branch in tree:
-            for k, v in six.iteritems(branch):
+            for k, v in branch.items():
                 if k == PATH_END:
                     acc.append(curr_path)
                 else:

--- a/src/rhsmlib/dbus/base_object.py
+++ b/src/rhsmlib/dbus/base_object.py
@@ -12,7 +12,6 @@
 # in this software or its documentation.
 #
 import logging
-import six
 import dbus.service
 
 from rhsmlib.dbus import constants, exceptions, util
@@ -45,7 +44,7 @@ class BaseObject(dbus.service.Object):
 
     def validate_only_proxy_options(self, proxy_options):
         error_msg = None
-        for k in six.iterkeys(proxy_options):
+        for k in proxy_options.keys():
             if k not in ['proxy_hostname', 'proxy_port', 'proxy_user', 'proxy_password', 'no_proxy']:
                 error_msg = "Error: %s is not a valid proxy option" % k
                 break

--- a/src/rhsmlib/dbus/dbus_utils.py
+++ b/src/rhsmlib/dbus/dbus_utils.py
@@ -22,7 +22,6 @@ import pwd
 import xml.etree.ElementTree as Et
 
 import dbus
-import six
 
 log = logging.getLogger(__name__)
 
@@ -206,7 +205,7 @@ def add_properties(xml, interface, props):
 
 def dict_to_variant_dict(in_dict):
     # Handle creating dbus.Dictionaries with signatures of 'sv'
-    for key, value in six.iteritems(in_dict):
+    for key, value in in_dict.items():
         if isinstance(value, dict):
             in_dict[key] = dict_to_variant_dict(value)
     return dbus.Dictionary(in_dict, signature="sv")

--- a/src/rhsmlib/dbus/objects/config.py
+++ b/src/rhsmlib/dbus/objects/config.py
@@ -13,7 +13,6 @@
 #
 import dbus
 import logging
-import six
 from iniparse import ini
 
 import rhsm
@@ -167,9 +166,9 @@ class ConfigDBusObject(base_object.BaseObject):
         Locale.set(locale)
 
         d = dbus.Dictionary({}, signature='sv')
-        for k, v in six.iteritems(self.config):
+        for k, v in self.config.items():
             d[k] = dbus.Dictionary({}, signature='ss')
-            for kk, vv in six.iteritems(v):
+            for kk, vv in v.items():
                 d[k][kk] = vv
 
         return d

--- a/src/rhsmlib/services/config.py
+++ b/src/rhsmlib/services/config.py
@@ -13,7 +13,6 @@
 #
 import rhsm.config
 import collections.abc
-import six
 
 
 class Config(collections.abc.MutableMapping):
@@ -43,7 +42,7 @@ class Config(collections.abc.MutableMapping):
 
     def __setitem__(self, key, value):
         try:
-            six.iteritems(value)
+            value.items()
         except Exception:
             raise
 
@@ -58,7 +57,7 @@ class Config(collections.abc.MutableMapping):
         self._parser.add_section(key)
         self._sections[key] = ConfigSection(self, self._parser, key, self.auto_persist)
 
-        for k, v in six.iteritems(value):
+        for k, v in value.items():
             self._sections[key][k] = v
 
         if self.auto_persist:

--- a/test/modelhelpers.py
+++ b/test/modelhelpers.py
@@ -15,8 +15,6 @@
 """
 Helper methods for mocking up JSON model objects, certificates, etc.
 """
-import six
-
 from datetime import timedelta, datetime
 
 from rhsm.certificate import GMT
@@ -87,7 +85,7 @@ def create_pool(product_id, product_name, quantity=10, consumed=0, provided_prod
 
 def create_attribute_list(attribute_map):
     attribute_list = []
-    for name, value in six.iteritems(attribute_map):
+    for name, value in attribute_map.items():
         attribute_props = {}
         attribute_props['name'] = name
         attribute_props['value'] = value


### PR DESCRIPTION
* Card ID: ENT-4588

six.iteritems(), six.iterkeys() are no longer needed for Python 3 only
code.

six.Iterator is aliased to object in Python 3 and is no longer
necessary, too.