### PR TITLE
2077153: Cleanup old *.egg-info dirs in %post

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -1155,6 +1155,11 @@ fi
     %endif
 %endif
 
+%posttrans
+# Remove old *.egg-info empty directories not removed be previous versions of RPMs
+# due to this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1927245
+rmdir %{python_sitearch}/subscription_manager-*-*.egg-info --ignore-fail-on-non-empty
+
 %if %{use_subman_gui}
 %postun -n subscription-manager-gui
 if [ $1 -eq 0 ] ; then


### PR DESCRIPTION
This is a cherry-pick of commit 44b5902175 from main back to the subscription-manager-1.24 branch.
Without removing old directories that were not labelled as part of our package (but came from there anyways), it is possible to end up with more than one subscription-manager-*.egg-info directories. In that situation subscription-manager becomes inoperable unless the bad *.egg-info directory is removed manually.