### PR TITLE
[1.24.13] Fix the checking for SCA in yum/dnf plugins 

### DIFF
--- a/src/dnf-plugins/subscription-manager.py
+++ b/src/dnf-plugins/subscription-manager.py
@@ -22,7 +22,7 @@ from subscription_manager.action_client import ProfileActionClient
 from subscription_manager.repolib import RepoActionInvoker
 from subscription_manager.entcertlib import EntCertActionInvoker
 from rhsmlib.facts.hwprobe import ClassicCheck
-from subscription_manager.utils import chroot
+from subscription_manager.utils import chroot, is_simple_content_access
 from subscription_manager.injectioninit import init_dep_injection
 from subscription_manager import logutil
 from rhsm import connection
@@ -135,7 +135,7 @@ class SubscriptionManager(dnf.Plugin):
             # Don't warn people to register if we see entitelements, but no identity:
             if not identity.is_valid() and len(ent_dir.list_valid()) == 0:
                 msg = not_registered_warning
-            elif len(ent_dir.list_valid()) == 0:
+            elif len(ent_dir.list_valid()) == 0 and not is_simple_content_access(identity=identity):
                 msg = no_subs_warning
 
         finally:

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -161,6 +161,44 @@ def is_valid_server_info(conn):
         return False
 
 
+def is_simple_content_access(uep=None, identity=None):
+    """
+    This function returns True, when current owner uses contentAccessMode equal to Simple Content Access.
+    This function has three optional arguments that can be reused for getting required information.
+    :param uep: connection to candlepin server
+    :param identity: reference on current identity
+    :return: True, when current owner uses contentAccesMode equal to org_environment. False otherwise.
+    """
+    cam = get_content_access_mode(uep, identity, None)
+    return cam is not None and cam == 'org_environment'
+
+
+def get_content_access_mode(uep=None, identity=None, owner=None):
+    """
+    Return the content access mode of the current owner
+    :param uep: connection to candlepin server
+    :param identity: reference on current identity
+    :param owner: reference on current owner
+    :return:
+    """
+    if identity is None:
+        identity = inj.require(inj.IDENTITY)
+
+    if uep is None:
+        cp_provider = inj.require(inj.CP_PROVIDER)
+        uep = cp_provider.get_consumer_auth_cp()
+
+    if owner is None:
+        try:
+            owner = uep.getOwner(identity.uuid)
+        except Exception as err:
+            log.debug("Unable to get owner: %s" % str(err))
+            return False
+    if 'contentAccessMode' in owner:
+        return owner['contentAccessMode']
+    return None
+
+
 def get_version(versions, package_name):
     """
     Return a string containing the version (and release if available).


### PR DESCRIPTION
Commit 944756e8a4daf27f7339a1c6e8d182b6112c08a3 checked for SCA in the yum plugin, however the early return breaks the flow in case of entitlement mode.

To fix this, align the implementation in the 1.24.13 branches with the 1.24 branch:
- copy the helper `get_content_access_mode()` function directly from the 1.24 branch
- add an helper `is_simple_content_access()` using `get_content_access_mode()` rather than newer caches that are not available in this branch
- fix the yum and dnf plugins to use the new helpers