### PR TITLE
ENT-4700: Switch away from 'imp'

### DIFF
--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -11,7 +11,7 @@
 #
 import logging
 
-import imp
+import importlib.util
 import rpm
 import os.path
 from rhsm import ourjson as json
@@ -34,11 +34,7 @@ try:
 except ImportError:
     yum = None
 
-try:
-    imp.find_module("zypp_plugin")
-    use_zypper = True
-except ImportError:
-    use_zypper = False
+use_zypper: bool = importlib.util.find_spec("zypp_plugin") is not None
 
 if use_zypper:
     REPOSITORY_PATH = "/etc/rhsm/zypper.repos.d/redhat.repo"


### PR DESCRIPTION
* Card ID: ENT-4700

'imp' module is deprecated since Python 3.4, and will be removed in near
future (it was initially scheduled to be removed in 3.8). Because we are
just testing if 'zypp_plugin' exists, we can use plain importlib call.