### PR TITLE
Various fixes/improvements related to registration & environments

### DIFF
--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -342,6 +342,11 @@ class RegisterCommand(UserPassCommand):
                 system_exit(os.EX_UNAVAILABLE, _("Error: Server does not support environments."))
             return None
 
+        # We have an activation key, so don't need to fill/check the bits
+        # related to environments, as they are part of the activation key
+        if self.options.activation_keys:
+            return None
+
         all_env_list = admin_cp.getEnvironmentList(owner_key)
         if self.options.environments:
             environments = self.options.environments

--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -231,7 +231,7 @@ class RegisterCommand(UserPassCommand):
                         get_owner_cb=self._get_owner_cb,
                         no_owner_cb=self._no_owner_cb
                     )
-                environment_ids = self._process_environments(admin_cp, owner_key, self.options)
+                environment_ids = self._process_environments(admin_cp, owner_key)
                 consumer = service.register(
                     owner_key,
                     activation_keys=self.options.activation_keys,
@@ -329,7 +329,7 @@ class RegisterCommand(UserPassCommand):
         readline.clear_history()
         return environment or self._prompt_for_environment()
 
-    def _process_environments(self, admin_cp, owner_key, options):
+    def _process_environments(self, admin_cp, owner_key):
         """
         Confirms that environment(s) have been chosen if they are supported
         and a choice needs to be made
@@ -337,31 +337,32 @@ class RegisterCommand(UserPassCommand):
         supported_resources = get_supported_resources()
         supports_environments = 'environments' in supported_resources
 
-        if not supports_environments and self.options.environments is not None:
-            system_exit(os.EX_UNAVAILABLE, _("Error: Server does not support environments."))
+        if not supports_environments:
+            if self.options.environments is not None:
+                system_exit(os.EX_UNAVAILABLE, _("Error: Server does not support environments."))
+            return None
 
-        if supports_environments:
-            all_env_list = admin_cp.getEnvironmentList(owner_key)
-            if self.options.environments:
-                environments = options.environments
-            else:
-                # If there aren't any environments, don't prompt for one
-                if not all_env_list:
-                    return None
+        all_env_list = admin_cp.getEnvironmentList(owner_key)
+        if self.options.environments:
+            environments = self.options.environments
+        else:
+            # If there aren't any environments, don't prompt for one
+            if not all_env_list:
+                return None
 
-                # If the envronment list is len 1, pick that environment
-                if len(all_env_list) == 1:
-                    log.debug("Using the only available environment: \"{name}\"".format(name=all_env_list[0]["name"]))
-                    return all_env_list[0]['id']
+            # If the envronment list is len 1, pick that environment
+            if len(all_env_list) == 1:
+                log.debug("Using the only available environment: \"{name}\"".format(name=all_env_list[0]["name"]))
+                return all_env_list[0]['id']
 
-                env_name_list = [env['name'] for env in all_env_list]
-                print(_('Hint: Organization "{key}" contains following environments: {list}').format(
-                      key=owner_key, list=", ".join(env_name_list)))
-                environments = self._prompt_for_environment()
-                if not self.cp.has_capability(MULTI_ENV) and ',' in environments:
-                    system_exit(os.EX_USAGE, _("The entitlement server does not allow multiple environments"))
+            env_name_list = [env['name'] for env in all_env_list]
+            print(_('Hint: Organization "{key}" contains following environments: {list}').format(
+                  key=owner_key, list=", ".join(env_name_list)))
+            environments = self._prompt_for_environment()
+            if not self.cp.has_capability(MULTI_ENV) and ',' in environments:
+                system_exit(os.EX_USAGE, _("The entitlement server does not allow multiple environments"))
 
-            return check_set_environment_names(all_env_list, environments)
+        return check_set_environment_names(all_env_list, environments)
 
     @staticmethod
     def _no_owner_cb(username):

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -252,6 +252,19 @@ class CliRegistrationTests(SubManFixture):
             except SystemExit:
                 self.fail("Exception Raised")
 
+    def test_validate_multi_environment_with_activation_key(self):
+        with patch('rhsm.connection.UEPConnection', new_callable=StubUEP) as mock_uep:
+            mock_uep.supports_resource = Mock(return_value=True)
+            self.stub_cp_provider.basic_auth_cp = mock_uep
+
+            rc = RegisterCommand()
+            rc.cp = mock_uep
+            rc.options = Mock()
+            rc.options.activation_keys = 'someAK'
+            rc.options.environments = None
+            ret = rc._process_environments(mock_uep, 'owner')
+            self.assertIsNone(ret)
+
     def test_set_duplicate_multi_environment(self):
         def env_list(*args, **kwargs):
             return [{"id": "1234", "name": "somename"},

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -142,7 +142,7 @@ class CliRegistrationTests(SubManFixture):
             rc.options = Mock()
             rc.options.activation_keys = None
             rc.options.environments = None
-            env_id = rc._process_environments(mock_uep, 'owner', None)
+            env_id = rc._process_environments(mock_uep, 'owner')
 
             expected = None
             self.assertEqual(expected, env_id)
@@ -160,7 +160,7 @@ class CliRegistrationTests(SubManFixture):
             rc.options = Mock()
             rc.options.activation_keys = None
             rc.options.environments = None
-            env_id = rc._process_environments(mock_uep, 'owner', None)
+            env_id = rc._process_environments(mock_uep, 'owner')
 
             expected = "1234"
             self.assertEqual(expected, env_id)
@@ -181,7 +181,7 @@ class CliRegistrationTests(SubManFixture):
             rc.options.activation_keys = None
             rc.options.environments = None
             rc._prompt_for_environment = Mock(return_value="othername")
-            env_id = rc._process_environments(mock_uep, 'owner', None)
+            env_id = rc._process_environments(mock_uep, 'owner')
 
             expected = "5678"
             self.assertEqual(expected, env_id)
@@ -205,7 +205,7 @@ class CliRegistrationTests(SubManFixture):
 
             with Capture(silent=True):
                 with self.assertRaises(SystemExit):
-                    rc._process_environments(mock_uep, 'owner', None)
+                    rc._process_environments(mock_uep, 'owner')
 
     def test_set_multi_environment_id_multi_available(self):
         def env_list(*args, **kwargs):
@@ -224,7 +224,7 @@ class CliRegistrationTests(SubManFixture):
             rc.options.activation_keys = None
             rc.options.environments = None
             rc._prompt_for_environment = Mock(return_value="somename,othername")
-            env_id = rc._process_environments(mock_uep, 'owner', None)
+            env_id = rc._process_environments(mock_uep, 'owner')
             expected = "1234,5678"
             self.assertEqual(expected, env_id)
 
@@ -271,7 +271,7 @@ class CliRegistrationTests(SubManFixture):
 
             with Capture(silent=True):
                 with self.assertRaises(SystemExit):
-                    rc._process_environments(mock_uep, 'owner', None)
+                    rc._process_environments(mock_uep, 'owner')
 
     def test_registration_with_failed_profile_upload(self):
 


### PR DESCRIPTION
In case an activation key is used to register to a Candlepin with 'environments' resources, do not try to check/query for environments: the activation key carries the information on environments already.

To do the case easily, refactor a bit `RegisterCommand._process_environments()`:
- drop the `options` parameter, as it is the same as the `options` class variable that is already used inside `_process_environments()`
- factorize the behaviour for the "not supports_environments" case:
  - still exit with an error if --environments was specified
  - explicitly return early from the function with `None` otherwise, instead of doing it implicitly because of the lack of return in the "if supports_environments" that used to follow
- remove the "if supports_environments" check, as it is no more needed since the opposite is checked earlier on

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2046516
Card ID: ENT-4679