### PR TITLE
2043331: Do not delete installed SCA cert during registration

### DIFF
--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -379,8 +379,10 @@ class Writer(object):
 
         key_filename = "%s-key.pem" % str(serial)
         key_path = Path.join(ent_dir_path, key_filename)
+        log.debug(f"Writing key file: '{key_path}'")
         key.write(key_path)
 
         cert_filename = "%s.pem" % str(serial)
         cert_path = Path.join(ent_dir_path, cert_filename)
+        log.debug(f"Writing certificate file: '{cert_path}'")
         cert.write(cert_path)


### PR DESCRIPTION
* Card ID: ENT-4726
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2043331
* This issue happens really rarely, but it can be pretty confusing.
  When SCA entitlement has changed during registration, then it
  could lead to deleting installed SCA certificate. Why?
  The subscription-manager asks for the list of available SCA
  certificate. Candlepin server responses with the list of
  serial numbers. The subscription-manager ask for the
  entitlement certificate(s) and candlepin returns certs. Problem
  is that candlepin server returns SCA certificate despite
  requested serial number does not exists, because the SCA
  certificate has changed meanwhile. The subscription-manager
  later compares serial number of returned certificate and
  it deletes just installed SCA cert, because it is not in
  the original list.
* Fixed this issue and added more debug prints.