### PR TITLE
[1.29.26] 2073551: clear the release cache on release change

### DIFF
--- a/src/subscription_manager/cli_command/refresh.py
+++ b/src/subscription_manager/cli_command/refresh.py
@@ -44,6 +44,9 @@ class RefreshCommand(CliCommand):
             content_access_mode = inj.require(inj.CONTENT_ACCESS_MODE_CACHE)
             if content_access_mode.exists():
                 content_access_mode.delete_cache()
+            # Remove the release status cache, in case it was changed
+            # on the server; it will be fetched when needed again
+            inj.require(inj.RELEASE_STATUS_CACHE).delete_cache()
 
             if self.options.force is True:
                 # get current consumer identity

--- a/src/subscription_manager/cli_command/release.py
+++ b/src/subscription_manager/cli_command/release.py
@@ -23,6 +23,7 @@ from subscription_manager.i18n import ugettext as _
 from subscription_manager.release import ReleaseBackend, MultipleReleaseProductsError
 from subscription_manager.repolib import RepoActionInvoker
 from subscription_manager.utils import parse_baseurl_info
+import subscription_manager.injection as inj
 
 log = logging.getLogger(__name__)
 
@@ -75,6 +76,7 @@ class ReleaseCommand(CliCommand):
         if self.options.unset:
             self.cp.updateConsumer(self.identity.uuid,
                                    release="")
+            inj.require(inj.RELEASE_STATUS_CACHE).delete_cache()
             repo_action_invoker.update()
             print(_("Release preference has been unset"))
         elif self.options.release is not None:
@@ -95,6 +97,7 @@ class ReleaseCommand(CliCommand):
                     "No releases match '{release}'.  "
                     "Consult 'release --list' for a full listing.").format(
                         release=self.options.release))
+            inj.require(inj.RELEASE_STATUS_CACHE).delete_cache()
             repo_action_invoker.update()
             print(_("Release set to: {release}").format(release=self.options.release))
         elif self.options.list:


### PR DESCRIPTION
Commit 7c764615e1c6208be6fd646c84edddd9ba75ee70 fixed the usage of the
status cache, making sure it is properly used in more cases. One side
effect it happened was that the release status cache was used as it was,
and since nothing invalidates it, any release change (done with
`release --set/--unset`) was never reflected.

Hence, whenever the release is successfully changed (via
updateConsumer()), delete the release status cache: the cache will be
refreshed whenever there is the need for it (e.g. when trying to expand
"$releasever" in repository URLs). Remove the cache before
RepoActionInvoker.update() is invoked, as it will update the
repositories, potentially asking for the release version to expand.

Remove also the release status cache on refresh, to make sure we fetch
it in case in the release status is changed server-side.

Backport of PR #3026 to 1.29.26.