### PR TITLE
2057053: [1.28] Facts: do no use heuristics detection of cloud

### DIFF
--- a/src/cloud_what/provider.py
+++ b/src/cloud_what/provider.py
@@ -67,13 +67,20 @@ def gather_system_facts() -> dict:
     return facts
 
 
-def _get_cloud_providers(facts: dict = None, threshold: float = 0.5) -> Tuple[list, bool]:
+def _get_cloud_providers(facts: dict = None,
+                         threshold: float = 0.5,
+                         methods: set = ('strong', 'heuristics')) -> Tuple[list, bool]:
     """
     This method tries to detect cloud providers and return list of possible cloud providers
     :param facts: Dictionary with system facts
     :param threshold: Threshold using for detection of cloud provider
+    :param methods: The set of methods used for detecting of cloud providers
     :return: List of cloud providers
     """
+
+    if not ('strong' in methods or 'heuristics' in methods):
+        raise ValueError(f'Method _get_cloud_providers() called with unsupported method(s) {methods}')
+
     if facts is None:
         facts = gather_system_facts()
 
@@ -82,56 +89,59 @@ def _get_cloud_providers(facts: dict = None, threshold: float = 0.5) -> Tuple[li
 
     log.debug('Trying to detect cloud provider')
 
-    # First try to detect cloud providers using strong signs
-    cloud_list = []
-    cloud_provider: BaseCloudProvider
-    for cloud_provider in cloud_providers:
-        cloud_detected = cloud_provider.is_running_on_cloud()
-        if cloud_detected is True:
-            cloud_list.append(cloud_provider)
+    if 'strong' in methods:
+        # First try to detect cloud providers using strong signs
+        cloud_list = []
+        cloud_provider: BaseCloudProvider
+        for cloud_provider in cloud_providers:
+            cloud_detected = cloud_provider.is_running_on_cloud()
+            if cloud_detected is True:
+                cloud_list.append(cloud_provider)
 
-    # When only one cloud provider was detected, then return this cloud provider
-    # probability
-    if len(cloud_list) == 1:
-        log.debug('Detected one cloud provider using strong signs: {provider}'.format(
-            provider=cloud_list[0].CLOUD_PROVIDER_ID)
-        )
-        return cloud_list, True
-    elif len(cloud_list) == 0:
-        log.debug('No cloud provider detected using strong signs')
-    elif len(cloud_list) > 1:
-        log.error('More than one cloud provider detected using strong signs ({providers})'.format(
-            providers=", ".join([cloud_provider.CLOUD_PROVIDER_ID for cloud_provider in cloud_list])
-        ))
+        # When only one cloud provider was detected, then return this cloud provider
+        if len(cloud_list) == 1:
+            log.debug('Detected one cloud provider using strong signs: {provider}'.format(
+                provider=cloud_list[0].CLOUD_PROVIDER_ID)
+            )
+            return cloud_list, True
+        elif len(cloud_list) == 0:
+            log.debug('No cloud provider detected using strong signs')
+        elif len(cloud_list) > 1:
+            log.error('More than one cloud provider detected using strong signs ({providers})'.format(
+                providers=", ".join([cloud_provider.CLOUD_PROVIDER_ID for cloud_provider in cloud_list])
+            ))
 
-    # When no cloud provider detected using strong signs, because behavior of cloud providers
-    # has changed, then try to detect cloud provider using some heuristics
-    cloud_list = []
-    for cloud_provider in cloud_providers:
-        probability: float = cloud_provider.is_likely_running_on_cloud()
-        # We have to filter out VMs, where is low probability that it runs on public cloud,
-        # because it would cause further attempts to contact IMDS servers of cloud providers.
-        # Default value 0.5 was just estimated from observation of existing data returned
-        # by cloud providers.
-        log.debug(f'Cloud provider {cloud_provider.CLOUD_PROVIDER_ID} has probability: {probability}')
-        if probability > threshold:
-            cloud_list.append((probability, cloud_provider))
-    # Sort list according only probability (provider with highest probability first)
-    cloud_list.sort(key=lambda x: x[0], reverse=True)
-    # We care only about order, not probability in the result (filter probability out)
-    cloud_list = [item[1] for item in cloud_list]
+    if 'heuristics' in methods:
+        # When no cloud provider detected using strong signs, because behavior of cloud providers
+        # has changed, then try to detect cloud provider using some heuristics
+        cloud_list = []
+        for cloud_provider in cloud_providers:
+            probability: float = cloud_provider.is_likely_running_on_cloud()
+            # We have to filter out VMs, where is low probability that it runs on public cloud,
+            # because it would cause further attempts to contact IMDS servers of cloud providers.
+            # Default value 0.5 was just estimated from observation of existing data returned
+            # by cloud providers.
+            log.debug(f'Cloud provider {cloud_provider.CLOUD_PROVIDER_ID} has probability: {probability}')
+            if probability > threshold:
+                cloud_list.append((probability, cloud_provider))
+        # Sort list according only probability (provider with the highest probability first)
+        cloud_list.sort(key=lambda x: x[0], reverse=True)
+        # We care only about order, not probability in the result (filter probability out)
+        cloud_list = [item[1] for item in cloud_list]
 
-    if len(cloud_list) == 0:
-        log.debug('No cloud provider detected using heuristics')
-    else:
-        log.debug('Following cloud providers detected using heuristics: {providers}'.format(
-            providers=', '.join([cloud_provider.CLOUD_PROVIDER_ID for cloud_provider in cloud_list])
-        ))
+        if len(cloud_list) == 0:
+            log.debug('No cloud provider detected using heuristics')
+        else:
+            log.debug('Following cloud providers detected using heuristics: {providers}'.format(
+                providers=', '.join([cloud_provider.CLOUD_PROVIDER_ID for cloud_provider in cloud_list])
+            ))
 
     return cloud_list, False
 
 
-def get_cloud_provider(facts: dict = None, threshold: float = 0.5) -> Union[
+def get_cloud_provider(facts: dict = None,
+                       threshold: float = 0.5,
+                       methods: set = ('strong', 'heuristics')) -> Union[
     BaseCloudProvider, AWSCloudProvider, AzureCloudProvider, GCPCloudProvider, None
 ]:
     """
@@ -139,9 +149,10 @@ def get_cloud_provider(facts: dict = None, threshold: float = 0.5) -> Union[
     cloud provider.
     :param facts: Dictionary with system facts
     :param threshold: Threshold used for heuristic detection of cloud provider
+    :param methods: set of methods to be used for detecting of cloud providers
     :return: Instance of cloud provider or None
     """
-    cloud_list, strong_sign = _get_cloud_providers(facts, threshold)
+    cloud_list, strong_sign = _get_cloud_providers(facts, threshold, methods)
 
     # When only one cloud provider detected using strong signs, then it is not
     # necessary to try to gather metadata from cloud provider
@@ -165,7 +176,9 @@ def get_cloud_provider(facts: dict = None, threshold: float = 0.5) -> Union[
     return None
 
 
-def detect_cloud_provider(facts: dict = None, threshold: float = 0.5) -> List[str]:
+def detect_cloud_provider(facts: dict = None,
+                          threshold: float = 0.5,
+                          methods: set = ('strong', 'heuristics')) -> List[str]:
     """
     This method tries to detect cloud provider using hardware information provided by dmidecode.
     When there is strong sign that the VM is running on one of the cloud provider, then return
@@ -175,10 +188,16 @@ def detect_cloud_provider(facts: dict = None, threshold: float = 0.5) -> List[st
     :param facts: dictionary of facts. When no facts are provided, then hardware, virtualization
         and custom facts are gathered.
     :param threshold: Threshold used for heuristic detection of cloud provider
+    :param methods: The set of methods used for detection of cloud providers (possible values
+        are following: 'strong', 'heuristics'). When only 'strong' is listed in the set, then
+        detection is performed only using strong signs. When only 'heuristics' is listed in the
+        list, then only heuristics detections is used. When both methods are listed, then first
+        this method tries to use first detection using strong signs and if no cloud provider
+        is detected, then it falls back to heuristics detection.
     :return: List of string representing detected cloud providers. E.g. ['aws'] or ['aws', 'gcp']
     """
 
-    cloud_list, strong_sign = _get_cloud_providers(facts, threshold)
+    cloud_list, strong_sign = _get_cloud_providers(facts, threshold, methods)
 
     # We care only about IDs of cloud providers in this method
     cloud_list = [cloud_provider.CLOUD_PROVIDER_ID for cloud_provider in cloud_list]

--- a/src/cloud_what/provider.py
+++ b/src/cloud_what/provider.py
@@ -19,7 +19,7 @@ This module contains several utils used for VMs running on clouds
 """
 
 from typing import Union, Tuple, List
-
+import enum
 import logging
 
 try:
@@ -50,6 +50,21 @@ CLOUD_PROVIDERS = [
 log = logging.getLogger(__name__)
 
 
+class DetectionMethod(enum.Flag):
+    """
+    Enumeration of allowed methods used for detection of cloud providers
+    """
+
+    # When this flag is set, then strong method will be used
+    STRONG = enum.auto()
+
+    # When this flag is set, then heuristic method will be used
+    HEURISTIC = enum.auto()
+
+    # All flags together
+    ALL = HEURISTIC | STRONG
+
+
 def gather_system_facts() -> dict:
     """
     Try to gather system facts necessary for detection of cloud provider
@@ -67,19 +82,18 @@ def gather_system_facts() -> dict:
     return facts
 
 
-def _get_cloud_providers(facts: dict = None,
-                         threshold: float = 0.5,
-                         methods: set = ('strong', 'heuristics')) -> Tuple[list, bool]:
+def _get_cloud_providers(
+        facts: dict = None,
+        threshold: float = 0.5,
+        methods: DetectionMethod = DetectionMethod.ALL
+) -> Tuple[list, bool]:
     """
     This method tries to detect cloud providers and return list of possible cloud providers
     :param facts: Dictionary with system facts
     :param threshold: Threshold using for detection of cloud provider
-    :param methods: The set of methods used for detecting of cloud providers
+    :param methods: The flag of methods used for detecting of cloud providers
     :return: List of cloud providers
     """
-
-    if not ('strong' in methods or 'heuristics' in methods):
-        raise ValueError(f'Method _get_cloud_providers() called with unsupported method(s) {methods}')
 
     if facts is None:
         facts = gather_system_facts()
@@ -89,9 +103,9 @@ def _get_cloud_providers(facts: dict = None,
 
     log.debug('Trying to detect cloud provider')
 
-    if 'strong' in methods:
+    cloud_list = []
+    if DetectionMethod.STRONG in methods:
         # First try to detect cloud providers using strong signs
-        cloud_list = []
         cloud_provider: BaseCloudProvider
         for cloud_provider in cloud_providers:
             cloud_detected = cloud_provider.is_running_on_cloud()
@@ -110,8 +124,10 @@ def _get_cloud_providers(facts: dict = None,
             log.error('More than one cloud provider detected using strong signs ({providers})'.format(
                 providers=", ".join([cloud_provider.CLOUD_PROVIDER_ID for cloud_provider in cloud_list])
             ))
+    else:
+        log.debug('Skipping detection of cloud provider using strong signs')
 
-    if 'heuristics' in methods:
+    if DetectionMethod.HEURISTIC in methods:
         # When no cloud provider detected using strong signs, because behavior of cloud providers
         # has changed, then try to detect cloud provider using some heuristics
         cloud_list = []
@@ -135,13 +151,17 @@ def _get_cloud_providers(facts: dict = None,
             log.debug('Following cloud providers detected using heuristics: {providers}'.format(
                 providers=', '.join([cloud_provider.CLOUD_PROVIDER_ID for cloud_provider in cloud_list])
             ))
+    else:
+        log.debug('Skipping detection of cloud providers using heuristic')
 
     return cloud_list, False
 
 
-def get_cloud_provider(facts: dict = None,
-                       threshold: float = 0.5,
-                       methods: set = ('strong', 'heuristics')) -> Union[
+def get_cloud_provider(
+        facts: dict = None,
+        threshold: float = 0.5,
+        methods: DetectionMethod = DetectionMethod.ALL
+) -> Union[
     BaseCloudProvider, AWSCloudProvider, AzureCloudProvider, GCPCloudProvider, None
 ]:
     """
@@ -149,7 +169,7 @@ def get_cloud_provider(facts: dict = None,
     cloud provider.
     :param facts: Dictionary with system facts
     :param threshold: Threshold used for heuristic detection of cloud provider
-    :param methods: set of methods to be used for detecting of cloud providers
+    :param methods: The flag of methods used for detecting of cloud providers
     :return: Instance of cloud provider or None
     """
     cloud_list, strong_sign = _get_cloud_providers(facts, threshold, methods)
@@ -176,9 +196,11 @@ def get_cloud_provider(facts: dict = None,
     return None
 
 
-def detect_cloud_provider(facts: dict = None,
-                          threshold: float = 0.5,
-                          methods: set = ('strong', 'heuristics')) -> List[str]:
+def detect_cloud_provider(
+        facts: dict = None,
+        threshold: float = 0.5,
+        methods: DetectionMethod = DetectionMethod.ALL
+) -> List[str]:
     """
     This method tries to detect cloud provider using hardware information provided by dmidecode.
     When there is strong sign that the VM is running on one of the cloud provider, then return
@@ -188,12 +210,12 @@ def detect_cloud_provider(facts: dict = None,
     :param facts: dictionary of facts. When no facts are provided, then hardware, virtualization
         and custom facts are gathered.
     :param threshold: Threshold used for heuristic detection of cloud provider
-    :param methods: The set of methods used for detection of cloud providers (possible values
-        are following: 'strong', 'heuristics'). When only 'strong' is listed in the set, then
-        detection is performed only using strong signs. When only 'heuristics' is listed in the
-        list, then only heuristics detections is used. When both methods are listed, then first
-        this method tries to use first detection using strong signs and if no cloud provider
-        is detected, then it falls back to heuristics detection.
+    :param methods: The flag of methods used for detection of cloud providers (possible enumerates
+        are following in DetectionMethod). When only STRONG is listed, then detection is
+        performed only using strong signs. When only HEURISTIC is listed, then only heuristics
+        detections is used. When both methods are listed, then this method tries to use detection
+        using strong signs first and if no cloud provider is detected, then it falls back to
+        heuristics detection.
     :return: List of string representing detected cloud providers. E.g. ['aws'] or ['aws', 'gcp']
     """
 

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -42,8 +42,8 @@ class CloudFactsCollector(collector.FactsCollector):
 
         self.hardware_methods = []
 
-        # Try to detect cloud provider
-        self.cloud_provider = get_cloud_provider(self._collected_hw_info)
+        # Try to detect cloud provider using only strong method
+        self.cloud_provider = get_cloud_provider(facts=self._collected_hw_info, methods={'strong'})
 
         if self.cloud_provider is not None:
             # Create dispatcher for supported cloud providers

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -20,7 +20,7 @@ from __future__ import print_function, division, absolute_import
 import logging
 import json
 
-from cloud_what.provider import get_cloud_provider
+from cloud_what.provider import get_cloud_provider, DetectionMethod
 from rhsmlib.facts import collector
 
 
@@ -43,7 +43,10 @@ class CloudFactsCollector(collector.FactsCollector):
         self.hardware_methods = []
 
         # Try to detect cloud provider using only strong method
-        self.cloud_provider = get_cloud_provider(facts=self._collected_hw_info, methods={'strong'})
+        self.cloud_provider = get_cloud_provider(
+            facts=self._collected_hw_info,
+            methods=DetectionMethod.STRONG
+        )
 
         if self.cloud_provider is not None:
             # Create dispatcher for supported cloud providers

--- a/test/cloud_what/test_cloud_what.py
+++ b/test/cloud_what/test_cloud_what.py
@@ -1057,6 +1057,22 @@ class TestCloudProvider(unittest.TestCase):
         detected_clouds = detect_cloud_provider()
         self.assertEqual(detected_clouds, ['aws'])
 
+    def test_detect_cloud_provider_only_strong_signs(self):
+        """
+        Test the case, when detecting of aws does not work using strong signs, but detecting
+        using only strong signs is requested
+        """
+        host_facts = {
+            'virt.is_guest': True,
+            'virt.host_type': 'kvm',
+            'dmi.bios.vendor': 'AWS',
+            'dmi.bios.version': '1.0',
+            'dmi.system.manufacturer': 'Amazon'
+        }
+        self.host_fact_collector_instance.get_all.return_value = host_facts
+        detected_clouds = detect_cloud_provider(methods={'strong'})
+        self.assertEqual(detected_clouds, [])
+
     def test_detect_cloud_provider_aws_heuristics(self):
         """
         Test the case, when detecting of aws does not work using strong signs, but it is necessary

--- a/test/cloud_what/test_cloud_what.py
+++ b/test/cloud_what/test_cloud_what.py
@@ -27,7 +27,7 @@ import json
 import requests
 
 from cloud_what.providers import aws, azure, gcp
-from cloud_what.provider import detect_cloud_provider, get_cloud_provider
+from cloud_what.provider import detect_cloud_provider, get_cloud_provider, DetectionMethod
 
 
 def send_only_imds_v2_is_supported(request, *args, **kwargs):
@@ -1070,7 +1070,7 @@ class TestCloudProvider(unittest.TestCase):
             'dmi.system.manufacturer': 'Amazon'
         }
         self.host_fact_collector_instance.get_all.return_value = host_facts
-        detected_clouds = detect_cloud_provider(methods={'strong'})
+        detected_clouds = detect_cloud_provider(methods=DetectionMethod.STRONG)
         self.assertEqual(detected_clouds, [])
 
     def test_detect_cloud_provider_aws_heuristics(self):


### PR DESCRIPTION
* Backport PR for 1.28
* Original PR: #2987
  * Original commits: 673fe74c12c0dbd6f8c6b880ea871ee1e6a6b6f3 c846e1e2854a54f12872049e412ff0e8ffd66669
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2057053
* When subscription-manager tries to collect information about
  public clouds, then it tried to detect public cloud using
  strong signs and when no public cloud was detected, then
  subscription-manager tried to detect public cloud provider
  using heuristics. It could cause false positive detection
  and subscription-manager tried to get metadata from
  IMDS servers. Using heuristics is not necessary, when we
  try to collect system facts.
* Methods for detection has new parameter 'methods'. It has
  default value ('strong', 'heuristics').
* When facts about public cloud is collected, then only
  this argument is changed to ('strong').
* Added one unit test for new parameter.