### PR TITLE
Drop the `rel-eng` directory for old tito versions

### DIFF
--- a/rel-eng/bugzilla-str.sh
+++ b/rel-eng/bugzilla-str.sh
@@ -1,1 +1,0 @@
-../.tito/bugzilla-str.sh

--- a/rel-eng/packages/python-rhsm
+++ b/rel-eng/packages/python-rhsm
@@ -1,1 +1,0 @@
-../../.tito/packages/python-rhsm

--- a/rel-eng/packages/subscription-manager
+++ b/rel-eng/packages/subscription-manager
@@ -1,1 +1,0 @@
-../../.tito/packages/subscription-manager

--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -1,1 +1,0 @@
-../.tito/releasers.conf

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,1 +1,0 @@
-../.tito/tito.props


### PR DESCRIPTION
tito 0.6.0 (released in June 2015) supports `.tito` as default & primary
location for its configuration; hence, the `rel-eng` directory (the old
location) is effectively unused, and can be safely removed. It only
contains symlinks to files in `.tito`, so there is nothing lost.