### PR TITLE
2028894: Don't allow service-level --serverurl on registered system

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -496,7 +496,7 @@ for products installed on the system. For example, if the service-level preferen
 
 .TP
 .B --serverurl=SERVER_URL
-Server URL in the form of https://hostname:port/prefix
+Server URL in the form of https://hostname:port/prefix [Usable on unregistered systems].
 
 .TP
 .B --insecure

--- a/src/subscription_manager/cli_command/service_level.py
+++ b/src/subscription_manager/cli_command/service_level.py
@@ -85,10 +85,11 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
             getattr(self.options, "username", None) or
             getattr(self.options, "password", None) or
             getattr(self.options, "token", None) or
-            getattr(self.options, "org", None)
+            getattr(self.options, "org", None) or
+            getattr(self.options, "server_url", None)
         ):
             system_exit(os.EX_USAGE, _(
-                "Error: --username, --password, --token and --org "
+                "Error: --username, --password, --token, --org and --serverurl "
                 "can be used only on unregistered systems"
             ))
 

--- a/test/cli_command_test/test_service_level.py
+++ b/test/cli_command_test/test_service_level.py
@@ -178,3 +178,20 @@ class TestServiceLevelCommand(TestCliProxyCommand):
             self.cc._validate_options()
         except SystemExit as e:
             self.assertEqual(e.code, os.EX_USAGE)
+
+    def test_serverurl_on_registered_system(self):
+        """Argument --serverurl cannot be used on registered system."""
+        self.cc.is_registered = Mock(return_value=True)
+        self.cc.options = Mock()
+        self.cc.options.set = None
+        self.cc.options.unset = None
+        self.cc.options.to_add = None
+        self.cc.options.to_remove = None
+        self.cc.options.show = None
+        self.cc.options.list = True
+        self.cc.options.org = None
+        self.cc.options.server_url = "https://example.com"
+        try:
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)


### PR DESCRIPTION
* Card ID: ENT-4567
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2028894

Setting server URL on registered systems results in 401: Unauthorized
answer. This commits adds an early prevention.

Users still has to unregister their machine first before querying other
servers. This commit only makes the subscription-manager return more
friendly output.