### PR TITLE
Add check for systems which using yum or dnf

### DIFF
--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -146,6 +146,8 @@ class HardwareCollector(collector.FactsCollector):
         version = "Unknown"
         distname = "Unknown"
         dist_id = "Unknown"
+        id = "Unknown"
+        id_like = [""]
         version_modifier = ""
 
         if os.path.exists("/etc/os-release"):
@@ -155,7 +157,8 @@ class HardwareCollector(collector.FactsCollector):
             data = {
                 "PRETTY_NAME": "Unknown",
                 "NAME": distname,
-                "ID": "Unknown",
+                "ID": id,
+                "ID_LIKE": "",
                 "VERSION": dist_id,
                 "VERSION_ID": version,
                 "CPE_NAME": "Unknown",
@@ -172,6 +175,8 @@ class HardwareCollector(collector.FactsCollector):
             dist_id_search = re.search(r"\((.*?)\)", dist_id)
             if dist_id_search:
                 dist_id = dist_id_search.group(1)
+            id_like = data["ID_LIKE"].split()
+            id = data["ID"]
             # Split on ':' that is not preceded by '\'
             vers_mod_data = re.split(r"(?<!\\):", data["CPE_NAME"])
             if len(vers_mod_data) >= 6:
@@ -194,7 +199,7 @@ class HardwareCollector(collector.FactsCollector):
             (distname, version, dist_id) = platform.linux_distribution()
             version_modifier = "Unknown"
 
-        return distname, version, dist_id, version_modifier
+        return distname, version, dist_id, version_modifier, id, id_like
 
     def get_mem_info(self):
         meminfo = {}

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -29,6 +29,7 @@ from subscription_manager.utils import get_supported_resources
 from rhsm.config import get_config_parser, in_container
 from rhsm import connection
 import configparser
+from rhsmlib.facts.hwprobe import HardwareCollector
 
 # FIXME: local imports
 
@@ -169,6 +170,11 @@ class YumPluginManager(object):
         # When user doesn't want to automatically enable yum plugins, then return empty list
         if cls.is_auto_enable_enabled() is False:
             log.debug("The rhsm.auto_enable_yum_plugins is disabled. Skipping the enablement of yum plugins.")
+            return []
+
+        dist_info = HardwareCollector().get_distribution()
+
+        if dist_info[4] == "debian" or "debian" in dist_info[5]:
             return []
 
         log.debug("The rhsm.auto_enable_yum_plugins is enabled")

--- a/test/rhsmlib_test/test_hwprobe.py
+++ b/test/rhsmlib_test/test_hwprobe.py
@@ -104,6 +104,32 @@ REDHAT_BUGZILLA_PRODUCT_VERSION=42.0
 REDHAT_SUPPORT_PRODUCT="AwesomeOS Enterprise"
 REDHAT_SUPPORT_PRODUCT_VERSION=42.0"""
 
+OS_RELEASE_ID_LIKE = """NAME="Awesome OS"
+VERSION="42 (Go4It)"
+ID="awesomeos"
+ID_LIKE="awe some os"
+VERSION_ID="42"
+PRETTY_NAME="Awesome OS 42 (Go4It)"
+CPE_NAME="cpe:/o:awesomeos:best_linux:42:beta:server"
+
+REDHAT_BUGZILLA_PRODUCT="AwesomeOS Enterprise 42"
+REDHAT_BUGZILLA_PRODUCT_VERSION=42.0
+REDHAT_SUPPORT_PRODUCT="AwesomeOS Enterprise"
+REDHAT_SUPPORT_PRODUCT_VERSION=42.0"""
+
+OS_RELEASE_SINGLE_ID_LIKE = """NAME="Awesome OS"
+VERSION="42 (Go4It)"
+ID="awesomeos"
+ID_LIKE="awe"
+VERSION_ID="42"
+PRETTY_NAME="Awesome OS 42 (Go4It)"
+CPE_NAME="cpe:/o:awesomeos:best_linux:42:beta:server"
+
+REDHAT_BUGZILLA_PRODUCT="AwesomeOS Enterprise 42"
+REDHAT_BUGZILLA_PRODUCT_VERSION=42.0
+REDHAT_SUPPORT_PRODUCT="AwesomeOS Enterprise"
+REDHAT_SUPPORT_PRODUCT_VERSION=42.0"""
+
 OS_RELEASE_COLON = r"""NAME="Awesome OS"
 VERSION="42 (Go4It)"
 ID="awesomeos"
@@ -514,6 +540,33 @@ VARIANT_ID=server
                 "distribution.version.modifier": "be:ta",
             }
             self.assertEqual(hw.get_release_info(), expected)
