### PR TITLE
Adding permissive coverage publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,15 +18,34 @@ pipeline {
         stage('RHEL 8 unit') {
           steps {
             sh readFile(file: 'jenkins/python3-tests.sh')
-            junit('coverage.xml')
-            // TODO: find the correct adapter or generate coverage tests that can be
-            //       parsed by an existing adapter:
-            //       https://plugins.jenkins.io/code-coverage-api/
-            // publishCoverage adapters: [jacocoAdapter('coverage.xml')]
+          }
+          post {
+            always {
+              archiveArtifacts allowEmptyArchive: true, artifacts: 'coverage.xml', fingerprint: true
+              // https://www.jenkins.io/doc/pipeline/steps/cobertura/
+              step([$class: 'CoberturaPublisher',
+                            autoUpdateHealth: false,
+                            autoUpdateStability: false,
+                            coberturaReportFile: 'coverage.xml',
+                            failNoReports: false,
+                            failUnhealthy: false,
+                            failUnstable: false,
+                            maxNumberOfBuilds: 10,
+                            onlyStable: false,
+                            sourceEncoding: 'ASCII',
+                            zoomCoverageChart: false])
+              // https://www.jenkins.io/doc/pipeline/steps/junit/
+              junit allowEmptyResults: true, keepLongStdio: true, skipMarkingBuildUnstable: true, skipPublishingChecks: true, testResults: 'coverage.xml'
+            }
+          }
+        }
+        // Unit tests of libdnf plugins
+        stage('Libdnf unit') {
+          steps {
+            sh readFile(file: 'jenkins/libdnf-tests.sh')
           }
         }
       }
     }
-  // stage('cleanup') {steps {echo 'cleanup'}}
   }
 }


### PR DESCRIPTION
This attempts to fix CI failures to archive/publish unit testing artifacts by cherry-picking ad174506fd2f3836b7e00266d1b8365205400653