### PR TITLE
[1.24] Backport support for GCP marketplace ID

### DIFF
--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -20,6 +20,7 @@ from __future__ import print_function, division, absolute_import
 import logging
 import json
 import socket
+import base64
 
 from rhsmlib.facts import collector
 from rhsm.https import httplib
@@ -37,6 +38,13 @@ AZURE_INSTANCE_IP = "169.254.169.254"
 AZURE_API_VERSION = "2021-02-01"
 AZURE_INSTANCE_PATH = "/metadata/instance?api-version=" + AZURE_API_VERSION
 AZURE_INSTANCE_TIMEOUT = 5  # value is in seconds
+
+AUDIENCE = "https://subscription.rhsm.redhat.com:443/subscription"
+GCP_INSTANCE_IP = "metadata"
+GCP_INSTANCE_PATH = "/computeMetadata/v1/instance/service-accounts/default/identity?audience={audience}&format=full".format(
+    audience=AUDIENCE
+)
+GCP_INSTANCE_TIMEOUT = 5
 
 
 class CloudFactsCollector(collector.FactsCollector):
@@ -71,6 +79,12 @@ class CloudFactsCollector(collector.FactsCollector):
                 self.get_azure_facts
             ]
 
+        if self.is_gcp() is True:
+            public_cloud = "gcp"
+            self.hardware_methods = [
+                self.get_gcp_facts
+            ]
+
         if public_cloud is not None:
             log.debug('Detected public cloud: {public_cloud}'.format(public_cloud=public_cloud))
 
@@ -80,6 +94,9 @@ class CloudFactsCollector(collector.FactsCollector):
         :return: True, when VM is running on AWS
         """
         hw_info = self._collected_hw_info
+
+        if hw_info is None:
+            return False
 
         if 'dmi.bios.version' in hw_info and 'amazon' in hw_info['dmi.bios.version']:
             return True
@@ -183,7 +200,7 @@ class CloudFactsCollector(collector.FactsCollector):
 
             # Note: There should be only two types of billing codes: bp-63a5400a and bp-6fa54006 in the list,
             # when RHEL is used. When the subscription-manager is used by some other Linux distribution,
-            # then there could be different codes or it could be null
+            # then there could be different codes, or it could be null
             if 'billingProducts' in values:
                 billing_products = values['billingProducts']
                 if isinstance(billing_products, list):
@@ -207,9 +224,12 @@ class CloudFactsCollector(collector.FactsCollector):
     def is_azure(self):
         """
         Is VM running on Azure public cloud
-        :return:
+        :return: True, when the system is running on Azure. Otherwise, return False.
         """
         hw_info = self._collected_hw_info
+
+        if hw_info is None:
+            return False
 
         if 'dmi.chassis.asset_tag' in hw_info and \
                 hw_info['dmi.chassis.asset_tag'] == '7783-7084-3265-9085-8269-3286-77':
@@ -219,7 +239,7 @@ class CloudFactsCollector(collector.FactsCollector):
 
     def get_azure_metadata(self):
         """
-        Try to get AWS metadata using only IMDSv1
+        Try to get Azure metadata
         :return: http response
         """
         headers = {
@@ -239,7 +259,7 @@ class CloudFactsCollector(collector.FactsCollector):
 
         https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service?tabs=linux#instance-metadata
 
-        :return: dictionary containing AWS facts or empty dictionary, when it wasn't
+        :return: dictionary containing Azure facts or empty dictionary, when it wasn't
         possible to get information from IMDS server
         """
         log.debug('Trying to get Azure metadata')
@@ -260,6 +280,104 @@ class CloudFactsCollector(collector.FactsCollector):
                     facts['azure_sku'] = values['compute']['sku']
                 if 'offer' in values['compute']:
                     facts['azure_offer'] = values['compute']['offer']
