### PR TITLE
cockpit: set `RPM_BUILD_ROOT` w/ installing

### DIFF
--- a/integration-tests/vm.install
+++ b/integration-tests/vm.install
@@ -12,7 +12,9 @@ tar -xzf subscription-manager.tar.gz --transform 's,[^/]*,/sm,'
 cd sm
 tar xzf ../subscription-manager-build-extra.tar.gz
 python3 ./setup.py build
-python3 ./setup.py install --prefix /usr --root /
+# Set $RPM_BUILD_ROOT to simulate a package build, so it works fine with the
+# new Python changes in Fedora 36: https://bugzilla.redhat.com/2026979
+RPM_BUILD_ROOT="/" python3 ./setup.py install --prefix /usr --root /
 
 mv /usr/bin/{rhsm-facts-service,rhsm-service,rhsmcertd-worker} /usr/libexec
 mv /usr/bin/subscription-manager /usr/sbin


### PR DESCRIPTION
Due to a recent change in Fedora 36 [1], the installation prefix is
mangled in certain scenarios [2].

Hence, set a `$RPM_BUILD_ROOT` environment variable when invoking
`setup.py install`, so it works again as it used in older versions of
Fedora. This script is used only for the cockpit CI testing, so there
is no change for usual builds.

[1] https://src.fedoraproject.org/rpms/python3.10/pull-request/63
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2026979