### PR TITLE
2073354: Print correct status, when access mode has changed

### DIFF
--- a/src/rhsmlib/services/refresh.py
+++ b/src/rhsmlib/services/refresh.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+"""
+This module provides service for refreshing entitlement certificates
+"""
+
+
+import logging
+
+import subscription_manager.injection as inj
+from subscription_manager.entcertlib import EntCertActionInvoker
+
+log = logging.getLogger(__name__)
+
+
+class Refresh(object):
+    """
+    Class used for refreshing entitlement certificates
+    """
+
+    def __init__(self, cp=None, ent_cert_lib=None):
+        """
+        Initialize Refresh object
+        """
+        if cp is not None:
+            self.cp = cp
+        else:
+            cp_provider = inj.require(inj.CP_PROVIDER)
+            self.cp = cp_provider.get_consumer_auth_cp()
+        if ent_cert_lib is not None:
+            self.ent_cert_lib = ent_cert_lib
+        else:
+            self.ent_cert_lib = EntCertActionInvoker()
+
+    def refresh(self, force=False):
+        """
+        Try to refresh entitlement certificates installed on the system. This method
+        can raise some exceptions, when it wasn't possible to refresh entitlement
+        certificate(s).
+        :param force: Force regeneration of entitlement certificates on the server
+        :return: None
+        """
+
+        # First remove the content access mode cache to be sure we display
+        # SCA or regular mode correctly
+        content_access_mode = inj.require(inj.CONTENT_ACCESS_MODE_CACHE)
+        if content_access_mode.exists():
+            content_access_mode.delete_cache()
+
+        # Remove the release status cache, in case it was changed
+        # on the server; it will be fetched when needed again
+        inj.require(inj.RELEASE_STATUS_CACHE).delete_cache()
+
+        if force is True:
+            # Get current consumer identity
+            consumer_identity = inj.require(inj.IDENTITY)
+            # Force a regeneration of the entitlement certs for this consumer
+            if not self.cp.regenEntitlementCertificates(consumer_identity.uuid, True):
+                log.debug("Warning: Unable to refresh entitlement certificates; service likely unavailable")
+
+        self.ent_cert_lib.update()
+        log.debug("Refreshed local data")

--- a/src/subscription_manager/cli_command/refresh.py
+++ b/src/subscription_manager/cli_command/refresh.py
@@ -17,8 +17,8 @@
 import logging
 import os
 
+from rhsmlib.services.refresh import Refresh
 import rhsm.connection as connection
-import subscription_manager.injection as inj
 
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand, handle_exception
@@ -31,44 +31,22 @@ log = logging.getLogger(__name__)
 class RefreshCommand(CliCommand):
     def __init__(self):
         shortdesc = _("Pull the latest subscription data from the server")
-
         super(RefreshCommand, self).__init__("refresh", shortdesc, True)
-
         self.parser.add_argument("--force", action="store_true", help=_("force certificate regeneration"))
 
     def _do_command(self):
         self.assert_should_be_registered()
         try:
-            # Also remove the content access mode cache to be sure we display
-            # SCA or regular mode correctly
-            content_access_mode = inj.require(inj.CONTENT_ACCESS_MODE_CACHE)
-            if content_access_mode.exists():
-                content_access_mode.delete_cache()
-            # Remove the release status cache, in case it was changed
-            # on the server; it will be fetched when needed again
-            inj.require(inj.RELEASE_STATUS_CACHE).delete_cache()
-
-            if self.options.force is True:
-                # get current consumer identity
-                consumer_identity = inj.require(inj.IDENTITY)
-                # Force a regen of the entitlement certs for this consumer
-                if not self.cp.regenEntitlementCertificates(consumer_identity.uuid, True):
-                    log.debug(
-                        "Warning: Unable to refresh entitlement certificates; service likely unavailable"
-                    )
-
-            self.entcertlib.update()
-
-            log.debug("Refreshed local data")
-            print(_("All local data refreshed"))
+            refresh_service = Refresh(cp=self.cp, ent_cert_lib=self.entcertlib)
+            refresh_service.refresh(force=self.options.force)
         except connection.RestlibException as re:
             log.error(re)
