### PR TITLE
environments: fix list for account in env-less org

### DIFF
--- a/src/subscription_manager/cli_command/environments.py
+++ b/src/subscription_manager/cli_command/environments.py
@@ -121,7 +121,7 @@ class EnvironmentsCommand(OrgCommand):
             system_exit(os.EX_UNAVAILABLE, _("Error: Server does not support multi-environment operations."))
         environments = []
         if self.options.enabled:
-            environments = self.cp.getConsumer(self.identity.uuid)['environments']
+            environments = self.cp.getConsumer(self.identity.uuid)['environments'] or []
         else:
             org_environments = self._get_environments(self.org)
             if self.options.disabled:


### PR DESCRIPTION
In case an account registers to an organization without environments on
a Candlepin with "environments" capability, the list of environments for
it is null. Hence, fall back to an empty string, so that
`environments --list` properly reports the "no environments to report"
message rather erroring out because "NoneType has no len()".