### PR TITLE
integration-test: Use custom TLS certs for mock-insights

### DIFF
--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -184,15 +184,13 @@ f"""
 [insights-client]
 auto_config=False
 auto_update=False
-base_url={hostname}:8888/r/insights
-cert_verify=/etc/cockpit/ws-certs.d/0-self-signed-ca.pem
+base_url={hostname}:8443/r/insights
+cert_verify=/var/lib/insights/mock-certs/ca.crt
 username=admin
 password=foobar
 """)
 
         m.upload(["files/mock-insights"], "/var/tmp")
-        # this re-uses cockpit ws certificate, so ensure that it exists
-        m.execute("systemctl start cockpit")
         m.spawn("/var/tmp/mock-insights", "mock-insights")
 
     def wait_subscription(self, product, is_subscribed):
@@ -362,9 +360,6 @@ class TestSubscriptions(SubscriptionsCase):
         m = self.machine
         b = self.browser
 
-        if m.image.startswith('rhel-9-'):
-            self.skipTest("insights-client is currently broken in RHEL 9")
-
         self.login_and_go("/subscriptions")
 
         b.click("button:contains('Register')")
@@ -413,9 +408,6 @@ class TestSubscriptions(SubscriptionsCase):
     def testSubAndInAndFail(self):
         m = self.machine
         b = self.browser
-
-        if m.image.startswith('rhel-9-'):
-            self.skipTest("insights-client is currently broken in RHEL 9")
 
         self.login_and_go("/subscriptions")
 

--- a/test/files/mock-insights
+++ b/test/files/mock-insights
@@ -10,10 +10,10 @@
 #
 # You need these in your insights-client.conf:
 #
-# gpg=False
 # auto_config=False
-# base_url=127.0.0.1:8888/r/insights
-# insecure_connection=True
+# auto_update=False
+# base_url=127.0.0.1:8443/r/insights
+# cert_verify=/var/lib/insights/mock-certs/ca.crt
 # username=admin
 # password=foobar
 
@@ -22,6 +22,7 @@ import json
 import os
 import re
 import ssl
+import subprocess
 
 systems = {}
 
@@ -133,25 +134,22 @@ class handler(BaseHTTPRequestHandler):
 
 
 def insights_server(port):
+    # Let's put the certs into /var/lib/insights so that SELinux
+    # allows insights-client to actually read ca.crt when running as a
+    # systemd service.
+    certdir = "/var/lib/insights/mock-certs"
+    if not os.path.exists(certdir):
+        os.makedirs(certdir)
+        subprocess.check_call(["sscg"], cwd=certdir)
+
     httpd = HTTPServer(('', port), handler)
-    certfile = '/etc/cockpit/ws-certs.d/0-self-signed.cert'
-    keyfile = '/etc/cockpit/ws-certs.d/0-self-signed.key'
     ssl_args = {
-        'certfile': certfile,
+        'certfile': f'{certdir}/service.pem',
+        'keyfile': f'{certdir}/service-key.pem',
         'server_side': True,
     }
-    # take into account a behaviour change in the way cockpit generates its
-    # self-signed bits:
-    # - cockpit < 242: the .cert file contains both certificate *and* key
-    # - cockpit >= 242: separate .cert and .key files
-    # hence, if the separate .key file exists, use it as keyfile,
-    # otherwise use the .cert for that
-    if os.path.isfile(keyfile):
-        ssl_args['keyfile'] = keyfile
-    else:
-        ssl_args['keyfile'] = certfile
     httpd.socket = ssl.wrap_socket(httpd.socket, **ssl_args)
     httpd.serve_forever()
 
 
-insights_server(8888)
+insights_server(8443)


### PR DESCRIPTION
This makes it work again on rhel-9-0.

There is a bug in sscg on rhel-9-0 that causes Cockpit to create its
certificates with openssl.  However, those don't work for
mock-insights, so let's just make a custom set just for it.