### PR TITLE
[1.28] cockpit: insights: fix displaying of `insights-client` errors/messages

### DIFF
--- a/cockpit/src/insights.jsx
+++ b/cockpit/src/insights.jsx
@@ -48,8 +48,23 @@ export function detect() {
     return cockpit.spawn([ "which", "insights-client" ], { err: "ignore" }).then(() => true, () => false);
 }
 
-export function catch_error(err) {
-    let msg = err.toString();
+/*
+ * Simple helper to get the string representation of the error of
+ * cockpit.spawn(), to be used as catch() handler.
+ */
+function spawn_error_to_string(err, data) {
+    // a problem in starting/running the process: get its string representation
+    // from cockpit directly
+    if (err.problem) {
+        return cockpit.message(err);
+    }
+    // the process ran correctly, and exited with a non-zero code: get its
+    // combined stdout + stderr
+    return data;
+}
+
+export function catch_error(err, data) {
+    let msg = spawn_error_to_string(err, data);
     // The insights-client frequently dumps
     // Python backtraces on us. Make them more
     // readable by wrapping the text in <pre>.

--- a/cockpit/src/insights.jsx
+++ b/cockpit/src/insights.jsx
@@ -254,7 +254,23 @@ function show_connect_dialog() {
                     caption: _("Connect"),
                     style: "primary",
                     clicked: (update_progress) => {
-                        return PK.install_missing_packages(install_data, update_install_progress(update_progress)).then(() => register(update_progress));
+                        return PK.install_missing_packages(install_data, update_install_progress(update_progress)).then(() =>
+                            new Promise((resolve, reject) => {
+                                register(update_progress)
+                                        .then(() => resolve())
+                                        .catch((err, data) => {
+                                            let msg = spawn_error_to_string(err, data);
+                                            // create a fake error object good enough
+                                            // to be caught by the catch() handler of
+                                            // actions of cockpit.DialogFooter
+                                            let new_err = { };
+                                            new_err.message = msg;
+                                            new_err.toString = function() {
+                                                return this.message;
+                                            };
+                                            reject(new Error(new_err));
+                                        })
+                            }));
                     },
                     disabled: checking_install,
                 }

--- a/cockpit/src/insights.jsx
+++ b/cockpit/src/insights.jsx
@@ -65,11 +65,13 @@ function spawn_error_to_string(err, data) {
 
 export function catch_error(err, data) {
     let msg = spawn_error_to_string(err, data);
-    // The insights-client frequently dumps
-    // Python backtraces on us. Make them more
-    // readable by wrapping the text in <pre>.
+    // usually the output of insights-client contains more than a single
+    // line; hence, put each line in its own paragraph, so the error message
+    // is displayed in the same format of what insights-client outputs
     if (msg.indexOf("\n") > 0)
-        msg = <pre>{msg}</pre>;
+        msg = msg.split("\n").map(line => {
+            return <p>{line}</p>;
+        });
     subscriptionsClient.setError("error", msg);
 }
 

--- a/cockpit/src/insights.jsx
+++ b/cockpit/src/insights.jsx
@@ -78,7 +78,7 @@ function ensure_installed(update_progress) {
 
 export function register(update_progress) {
     return ensure_installed(update_progress).then(() => {
-        const proc = cockpit.spawn([ "insights-client", "--register" ], { superuser: true, err: "message" });
+        const proc = cockpit.spawn([ "insights-client", "--register" ], { superuser: true, err: "out" });
         if (update_progress)
             update_progress(_("Connecting to Insights"), () => { proc.close() });
         return proc;
@@ -87,7 +87,7 @@ export function register(update_progress) {
 
 export function unregister() {
     if (insights_timer.enabled) {
-        return cockpit.spawn([ "insights-client", "--unregister" ], { superuser: true, err: "message" })
+        return cockpit.spawn([ "insights-client", "--unregister" ], { superuser: true, err: "out" })
                 .catch(catch_error);
     } else {
         return cockpit.resolve();

--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -534,7 +534,7 @@ class SubscriptionsView extends React.Component {
                 severity = "danger";
             error = (
                 <AlertGroup isToast>
-                    <Alert isLiveRegion variant={severity} title={this.props.error.msg.toString()}
+                    <Alert isLiveRegion variant={severity} title={this.props.error.msg}
                         actionClose={<AlertActionCloseButton onClose={this.props.dismissError} />} />
                 </AlertGroup>
             );


### PR DESCRIPTION
Recent versions of insights-client started to produce the errors messages on stdout rather than stderr, and thus nothing was shown anymore to the users on failures.

To fix this, massage a bit the code that handles the failures of `cockpit.spawn()`:
- merge stderr with stdout
- add (and use) an helper function to properly format an error string from the catch() handler of a `cockpit.spawn()` promise, properly using the process stdout/stderr
- fix the multiline display for errors in the floating `<Alert>`
- properly handle the error message from actions in the Insights dialog itself

Please refer to the single commits for longer explanations.

This is how the floating `<Alert>` appears:

![error-floating](https://user-images.githubusercontent.com/6048552/167395145-79b59094-d1ca-4ed1-81fe-5cabc99b6f8e.png)

This is how the Insights dialog appears:

![error-inline](https://user-images.githubusercontent.com/6048552/167395168-c107c83f-dbd7-4d57-9f1a-a649d3f66ad5.png)

The only problem is that, due to the current version of the cockpit components in use (253), `cockpit.DialogFooter` can only fill the title of its `<Alert>` elements, and I have found no way to make multiline text properly formatted. This will be doable once we upgrade to at least cockpit 267 for the components, as `cockpit.DialogFooter` since that version supports filling the details of `<Alert>` objects. Updating to a newer version of the cockpit components is theoretically doable, however it involves more checking and potential adapting, as the cockpit components have no API stability (that's why a precise version is used).

Card ID: ENT-2695
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1859232

Backport of commits from subscription-manager-cockpit:
- https://github.com/candlepin/subscription-manager-cockpit/pull/20