### PR TITLE
2039322: fix string representation of DMI facts

### DIFF
--- a/src/rhsmlib/facts/dmiinfo.py
+++ b/src/rhsmlib/facts/dmiinfo.py
@@ -112,7 +112,7 @@ class DmiFirmwareInfoCollector(collector.FactsCollector):
                     self._socket_designation.append(value1)
 
                 nkey = ''.join([tag, key1.lower()]).replace(" ", "_")
-                ddict[nkey] = str(value1)
+                ddict[nkey] = str(value1, 'utf-8')
 
         # Populate how many socket descriptions we saw in a faux-fact, so we can
         # use it to munge lscpu info later if needed.


### PR DESCRIPTION
Make sure to encode bytes as unicode strings, so they get represented as
strings and not as bytes.

Fixes commit 95058ae7e2eaf8e98aa2f7e3b6ed32f6e1c0e5dc