### PR TITLE
cockpit: Read files in /var/lib/insights as superuser

### DIFF
--- a/cockpit/src/insights.jsx
+++ b/cockpit/src/insights.jsx
@@ -448,9 +448,11 @@ export class InsightsStatus extends React.Component {
         insights_service.addEventListener("changed", this.on_changed);
         last_upload_monitor.addEventListener("changed", this.on_changed);
 
-        this.hosts_details_file = cockpit.file("/var/lib/insights/host-details.json", { syntax: JSON });
+        this.hosts_details_file = cockpit.file("/var/lib/insights/host-details.json",
+                                               { syntax: JSON, superuser: true });
         this.hosts_details_file.watch(data => this.setState({ host_details: data }));
-        this.insights_details_file = cockpit.file("/var/lib/insights/insights-details.json", { syntax: JSON });
+        this.insights_details_file = cockpit.file("/var/lib/insights/insights-details.json",
+                                                  { syntax: JSON, superuser: true });
         this.insights_details_file.watch(data => this.setState({ insights_details: data }));
     }
 


### PR DESCRIPTION
Permissions of that directory have recently been narrowed.  The page
needs to be reloaded when the superuser level changes, so this
component does not need to follow along dynamically.