### PR TITLE
ENT-5286: Unify environment variable evaluation

### DIFF
--- a/src/cloud_what/_base_provider.py
+++ b/src/cloud_what/_base_provider.py
@@ -133,7 +133,7 @@ class BaseCloudProvider(object):
 
         # HTTP Session
         self._session = requests.Session()
-        if "SUBMAN_DEBUG_PRINT_RESPONSE" in os.environ:
+        if os.environ.get("SUBMAN_DEBUG_PRINT_RESPONSE", ""):
             self._session.hooks["response"].append(self._cb_debug_print_http_response)
 
         # In-memory cache of token. The token is simple string
@@ -351,10 +351,10 @@ class BaseCloudProvider(object):
         end_col = "\033[0m"
         msg = blue_col + "Making request: " + end_col
         msg += red_col + request.method + " " + request.url + end_col
-        if "SUBMAN_DEBUG_PRINT_REQUEST_HEADER" in os.environ:
+        if os.environ.get("SUBMAN_DEBUG_PRINT_REQUEST_HEADER", ""):
             headers = ", ".join("{}: {}".format(k, v) for k, v in request.headers.items())
             msg += blue_col + " {{{headers}}}".format(headers=headers) + end_col
-        if "SUBMAN_DEBUG_PRINT_REQUEST_BODY" in os.environ and request.body is not None:
+        if os.environ.get("SUBMAN_DEBUG_PRINT_REQUEST_BODY", "") and request.body is not None:
             msg += yellow_col + f" {request.body}" + end_col
         print()
         print(msg)
@@ -396,7 +396,7 @@ class BaseCloudProvider(object):
         http_req = requests.Request(method="GET", url=url, headers=headers)
         prepared_http_req = self._session.prepare_request(http_req)
 
-        if "SUBMAN_DEBUG_PRINT_REQUEST" in os.environ:
+        if os.environ.get("SUBMAN_DEBUG_PRINT_REQUEST", ""):
             self._debug_print_http_request(prepared_http_req)
 
         try:

--- a/src/cloud_what/providers/aws.py
+++ b/src/cloud_what/providers/aws.py
@@ -195,7 +195,7 @@ class AWSCloudProvider(BaseCloudProvider):
 
         http_req = requests.Request(method="PUT", url=self.CLOUD_PROVIDER_TOKEN_URL, headers=headers)
         prepared_http_req = self._session.prepare_request(http_req)
-        if "SUBMAN_DEBUG_PRINT_REQUEST" in os.environ:
+        if os.environ.get("SUBMAN_DEBUG_PRINT_REQUEST", ""):
             self._debug_print_http_request(prepared_http_req)
 
         try:

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -105,7 +105,7 @@ def in_container():
     """
     # For development in containers we must be able to turn container detection
     # off
-    if os.environ.get("SMDEV_CONTAINER_OFF", False):
+    if os.environ.get("SMDEV_CONTAINER_OFF", ""):
         return False
     # Known locations to check for as an easy way to detect whether
     # we are running in a container

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -772,7 +772,7 @@ class BaseRestLib(object):
         :return: None
         """
 
-        if "SUBMAN_DEBUG_PRINT_REQUEST" in os.environ:
+        if os.environ.get("SUBMAN_DEBUG_PRINT_REQUEST", ""):
             yellow_col = "\033[93m"
             blue_col = "\033[94m"
             green_col = "\033[92m"
@@ -793,7 +793,7 @@ class BaseRestLib(object):
                 auth = "undefined auth"
 
             if (
-                "SUBMAN_DEBUG_TCP_IP" in os.environ
+                os.environ.get("SUBMAN_DEBUG_TCP_IP", "")
                 and self.__conn is not None
                 and self.__conn.sock is not None
             ):
@@ -812,14 +812,14 @@ class BaseRestLib(object):
                     + f"{self.proxy_hostname}:{self.proxy_port}"
                     + end_col
                 )
-            if "SUBMAN_DEBUG_PRINT_REQUEST_HEADER" in os.environ:
+            if os.environ.get("SUBMAN_DEBUG_PRINT_REQUEST_HEADER", ""):
                 msg += blue_col + " %s" % final_headers + end_col
-            if "SUBMAN_DEBUG_PRINT_REQUEST_BODY" in os.environ and body is not None:
+            if os.environ.get("SUBMAN_DEBUG_PRINT_REQUEST_BODY", "") and body is not None:
                 msg += yellow_col + " %s" % body + end_col
             print()
             print(msg)
             print()
-            if "SUBMAN_DEBUG_SAVE_TRACEBACKS" in os.environ:
+            if os.environ.get("SUBMAN_DEBUG_SAVE_TRACEBACKS", ""):
                 debug_dir = Path("/tmp/rhsm/")
                 debug_dir.mkdir(exist_ok=True)
 
@@ -849,7 +849,7 @@ class BaseRestLib(object):
         :return: None
         """
 
-        if "SUBMAN_DEBUG_PRINT_RESPONSE" in os.environ:
+        if os.environ.get("SUBMAN_DEBUG_PRINT_RESPONSE", ""):
             print("%s %s" % (result["status"], result["headers"]))
             print(result["content"])
             print()

--- a/src/rhsm/logutil.py
+++ b/src/rhsm/logutil.py
@@ -68,7 +68,7 @@ class SubmanDebugLoggingFilter(object):
 
     def __init__(self, name):
         self.name = name
-        self.on = "SUBMAN_DEBUG" in os.environ
+        self.on = os.environ.get("SUBMAN_DEBUG", "") != ""
 
     def filter(self, record):
         return self.on

--- a/src/rhsm/utils.py
+++ b/src/rhsm/utils.py
@@ -446,7 +446,7 @@ class StatusMessage:
             self.quiet = True
         if not sys.stdout.isatty():
             self.quiet = True
-        if "SUBMAN_DEBUG_PRINT_REQUEST" in os.environ:
+        if os.environ.get("SUBMAN_DEBUG_PRINT_REQUEST", ""):
             self.quiet = True
 
     def print(self):

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -441,9 +441,7 @@ class ProfileManager(CacheManager):
         # If profile reporting is disabled from the environment, that overrides the setting in the conf file
         # If the environment variable is 0, defer to the setting in the conf file; likewise if the environment
         # variable is completely unset.
-        if "SUBMAN_DISABLE_PROFILE_REPORTING" in os.environ and os.environ[
-            "SUBMAN_DISABLE_PROFILE_REPORTING"
-        ].lower() in ["true", "1", "yes", "on"]:
+        if os.environ.get("SUBMAN_DISABLE_PROFILE_REPORTING", "").lower() in ["true", "1", "yes", "on"]:
             return False
         return conf["rhsm"].get_int("report_package_profile") == 1
 


### PR DESCRIPTION
* Card ID: ENT-5286

Make all environment variables false-y when they contain empty string.
This commit unifies the behavior, as SMDEV_CONTAINER_OFF already behaves
like this and is used by RHOSP as a workaround for Podman BZ 2097694.