### PR TITLE
[1.28] 2076522: enable sslverifystatus on repos if advertized by CP

### DIFF
--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -64,6 +64,7 @@ class Repo(dict):
             'sslcacert': (0, None),
             'sslclientkey': (0, None),
             'sslclientcert': (0, None),
+            "sslverifystatus": (1, None),
             'metadata_expire': (1, None),
             'enabled_metadata': (1, '0'),
             'proxy': (0, None),

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -342,6 +342,7 @@ class RepoUpdateActionCommand(object):
         self.ent_source = ent_cert.EntitlementDirEntitlementSource()
 
         self.cp_provider = inj.require(inj.CP_PROVIDER)
+        self.uep = None
 
         self.manage_repos = 1
         self.apply_overrides = apply_overrides
@@ -384,14 +385,18 @@ class RepoUpdateActionCommand(object):
             if cache_only:
                 status = override_cache.read_cache_only()
             else:
-                self.uep = self.cp_provider.get_consumer_auth_cp()
-                status = override_cache.load_status(self.uep, self.identity.uuid)
+                status = override_cache.load_status(self.get_consumer_auth_cp(), self.identity.uuid)
 
             for item in status or []:
                 # Don't iterate through the list
                 if item['contentLabel'] not in self.overrides:
                     self.overrides[item['contentLabel']] = {}
                 self.overrides[item['contentLabel']][item['name']] = item['value']
+
+    def get_consumer_auth_cp(self):
+        if self.uep is None:
+            self.uep = self.cp_provider.get_consumer_auth_cp()
+        return self.uep
 
     def perform(self):
         # the [rhsm] manage_repos can be overridden to disable generation of the

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -506,9 +506,15 @@ class RepoUpdateActionCommand(object):
         # cache_only as well.
         release_source = YumReleaseverSource()
 
+        # query whether OCSP stapling is advertized by CP for the repositories
+        has_ssl_verify_status = self.get_consumer_auth_cp().has_capability("ssl_verify_status")
+
         for content in matching_content:
             repo = Repo.from_ent_cert_content(content, baseurl, ca_cert,
                                               release_source)
+
+            if has_ssl_verify_status:
+                repo["sslverifystatus"] = "1"
 
             # overrides are yum repo only at the moment, but
             # content sources will likely need to learn how to

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -677,6 +677,26 @@ class RepoUpdateActionTests(fixture.SubManFixture):
         update_action.update_repo(old_repo, new_repo)
         self.assertFalse('somekey' in old_repo)
 
+    @patch.object(RepoUpdateActionCommand, "get_consumer_auth_cp")
+    def test_no_ssl_verify_status(self, mock_get_consumer_auth_cp):
+        mock_cp = Mock()
+        mock_cp.has_capability = Mock(return_value=False)
+        mock_get_consumer_auth_cp.return_value = mock_cp
+        update_action = RepoUpdateActionCommand()
+        content = update_action.get_all_content(baseurl="http://example.com", ca_cert=None)
+        c1 = self._find_content(content, "c1")
+        self.assertIsNone(c1["sslverifystatus"])
+
+    @patch.object(RepoUpdateActionCommand, "get_consumer_auth_cp")
+    def test_with_ssl_verify_status(self, mock_get_consumer_auth_cp):
+        mock_cp = Mock()
+        mock_cp.has_capability = Mock(return_value=True)
+        mock_get_consumer_auth_cp.return_value = mock_cp
+        update_action = RepoUpdateActionCommand()
+        content = update_action.get_all_content(baseurl="http://example.com", ca_cert=None)
+        c1 = self._find_content(content, "c1")
+        self.assertEqual("1", c1["sslverifystatus"])
+
 
 class TidyWriterTests(unittest.TestCase):
 


### PR DESCRIPTION
An upcoming change to Candlepin is the addition of a capability to 
advertize the possibility to perform OCSP checking when connecting to 
its repositories. If it is possible, set the "sslverifystatus" repo key
to "1", as dnf supports it already.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2076522
Card ID: ENT-4996

The corresponding implementation in Candlepin is done by:
- PR: https://github.com/candlepin/candlepin/pull/3332

Backport of PR #3050 to 1.28.