### PR TITLE
[1.28] spec: relax subscription-manager-rhsm-certificates requires

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -635,7 +635,7 @@ Requires: %{py_package_prefix}-dateutil
 Requires: %{py_package_prefix}-iniparse
 # rpm-python is an old name for python2-rpm but RHEL6 uses the old name
 Requires: %{py_package_prefix}-six
-Requires: subscription-manager-rhsm-certificates = %{version}-%{release}
+Requires: subscription-manager-rhsm-certificates
 # Required by Fedora packaging guidelines
 %{?python_provide:%python_provide %{py_package_prefix}-rhsm}
 %if %{with python3}
@@ -675,7 +675,7 @@ Requires: %{py2_package_prefix}-dateutil
 Requires: %{py2_package_prefix}-iniparse
 # rpm-python is an old name for python2-rpm but RHEL6 uses the old name
 Requires: %{py2_package_prefix}-six
-Requires: subscription-manager-rhsm-certificates = %{version}-%{release}
+Requires: subscription-manager-rhsm-certificates
 # Required by Fedora packaging guidelines
 %{?python_provide:%python_provide %{py2_package_prefix}-rhsm}
 Requires: rpm-python


### PR DESCRIPTION
Soon subscription-manager-rhsm-certificates will be moved to an own
repository with a different versioning scheme, and thus the strict
versioning here will not work.

subscription-manager-rhsm-certificates contains only certificates for
the remote RHSM server, so there is no need to require a strict version
anyway.

(cherry picked from commit 4ca19853199f60c59e6a6f9fdadfa684a96335b5)

Backport to 1.28 of one commit from PR #3004 to ease future downstream work.