### PR TITLE
2076914: Translate two error messages

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -849,9 +849,10 @@ class BaseRestLib(object):
                         raise
                 except socket.gaierror as err:
                     if self.proxy_hostname and self.proxy_port:
+                        proxy_hostname = normalized_host(self.proxy_hostname)
+                        proxy_port = safe_int(self.proxy_port)
                         raise ProxyException(
-                            "Unable to connect to: %s:%s %s "
-                            % (normalized_host(self.proxy_hostname), safe_int(self.proxy_port), err)
+                            _(f"Unable to connect to: {proxy_hostname}:{proxy_port} {err}")
                         )
                     raise
                 except (socket.error, OSError) as err:
@@ -859,9 +860,10 @@ class BaseRestLib(object):
                     # then the issue was the connection to the proxy, not to the
                     # destination host.
                     if isinstance(err, ConnectionError) and self.proxy_hostname and self.proxy_port:
+                        proxy_hostname = normalized_host(self.proxy_hostname)
+                        proxy_port = safe_int(self.proxy_port)
                         raise ProxyException(
-                            "Unable to connect to: %s:%s %s "
-                            % (normalized_host(self.proxy_hostname), safe_int(self.proxy_port), err)
+                            _(f"Unable to connect to: {proxy_hostname}:{proxy_port} {err}")
                         )
                     code = httplib.PROXY_AUTHENTICATION_REQUIRED.value
                     if str(code) in str(err):


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2076914
* Card ID: ENT-4943
* Two error messages marked with `_()` to be translated
* Issue with untranslated string in Cockpit plugin has been fixed in this PR: https://github.com/candlepin/subscription-manager-cockpit/pull/23