### PR TITLE
ENT-4650: Remove python-six from build system

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ verify_ssl = true
 
 [packages]
 decorator = "*"
-six = "*"
 python-dateutil = ">=2.0"
 
 [requires]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # note there are also rpm packaged deps that aren't
 # setup in pypi or with setup.py
 decorator
-six
 # The version of iniparse in PyPi does not run under Python3.  Fedora has
 # patched it so we have to rely on the RPM.
 # iniparse

--- a/setup.py
+++ b/setup.py
@@ -269,7 +269,6 @@ class GettextWithArgparse(i18n.Gettext):
 setup_requires = []
 
 install_requires = [
-    'six',
     'iniparse',
     'python-dateutil',
     'ethtool',

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -157,7 +157,6 @@ Requires:  %{py_package_prefix}-iniparse
 Requires:  %{py_package_prefix}-decorator
 Requires:  virt-what
 Requires:  %{rhsm_package_name} = %{version}
-Requires:  %{py_package_prefix}-six
 
 %if 0%{?suse_version}
 Requires: %{py_package_prefix}-python-dateutil
@@ -213,7 +212,6 @@ BuildRequires: %{py_package_prefix}-setuptools
 BuildRequires: gettext
 BuildRequires: intltool
 BuildRequires: libnotify-devel
-BuildRequires: %{py_package_prefix}-six
 
 %if %{use_cockpit}
 BuildRequires: desktop-file-utils
@@ -365,7 +363,6 @@ Requires:  %{py_package_prefix}-python-dateutil
 Requires: %{py_package_prefix}-dateutil
 %endif
 Requires: %{py_package_prefix}-iniparse
-Requires: %{py_package_prefix}-six
 Requires: subscription-manager-rhsm-certificates = %{version}-%{release}
 # Required by Fedora packaging guidelines
 %{?python_provide:%python_provide %{py_package_prefix}-rhsm}


### PR DESCRIPTION
* Card ID: ENT-4650

python3-six is a package used as Python 2 - Python 3 compatibility
wrapper. It has been removed from the codebase step by step, and now it
is not required at all, and can be removed from dev and build systems.