### PR TITLE
flake8: ignore the build directory

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,6 +18,8 @@ per-file-ignores =
     # trailing whitespace in test data
     test/certdata.py: W291
 extend-exclude =
+    # default build directory
+    build/,
     # cockpit bits downloaded during the cockpit CI run
     integration-tests/submancockpit/,
     # virtualenvs for testing, e.g. as used in the jenkins CI


### PR DESCRIPTION
Make sure to not run flake8 on the Python sources in the build
directory, which is "build" by default.

Spotted while reviewing other PRs.