### PR TITLE
[1.28] Try to not use junit('coverage.xml')

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,11 +18,25 @@ pipeline {
         stage('RHEL 8 unit') {
           steps {
             sh readFile(file: 'jenkins/python3-tests.sh')
-            //junit('coverage.xml')
-            // TODO: find the correct adapter or generate coverage tests that can be
-            //       parsed by an existing adapter:
-            //       https://plugins.jenkins.io/code-coverage-api/
-            // publishCoverage adapters: [jacocoAdapter('coverage.xml')]
+          }
+          post {
+            always {
+              archiveArtifacts allowEmptyArchive: true, artifacts: 'coverage.xml', fingerprint: true
+              // https://www.jenkins.io/doc/pipeline/steps/cobertura/
+              step([$class: 'CoberturaPublisher',
+                            autoUpdateHealth: false,
+                            autoUpdateStability: false,
+                            coberturaReportFile: 'coverage.xml',
+                            failNoReports: false,
+                            failUnhealthy: false,
+                            failUnstable: false,
+                            maxNumberOfBuilds: 10,
+                            onlyStable: false,
+                            sourceEncoding: 'ASCII',
+                            zoomCoverageChart: false])
+              // https://www.jenkins.io/doc/pipeline/steps/junit/
+              junit allowEmptyResults: true, keepLongStdio: true, skipMarkingBuildUnstable: true, skipPublishingChecks: true, testResults: 'coverage.xml'
+            }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
         stage('RHEL 8 unit') {
           steps {
             sh readFile(file: 'jenkins/python3-tests.sh')
-            junit('coverage.xml')
+            //junit('coverage.xml')
             // TODO: find the correct adapter or generate coverage tests that can be
             //       parsed by an existing adapter:
             //       https://plugins.jenkins.io/code-coverage-api/


### PR DESCRIPTION
Backport of PR #2922 to the 1.28 branch, to fix the Jenkins/junit issue in that branch too.