### PR TITLE
ENT-5215: Handle errors raised in DNF plugin

### DIFF
--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -24,6 +24,7 @@ import tempfile
 import os
 from iniparse import ConfigParser
 
+import rhsm.connection
 from subscription_manager import repofile
 
 # repofile must be patched and reloaded to import AptRepofile, otherwise
@@ -707,6 +708,30 @@ class RepoUpdateActionTests(fixture.SubManFixture):
         content = update_action.get_all_content(baseurl="http://example.com", ca_cert=None)
         c1 = self._find_content(content, "c1")
         self.assertEqual("1", c1["sslverifystatus"])
+
+    @patch.object(RepoUpdateActionCommand, "get_consumer_auth_cp")
+    def test_with_ssl_verify_ConnectionException(self, mock_get_consumer_auth_cp):
+        """Test that network exception is handled and does not use SSL verification."""
+        mock_cp = Mock()
+        mock_cp.has_capability = Mock(side_effect=rhsm.connection.ConnectionException)
+        mock_get_consumer_auth_cp.return_value = mock_cp
+
+        update_action = RepoUpdateActionCommand()
+        content = update_action.get_all_content(baseurl="http://example.com", ca_cert=None)
+        c1 = self._find_content(content, "c1")
+        self.assertIsNone(c1["sslverifystatus"])
+
+    @patch.object(RepoUpdateActionCommand, "get_consumer_auth_cp")
+    def test_with_ssl_verify_ProxyException(self, mock_get_consumer_auth_cp):
+        """Test that proxy exception is handled and does not use SSL verification."""
+        mock_cp = Mock()
+        mock_cp.has_capability = Mock(side_effect=rhsm.connection.ProxyException)
+        mock_get_consumer_auth_cp.return_value = mock_cp
+
+        update_action = RepoUpdateActionCommand()
+        content = update_action.get_all_content(baseurl="http://example.com", ca_cert=None)
+        c1 = self._find_content(content, "c1")
+        self.assertIsNone(c1["sslverifystatus"])
 
 
 class TidyWriterTests(unittest.TestCase):


### PR DESCRIPTION
* Card ID: ENT-5215

On invalid proxy configuration (e.g. bad port or credentials, ...) our
DNF plugin would silently fail. Every time DNF is run, sub-man checks
its configuration and updates 'redhat.repo' file if there are changes.

One of recent changes was support for 'ssl_verify_status' capability,
providing OCSP stapling. When sub-man cannot contact its server due to
being misconfigured, exception is raised. DNF suppresses all exceptions
raised by its plugins, so the user was not notified of the crash.

Because the crash happened, 'redhat.repo' file was not updated and was
kept in original state. This commit now catches these exceptions, logs
them and disables the SSL verification for this invocation.