### PR TITLE
2049441: [1.28] Cockpit registration dialog: enable insights by default

### DIFF
--- a/cockpit/src/index.js
+++ b/cockpit/src/index.js
@@ -43,7 +43,7 @@ let registerDialogDetails = {
     proxy_server: '',
     proxy_user: '',
     proxy_password: '',
-    insights: false
+    insights: true
 };
 
 function dismissStatusError() {
@@ -76,7 +76,7 @@ function openRegisterDialog() {
             password: '',
             activation_keys: '',
             org: '',
-            insights: false,
+            insights: true,
             insights_available: subscriptionsClient.insightsAvailable,
             insights_detected: false,
             register_method: 'account',

--- a/cockpit/src/subscriptions-register.jsx
+++ b/cockpit/src/subscriptions-register.jsx
@@ -85,8 +85,17 @@ class SubscriptionRegisterDialog extends React.Component {
             <FormGroup key="0" fieldId="subscription-insights" label={_("Insights")} hasNoPaddingTop>
                 <Checkbox id="subscription-insights" isChecked={this.props.insights}
                           label={ Insights.arrfmt(_("Connect this system to $0."), Insights.link) }
-                          isDisabled={ insights_checkbox_disabled } onChange={value => this.props.onChange('insights', value)} />
-                {(this.props.insights && !this.props.insights_detected) && <p>{ Insights.arrfmt(_("The $0 package will be installed."), <strong>{subscriptionsClient.insightsPackage}</strong>)}</p>}
+                          isDisabled={ insights_checkbox_disabled }
+                          onChange={value => this.props.onChange('insights', value)}
+                />
+                {(this.props.insights && !this.props.insights_detected) &&
+                    <p>
+                        { Insights.arrfmt(
+                            _("The $0 package will be installed."),
+                            <strong>{subscriptionsClient.insightsPackage}</strong>
+                        )}
+                    </p>
+                }
             </FormGroup>,
         ];
 
@@ -165,7 +174,10 @@ class SubscriptionRegisterDialog extends React.Component {
                 <FormGroup className="control-label" label={_("Subscriptions")} hasNoPaddingTop>
                     <Checkbox id="subscription-auto-attach-use" isChecked={this.props.auto_attach}
                               label={_("Attach automatically")}
-                              onChange={value => this.props.onChange('auto_attach', value)}
+                              onChange={value => {
+                                  this.props.onChange('auto_attach', value);
+                                  this.props.insights && !value && this.props.onChange('insights', value);
+                              }}
                     />
                 </FormGroup>
                 { insights }

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -198,6 +198,9 @@ class TestSubscriptions(SubscriptionsCase):
         b.set_input_text("#subscription-register-username", "doc")
         b.set_input_text("#subscription-register-password", "wrongpass")
 
+        # Do not try to connect to insights
+        b.set_checked("#subscription-insights", False)
+
         # try to register
         dialog_register_button_sel = "footer .pf-m-primary"
         b.click(dialog_register_button_sel)
@@ -250,6 +253,9 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_visible("#subscription-register-url")
         b.set_val("#subscription-register-url", "custom")
         b.set_input_text("#subscription-register-url-custom", CANDLEPIN_URL)
+
+        # Do not try to connect to insights
+        b.set_checked("#subscription-insights", False)
 
         # select registration method "activation key"
         activation_key_checkbox = "#subscription-register-activation-key-method"
@@ -335,6 +341,10 @@ class TestSubscriptions(SubscriptionsCase):
         b.set_input_text("#subscription-register-username", "admin")
         b.set_input_text("#subscription-register-password", "admin")
         b.set_input_text("#subscription-register-org", "admin")
+
+        # Do not try to connect to insights
+        b.set_checked("#subscription-insights", False)
+
         dialog_register_button_sel = "footer .pf-m-primary"
         b.click(dialog_register_button_sel)
         b.wait_not_present(dialog_register_button_sel)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2049441
* Card ID: ENT-4723
* Original PR: #2929
  * Cherry-picked commit: 35da66abf302509b696da52e9e543b0052f43f1e
* Enable by default checkbox "Connect this system to Red Hat Insights"
* It was little bit more tricky than expected. Why? When insights-client
  is not installed, then auto-attach (enable_content) has to be
  enabled to be able to install insights-client first. Thus when
  auto-attach is not enabled, then it is not possible to connect
  system to Red Hat Insights.
* Fixed cockpit integration tests