### PR TITLE
1.28 Add gcp_license_codes to system facts.

### DIFF
--- a/src/cloud_what/providers/gcp.py
+++ b/src/cloud_what/providers/gcp.py
@@ -50,7 +50,7 @@ class GCPCloudProvider(BaseCloudProvider):
     # Google uses little bit different approach. It provides everything in JSON Web Token (JWT)
     CLOUD_PROVIDER_METADATA_URL = None
 
-    CLOUD_PROVIDER_METADATA_URL_TEMPLATE = "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience={audience}&format=full"
+    CLOUD_PROVIDER_METADATA_URL_TEMPLATE = "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience={audience}&format=full&licenses=TRUE"
 
     # Token (metadata) expires within one hour. Thus it is save to cache the token.
     CLOUD_PROVIDER_METADATA_TTL = 3600

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -144,14 +144,20 @@ class CloudFactsCollector(collector.FactsCollector):
             jose_header, metadata, signature = self.cloud_provider.decode_jwt(encoded_jwt_token)
             if metadata is not None:
                 values = self.parse_json_content(metadata)
-                if 'google' in values and \
-                        'compute_engine' in values['google'] and \
-                        'instance_id' in values['google']['compute_engine']:
-                    facts = {
-                        "gcp_instance_id": values['google']['compute_engine']['instance_id']
-                    }
+                if "google" in values and "compute_engine" in values["google"]:
+                    # ID of instance
+                    if "instance_id" in values["google"]["compute_engine"]:
+                        facts["gcp_instance_id"] = values["google"]["compute_engine"]["instance_id"]
+                    else:
+                        log.debug("GCP instance_id not found in JWT token")
+                    # IDs of licenses
+                    if "license_id" in values["google"]["compute_engine"]:
+                        gcp_license_codes = values["google"]["compute_engine"]["license_id"]
+                        facts["gcp_license_codes"] = " ".join(gcp_license_codes)
+                    else:
+                        log.debug("GCP license codes not found in JWT token")
                 else:
-                    log.debug('GCP instance_id not found in JWT token')
+                    log.debug("GCP google.compute_engine on found in JWT token")
         return facts
 
     @staticmethod

--- a/test/cloud_what/test_cloud_what.py
+++ b/test/cloud_what/test_cloud_what.py
@@ -918,12 +918,9 @@ class TestGCPCloudProvider(unittest.TestCase):
         token = gcp_collector.get_metadata()
         self.requests_mock.Request.assert_called_once_with(
             method="GET",
-            url='http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?'
-                'audience=https://subscription.rhsm.redhat.com:443/subscription&format=full',
-            headers={
-                'User-Agent': 'cloud-what/1.0',
-                'Metadata-Flavor': 'Google'
-            }
+            url="http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?"
+            "audience=https://subscription.rhsm.redhat.com:443/subscription&format=full&licenses=TRUE",
+            headers={"User-Agent": "cloud-what/1.0", "Metadata-Flavor": "Google"},
         )
         self.assertEqual(token, GCP_JWT_TOKEN)
 
@@ -946,12 +943,9 @@ class TestGCPCloudProvider(unittest.TestCase):
         token = gcp_collector.get_metadata()
         self.requests_mock.Request.assert_called_once_with(
             method="GET",
-            url='http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?'
-                'audience=https://example.com:8443/rhsm&format=full',
-            headers={
-                'User-Agent': 'cloud-what/1.0',
-                'Metadata-Flavor': 'Google'
-            }
+            url="http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?"
+            "audience=https://example.com:8443/rhsm&format=full&licenses=TRUE",
+            headers={"User-Agent": "cloud-what/1.0", "Metadata-Flavor": "Google"},
         )
         mock_session.send.assert_called_once()
         self.assertEqual(token, GCP_JWT_TOKEN)

--- a/test/rhsmlib_test/test_cloud_facts.py
+++ b/test/rhsmlib_test/test_cloud_facts.py
@@ -328,6 +328,8 @@ class TestCloudCollector(unittest.TestCase):
 
         self.assertIn("gcp_instance_id", facts)
         self.assertEqual(facts["gcp_instance_id"], "2589221140676718026")
+        self.assertIn("gcp_license_codes", facts)
+        self.assertEqual(facts["gcp_license_codes"], "5731035067256925298")
 
     @patch('cloud_what.providers.aws.requests.Session', name='mock_session_class')
     def test_get_not_aws_instance(self, mock_session_class):


### PR DESCRIPTION
* Backport PR for 1.28 branch. Original PR: #3023
  * Original commit: 33e50de1751bb527e0c9a438ac26ec86f4a1f63e
* Card ID: ENT-4825
* When system is running on Google Cloud Platform, then add
  information about license codes to system facts
* List of codes (IDs) is separated by spaces
* The list is gathered from metadata, but it was necessary
  to modify little bit URL (&licenses=TRUE at the end
  of the URL template)
* Modified unit tests a little bit