### PR TITLE
Increase security level for zypper repos managed by sub-man

### DIFF
--- a/etc-conf/zypper.conf
+++ b/etc-conf/zypper.conf
@@ -3,7 +3,7 @@
 enabled = 1
 
 # When gpgcheck is set to 0, then 'gpgcheck' will be set to 0 in generated repo file too.
-gpgcheck = 0
+gpgcheck = 1
 
 # When repo_gpgcheck is set to 0, then 'repo_gpgcheck' will be set to 0 in generated repo file too.
 repo_gpgcheck = 0
@@ -11,8 +11,8 @@ repo_gpgcheck = 0
 # Enable/Disable autorefresh on all repositories
 autorefresh = 0
 
-# Set SSL verification method for gpgkey download. Valid values: "yes", "no", "host", "peer".
-# gpgkey-ssl-verify = 'yes'
+# Set SSL verification method for gpgkey download. Valid values: "yes", "no", "host", "peer" (without the quotes).
+gpgkey-ssl-verify = host
 
-# Set SSL verification method for repository usage. Valid values: "yes", "no", "host", "peer".
-# repo-ssl-verify = 'host'
+# Set SSL verification method for repository usage. Valid values: "yes", "no", "host", "peer" (without the quotes).
+# repo-ssl-verify = host


### PR DESCRIPTION
Increase the security mechanism for zypper repositories manged by subscription-manager.
gpgcheck should be done automatically, if the server is capable to do it. Setting gpgcheck to 0 does completely disable the gpgcheck.

According to https://github.com/openSUSE/libzypp/blob/master/zypp/media/MediaManager.h#L377 the gpg key validation 'host' check should work for private/public ssl certs. 

Additionally, the values need to be without the quotes - otherwise the download of the gpg key would fail. 