### PR TITLE
2018215: Cockpit use "Organization ID" in label

### DIFF
--- a/cockpit/src/subscriptions-register.jsx
+++ b/cockpit/src/subscriptions-register.jsx
@@ -129,7 +129,7 @@ class SubscriptionRegisterDialog extends React.Component {
                                    placeholder="key_one,key_two" value={this.props.activation_keys}
                                    onChange={value => this.props.onChange('activation_keys', value)} />
                     </FormGroup>
-                    <FormGroup fieldId="subscription-register-org" label={_("Organization")}>
+                    <FormGroup fieldId="subscription-register-org" label={_("Organization ID")}>
                         <TextInput id="subscription-register-org"
                                    value={this.props.org}
                                    onChange={value => this.props.onChange('org', value)} />


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2018215
* Backport commit for 1.28 branch.
* Original PR: #2997
  * Original commit: 825a28d78a9d2adf9f503769b8dd787adec04cc5
* Card ID: ENT-4359
* Display "Organization ID" in the label of cockpit UI and
  do not display only "Organization", because it could
  imply that user should type organization name.