### PR TITLE
Ignore black commit hashes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,3 +8,12 @@
 # - Add comment above every commit hash, preferably with timestamp,
 #   author and commit title.
 # - Append new hashes to the bottom; keep the list chronological.
+
+# 2022-03-24, mhorky@redhat.com: Format the code with black
+835a6b80ee84237b0796ad464438e5b6e5ab0523
+
+# 2022-03-24, mhorky@redhat.com: Use double quotes for strings
+6286f6cfc6f9aa9d69fa002d2f2f6c04b324eb72
+
+# 2022-03-30, mhorky@redhat.com: Format code with black==22.3.0
+b0170cb70ea4eed1b323e6434863108a6bd90f08


### PR DESCRIPTION
* Card ID: ENT-4846

Two giant commits reformatted whole repository with `black`. Their
hashes are being added to .git-blame-ignore-revs file, which can be used
by git to ignore them in `git blame` command:
$ git config blame.ignoreRevsFile .git-blame-ignore-revs