### PR TITLE
Improve azure determination method

### DIFF
--- a/src/cloud_what/providers/azure.py
+++ b/src/cloud_what/providers/azure.py
@@ -20,6 +20,7 @@ This is module implementing detector and metadata collector of virtual machine r
 import logging
 import json
 from typing import Union, List
+from shutil import which
 
 from cloud_what._base_provider import BaseCloudProvider
 
@@ -113,6 +114,10 @@ class AzureCloudProvider(BaseCloudProvider):
                 self.hw_info['dmi.chassis.asset_tag'] == '7783-7084-3265-9085-8269-3286-77':
             probability += 0.3
 
+        # The waagent is installed
+        if self._has_azure_linux_agent() is True:
+            probability += 0.3
+
         # Try to find "Azure" or "Microsoft" keywords in output of dmidecode
         found_microsoft = False
         found_azure = False
@@ -145,6 +150,14 @@ class AzureCloudProvider(BaseCloudProvider):
             if 'apiVersions' in api_versions_dict:
                 api_versions = api_versions_dict['apiVersions']
         return api_versions
+
+    def _has_azure_linux_agent(self):
+        """
+        Determine, if the waagent is installed. The waagent manages Linux & FreeBSD provisioning
+        on Azure. See: https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/agent-linux
+        :return: True if waagent is installed
+        """
+        return which('waagent') is not None
 
     def _fix_supported_api_version(self) -> Union[str, None]:
         """


### PR DESCRIPTION
The "is likely running on azure is error prone":

The issue is mainly because of this two checks:
```
        if 'virt.host_type' in self.hw_info:
            if 'hyperv' in self.hw_info['virt.host_type']:
                probability += 0.3
```
```
        if found_microsoft is True:
            probability += 0.3
```
### Without this PR

**With python3-dmidecode**:
Azure: 0.9 (virt.host_type 0.3, chassis 0.3, found_microsoft 0.3)
HyperV: 0.6 (virt.host_type 0.3 and found_microsoft 0.3) => Issue false positive 0.6 => threshold 0.5 => is cloud/azure host would be true
This needs to be prevented.

**Without python3-dmidecode**:
Azure: 0.3 (virt.host_type 0.3) => issue. No azure detection.
HyperV: 0.3 (virt.host_type 0.3)

### Changes of this PR

This PR changes both probability calculation values from 0.3 to 0.2 (host_type) and 0.1 (microsoft). 
Additionally, it checks for waagent.log. The /var/log/waagent.log exists only on azure, but not on hyperV. The Azure Agent can be uninstalled, but with dmidecode installed, it would still be >= 0.5

### With PR 

**With python3-dmidecode**:
Azure: 1.0 (virt.host_type 0.2, chassis 0.3, found_microsoft 0.1, waagent 0.4). Without waagent: 0.6
HyperV: 0.3 (virt.host_type 0.2, found_microsoft 0.1)

**Without python3-dmidecode**:
Azure: 0.5 (virt.host_type 0.2, waagent 0.4)
HyperV: 0.2 (virt.host_type 0.2)

