### PR TITLE
[1.28] environments: fix usage of injection

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1546,7 +1546,7 @@ class EnvironmentsCommand(OrgCommand):
         An override is needed here because we need to use the org from the
         identity for this command if this system is already registered
         """
-        self.identity = require(IDENTITY)
+        self.identity = inj.require(inj.IDENTITY)
         if self.identity.is_valid():
             self._org = self.cp.getOwner(self.identity.uuid)['key']
             return self._org


### PR DESCRIPTION
Fixes 4b2c3334eb44a0dc28b9859d53ddc72c60092d76 due to the different way
of using subscription_manager.injection in current main vs 1.28.

Card ID: ENT-4751