+        return facts
+
+    def is_gcp(self):
+        """
+        Is VM running on GCP public cloud
+        :return: True, when the system is running on GCP. Otherwise, return False.
+        """
+        hw_info = self._collected_hw_info
+
+        if hw_info is None:
+            return False
+
+        if 'dmi.bios.vendor' in hw_info and \
+                'google' in hw_info['dmi.bios.vendor'].lower():
+            return True
+
+        return False
+
+    def get_gcp_metadata(self):
+        """
+        Try to collect metadata from GCP metadata server
+        :return: http response
+        """
+        headers = {
+            'Metadata-Flavor': 'Google',
+        }
+        headers.update(self.HEADERS)
+        return self.get_cloud_metadata(
+            ip_addr=GCP_INSTANCE_IP,
+            path=GCP_INSTANCE_PATH,
+            headers=headers,
+            timeout=GCP_INSTANCE_TIMEOUT
+        )
+
+    @staticmethod
+    def decode_jwt(jwt_token):
+        """
+        Try to decode metadata stored in JWT token described in this RFC: https://tools.ietf.org/html/rfc7519
+        :param jwt_token: string representing JWT token
+        :return: tuple with: string representing header, string representing metadata and base64 encoded signature
+        """
+        # Get the actual payload part: [0] is JOSE header, [1] is metadata and [2] is signature
+        parts = jwt_token.split('.')
+        if len(parts) >= 3:
+            encoded_jose_header = parts[0]
+            encoded_metadata = parts[1]
+            encoded_signature = parts[2]
+            # Add some extra padding, JWT tokens have padding trimmed - see https://stackoverflow.com/a/49459036
+            encoded_jose_header += '==='
+            encoded_metadata += '==='
+            encoded_signature += '==='
+            # Decode only header and metadata, not signature
+            try:
+                jose_header = base64.b64decode(encoded_jose_header).decode('utf-8')
+            except UnicodeDecodeError as err:
+                log.error('Unable to decode JWT JOSE header: {err}'.format(err=err))
+                jose_header = None
+            try:
+                metadata = base64.b64decode(encoded_metadata).decode('utf-8')
+            except UnicodeDecodeError as err:
+                log.error('Unable to decode JWT metadata: {err}'.format(err=err))
+                metadata = None
+            return jose_header, metadata, encoded_signature
+        else:
+            log.warning('JWT token with wrong format')
+            return None, None, None
+
+    def get_gcp_facts(self):
+        """
+        Try to get GCP facts from IMDS server according this documentation:
+
+        https://cloud.google.com/compute/docs/instances/verifying-instance-identity
+
+        :return: dictionary containing GCP facts or empty dictionary, when it wasn't
+        possible to get information from IMDS server
+        """
+        log.debug('Trying to get GCP metadata')
+        facts = {}
+        try:
+            response = self.get_gcp_metadata()
+            token = response.read()
+        except (httplib.HTTPException, ValueError, socket.timeout) as e:
+            # Any exception is logged by value is simply not added.
+            log.exception("Cannot retrieve JWT Token: %s" % e)
+        else:
+            jose_header, metadata, encoded_signature = self.decode_jwt(token)
+            if metadata is not None:
+                log.debug('GCP metadata gathered')
+                values = self.parse_content(metadata)
+                if 'google' in values and \
+                        'compute_engine' in values['google'] and \
+                        'instance_id' in values['google']['compute_engine']:
+                    facts = {
+                        "gcp_instance_id": values['google']['compute_engine']['instance_id']
+                    }
+                    log.debug('GCP instance_id found in metadata')
+                else:
+                    log.debug('GCP instance_id not found in JWT token')
         return facts
 
     @staticmethod


### PR DESCRIPTION
* Card ID: ENT-4862
* When RHEL7 system runs on GCP public cloud, then no marketplace
  ID was included in reported facts. This commit adds support
  for GCP marketplace ID for RHEL7.
* System facts contains now new fact gcp_instance_id.