### PR TITLE
[1.29.26] webpack: Avoid md4 hash for OpenSSL 3 compatibility

### DIFF
--- a/cockpit/webpack.config.js
+++ b/cockpit/webpack.config.js
@@ -3,6 +3,10 @@ const copy = require("copy-webpack-plugin");
 const fs = require("fs");
 const TerserJSPlugin = require('terser-webpack-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
+// HACK: OpenSSL 3 does not support md4 any more, but webpack hardcodes it all over the place: https://github.com/webpack/webpack/issues/13572
+const crypto = require("crypto");
+const crypto_orig_createHash = crypto.createHash;
+crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
 const webpack = require("webpack");
 const CompressionPlugin = require("compression-webpack-plugin");
 const ESLintPlugin = require('eslint-webpack-plugin');


### PR DESCRIPTION
CentOS/RHEL 9 switched to OpenSSL 3, which does not support the `md4`
hash any more. webpack 5 hardcodes that in no less than 21 places, so
monkey-patch `crypto.createHash()` to substitute sha256 for md4.

Hack to work around https://github.com/webpack/webpack/issues/13572

Cherry-picked from subscription-manager-cockpit commit 8e480295a89

---

The 1.29.26 branch currently [fails like this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-3646-20220725-073543-8149e610-rhel-9-0-candlepin-subscription-manager-subscription-manager-1.29.26/log.html).