+
+    @patch("os.path.exists")
+    @patch(OPEN_FUNCTION)
+    def test_get_distribution(self, MockOpen, MockExists):
+        MockExists.return_value = True
+        hw = hwprobe.HardwareCollector()
+        MockOpen.return_value.readlines.return_value = OS_RELEASE.split("\n")
+        expected = ("Awesome OS", "42", "Go4It", "beta", "awesomeos", [])
+        self.assertEqual(hw.get_distribution(), expected)
+
+    @patch("os.path.exists")
+    @patch(OPEN_FUNCTION)
+    def test_get_distribution_id_like(self, MockOpen, MockExists):
+        MockExists.return_value = True
+        hw = hwprobe.HardwareCollector()
+        MockOpen.return_value.readlines.return_value = OS_RELEASE_ID_LIKE.split("\n")
+        expected = ("Awesome OS", "42", "Go4It", "beta", "awesomeos", ["awe", "some", "os"])
+        self.assertEqual(hw.get_distribution(), expected)
+
+    @patch("os.path.exists")
+    @patch(OPEN_FUNCTION)
+    def test_get_distribution_single_id_like(self, MockOpen, MockExists):
+        MockExists.return_value = True
+        hw = hwprobe.HardwareCollector()
+        MockOpen.return_value.readlines.return_value = OS_RELEASE_SINGLE_ID_LIKE.split("\n")
+        expected = ("Awesome OS", "42", "Go4It", "beta", "awesomeos", ["awe"])
+        self.assertEqual(hw.get_distribution(), expected)
 
     def test_meminfo(self):
         hw = hwprobe.HardwareCollector()

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -1268,8 +1268,48 @@ class TestYumPluginManager(unittest.TestCase):
         os.unlink(self.plug_file_name_02)
         os.rmdir(self.tmp_dir)
 
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "debian", []),
+    )
+    def test_enable_pkg_plugins_deb(self, mock_get_distribution):
+        """
+        Test not enabling of yum plugins on deb based systems (Test 1 of 2)
+        """
+        plugin_list = YumPluginManager.enable_pkg_plugins()
+        self.assertEqual(len(plugin_list), 0)
+
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "", ["debian"]),
+    )
+    def test_enable_pkg_plugins_deb_like(self, mock_get_distribution):
+        """
+        Test not enabling of yum plugins on deb based systems (Test 2 of 2)
+        """
+        plugin_list = YumPluginManager.enable_pkg_plugins()
+        self.assertEqual(len(plugin_list), 0)
+
     @patch.object(repolib, "conf", ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
-    def test_enabling_disabled_dnf_plugin(self):
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "rhel", []),
+    )
+    def test_enable_pkg_plugins_yum(self, mock_get_distribution):
+        """
+        Test enabling of yum plugins on yum based systems
+        """
+        self.init_dnf_plugin_conf_files(conf_string=PKG_PLUGIN_CONF_FILE_DISABLED_INT)
+        plugin_list = YumPluginManager.enable_pkg_plugins()
+        print(plugin_list)
+        self.assertEqual(len(plugin_list), 2)
+
+    @patch.object(repolib, "conf", ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "rhel", []),
+    )
+    def test_enabling_disabled_dnf_plugin(self, mock_get_distribution):
         """
         Test automatic enabling of configuration files of disabled plugins
         """