-
             mapped_message: str = ExceptionMapper().get_message(re)
             system_exit(os.EX_SOFTWARE, mapped_message)
         except Exception as e:
             handle_exception(
                 _("Unable to perform refresh due to the following exception: {e}").format(e=e), e
             )
-
+        else:
+            print(_("All local data refreshed"))
         self._request_validity_check()

--- a/src/subscription_manager/cli_command/status.py
+++ b/src/subscription_manager/cli_command/status.py
@@ -22,6 +22,7 @@ from rhsm.certificate2 import CONTENT_ACCESS_CERT_TYPE
 from rhsm.connection import ConnectionException
 
 from rhsmlib.services import entitlement
+from rhsmlib.services.refresh import Refresh
 
 from subscription_manager import syspurposelib
 from subscription_manager.cli import system_exit
@@ -46,26 +47,28 @@ class StatusCommand(CliCommand):
             ),
         )
 
-    def _do_command(self):
-        # list status and all reasons it is not valid
+    def _get_date_cli_option(self):
+        """
+        Try to get and validate command line options date
+        :return: Return date or None, when date was not provided
+        """
         on_date = None
         if self.options.on_date:
             try:
                 on_date = entitlement.EntitlementService.parse_date(self.options.on_date)
             except ValueError as err:
                 system_exit(os.EX_DATAERR, err)
+        return on_date
+
+    def _print_status(self, service_status):
+        """
+        Print only status
+        :return: Print overall status
+        """
 
         print("+-------------------------------------------+")
         print("   " + _("System Status Details"))
         print("+-------------------------------------------+")
-
-        service_status = entitlement.EntitlementService(None).get_status(on_date)
-        reasons = service_status["reasons"]
-
-        if service_status["valid"]:
-            result = 0
-        else:
-            result = 1
 
         ca_message = ""
         has_cert = _(
@@ -73,11 +76,33 @@ class StatusCommand(CliCommand):
         )
 
         certs = self.entitlement_dir.list_with_content_access()
-        ca_certs = [cert for cert in certs if cert.entitlement_type == CONTENT_ACCESS_CERT_TYPE]
-        if ca_certs:
-            ca_message = has_cert
+        sca_certs = [cert for cert in certs if cert.entitlement_type == CONTENT_ACCESS_CERT_TYPE]
+        sca_mode_detected = False
+
+        refresh_service = Refresh(cp=self.cp, ent_cert_lib=self.entcertlib)
+
+        if sca_certs:
+            sca_mode_detected = True
         else:
+            # When there are no entitlement SCA certificates, but status_id is "disabled", then
+            # it means that content access mode has changed on the server and entitlement certificates
+            # have to be refreshed
+            if service_status["status_id"] == "disabled":
+                refresh_service.refresh()
             if is_simple_content_access(uep=self.cp, identity=self.identity):
+                sca_mode_detected = True
+
+        if sca_mode_detected is True:
+            # When SCA mode was detected using cache or installed SCA entitlement certificates, but status_id
+            # is not "disabled", then it means that content access mode has changed on the server and entitlement
+            # certificates have to be refreshed
+            status_id = service_status["status_id"]
+            if status_id != "disabled":
+                log.debug(
+                    f"Found SCA cert, but status ID is not 'disabled' ({status_id}). Refreshing entitlement certs..."
+                )
+                refresh_service.refresh()
+            else:
                 ca_message = has_cert
 
         print(
@@ -86,6 +111,14 @@ class StatusCommand(CliCommand):
             )
         )
 
+    def _print_reasons(self, service_status):
+        """
+        Print reasons for overall status
+        :param service_status:
+        :return: None
+        """
+        reasons = service_status["reasons"]
+
         columns = get_terminal_width()
         for name in reasons:
             print(format_name(name + ":", 0, columns))
