### PR TITLE
WIP: Cockpit: Enable to select organization from the list

### DIFF
--- a/cockpit/src/index.js
+++ b/cockpit/src/index.js
@@ -40,6 +40,7 @@ let registerDialogDetails = {
     password: '',
     activation_keys: '',
     org: '',
+    show_org_list: false,
     proxy_server: '',
     proxy_user: '',
     proxy_password: '',
@@ -76,12 +77,14 @@ function openRegisterDialog() {
             password: '',
             activation_keys: '',
             org: '',
+            show_org_list: false,
             insights: true,
             insights_available: subscriptionsClient.insightsAvailable,
             insights_detected: false,
             register_method: 'account',
             auto_attach: true
         });
+        subscriptionsClient.orgList = [];
 
         Insights.detect().then(installed => {
             registerDialogDetails.insights_detected = installed;
@@ -101,10 +104,11 @@ function openRegisterDialog() {
                     'body': React.createElement(SubscriptionRegisterDialog, registerDialogDetails),
                 };
 
-                if (renderDialog)
+                if (renderDialog) {
                     renderDialog.setProps(dialogProps);
-                else
+                } else {
                     renderDialog = Dialog.show_modal_dialog(dialogProps, footerProps);
+                }
             };
             updatedData();
         });

--- a/cockpit/src/subscriptions-register.jsx
+++ b/cockpit/src/subscriptions-register.jsx
@@ -44,8 +44,11 @@ class SubscriptionRegisterDialog extends React.Component {
         let customURL;
         if (this.props.url === 'custom') {
             customURL = (
-                <TextInput id="subscription-register-url-custom"
-                           value={this.props.server_url} onChange={value => this.props.onChange('server_url', value)} />
+                <TextInput
+                    id="subscription-register-url-custom"
+                    value={this.props.server_url}
+                    onChange={value => this.props.onChange('server_url', value)}
+                />
             );
         }
         let proxy;
@@ -92,7 +95,7 @@ class SubscriptionRegisterDialog extends React.Component {
                     <p>
                         { Insights.arrfmt(
                             _("The $0 package will be installed."),
-                            <strong>{subscriptionsClient.insightsPackage}</strong>
+                            <strong key='insights_package'>{subscriptionsClient.insightsPackage}</strong>
                         )}
                     </p>
                 }
@@ -101,7 +104,53 @@ class SubscriptionRegisterDialog extends React.Component {
 
 
         let credentials;
+        let organizations;
         if (this.props.register_method === "account") {
+            // Show the list of available organizations, when user have to choose one org from the list
+            if (subscriptionsClient.orgList.length > 0) {
+                let orgs_list = [];
+                let org;
+                // Javascript/JSX is doomed, when I have to do it in this way :-/
+                let disabled=true;
+                let is_placeholder=true
+                // It seems that FormSelect does not have regular placeholder :-(
+                orgs_list.push(
+                    <FormSelectOption
+                        value=''
+                        label={_('Choose an organization')}
+                        isDisabled={disabled}
+                        isPlaceholder={is_placeholder}
+                        key='form_select_placeholder'
+                    />
+                );
+                for (let i = 0; i < subscriptionsClient.orgList.length; i++) {
+                    // console.debug(i);
+                    org = subscriptionsClient.orgList[i];
+                    // console.debug(org);
+                    orgs_list.push(
+                        <FormSelectOption
+                            key={org.key}
+                            value={org.key}
+                            label={org.displayName}
+                            isDisabled={false}
+                        />
+                    );
+                }
+
+                console.debug('>>> Organizations', orgs_list);
+                organizations = (
+                    <FormGroup fieldId="org=selector" label={_("Organization")}>
+                        <FormSelect
+                           value={this.props.org}
+                           onChange={value => this.props.onChange('org', value)}
+                           aria-label="FormSelect Input"
+                        >
+                            {orgs_list}
+                        </FormSelect>
+                    </FormGroup>
+                );
+            }
+
             credentials = (
                 <>
                     <FormGroup fieldId="subscription-register-username" label={_("Username")}>
@@ -114,11 +163,7 @@ class SubscriptionRegisterDialog extends React.Component {
                                    value={this.props.password}
                                    onChange={value => this.props.onChange('password', value)} />
                     </FormGroup>
-                    <FormGroup fieldId="subscription-register-org" label={_("Organization")}>
-                        <TextInput id="subscription-register-org"
-                                   value={this.props.org}
-                                   onChange={value => this.props.onChange('org', value)} />
-                    </FormGroup>
+                    {organizations}
                 </>
             );
         } else {


### PR DESCRIPTION
* When user is member of more than one organization, then
  allow to select organization from the list of organization
  in registration dialog
* FIXME:
  - The `<SelectForm/>` with available organizations is still not displayed automatically. It is necessary to click at e.g. different activation method and then select original activation method to enforce redrawing of the dialog.
  - Error messages is displayed in dialog (no clue how to avoid that: e.g. change severity of error to some info or completely hide it)