### PR TITLE
[1.28] Bump cockpit test API to 273 + run-tests scheduler fix

### DIFF
--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -165,6 +165,10 @@ password=foobar
         m.execute("systemctl start cockpit")
         m.spawn("/var/tmp/mock-insights", "mock-insights")
 
+        # HACK: older c-ws versions always log an assertion; https://github.com/cockpit-project/cockpit/pull/16765
+        if m.image == "rhel-8-5":
+            self.allow_journal_messages("json_object_get_string_member: assertion 'node != NULL' failed")
+
     def wait_subscription(self, product, is_subscribed):
         if is_subscribed is True:
             self.browser.wait_text(

--- a/integration-tests/run
+++ b/integration-tests/run
@@ -69,8 +69,9 @@ bots:
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time
+# 273 + https://github.com/cockpit-project/cockpit/commit/49a7122df2
 integration-test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 243
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 49a7122df205ab434bab884eb3a7be94d1a8e255
 	git archive FETCH_HEAD -- test/common | tar -x -C integration-tests --strip-components=1 -f -
 
 node_modules:

--- a/integration-tests/run
+++ b/integration-tests/run
@@ -28,7 +28,7 @@ SMBEXT_TAR=$(CURDIR)/dist/subscription-manager-build-extra.tar.gz
 TEST_NODE_MODULES = node_modules/chrome-remote-interface node_modules/sizzle
 
 check: prepare
-	integration-tests/common/run-tests --test-dir integration-tests
+	integration-tests/common/run-tests --test-dir integration-tests --track-naughties
 
 reset:
 	rm -f $(COCKPIT_TAR) $(SUBMAN_TAR) $(SMBEXT_TAR) $(VM_IMAGE)


### PR DESCRIPTION
In particular this improves the run-tests scheduler to work better on
our current infrastructure:
https://github.com/cockpit-project/cockpit/commit/49a7122df2

Backported from https://github.com/candlepin/subscription-manager-cockpit/commit/0dd1b1f5a6f7a6