### PR TITLE
[1.28] i18n fixes for cockpit

### DIFF
--- a/build_ext/build_ext/i18n.py
+++ b/build_ext/build_ext/i18n.py
@@ -190,7 +190,7 @@ class Gettext(BaseCommand):
             ('%s.c_files', self.find_c, 'C', ['-k_', '-kN_']),
             ('%s.py_files', self.find_py, 'Python', []),
             ('%s.glade_files', self.find_glade, 'Glade', []),
-            ('%s.js_files', self.find_js, 'JavaScript', []),
+            ('%s.js_files', self.find_js, 'C', ['-k_', '-kN_', '-kngettext:1,2,3t']),
         ]
 
         for manifest_template, search_func, language, other_options in trans_types:

--- a/cockpit/src/subscriptions-view.jsx
+++ b/cockpit/src/subscriptions-view.jsx
@@ -501,9 +501,9 @@ class SubscriptionsView extends React.Component {
         let message;
 
         if (status === "service-unavailable") {
-            message = _("The rhsm service is unavailable. Make sure subscription-manager is installed " +
-                "and try reloading the page. Additionally, make sure that you have checked the " +
-                "'Reuse my password for privileged tasks' checkbox on the login page.");
+            message = _("The rhsm service is unavailable. Make sure subscription-manager is installed \
+and try reloading the page. Additionally, make sure that you have checked the \
+'Reuse my password for privileged tasks' checkbox on the login page.");
             description = _("Unable to the reach the rhsm service.");
         } else if (status === 'access-denied') {
             message = _("Access denied");
@@ -511,8 +511,8 @@ class SubscriptionsView extends React.Component {
         } else {
             message = _("Unable to connect");
             description = cockpit.format(
-                _("Couldn't get system subscription status. Please ensure subscription-manager " +
-                    "is installed. Reported status: $0 ($1)"),
+                _("Couldn't get system subscription status. Please ensure subscription-manager \
+is installed. Reported status: $0 ($1)"),
                 status_msg,
                 status,
             );


### PR DESCRIPTION
Fix i18n issues in the cockpit plugin, so it is possible to run a proper message extraction (and thus translate all the messages):
- backport one commit from subscription-manager-cockpit:
  - https://github.com/candlepin/subscription-manager-cockpit/commit/acf48e9876416440563d100ab74504483a28a300
- switch to "C" as language for the JS sources, as "JavaScript" does not work properly with React
