### PR TITLE
Use dmidecode on aarch64

### DIFF
--- a/src/rhsmlib/facts/firmware_info.py
+++ b/src/rhsmlib/facts/firmware_info.py
@@ -17,11 +17,8 @@ import logging
 
 from rhsmlib.facts import dmiinfo
 from rhsmlib.facts import collector
-from uuid import UUID
 
 ARCHES_WITHOUT_DMI = ["ppc64", "ppc64le", "s390x"]
-ARCHES_WITH_ALTERNATE_UUID_LOC = ["aarch64"]
-ARCH_UUID_LOCATION = {"aarch64": "/sys/devices/virtual/dmi/id/product_uuid"}
 
 log = logging.getLogger(__name__)
 
@@ -38,34 +35,6 @@ class NullFirmwareInfoCollector(object):
 
     def get_all(self):
         return self.info
-
-
-class UuidFirmwareInfoCollector(collector.FactsCollector):
-    """
-    If we are on an arch where dmi.system.uuid is not collected
-    but is available in a directory, we will collect it here.
-    """
-
-    def __init__(self, prefix=None, testing=None, collected_hw_info=None):
-        super(UuidFirmwareInfoCollector, self).__init__(
-            prefix=prefix, testing=testing, collected_hw_info=collected_hw_info
-        )
-
-    def get_all(self):
-        uuidinfo = {}
-        try:
-            with open(ARCH_UUID_LOCATION[self.arch], "r") as uuid_file:
-                uuid = uuid_file.read().strip()
-            if uuid:
-                UUID(uuid)
-                uuidinfo["dmi.system.uuid"] = uuid
-        except ValueError as err:
-            log.error(
-                "Wrong UUID value: %s read from: %s, error: %s" % (uuid, ARCH_UUID_LOCATION[self.arch], err)
-            )
-        except Exception as e:
-            log.warning("Error reading system uuid information: %s", e, exc_info=True)
-        return uuidinfo
 
 
 class FirmwareCollector(collector.FactsCollector):
@@ -110,15 +79,12 @@ def get_firmware_collector(arch, prefix=None, testing=None, collected_hw_info=No
     ie, DmiFirmwareInfoProvider on intel platforms, and a
     NullFirmwareInfoProvider otherwise.
     """
-    # we could potential consider /proc/sysinfo as a FirmwareInfoProvider
+    # we could potentially consider /proc/sysinfo as a FirmwareInfoProvider
     # but at the moment, it is just firmware/dmi stuff.
 
     if arch in ARCHES_WITHOUT_DMI:
         log.debug("Not looking for DMI info since it is not available on '%s'" % arch)
         firmware_provider_class = NullFirmwareInfoCollector
-    elif arch in ARCHES_WITH_ALTERNATE_UUID_LOC:
-        log.debug("Looking in file structure for UUID for arch '%s'" % arch)
-        firmware_provider_class = UuidFirmwareInfoCollector
     else:
         firmware_provider_class = dmiinfo.DmidecodeFactCollector
 

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -10,7 +10,7 @@
 %global use_container_plugin 1
 %endif
 
-%global dmidecode_arches %{ix86} x86_64
+%global dmidecode_arches %{ix86} x86_64 aarch64
 
 %global completion_dir %{_datadir}/bash-completion/completions
 

--- a/test/rhsmlib/facts/test_collector.py
+++ b/test/rhsmlib/facts/test_collector.py
@@ -15,10 +15,9 @@ import unittest
 
 import platform
 import mock
-from test.fixture import open_mock, OPEN_FUNCTION
+from test.fixture import open_mock
 
 from rhsmlib.facts import collector, firmware_info
-from rhsmlib.facts.firmware_info import UuidFirmwareInfoCollector
 
 
 class GetArchTest(unittest.TestCase):
@@ -39,24 +38,3 @@ class GetArchTest(unittest.TestCase):
     def test_get_platform_specific_info_provider(self):
         info_provider = firmware_info.get_firmware_collector(arch=platform.machine())
         self.assertTrue(info_provider is not None)
-
-
-class GetNonDmiUuid(unittest.TestCase):
-    def test_get_aarch64_firmware_collector(self):
-        firmware_provider_class = firmware_info.get_firmware_collector(arch="aarch64")
-        self.assertTrue(isinstance(firmware_provider_class, UuidFirmwareInfoCollector))
-
-    @mock.patch(OPEN_FUNCTION, mock.mock_open(read_data="356B6CCC-30C4-11B2-A85C-BBB0CCD29F36"))
-    def test_get_aarch64_uuid_collection(self):
-        firmware_provider_class = firmware_info.get_firmware_collector(arch="aarch64")
-        firmware_provider_class.arch = "aarch64"
-        result = firmware_provider_class.get_all()
-        self.assertTrue(result["dmi.system.uuid"] == "356B6CCC-30C4-11B2-A85C-BBB0CCD29F36")
-
-    def test_get_aarch64_uuid_collection_no_file(self):
-        mock.mock_open(read_data="no file")
-        mock.mock_open.side_effect = IOError()
-        firmware_provider_class = firmware_info.get_firmware_collector(arch="aarch64")
-        firmware_provider_class.arch = "aarch64"
-        result = firmware_provider_class.get_all()
-        self.assertTrue("dmi.system.uuid" not in result)


### PR DESCRIPTION
* Card ID: ENT-5112
* The dmidecode is available on ARM64. Thus it make sense to
  use same approach, which is used on x86_64 platform and
  parse output of dmidecode
* Old code and old tests were dropped
* subscription-manager.spec file was modified