@@ -93,6 +126,11 @@ class StatusCommand(CliCommand):
                 print("- {name}".format(name=format_name(message, 2, columns)))
             print("")
 
+    def _print_syspurpose_status(self, on_date):
+        """
+        Print syspurpose status
+        :return: None
+        """
         try:
             store = syspurposelib.get_sys_purpose_store()
             if store:
@@ -111,5 +149,26 @@ class StatusCommand(CliCommand):
                 for reason in reasons:
                     print("- {reason}".format(reason=reason))
         print("")
+
+    def _do_command(self):
+        """
+        Print status and all reasons it is not valid
+        """
+
+        # First get/check if provided date is valid
+        on_date = self._get_date_cli_option()
+
+        service_status = entitlement.EntitlementService(cp=self.cp).get_status(on_date)
+
+        self._print_status(service_status)
+
+        self._print_reasons(service_status)
+
+        self._print_syspurpose_status(on_date)
+
+        if service_status["valid"]:
+            result = 0
+        else:
+            result = 1
 
         return result

--- a/test/cli_command/test_status.py
+++ b/test/cli_command/test_status.py
@@ -1,9 +1,27 @@
 from subscription_manager import managercli
+from rhsm.certificate2 import CONTENT_ACCESS_CERT_TYPE
 
 from ..stubs import StubConsumerIdentity, StubUEP
 from ..fixture import SubManFixture, Capture
 
-from mock import Mock
+from mock import Mock, patch
+
+
+MOCK_SERVICE_STATUS_SCA = {
+    "status": "Disabled",
+    "status_id": "disabled",
+    "reasons": {},
+    "reason_ids": {},
+    "valid": True,
+}
+
+MOCK_SERVICE_STATUS_ENTITLEMENT = {
+    "status": "Current",
+    "status_id": "valid",
+    "reasons": {},
+    "reason_ids": {},
+    "valid": True,
+}
 
 
 class TestStatusCommand(SubManFixture):
@@ -12,6 +30,84 @@ class TestStatusCommand(SubManFixture):
     def setUp(self):
         super(TestStatusCommand, self).setUp()
         self.cc = self.command_class()
