### PR TITLE
2023430: cockpit: improve handling of main curtain view

### DIFF
--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -489,21 +489,32 @@ class SubscriptionsView extends React.Component {
         let description;
         let message;
 
-        if (this.props.status === "service-unavailable") {
+        if (!subscriptionsClient.config.loaded &&
+            (this.props.status === undefined ||
+             this.props.status === 'valid' ||
+             this.props.status === 'invalid' ||
+             this.props.status === 'partial' ||
+             this.props.status === 'disabled' ||
+             this.props.status === 'unknown')) {
+            loading = true;
+            message = _("Updating");
+            description = _("Retrieving subscription status...");
+        } else if (this.props.status === "service-unavailable") {
             message = _("The rhsm service is unavailable. Make sure subscription-manager is installed " +
                 "and try reloading the page. Additionally, make sure that you have checked the " +
                 "'Reuse my password for privileged tasks' checkbox on the login page.");
             description = _("Unable to the reach the rhsm service.");
-        } else if (this.props.status === undefined && !subscriptionsClient.config.loaded) {
-            loading = true;
-            message = _("Updating");
-            description = _("Retrieving subscription status...");
         } else if (this.props.status === 'access-denied') {
             message = _("Access denied");
             description = _("The current user isn't allowed to access system subscription status.");
         } else {
             message = _("Unable to connect");
-            description = _("Couldn't get system subscription status. Please ensure subscription-manager is installed.");
+            description = cockpit.format(
+                _("Couldn't get system subscription status. Please ensure subscription-manager " +
+                    "is installed. Reported status: $0 ($1)"),
+                this.props.status_msg,
+                this.props.status,
+            );
         }
 
         return <EmptyStatePanel icon={loading ? null : ExclamationCircleIcon} paragraph={description} loading={loading} title={message} />;
@@ -540,6 +551,7 @@ class SubscriptionsView extends React.Component {
         if (this.props.status === undefined ||
             this.props.status === 'not-found' ||
             this.props.status === 'access-denied' ||
+            this.props.status === 'service-unavailable' ||
             !subscriptionsClient.config.loaded) {
             return this.renderCurtains();
         } else {


### PR DESCRIPTION
The logic used to determine what to show as curtain view (i.e. before
all the subscription data & status were loaded) was partially flawed:
if a valid subscription status was determined not as very last data
at the very end of the loading phase, then the curtain view briefly
showed the "Unable to connect" error message, just to be quickly
replaced by the actual subscription view. This happended because the
logic used in `SubscriptionsView.renderCurtains()` did not know the valid
subscription statuses.

Shuffle the logic a bit to more to avoid such mistakes:
- move the check for the "Updating" view as first, using it when either
  it is loaded w/o a valid state, or w/ a valid state and not fully
  loaded; both situation are correct, as they represent that only some
  data was fetched (and the rest is still being loaded)
- explicitly check for all the currently (as of sub-man 1.29.23) valid
  statuses for subscriptions; any new status in the future can simply be
  added to the list of checked states, and its lack will simply show the
  "Unable to connect" view again
- enhance the "Unable to connect" `EmptyStatePanel` to show also the
  status and its UI string; while we could easily log them to console,
  having the not known status printed to the screen will greatly help
  debugging such issues in the future, especially when reported without
  the open browser console
- also add the "service-unavailable" status among the ones that force
  the curtain view; it is already checked in `renderCurtains()`

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2023430
Card ID: ENT-2290