### PR TITLE
integration-test: Updates for newer insights-client

### DIFF
--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -182,8 +182,8 @@ class SubscriptionsCase(MachineCase):
             m.write("/etc/insights-client/insights-client.conf",
 f"""
 [insights-client]
-gpg=False
 auto_config=False
+auto_update=False
 base_url={hostname}:8888/r/insights
 cert_verify=/etc/cockpit/ws-certs.d/0-self-signed-ca.pem
 username=admin
@@ -388,9 +388,6 @@ class TestSubscriptions(SubscriptionsCase):
         b.click('footer button.apply')
         with b.wait_timeout(360):
             b.wait_not_present('.pf-c-modal-box')
-
-        # HACK - this should eventually not be necessary
-        m.execute("insights-client --check-results")
 
         b.wait_visible("#overview a[href='http://cloud.redhat.com/insights/inventory/123-nice-id']")
         b.wait_visible("#overview a:contains('3 hits, including important')")

--- a/test/files/mock-insights
+++ b/test/files/mock-insights
@@ -39,12 +39,6 @@ class handler(BaseHTTPRequestHandler):
             self.wfile.write(b"lub-dup")
             return
 
-        m = self.match("/r/insights/v1/static/core/insights-core.egg")
-        if m:
-            self.send_response(304)
-            self.end_headers()
-            return
-
         m = self.match("/r/insights/v1/static/uploader.v2.json")
         if m:
             # This is not a valid response and will cause the client


### PR DESCRIPTION
Running "insights-client --check-results" explicitly is no longer
necessary, it happens as part of the registration now.

The insights-client started to output harmless messages like

    Error importing insights.client for pre_update as
    /var/lib/insights/newest.egg: No module named 'insights'

These can avoided by not setting "gpg=False". See
https://bugzilla.redhat.com/show_bug.cgi?id=2022655

Setting "auto_updates=False" allows the mock-insights server to not
implement egg updates requests.  That has stopped working anyway with
the current insights-client version.