### PR TITLE
2057053: Facts: do no use heuristics detection of cloud

### DIFF
--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -37,8 +37,8 @@ class CloudFactsCollector(collector.FactsCollector):
 
         self.hardware_methods = []
 
-        # Try to detect cloud provider
-        self.cloud_provider = get_cloud_provider(self._collected_hw_info)
+        # Try to detect cloud provider using only strong method
+        self.cloud_provider = get_cloud_provider(facts=self._collected_hw_info, methods={'strong'})
 
         if self.cloud_provider is not None:
             # Create dispatcher for supported cloud providers

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -15,7 +15,7 @@
 import logging
 import json
 
-from cloud_what.provider import get_cloud_provider
+from cloud_what.provider import get_cloud_provider, DetectionMethod
 from rhsmlib.facts import collector
 
 
@@ -38,7 +38,10 @@ class CloudFactsCollector(collector.FactsCollector):
         self.hardware_methods = []
 
         # Try to detect cloud provider using only strong method
-        self.cloud_provider = get_cloud_provider(facts=self._collected_hw_info, methods={'strong'})
+        self.cloud_provider = get_cloud_provider(
+            facts=self._collected_hw_info,
+            methods=DetectionMethod.STRONG
+        )
 
         if self.cloud_provider is not None:
             # Create dispatcher for supported cloud providers

--- a/test/cloud_what/test_cloud_what.py
+++ b/test/cloud_what/test_cloud_what.py
@@ -1055,6 +1055,22 @@ class TestCloudProvider(unittest.TestCase):
         detected_clouds = detect_cloud_provider()
         self.assertEqual(detected_clouds, ['aws'])
 
+    def test_detect_cloud_provider_only_strong_signs(self):
+        """
+        Test the case, when detecting of aws does not work using strong signs, but detecting
+        using only strong signs is requested
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.vendor': 'AWS',
+            'dmi.bios.version': '1.0',
+            'dmi.system.manufacturer': 'Amazon'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        detected_clouds = detect_cloud_provider(methods={'strong'})
+        self.assertEqual(detected_clouds, [])
+
     def test_detect_cloud_provider_aws_heuristics(self):
         """
         Test the case, when detecting of aws does not work using strong signs, but it is necessary

--- a/test/cloud_what/test_cloud_what.py
+++ b/test/cloud_what/test_cloud_what.py
@@ -25,7 +25,7 @@ import json
 import requests
 
 from cloud_what.providers import aws, azure, gcp
-from cloud_what.provider import detect_cloud_provider, get_cloud_provider
+from cloud_what.provider import detect_cloud_provider, get_cloud_provider, DetectionMethod
 
 
 def send_only_imds_v2_is_supported(request, *args, **kwargs):
@@ -1068,7 +1068,7 @@ class TestCloudProvider(unittest.TestCase):
             'dmi.system.manufacturer': 'Amazon'
         }
         self.host_fact_collector_instance.get_all.return_value = host_facts
-        detected_clouds = detect_cloud_provider(methods={'strong'})
+        detected_clouds = detect_cloud_provider(methods=DetectionMethod.STRONG)
         self.assertEqual(detected_clouds, [])
 
     def test_detect_cloud_provider_aws_heuristics(self):


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2057053
* When subscription-manager tries to collect information about
  public clouds, then it tried to detect public cloud using
  strong signs and when no public cloud was detected, then
  subscription-manager tried to detect public cloud provider
  using heuristics. It could cause false positive detection
  and subscription-manager tried to get metadata from
  IMDS servers. Using heuristics is not necessary, when we
  try to collect system facts.
* Methods for detection has new parameter 'methods'. It has
  default value ('strong', 'heuristics').
* When facts about public cloud is collected, then only
  this argument is changed to ('strong').
* Added one unit test for new parameter.