### PR TITLE
Add Black to CI

### DIFF
--- a/jenkins/stylish.sh
+++ b/jenkins/stylish.sh
@@ -41,3 +41,4 @@ export PYTHONPATH="$PYTHON_RHSM"/src
 
 # make set-versions
 make stylish
+black --diff --check .

--- a/src/rhsm/bitstream.py
+++ b/src/rhsm/bitstream.py
@@ -92,7 +92,7 @@ class GhettoBitStream:
         """
         chars = []
         for n in range(7, -1, -1):
-            y = x - 2 ** n
+            y = x - 2**n
             if y >= 0:
                 chars.append("1")
                 x = y

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,7 @@
 # immediately available.
 -e ./build_ext
 
+black==22.3.0
 flake8<4
 pytest<7
 pytest-randomly

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -874,7 +874,7 @@ class TestEntitlementStatusCache(SubManFixture):
         self.assertEqual(None, self.status_cache.load_status(uep, "SOMEUUID"))
 
     def test_write_cache(self):
-        mock_server_status = {"fake server status": random.uniform(1, 2 ** 32)}
+        mock_server_status = {"fake server status": random.uniform(1, 2**32)}
         status_cache = EntitlementStatusCache()
         status_cache.server_status = mock_server_status
         cache_dir = tempfile.mkdtemp()


### PR DESCRIPTION
* Card ID: ENT-4847

The version is pinned for consistency. If you have different version
than the Jenkins does (because one of the systems was not updated while
the other one was), the build will fail even though your local Black
claims everything is in order.

For that reason it would be the best to use the version from PyPI via
pip and not system package version from repository, which may be out of
sync.

If this situation does happen and Black in CI finds some issues, it will
show a diff for the changes, so it can be fixed even manually. But the
best-case scenario is seamless check with the versions synchronized.

The repository was previously reformatted with black==21.12b0. Version
22.1.0+ removes spaces around operators if both operands are simple, and
those two files are affected.