### PR TITLE
Run CI's pytest with verbose flag

### DIFF
--- a/jenkins/unit.sh
+++ b/jenkins/unit.sh
@@ -22,7 +22,7 @@ python3 setup.py build
 python3 setup.py build_ext --inplace
 
 # make sure we have a dbus session for the dbus tests
-dbus-run-session coverage run
+dbus-run-session coverage run -m pytest -v
 RETVAL="$?"
 coverage report
 coverage xml


### PR DESCRIPTION
When tests produce some unexpected output ("write to closed file") or
print a traceback, it is difficult to pinpoint which of them is the
cause, because we're randomizing their order every time.

By using verbose mode, we'll see exactly which test is misbehaving and
we can skip the part where we have to go looking for it.