### PR TITLE
[1.28] cockpit: fix system installation of subscription-manager

### DIFF
--- a/integration-tests/vm.install
+++ b/integration-tests/vm.install
@@ -12,9 +12,10 @@ tar -xzf subscription-manager.tar.gz --transform 's,[^/]*,/sm,'
 cd sm
 tar xzf ../subscription-manager-build-extra.tar.gz
 python3 ./setup.py build
-python3 ./setup.py install --prefix /usr
+python3 ./setup.py install --prefix /usr --root /
 
 mv /usr/bin/{rhsm-facts-service,rhsm-service,rhsmcertd-worker} /usr/libexec
+mv /usr/bin/subscription-manager /usr/sbin
 
 # don't force https:// (self-signed cert)
 printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf


### PR DESCRIPTION
It seems that newer versions of Python or setuptools create a different
layout in the Python site-package depending whether the installation is
direct to the specified prefix, or there is temporary location (a local
destdir). Because of this, force "--root /" when installing directly to
/usr for testing: this seems to use the same layout of the system
installation (via distribution packages), and thus the existing files
will be properly overwritten.

Another change is the location of the "subscription-manager" executable:
setuptools installs it in $prefix/bin, while our Makefile moves it to
$prefix/sbin; hence, move it to the desired place, so it properly
overwrites the package version.

(cherry picked from commit c7d74b75bdbd55cd1d1f760a894f154fbf293c1c)

Backport of one commit from PR #2840.