### PR TITLE
build: pin pytest to < 7

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@
 -e ./build_ext
 
 flake8<4
-pytest
+pytest<7
 pytest-randomly
 pytest-timeout
 pytest-forked


### PR DESCRIPTION
It seems like pytest 7 breaks pytest-forked somehow, as also reported in
https://github.com/pytest-dev/pytest/issues/9621

Hence, for now pin it to any version lower than 7 to keep the unit tests
working.