### PR TITLE
[1.28] 2046302: Apply Conscious language initiative changes

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -34,7 +34,7 @@ proxy_user =
 # password for basic http proxy auth, if needed
 proxy_password =
 
-# host/domain suffix blacklist for proxy, if needed
+# host/domain suffix blocklist for proxy, if needed
 no_proxy =
 
 [rhsm]

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -1484,7 +1484,7 @@ respects environment variables for proxy configuration, this should be avoided i
 .B rhsmcertd
 ) do not provide ways to modify their environments.
 
-Each option of the proxy configuration (hostname, port, host/domain pattern blacklist, username, password) is read independently, with precedence being command-line over configuration over environment, and then the resulting set of options is used to configure the proxy configuration.
+Each option of the proxy configuration (hostname, port, host/domain pattern blocklist, username, password) is read independently, with precedence being command-line over configuration over environment, and then the resulting set of options is used to configure the proxy configuration.
 
 For example,
 if the


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2046302
* Card ID: ENT-4680

This is a partial backport of ENT-3764 (5b6db92), as it only changes the
words that are visible to the users: config files and man pages.

For maintenance and testing reasons no other changes have been made:
variable names and comments were not updated and have been kept the
same.