### PR TITLE
[1.28.29] 2073558: clear the release cache on release change

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2317,6 +2317,7 @@ class ReleaseCommand(CliCommand):
         if self.options.unset:
             self.cp.updateConsumer(self.identity.uuid,
                         release="")
+            inj.require(inj.RELEASE_STATUS_CACHE).delete_cache()
             repo_action_invoker.update()
             print(_("Release preference has been unset"))
         elif self.options.release is not None:
@@ -2337,6 +2338,7 @@ class ReleaseCommand(CliCommand):
                     "No releases match '%s'.  "
                     "Consult 'release --list' for a full listing.")
                     % self.options.release)
+            inj.require(inj.RELEASE_STATUS_CACHE).delete_cache()
             repo_action_invoker.update()
             print(_("Release set to: %s") % self.options.release)
         elif self.options.list:

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1268,6 +1268,9 @@ class RefreshCommand(CliCommand):
             content_access_mode = inj.require(inj.CONTENT_ACCESS_MODE_CACHE)
             if content_access_mode.exists():
                 content_access_mode.delete_cache()
+            # Remove the release status cache, in case it was changed
+            # on the server; it will be fetched when needed again
+            inj.require(inj.RELEASE_STATUS_CACHE).delete_cache()
             if self.options.force is True:
                 # get current consumer identity
                 consumer_identity = inj.require(inj.IDENTITY)


### PR DESCRIPTION
Commit dd6eba0b1d6722d06967e1a7e8e65ccb9ba00858 fixed the usage of the
status cache, making sure it is properly used in more cases. One side
effect it happened was that the release status cache was used as it was,
and since nothing invalidates it, any release change (done with
`release --set/--unset`) was never reflected.

Hence, whenever the release is successfully changed (via
updateConsumer()), delete the release status cache: the cache will be
refreshed whenever there is the need for it (e.g. when trying to expand
"$releasever" in repository URLs). Remove the cache before
RepoActionInvoker.update() is invoked, as it will update the
repositories, potentially asking for the release version to expand.

Remove also the release status cache on refresh, to make sure we fetch
it in case in the release status is changed server-side.

Backport of PR #3026 to 1.28.29.