### PR TITLE
Set version of deb packages during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ STYLEFILES=$(PYFILES) $(BIN_FILES)
 
 build: rhsmcertd
 	EXCLUDE_PACKAGES="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py clean --all
-	EXCLUDE_PACKAGES="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py build --quiet --rpm-version=$(VERSION)
+	EXCLUDE_PACKAGES="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py build --quiet --pkg-version=$(VERSION)
 
 # we never "remake" this makefile, so add a target so
 # we stop searching for implicit rules on how to remake it
@@ -195,7 +195,7 @@ install-example-plugins: install-plugins
 
 .PHONY: install-via-setup
 install-via-setup: install-subpackages-via-setup
-	EXCLUDE_PACKAGES="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py install --root $(DESTDIR) --rpm-version=$(VERSION) --prefix=$(PREFIX) \
+	EXCLUDE_PACKAGES="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py install --root $(DESTDIR) --pkg-version=$(VERSION) --prefix=$(PREFIX) \
 	--with-cockpit-desktop-entry=${WITH_COCKPIT} \
 	$(SETUP_PY_INSTALL_PARAMS)
 	mkdir -p $(DESTDIR)/$(PREFIX)/sbin/

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -18,10 +18,10 @@ override_dh_auto_clean:
 	rm -rf *.egg-info
 
 override_dh_auto_build:
-	make -f Makefile GTK_VERSION=2 OS_DIST=debian PREFIX=/usr
+	make -f Makefile GTK_VERSION=2 OS_DIST=debian PREFIX=/usr VERSION=${DEB_VERSION_UPSTREAM_REVISION}
 
 override_dh_auto_install:
-	make -f Makefile install GTK_VERSION=2 OS_DIST=debian PREFIX=/usr DESTDIR=debian/python-subscription-manager
+	make -f Makefile install GTK_VERSION=2 OS_DIST=debian PREFIX=/usr VERSION=${DEB_VERSION_UPSTREAM_REVISION} DESTDIR=debian/python-subscription-manager
 	sed -i -e '/dbus-python/d' debian/python-subscription-manager/usr/lib/python2.7/site-packages/subscription_manager-*.egg-info/requires.txt
 
 override_dh_auto_test:

--- a/setup.py
+++ b/setup.py
@@ -48,36 +48,36 @@ exclude_packages.extend(
 )
 
 
-RPM_VERSION = None
+PKG_VERSION = None
 
 
-# subclass build_py so we can generate version.py based on --rpm-version or
+# subclass build_py so we can generate version.py based on --pkg-version or
 # from a guess generated from 'git describe'
-class rpm_version_release_build_py(_build_py):
+class pkg_version_release_build_py(_build_py):
     user_options = _build_py.user_options + [
-        ("rpm-version=", None, "version and release of the RPM this is built for")
+        ("pkg-version=", None, "version and release of the PKG this is built for")
     ]
 
     def initialize_options(self):
         _build_py.initialize_options(self)
-        self.rpm_version = None
+        self.pkg_version = None
         self.versioned_packages = []
 
     def finalize_options(self):
-        # When --rpm-version was provided as command line
+        # When --pkg-version was provided as command line
         # option of install command, then get this value from global variables
-        if self.rpm_version is None and RPM_VERSION is not None:
-            self.rpm_version = RPM_VERSION
+        if self.pkg_version is None and PKG_VERSION is not None:
+            self.pkg_version = PKG_VERSION
         _build_py.finalize_options(self)
         self.set_undefined_options(
             "build",
-            ("rpm_version", "rpm_version"),
+            ("pkg_version", "pkg_version"),
         )
 
     def run(self):
-        log.debug("Building with RPM_VERSION=%s" % self.rpm_version)
+        log.debug("Building with PKG_VERSION=%s" % self.pkg_version)
         _build_py.run(self)
-        # create a "version.py" that includes the rpm version
+        # create a "version.py" that includes the pkg version
         # info passed to our new build_py args
         if not self.dry_run:
             for package in self.versioned_packages:
@@ -87,7 +87,7 @@ class rpm_version_release_build_py(_build_py):
                     lines = []
                     with open(version_file, "r") as file:
                         for line in file.readlines():
-                            line = line.replace("RPM_VERSION", str(self.rpm_version))
+                            line = line.replace("PKG_VERSION", str(self.pkg_version))
                             lines.append(line)
 
                     with open(version_file, "w") as file:
@@ -99,7 +99,7 @@ class rpm_version_release_build_py(_build_py):
 
 class install(_install):
     user_options = _install.user_options + [
-        ("rpm-version=", None, "version and release of the RPM this is built for"),
+        ("pkg-version=", None, "version and release of the PKG this is built for"),
         (
             "with-cockpit-desktop-entry=",
             None,
@@ -109,42 +109,42 @@ class install(_install):
 
     def initialize_options(self):
         _install.initialize_options(self)
-        self.rpm_version = None
+        self.pkg_version = None
         self.with_cockpit_desktop_entry = None
 
     def finalize_options(self):
-        global RPM_VERSION
-        if self.rpm_version is not None:
-            RPM_VERSION = self.rpm_version
+        global PKG_VERSION
+        if self.pkg_version is not None:
+            PKG_VERSION = self.pkg_version
         _install.finalize_options(self)
         self.set_undefined_options(
             "build",
-            ("rpm_version", "rpm_version"),
+            ("pkg_version", "pkg_version"),
         )
 
 
 class build(_build):
     user_options = _build.user_options + [
-        ("rpm-version=", None, "version and release of the RPM this is built for")
+        ("pkg-version=", None, "version and release of the PKG this is built for")
     ]
 
     def initialize_options(self):
         _build.initialize_options(self)
-        self.rpm_version = None
+        self.pkg_version = None
         self.git_tag_prefix = "subscription-manager-"
 
     def finalize_options(self):
-        # When --rpm-version was provided as command line
+        # When --pkg-version was provided as command line
         # option of install command, then get this value from global variables
-        if self.rpm_version is None and RPM_VERSION is not None:
-            self.rpm_version = RPM_VERSION
+        if self.pkg_version is None and PKG_VERSION is not None:
+            self.pkg_version = PKG_VERSION
 
         _build.finalize_options(self)
 
-        # When the rpm-version was not provided as command line options,
+        # When the pkg-version was not provided as command line options,
         # then try to get such information from .git or rpm
-        if not self.rpm_version:
-            self.rpm_version = self.get_git_describe()
+        if not self.pkg_version:
+            self.pkg_version = self.get_git_describe()
 
     def get_git_describe(self):
         try:
@@ -154,8 +154,8 @@ class build(_build):
             if output.startswith(self.git_tag_prefix):
                 return output[len(self.git_tag_prefix) :]
         except OSError:
-            # When building the RPM there won't be a git repo to introspect so
-            # builders *must* specify the version via the --rpm-version option
+            # When building the package there won't be a git repo to introspect so
+            # builders *must* specify the version via the --pkg-version option
             return "unknown"
 
     def has_po_files(self):
@@ -291,7 +291,7 @@ cmdclass = {
     "install": install,
     "install_data": install_data,
     "build": build,
-    "build_py": rpm_version_release_build_py,
+    "build_py": pkg_version_release_build_py,
     "build_trans": i18n.BuildTrans,
     "build_template": template.BuildTemplate,
     "update_trans": i18n.UpdateTrans,

--- a/src/rct/version.py
+++ b/src/rct/version.py
@@ -1,2 +1,2 @@
 # The values in this file are populated by setup.py build
-rpm_version = "RPM_VERSION"
+pkg_version = "PKG_VERSION"

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -41,7 +41,7 @@ from rhsm import utils
 try:
     import subscription_manager.version
 
-    subman_version = subscription_manager.version.rpm_version
+    subman_version = subscription_manager.version.pkg_version
 except ImportError:
     subman_version = "unknown"
 

--- a/src/subscription_manager/api/__init__.py
+++ b/src/subscription_manager/api/__init__.py
@@ -18,7 +18,7 @@ All reasonable efforts will be made to maintain compatibility.
 from functools import wraps
 from rhsm import logutil
 
-from subscription_manager.version import rpm_version as version
+from subscription_manager.version import pkg_version as version
 
 
 injected = False

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -252,7 +252,7 @@ def get_client_versions():
     sm_version = _("Unknown")
 
     try:
-        sm_version = subscription_manager.version.rpm_version
+        sm_version = subscription_manager.version.pkg_version
         if sm_version is None or sm_version == "None":
             sm_version = pkg_resources.require("subscription-manager")[0].version
     except Exception as e:

--- a/src/subscription_manager/version.py
+++ b/src/subscription_manager/version.py
@@ -1,2 +1,2 @@
 # The values in this file are populated by setup.py build
-rpm_version = "RPM_VERSION"
+pkg_version = "PKG_VERSION"

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -22,7 +22,7 @@ class ApiVersionTest(SubManFixture):
     def test_version_is_available(self):
         from subscription_manager import version
 
-        self.assertEqual(version.rpm_version, api.version)
+        self.assertEqual(version.pkg_version, api.version)
 
 
 class RepoApiTest(SubManFixture):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -492,14 +492,14 @@ class TestGetServerVersions(fixture.SubManFixture):
 class TestGetClientVersions(fixture.SubManFixture):
     @patch("subscription_manager.utils.subscription_manager.version")
     def test_get_client_versions(self, mock_sub_version):
-        mock_sub_version.rpm_version = "9.8.7-6"
+        mock_sub_version.pkg_version = "9.8.7-6"
         cv = get_client_versions()
         self.assertEqual(cv["subscription-manager"], "9.8.7-6")
         self.assertTrue(isinstance(cv["subscription-manager"], str))
 
     @patch("subscription_manager.utils.subscription_manager.version")
     def test_get_client_versions_strings(self, mock_sub_version):
-        mock_sub_version.rpm_version = "ef-gh"
+        mock_sub_version.pkg_version = "ef-gh"
         cv = get_client_versions()
         self.assertEqual(cv["subscription-manager"], "ef-gh")
 


### PR DESCRIPTION
Currently the version of subscription-manager isn't set during the build of the deb package. As a result the subscription-manager version is empty when running `subscription-manager version` on deb based systems.

As a first step **rpm-version** is refactored to **pkg-version** as the set version relates to both rpm and deb packages.

Secondly the version is passed to **make** in _contrib/debian/rules_ using **pkg-info.mk**.