@@ -1287,7 +1327,11 @@ class TestYumPluginManager(unittest.TestCase):
         self.restore_dnf_plugin_conf_files()
 
     @patch.object(repolib, "conf", ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
-    def test_enabling_enabled_dnf_plugin_int(self):
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "rhel", []),
+    )
+    def test_enabling_enabled_dnf_plugin_int(self, mock_get_distribution):
         """
         Test automatic enabling of configuration files of already enabled plugins
         """
@@ -1305,7 +1349,11 @@ class TestYumPluginManager(unittest.TestCase):
         self.restore_dnf_plugin_conf_files()
 
     @patch.object(repolib, "conf", ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
-    def test_enabling_enabled_dnf_plugin_bool(self):
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "rhel", []),
+    )
+    def test_enabling_enabled_dnf_plugin_bool(self, mock_get_distribution):
         """
         Test automatic enabling of configuration files of already enabled plugins
         """
@@ -1324,7 +1372,11 @@ class TestYumPluginManager(unittest.TestCase):
         self.restore_dnf_plugin_conf_files()
 
     @patch.object(repolib, "conf", ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
-    def test_enabling_dnf_plugin_with_invalid_values(self):
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "rhel", []),
+    )
+    def test_enabling_dnf_plugin_with_invalid_values(self, mock_get_distribution):
         """
         Test automatic enabling of configuration files of already enabled plugins
         """
@@ -1342,7 +1394,11 @@ class TestYumPluginManager(unittest.TestCase):
         self.restore_dnf_plugin_conf_files()
 
     @patch.object(repolib, "conf", ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
-    def test_enabling_dnf_plugin_with_wrong_conf(self):
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "rhel", []),
+    )
+    def test_enabling_dnf_plugin_with_wrong_conf(self, mock_get_distribution):
         """
         Test automatic enabling of configuration files of already plugins with wrong values in conf file.
         """
@@ -1360,7 +1416,11 @@ class TestYumPluginManager(unittest.TestCase):
         self.restore_dnf_plugin_conf_files()
 
     @patch.object(repolib, "conf", ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
-    def test_enabling_dnf_plugin_with_corrupted_conf_file(self):
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "rhel", []),
+    )
+    def test_enabling_dnf_plugin_with_corrupted_conf_file(self, mock_get_distribution):
         """
         This test only test YumPluginManager.enable_yum_plugins() can survive reading of corrupted
         dnf plugin configuration file
@@ -1370,7 +1430,11 @@ class TestYumPluginManager(unittest.TestCase):
         self.assertEqual(len(plugin_list), 0)
 
     @patch.object(repolib, "conf", ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
-    def test_enabling_dnf_plugin_with_missing_main_section(self):
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "rhel", []),
+    )
+    def test_enabling_dnf_plugin_with_missing_main_section(self, mock_get_distribution):
         """
         This test only test YumPluginManager.enable_yum_plugins() can survive reading of corrupted
         dnf plugin configuration file (missing main section)
@@ -1380,7 +1444,11 @@ class TestYumPluginManager(unittest.TestCase):
         self.assertEqual(len(plugin_list), 2)
 
     @patch.object(repolib, "conf", ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
-    def test_enabling_dnf_plugin_with_missing_enabled_option(self):
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "rhel", []),
+    )
+    def test_enabling_dnf_plugin_with_missing_enabled_option(self, mock_get_distribution):
         """
         This test only test YumPluginManager.enable_yum_plugins() can survive reading of corrupted
         dnf plugin configuration file (missing option 'enabled')


### PR DESCRIPTION
The change removes a warning in rhsm.log

More information: https://community.theforeman.org/t/subscription-manager-for-debian-ubuntu-on-apt-atix-de/20667/67