### PR TITLE
[1.28] build: always build & ship syspurpose bits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ INITIAL_SETUP_INST_DIR := $(ANACONDA_ADDON_INST_DIR)/$(ANACONDA_ADDON_NAME)
 POLKIT_ACTIONS_INST_DIR := $(INSTALL_DIR)/polkit-1/actions
 COMPLETION_DIR ?= $(INSTALL_DIR)/bash-completion/completions/
 LIBEXEC_DIR ?= $(shell rpm --eval='%_libexecdir')
-SUBPACKAGES ?= $(shell ls -d syspurpose)
+SUBPACKAGES = syspurpose
 
 # If we skip install ostree plugin, unset by default
 # override from spec file for rhel6
@@ -95,7 +95,6 @@ INSTALL_DNF_PLUGINS ?= false
 DNF_PLUGINS_SRC_DIR := src/plugins
 
 INSTALL_ZYPPER_PLUGINS ?= false
-INCLUDE_SYSPURPOSE ?= 0
 
 # sets a version that is more or less latest tag plus commit sha
 VERSION ?= $(shell git describe | awk ' { sub(/subscription-manager-/,"")};1' )
@@ -205,10 +204,8 @@ install-conf:
 	install -d $(DESTDIR)/$(POLKIT_ACTIONS_INST_DIR)
 	install -m 644 etc-conf/dbus/polkit/com.redhat.RHSM1.policy $(DESTDIR)/$(POLKIT_ACTIONS_INST_DIR)
 	install -m 644 etc-conf/dbus/polkit/com.redhat.RHSM1.Facts.policy $(DESTDIR)/$(POLKIT_ACTIONS_INST_DIR)
-	if [[ "$(INCLUDE_SYSPURPOSE)" = "1" ]]; then \
-		install -m 644 etc-conf/syspurpose/valid_fields.json $(DESTDIR)/etc/rhsm/syspurpose/valid_fields.json; \
-		install -m 644 etc-conf/syspurpose.completion.sh $(DESTDIR)/$(COMPLETION_DIR)/syspurpose; \
-	fi;
+	install -m 644 etc-conf/syspurpose/valid_fields.json $(DESTDIR)/etc/rhsm/syspurpose/valid_fields.json
+	install -m 644 etc-conf/syspurpose.completion.sh $(DESTDIR)/$(COMPLETION_DIR)/syspurpose
 	if [[ "$(WITH_SUBMAN_GUI)" == "true" ]]; then \
 	    install -m 644 etc-conf/dbus/polkit/com.redhat.SubscriptionManager.policy $(DESTDIR)/$(POLKIT_ACTIONS_INST_DIR); \
 		install -m 644 etc-conf/subscription-manager-gui.appdata.xml $(DESTDIR)/$(INSTALL_DIR)/appdata/subscription-manager-gui.appdata.xml; \
@@ -348,9 +345,7 @@ install-via-setup: install-subpackages-via-setup
 	else \
 	    rm $(DESTDIR)/$(PREFIX)/bin/rhn-migrate-classic-to-rhsm; \
 	fi;
-	if [[ "$(INCLUDE_SYSPURPOSE)" = "1" ]]; then \
-		mv $(DESTDIR)/$(PREFIX)/bin/syspurpose $(DESTDIR)/$(PREFIX)/sbin/; \
-	fi;
+	mv $(DESTDIR)/$(PREFIX)/bin/syspurpose $(DESTDIR)/$(PREFIX)/sbin/
 	find $(DESTDIR)/$(PYTHON_SITELIB) -name requires.txt -exec sed -i '/dbus-python/d' {} \;
 
 

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -123,8 +123,6 @@
 %global rhsm_package_name subscription-manager-rhsm
 %endif
 
-%global include_syspurpose 1
-
 %global _hardened_build 1
 %{!?__global_ldflags: %global __global_ldflags -Wl,-z,relro -Wl,-z,now}
 
@@ -201,8 +199,6 @@
 %else
 %global with_cockpit WITH_COCKPIT=false
 %endif
-
-%global subpackages SUBPACKAGES="%{?include_syspurpose:syspurpose}"
 
 # Build a list of python package to exclude from the build.
 # This is necessary because we have multiple rpms which may or may not
@@ -765,7 +761,7 @@ cloud metadata and signatures.
 %build
 make -f Makefile VERSION=%{version}-%{release} CFLAGS="%{optflags}" \
     LDFLAGS="%{__global_ldflags}" OS_DIST="%{dist}" PYTHON="%{__python}" \
-    %{?gtk_version} %{?subpackages} %{?include_syspurpose:INCLUDE_SYSPURPOSE="1"} \
+    %{?gtk_version} \
     %{exclude_packages} %{?with_subman_gui} %{?with_subman_migration}
 
 %if %{with python2_rhsm}
@@ -797,8 +793,6 @@ make -f Makefile install VERSION=%{version}-%{release} \
     %{?with_subman_gui} \
     %{?with_subman_migration} \
     %{?with_cockpit} \
-    %{?subpackages} \
-    %{?include_syspurpose:INCLUDE_SYSPURPOSE="1"} \
     %{?exclude_packages}
 
 %if (%{use_dnf} && (0%{?fedora} >= 29 || 0%{?rhel} >= 8))
@@ -838,9 +832,7 @@ desktop-file-validate %{buildroot}/usr/share/applications/subscription-manager-c
 %endif
 
 %find_lang rhsm
-%if 0%{?include_syspurpose}
 %find_lang syspurpose
-%endif
 
 # fake out the redhat.repo file
 %if %{use_yum} || %{use_dnf}


### PR DESCRIPTION
Using `INCLUDE_SYSPURPOSE` to disable the syspurpose tool has the effect
of also disabling the `syspurpose` Python module. Since the backports
from main in the latest months assumed an always-available `syspurpose`
module, then building without it results in a broken
subscription-manager. [1]

Hence, simply drop `INCLUDE_SYSPURPOSE` from the Makefile, unconditionally
installing the syspurpose tool & module. Also hardcode `SUBPACKAGES` to
syspurpose, and drop the possibility of overriding it in the spec file.

[1] https://github.com/candlepin/subscription-manager/pull/2906