### PR TITLE
Test-related flake8 changes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,7 @@
 [flake8]
+filename =
+    *.py,
+    */debian-stuff/katello,
 ignore =
     # E203 whitespace before ':'
     # result of black-formatted code
@@ -14,7 +17,9 @@ per-file-ignores =
     test/test_repolib.py: E402
     # trailing whitespace in test data
     test/certdata.py: W291
-exclude =
+extend-exclude =
     # cockpit bits downloaded during the cockpit CI run
     integration-tests/submancockpit/,
+    # virtualenvs for testing, e.g. as used in the jenkins CI
+    env-*,
 max-line-length = 110

--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,7 @@ cmdclass = {
     "gettext": GettextWithArgparse,
     "lint": lint.Lint,
     "lint_rpm": lint.RpmLint,
-    "flake8": lint.PluginLoadingFlake8,
+    "flake8": lint.Flake8,
 }
 
 setup(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@
 -e ./build_ext
 
 black==22.3.0
-flake8<4
+flake8
 pytest<7
 pytest-randomly
 pytest-timeout


### PR DESCRIPTION
- include `debian-stuff/katello` among the files checked by default by flake8
- switch from `exclude` to `extend-exclude` to not override the default excludes
- exclude possible virtualenvs
- simply call `flake8` to check for flake8 issues, rather than using its API (we don't have plugins)
- no more need to pin "flake8" to versions older than 4, as we can simply use it without issues now