### PR TITLE
Squelch `DeprecationWarning`'s when importing `pyinotify`

### DIFF
--- a/src/rhsmlib/file_monitor.py
+++ b/src/rhsmlib/file_monitor.py
@@ -19,9 +19,14 @@ import logging
 import os.path
 import fnmatch
 import time
+import warnings
 
 try:
-    import pyinotify
+    # temporarily disable DeprecationWarning's while importing pyinotify,
+    # as it uses asyncore which is deprecated since Python 3.6
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        import pyinotify
 except ImportError:
     pyinotify = None
 


### PR DESCRIPTION
`pyinotify` uses `asyncore`, which was deprecated in Python 3.6. Since `pyinotify` has been (at the time of this writing) not active for 6 years and more, we will probably not get a newer version switching away from `asyncore` soon.

Hence, apply a localized hammer: temporarily disable the `DeprecationWarning` warnings when importing `pyinotify`.