### PR TITLE
2059631: rhsm.conf: fix typo in comment

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -90,7 +90,7 @@ autoAttachInterval = 1440
 splay = 1
 # If set to 1, rhsmcertd will not execute.
 disable = 0
-# Set to 1, when rhsmcerd will try to do automatic registration.
+# Set to 1, when rhsmcertd will try to do automatic registration.
 # Setting this option make sense only on machines running on public
 # clouds. Currently only AWS, Azure and GCP are supported
 auto_registration = 0


### PR DESCRIPTION
- "rhsmcerd" -> "rhsmcertd"