### PR TITLE
[1.28] 1822242: cockpit: fix/simplify the loading/error view checks

### DIFF
--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -485,27 +485,22 @@ class SubscriptionStatus extends React.Component {
  */
 class SubscriptionsView extends React.Component {
     /*
-     * This method has the following arguments: loaded, status and status_msg, because.
-     * Using properties is not safe here due to asynchronous changes. Using properties
-     * (this.props.status, etc.) for decision here could lead to invalid state.
+     * Render a "loading" view.
      */
-    renderCurtains(loaded, status, status_msg) {
-        let loading = false;
+    renderLoading() {
+        let message = _("Updating");
+        let description = _("Retrieving subscription status...");
+        return <EmptyStatePanel paragraph={description} loading title={message} />;
+    }
+
+    /*
+     * Render an error view representing an error status & message.
+     */
+    renderError(status, status_msg) {
         let description;
         let message;
 
-        if (!loaded &&
-            (status === undefined ||
-             status === 'valid' ||
-             status === 'invalid' ||
-             status === 'partial' ||
-             status === 'disabled' ||
-             status === 'unknown'))
-        {
-            loading = true;
-            message = _("Updating");
-            description = _("Retrieving subscription status...");
-        } else if (status === "service-unavailable") {
+        if (status === "service-unavailable") {
             message = _("The rhsm service is unavailable. Make sure subscription-manager is installed " +
                 "and try reloading the page. Additionally, make sure that you have checked the " +
                 "'Reuse my password for privileged tasks' checkbox on the login page.");
@@ -523,7 +518,7 @@ class SubscriptionsView extends React.Component {
             );
         }
 
-        return <EmptyStatePanel icon={loading ? null : ExclamationCircleIcon} paragraph={description} loading={loading} title={message} />;
+        return <EmptyStatePanel icon={ExclamationCircleIcon} paragraph={description} loading={false} title={message} />;
     }
 
     renderSubscriptions() {
@@ -557,12 +552,12 @@ class SubscriptionsView extends React.Component {
         let status = this.props.status;
         let status_msg = this.props.status_msg;
         let loaded = subscriptionsClient.config.loaded;
-        if (!loaded ||
-            status === undefined ||
-            status === 'not-found' ||
+        if (status === 'not-found' ||
             status === 'access-denied' ||
             status === 'service-unavailable') {
-            return this.renderCurtains(loaded, status, status_msg);
+            return this.renderError(status, status_msg);
+        } else if (!loaded || status === undefined) {
+            return this.renderLoading();
         } else {
             return this.renderSubscriptions();
         }


### PR DESCRIPTION
Even after commit 30bf4e9f1bcc106c4658cb5a04a3827d7e93c6c9 and
commit 6b544fda121c7c4fe3fa6a617f4e5bf7f007d520, the situation of the
main curtain view still remained a bit flaky: in particular, if the
configuration was loaded before the subscription status, there would be
a (brief) flash of the view "couldn't get system subscription status".

There is a bit of duplicated logic for loaded & status in `render()` and
`renderCurtains()`, plus the logic did not even consider all the cases
correctly, so let's try to reorganize & simplify this a bit.
In particular:
- split the creation of a "loading view" and an "error view" in own
  function: this will make it easier to call the right one when needed
- move all the checks for the status (excluding the ones needed for the
  actual error to show in the "error view") directly in `render()`, which
  will make it easier to pick the right view
- first check for a known error, showing the "error view" in that case;
  there is no need to check for "loaded", as it does not matter for that
- then, when either the config was not loaded or the status is not
  determined yet, consider it as loading, showing the "loading view"
- in any other case we have that the config was loaded and the status is
  not a known error status, hence we consider that as fully loaded
  showing the subscriptions

This should hopefully fix the loading/error/loaded view in the plugin,
switching status only when needed without extra "glitches".

(cherry picked from commit 928229720dace8a8c392f4f3574df6a998fa5e88 in
the subscription-manager-cockpit repository)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1822242
Card ID: ENT-4766

Backport of commits from subscription-manager-cockpit:
- https://github.com/candlepin/subscription-manager-cockpit/pull/27