### PR TITLE
2064002: fix named argument for `registerConsumer()`

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -1991,7 +1991,7 @@ class AsyncBackend(object):
 
             cp = self.backend.cp_provider.get_basic_auth_cp()
             retval = cp.registerConsumer(name=name, facts=facts_dict,
-                                         owner=owner, environment=env,
+                                         owner=owner, environments=env,
                                          keys=activation_keys,
                                          installed_products=installed_mgr.format_for_server(),
                                          role=syspurpose.get('role'),


### PR DESCRIPTION
As result of commit 4b2c3334eb44a0dc28b9859d53ddc72c60092d76 (i.e. the
changes for multi-environments), the GUI code was not adapted to the
renamed named argument of `UEPConnection.registerConsumer()`.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2064002
Card ID: ENT-4813