### PR TITLE
2024573: [1.28] Do not delete cache of content_access during refresh

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1262,11 +1262,6 @@ class RefreshCommand(CliCommand):
     def _do_command(self):
         self.assert_should_be_registered()
         try:
-            # remove content_access cache, ensuring we get it fresh
-            content_access = inj.require(inj.CONTENT_ACCESS_CACHE)
-            if content_access.exists():
-                content_access.remove()
-
             # Also remove the content access mode cache to be sure we display
             # SCA or regular mode correctly
             content_access_mode = inj.require(inj.CONTENT_ACCESS_MODE_CACHE)

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -410,10 +410,13 @@ class TestRefreshCommandWithDoCommand(SubManFixture):
         mock_content_access_mode_cache.return_value.exists.return_value = True
         provide(CONTENT_ACCESS_MODE_CACHE, mock_content_access_mode_cache)
         self.cc.main([])
-        mock_content_access_cache.return_value.remove.assert_called_once()
-        mock_content_access_mode_cache.return_value.delete_cache.assert_called_once()
-        mock_content_access_cache.return_value.exists.assert_called_once()
+
+        # This cache should not be deleted to be able to use HTTP header 'If-Modified-Since'
+        mock_content_access_cache.return_value.remove.assert_not_called()
+        # Cache about content access mode should be deleted, because content access mode
+        # can be changed from SCA to entitlement and vice versa
         mock_content_access_mode_cache.return_value.exists.assert_called_once()
+        mock_content_access_mode_cache.return_value.delete_cache.assert_called_once()
 
 
 class TestIdentityCommand(TestCliProxyCommand):


### PR DESCRIPTION
* https://bugzilla.redhat.com/show_bug.cgi?id=2024573
* Backport of PR: #2921. It was necessary to do manual backporting,  because cherry-picking was not possible
* Card ID: ENT-4537
* It is safe to not delete this cache file, when If-Modified-Since
  HTTP header is used
* It wasn't necessary to modify repos command
* Modified one unit test to cover this case