### PR TITLE
Remove print statements from test suite

### DIFF
--- a/test/syspurpose/test_syspurposefiles.py
+++ b/test/syspurpose/test_syspurposefiles.py
@@ -664,7 +664,6 @@ class TestSyncedStore(unittest.TestCase):
             self.assertTrue(synced_store.changed)
         mock_sync.assert_called_once()
         local_result = json.load(io.open(self.local_syspurpose_file, "r"))
-        print(local_result)
         self.assertTrue("cool" in local_result)
         self.assertEqual(local_result["cool"], "shark")
         self.assertTrue("foo" in local_result)

--- a/test/test_lock.py
+++ b/test/test_lock.py
@@ -69,8 +69,8 @@ class TestLock(unittest.TestCase):
     def close_lock_holder(self):
         try:
             self.other_process.communicate("whatever".encode("utf-8"))
-        except Exception as e:
-            print(e)
+        except Exception:
+            pass
             # whatever, we closed it in the other thread
 
     def timeout_fail(self):

--- a/test/test_ostree_content_plugin.py
+++ b/test/test_ostree_content_plugin.py
@@ -741,7 +741,6 @@ class TestOsTreeContents(fixture.SubManFixture):
         ent_src.product_tags = ["awesomeos-ostree-1", "awesomeos-ostree-super"]
 
         contents = find_content(ent_src, content_type=action_invoker.OSTREE_CONTENT_TYPE)
-        print("contents", contents)
         self.assertEqual(len(contents), 1)
 
         for content in contents:

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -1301,7 +1301,6 @@ class TestYumPluginManager(unittest.TestCase):
         """
         self.init_dnf_plugin_conf_files(conf_string=PKG_PLUGIN_CONF_FILE_DISABLED_INT)
         plugin_list = YumPluginManager.enable_pkg_plugins()
-        print(plugin_list)
         self.assertEqual(len(plugin_list), 2)
 
     @patch.object(repolib, "conf", ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))

--- a/test/test_rhsm_debug_command.py
+++ b/test/test_rhsm_debug_command.py
@@ -219,7 +219,6 @@ class TestCompileCommand(TestCliCommand):
             self.assertTrue(os.path.exists(path_join(path2, path_join(path1, "7890.pem"))))
             self.assertFalse(os.path.exists(path_join(path2, path_join(path1, "22222-key.pem"))))
         except Exception as e:
-            print(e)
             raise
         finally:
             self._rmtree(path1)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -469,7 +469,6 @@ class TestGetServerVersions(fixture.SubManFixture):
         self.mock_get_resources.side_effect = raise_exception
         MockUep.getStatus.return_value = {"version": "101", "release": "23423c"}
         sv = get_server_versions(MockUep)
-        print(sv)
         self.assertEqual(sv["server-type"], "Red Hat Subscription Management")
         self.assertEqual(sv["candlepin"], "Unknown")
 
@@ -900,7 +899,6 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
             # Allow our mock open function to be made to raise errors selectively
             for path in path_to_error.keys():
                 if path in original_path:
-                    print("raise the roof")
                     raise path_to_error.get(original_path)
             corrected_path = os.path.join(new_root, original_path)
             return original_open(corrected_path, *args[1:], **kwargs)


### PR DESCRIPTION
Unless I missed something, they were used for debugging and there is no
reason to keep them.