### PR TITLE
[1.28] Reverting disabling AutoAttach() and PoolAttach() in SCA mode

### DIFF
--- a/src/rhsmlib/dbus/objects/attach.py
+++ b/src/rhsmlib/dbus/objects/attach.py
@@ -57,8 +57,13 @@ class AttachDBusObject(base_object.BaseObject):
 
         cp = self.build_uep(proxy_options, proxy_only=True)
 
+        # TODO: Change log.info() to:
+        # raise dbus.DBusException('Auto-attaching is not allowed in simple content access mode')
+        # in the next minor release of subscription-manager
         if is_simple_content_access(uep=cp) is True:
-            raise dbus.DBusException('Auto-attaching is not allowed in simple content access mode')
+            log.info('Calling D-Bus method AutoAttach() is deprecated, when Simple Content Access mode '
+                     'is used and it will be not be supported in the next minor release of '
+                     'subscription-manager')
 
         attach_service = AttachService(cp)
 
@@ -91,8 +96,13 @@ class AttachDBusObject(base_object.BaseObject):
 
         cp = self.build_uep(proxy_options, proxy_only=True)
 
+        # TODO: Change log.info() to:
+        # raise dbus.DBusException('Attaching of pool(s) is not allowed in simple content access mode')
+        # in the next minor release of subscription-manager
         if is_simple_content_access(uep=cp) is True:
-            raise dbus.DBusException('Attaching of pool(s) is not allowed in simple content access mode')
+            log.info('Calling D-Bus method PoolAttach() is deprecated, when Simple Content Access mode '
+                     'is used and it will be not be supported in the next minor release of '
+                     'subscription-manager')
 
         attach_service = AttachService(cp)
 

--- a/test/rhsmlib_test/test_attach.py
+++ b/test/rhsmlib_test/test_attach.py
@@ -314,8 +314,11 @@ class TestAttachDBusObject(DBusObjectTest, InjectionMockingTest):
         self.mock_attach.attach_auto.return_value = CONTENT_JSON
 
         dbus_method_args = ['service_level', {}, '']
-        with self.assertRaises(dbus.exceptions.DBusException):
-            self.dbus_request(None, self.interface.AutoAttach, dbus_method_args)
+
+        # TODO: change following code to assert, when calling AutoAttach will not be supported in SCA mode
+        # with self.assertRaises(dbus.exceptions.DBusException):
+        #     self.dbus_request(None, self.interface.AutoAttach, dbus_method_args)
+        self.dbus_request(None, self.interface.AutoAttach, dbus_method_args)
 
     def test_attach_pool_sca(self):
         """
@@ -326,5 +329,7 @@ class TestAttachDBusObject(DBusObjectTest, InjectionMockingTest):
         self.mock_attach.attach_pool.return_value = CONTENT_JSON
         dbus_method_args = [['x', 'y'], 1, {}, '']
 
-        with self.assertRaises(dbus.exceptions.DBusException):
-            self.dbus_request(None, self.interface.PoolAttach, dbus_method_args)
+        # TODO: change following code to assert, when calling PoolAttach will not be supported in SCA mode
+        # with self.assertRaises(dbus.exceptions.DBusException):
+        #     self.dbus_request(None, self.interface.PoolAttach, dbus_method_args)
+        self.dbus_request(None, self.interface.PoolAttach, dbus_method_args)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2049101
* Card ID: ENT-4718
* Backport of original PR https://github.com/candlepin/subscription-manager/pull/2961 to 1.28.
* Reverting of following commit:
  https://github.com/candlepin/subscription-manager/commit/a0b5d65e9afd89a609123919443dc2100c304f25
* We were too aggressive, when we decided to disable this
  auto-attaching and attaching of pool for D-Bus API, when SCA mode
  is used.
* This reverting should also give enough time for solving other BZs:
  https://bugzilla.redhat.com/show_bug.cgi?id=2049101 (Anaconda)
  https://bugzilla.redhat.com/show_bug.cgi?id=2049620 (Gnome)