### PR TITLE
1.24 Add gcp_license_codes to system facts.

### DIFF
--- a/src/cloud_what/providers/gcp.py
+++ b/src/cloud_what/providers/gcp.py
@@ -46,7 +46,7 @@ class GCPCloudProvider(BaseCloudProvider):
     # Google uses little bit different approach. It provides everything in JSON Web Token (JWT)
     CLOUD_PROVIDER_METADATA_URL = None
 
-    CLOUD_PROVIDER_METADATA_URL_TEMPLATE = "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience={audience}&format=full"
+    CLOUD_PROVIDER_METADATA_URL_TEMPLATE = "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience={audience}&format=full&licenses=TRUE"
 
     # Token (metadata) expires within one hour. Thus it is save to cache the token.
     CLOUD_PROVIDER_METADATA_TTL = 3600
@@ -298,6 +298,10 @@ def _smoke_test():
         # 1. using default audience
         token = gcp_cloud_provider.get_metadata()
         print('>>> debug <<< 1. token: {}'.format(token))
+        jose, metadata, signature = gcp_cloud_provider.decode_jwt(token)
+        print('>>> jose header: {jose}'.format(jose=jose))
+        print('>>> metadata: {metadata}'.format(metadata=metadata))
+        print('>>> signature: {signature}'.format(signature=signature))
         # 2. using some custom audience
         gcp_cloud_provider = GCPCloudProvider(facts, audience_url="https://localhost:8443/candlepin")
         token = gcp_cloud_provider.get_metadata()
@@ -305,6 +309,6 @@ def _smoke_test():
 
 
 # Some temporary smoke testing code. You can test this module using:
-# sudo PYTHONPATH=./src python3 -m cloud_what.providers.gcp
+# sudo PYTHONPATH=./src python -m cloud_what.providers.gcp
 if __name__ == '__main__':
     _smoke_test()

--- a/test/cloud_what/test_cloud_what.py
+++ b/test/cloud_what/test_cloud_what.py
@@ -925,7 +925,7 @@ class TestGCPCloudProvider(unittest.TestCase):
         self.requests_mock.Request.assert_called_once_with(
             method="GET",
             url='http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?'
-                'audience=https://subscription.rhsm.redhat.com:443/subscription&format=full',
+                'audience=https://subscription.rhsm.redhat.com:443/subscription&format=full&licenses=TRUE',
             headers={
                 'User-Agent': 'cloud-what/1.0',
                 'Metadata-Flavor': 'Google'
@@ -953,7 +953,7 @@ class TestGCPCloudProvider(unittest.TestCase):
         self.requests_mock.Request.assert_called_once_with(
             method="GET",
             url='http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?'
-                'audience=https://example.com:8443/rhsm&format=full',
+                'audience=https://example.com:8443/rhsm&format=full&licenses=TRUE',
             headers={
                 'User-Agent': 'cloud-what/1.0',
                 'Metadata-Flavor': 'Google'


### PR DESCRIPTION
* Backport PR for 1.28 branch. Original PR: #3023
  * Original commit: 33e50de1751bb527e0c9a438ac26ec86f4a1f63e
* Card ID: ENT-4825
* When system is running on Google Cloud Platform, then add
  information about license codes to system facts
* List of codes (IDs) is separated by spaces
* The list is gathered from metadata, but it was necessary
  to modify little bit URL (&licenses=TRUE at the end
  of the URL template)
* Modified unit tests a little bit