### PR TITLE
2092014: Disable progress messages when sub-man RPM is not installed

### DIFF
--- a/src/rhsm/utils.py
+++ b/src/rhsm/utils.py
@@ -23,7 +23,26 @@ import urllib.parse
 
 import rhsm.config
 from rhsm.config import DEFAULT_PROXY_PORT
-import subscription_manager.injection as inj
+
+try:
+    import subscription_manager.injection as inj
+except ImportError:
+
+    class inj:
+        """Fake injection used for progress messages.
+
+        When subscription-manager is not installed, the import will fail.
+        This fallback solution disables the progress messages completely;
+        that feature is primarily targeted at subscription-manager, but has been
+        placed into rhsm package for technical reasons.
+        """
+
+        PROGRESS_MESSAGES: str = "PROGRESS_MESSAGES"
+        enabled: bool = False
+
+        @classmethod
+        def require(cls, *args, **kwargs) -> bool:
+            return cls.enabled
 
 
 def remove_scheme(uri):

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -206,6 +206,7 @@ class SubManFixture(unittest.TestCase):
         inj.provide(inj.RELEASE_STATUS_CACHE, stubs.StubReleaseStatusCache())
         inj.provide(inj.AVAILABLE_ENTITLEMENT_CACHE, stubs.StubAvailableEntitlementsCache())
         inj.provide(inj.PROFILE_MANAGER, stubs.StubProfileManager())
+        inj.provide(inj.PROGRESS_MESSAGES, False)
         # By default set up an empty stub entitlement and product dir.
         # Tests need to modify or create their own but nothing should hit
         # the system.

--- a/test/rhsm/unit/test_connection.py
+++ b/test/rhsm/unit/test_connection.py
@@ -492,6 +492,7 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(expected_guestIds, resultGuestIds)
 
     def test_bad_ca_cert(self):
+        inj.provide(inj.PROGRESS_MESSAGES, False)
         with open(os.path.join(self.temp_ent_dir, "foo.pem"), "w+") as cert:
             cert.write("xxxxxx\n")
         with open(os.path.join(self.temp_ent_dir, "foo-key.pem"), "w+") as key:


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2092014
* Card ID: ENT-240

This is addition to the main PR #3003. subscription-manager may be not
available in some cases, rhsm can be used on its own. We need to take
into account these situations.

By having a fallback scenario we can ensure that this module will work
as intended.