### PR TITLE
ENT-4590: Switch away from six.callable

### DIFF
--- a/src/subscription_manager/injection.py
+++ b/src/subscription_manager/injection.py
@@ -11,9 +11,6 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import six
-
 # Supported Features:
 IDENTITY = "IDENTITY"
 CERT_SORTER = "CERT_SORTER"
@@ -81,7 +78,7 @@ class FeatureBroker(object):
 
         if isinstance(provider, type):
             self.providers[feature] = provider(*args, **kwargs)
-        elif six.callable(provider):
+        elif callable(provider):
             return provider(*args, **kwargs)
 
         return self.providers[feature]

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -709,7 +709,7 @@ class BasePluginManager(object):
                 # not have known about. aka, all_hooks is complicated
 
                 # verify the hook is a callable
-                if six.callable(getattr(instance, func_name)):
+                if callable(getattr(instance, func_name)):
                     self._slot_to_funcs[slot].append(getattr(instance, func_name))
                     class_is_used = True
                 else:

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -14,7 +14,6 @@
 
 from collections import defaultdict
 from datetime import datetime, timedelta
-import six
 import io
 import mock
 import random
@@ -486,7 +485,7 @@ class StubUEP(object):
     def getConsumer(self, consumerId, username=None, password=None):
         if hasattr(self, 'consumer') and self.consumer:
             return self.consumer
-        if six.callable(self.registered_consumer_info):
+        if callable(self.registered_consumer_info):
             return self.registered_consumer_info()
         return self.registered_consumer_info
 


### PR DESCRIPTION
* Card ID: ENT-4590

callable() is a built-in function that was not available in Python 3.0
and 3.1. We are not supporting these old versions, so we can use the
function directly.