### PR TITLE
ENT-5271: Fix spelling of Candlepin API endpoint description

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -2143,7 +2143,7 @@ class UEPConnection(BaseConnection):
         Given a job id representing a candlepin JobStatus, cancel it.
         """
         method = "/jobs/%s" % (job_id)
-        results = self.conn.request_delete(method, description=_("Cancelling job"))
+        results = self.conn.request_delete(method, description=_("Canceling job"))
         return results
 
     def sanitize(self, url_param, plus=False):


### PR DESCRIPTION
Spellcheck run by QE flagged this as an issue. We should be using
American English for spelling.