### PR TITLE
2043331: [1.28] Do not delete installed SCA cert during registration

### DIFF
--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -383,8 +383,10 @@ class Writer(object):
 
         key_filename = '%s-key.pem' % str(serial)
         key_path = Path.join(ent_dir_path, key_filename)
+        log.debug(f"Writing key file: '{key_path}'")
         key.write(key_path)
 
         cert_filename = '%s.pem' % str(serial)
         cert_path = Path.join(ent_dir_path, cert_filename)
+        log.debug(f"Writing certificate file: '{cert_path}'")
         cert.write(cert_path)

--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -127,7 +127,7 @@ class EntCertUpdateAction(object):
         rogue_serials = self._find_rogue_serials(local, expected)
 
         self.delete(rogue_serials)
-        self.install(missing_serials)
+        installed_serials = self.install(missing_serials)
 
         log.info('certs updated:\n%s', self.report)
         self.syslog_results()
@@ -147,6 +147,8 @@ class EntCertUpdateAction(object):
                 # This addresses BZs: 1448855, 1450862
                 obsolete_certs = []
                 for cont_access_cert in content_access_certs:
+                    if cont_access_cert.serial in installed_serials:
+                        continue
                     if cont_access_cert.serial not in expected:
                         obsolete_certs.append(cont_access_cert)
                 if len(obsolete_certs) > 0:
@@ -178,7 +180,7 @@ class EntCertUpdateAction(object):
         cert_bundles = self.get_certificates_by_serial_list(missing_serials)
 
         ent_cert_bundles_installer = EntitlementCertBundlesInstaller(self.report)
-        ent_cert_bundles_installer.install(cert_bundles)
+        return ent_cert_bundles_installer.install(cert_bundles)
 
     def _find_content_access_certs(self):
         certs = self.ent_dir.list_with_content_access()
@@ -329,10 +331,14 @@ class EntitlementCertBundlesInstaller(object):
     def install(self, cert_bundles):
         """Fetch entitliement certs, install them, and update the report."""
         bundle_installer = EntitlementCertBundleInstaller(self.report)
+        installed_serials = []
         for cert_bundle in cert_bundles:
-            bundle_installer.install(cert_bundle)
+            cert_serial = bundle_installer.install(cert_bundle)
+            if cert_serial is not None:
+                installed_serials.append(cert_serial)
         self.exceptions = bundle_installer.exceptions
         self.post_install()
+        return installed_serials
 
     # TODO: add subman plugin slot,conduit,hooks
     def pre_install(self):
@@ -375,15 +381,18 @@ class EntitlementCertBundleInstaller(object):
         self.pre_install(bundle)
 
         cert_bundle_writer = Writer()
+        cert_serial = None
         try:
             key, cert = self.build_cert(bundle)
             cert_bundle_writer.write(key, cert)
-
             self.report.added.append(cert)
+            cert_serial = cert.serial
         except Exception as e:
             self.install_exception(bundle, e)
 
         self.post_install(bundle)
+
+        return cert_serial
 
     # TODO: add subman plugin, slot, and conduit
     def pre_install(self, bundle):


### PR DESCRIPTION
* Backport of #3039
  * Original commit: f21da0a92d2a1702c77a6f33a804964bb5256978
* Card ID: ENT-4810
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2043331
* This issue happens really rarely, but it can be pretty confusing.
  When SCA entitlement has changed during registration, then it
  could lead to deleting installed SCA certificate. Why?
  The subscription-manager asks for the list of available SCA
  certificate. Candlepin server responses with the list of
  serial numbers. The subscription-manager ask for the
  entitlement certificate(s) and candlepin returns certs. Problem
  is that candlepin server returns SCA certificate despite
  requested serial number does not exists, because the SCA
  certificate has changed meanwhile. The subscription-manager
  later compares serial number of returned certificate and
  it deletes just installed SCA cert, because it is not in
  the original list.
* Fixed this issue and added more debug prints.