### PR TITLE
ENT-4618: Switch away from six.get_method_*

### DIFF
--- a/src/subscription_manager/cli_command/plugins.py
+++ b/src/subscription_manager/cli_command/plugins.py
@@ -14,8 +14,6 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-import six
-
 from subscription_manager.cli_command.cli import CliCommand
 from subscription_manager.i18n import ugettext as _
 
@@ -72,5 +70,5 @@ class PluginsCommand(CliCommand):
                 print(slot)
                 for hook in sorted(self.plugin_manager._slot_to_funcs[slot],
                                    key=lambda func: func.__name__):
-                    hook_key = six.get_method_self(hook).__class__.get_plugin_key()
+                    hook_key = hook.__self__.__class__.get_plugin_key()
                     print("\t{key}.{name}".format(key=hook_key, name=hook.__name__))

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -15,7 +15,6 @@ import glob
 import inspect
 import logging
 import os
-import six
 import importlib.util
 
 from iniparse import SafeConfigParser
@@ -767,9 +766,9 @@ class BasePluginManager(object):
                     func_module_name = module.__name__
                 else:
                     func_module_name = 'unknown_module'
-            func_class_name = six.get_method_self(func).__class__.__name__
+            func_class_name = func.__self__.__class__.__name__
             plugin_key = ".".join([func_module_name, func_class_name])
-            log.debug("Running %s in %s" % (six.get_method_function(func).__name__, plugin_key))
+            log.debug("Running %s in %s" % (func.__name__, plugin_key))
             # resolve slot_name to conduit
             # FIXME: handle cases where we don't have a conduit for a slot_name
             #   (should be able to handle this since we map those at the same time)
@@ -778,7 +777,7 @@ class BasePluginManager(object):
             try:
                 # create a Conduit
                 # FIXME: handle cases where we can't create a Conduit()
-                conduit_instance = conduit(six.get_method_self(func).__class__, **kwargs)
+                conduit_instance = conduit(func.__self__.__class__, **kwargs)
             # TypeError tends to mean we provided the wrong kwargs for this
             # conduit
             # if we get an Exception above, should we exit early, or


### PR DESCRIPTION
* Card ID: ENT-4618

As subscription-manager is Python 3 only we can use built-in functions.