+        patcher = patch("subscription_manager.cli_command.status.entitlement")
+        self.entitlement_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.mock_entitlement_instance = Mock()
+        self.mock_entitlement_instance.get_status = Mock(return_value=MOCK_SERVICE_STATUS_SCA)
+        self.entitlement_mock.EntitlementService = Mock(return_value=self.mock_entitlement_instance)
+
+    def test_disabled_status_sca_mode(self):
+        """
+        Test status, when SCA mode is used
+        """
+        self.cc.consumerIdentity = StubConsumerIdentity
+        self.cc.cp = StubUEP()
+        self.cc.cp.setSyspurposeCompliance({"status": "disabled"})
+        self.cc.cp._capabilities = ["syspurpose"]
+        self.cc.options = Mock()
+        self.cc.options.on_date = None
+        mock_cert = Mock()
+        mock_cert.entitlement_type = CONTENT_ACCESS_CERT_TYPE
+        cert_list = [mock_cert]
+        self.cc.entitlement_dir = Mock()
+        self.cc.entitlement_dir.list_with_content_access = Mock(return_value=cert_list)
+        self.cc.entcertlib = Mock()
+        with Capture() as cap:
+            self.cc._do_command()
+        self.assertIn("Overall Status: Disabled", cap.out)
+        self.assertIn("Content Access Mode is set to Simple Content Access.", cap.out)
+        self.assertIn("This host has access to content, regardless of subscription status.", cap.out)
+        self.assertIn("System Purpose Status: Disabled", cap.out)
+
+    def test_current_status_entitlement_mode(self):
+        """
+        Test status, when old entitlement mode is used
+        """
+        # Note that server sent response with "Current" status
+        self.mock_entitlement_instance.get_status = Mock(return_value=MOCK_SERVICE_STATUS_ENTITLEMENT)
+        self.cc.consumerIdentity = StubConsumerIdentity
+        self.cc.cp = StubUEP()
+        self.cc.cp.setSyspurposeCompliance({"status": "valid"})
+        self.cc.cp._capabilities = ["syspurpose"]
+        self.cc.options = Mock()
+        self.cc.options.on_date = None
+        # There is not SCA certificate (only old entitlement)
+        mock_cert = Mock()
+        mock_cert.entitlement_type = "entitlement"
+        cert_list = [mock_cert]
+        self.cc.entitlement_dir = Mock()
+        self.cc.entitlement_dir.list_with_content_access = Mock(return_value=cert_list)
+        self.cc.entcertlib = Mock()
+        with Capture() as cap:
+            self.cc._do_command()
+        self.assertIn("Overall Status: Current", cap.out)
+        self.assertIn("System Purpose Status: Matched", cap.out)
+
+    def test_status_content_access_mode_changed(self):
+        """
+        Test status, when old entitlement mode is used
+        """
+        # Note that server sent response with "Current" status
+        self.mock_entitlement_instance.get_status = Mock(return_value=MOCK_SERVICE_STATUS_ENTITLEMENT)
+        self.cc.consumerIdentity = StubConsumerIdentity
+        self.cc.cp = StubUEP()
+        self.cc.cp.setSyspurposeCompliance({"status": "valid"})
+        self.cc.cp._capabilities = ["syspurpose"]
+        self.cc.options = Mock()
+        self.cc.options.on_date = None
+        # But entitlement directory still contain SCA certificate
+        mock_cert = Mock()
+        mock_cert.entitlement_type = CONTENT_ACCESS_CERT_TYPE
+        cert_list = [mock_cert]
+        self.cc.entitlement_dir = Mock()
+        self.cc.entitlement_dir.list_with_content_access = Mock(return_value=cert_list)
+        self.cc.entcertlib = Mock()
+        # sub-man should be able to resurrect from this situation
+        with Capture() as cap:
+            self.cc._do_command()
+        self.assertIn("Overall Status: Current", cap.out)
+        self.assertIn("System Purpose Status: Matched", cap.out)
 
     def test_purpose_status_success(self):
         self.cc.consumerIdentity = StubConsumerIdentity
@@ -20,6 +116,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.cp._capabilities = ["syspurpose"]
         self.cc.options = Mock()
         self.cc.options.on_date = None
+        self.cc.entcertlib = Mock()
         with Capture() as cap:
             self.cc._do_command()
         self.assertTrue("System Purpose Status: Matched" in cap.out)
@@ -31,6 +128,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.cp._capabilities = ["syspurpose"]
         self.cc.options = Mock()
         self.cc.options.on_date = None
+        self.cc.entcertlib = Mock()
         with Capture() as cap:
             self.cc._do_command()
         self.assertTrue("System Purpose Status: Unknown" in cap.out)
@@ -42,6 +140,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.cp._capabilities = []
         self.cc.options = Mock()
         self.cc.options.on_date = None
+        self.cc.entcertlib = Mock()
         with Capture() as cap:
             self.cc._do_command()
         self.assertTrue("System Purpose Status: Unknown" in cap.out)
@@ -55,6 +154,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.cp._capabilities = ["syspurpose"]
         self.cc.options = Mock()
         self.cc.options.on_date = None
+        self.cc.entcertlib = Mock()
         with Capture() as cap:
             self.cc._do_command()
         self.assertTrue("System Purpose Status: Mismatched" in cap.out)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2073354
* Card ID: ENT-4885
* When content access mode has changed from SCA mode to
  entitlement mode, then sub-man should resurrect from this
  situation gracefully, when status command is triggered
* Added new service refresh, because it is necessary to
  refresh certificate not only from refresh command, but
  status needs this functionality in edge cases too
* Refactored code of status command
* Fixed some unit tests
* Added unit tests for status command and for this case