### PR TITLE
ENT-4664: Ensure tests clean up after themselves

### DIFF
--- a/test/cli_command/test_attach.py
+++ b/test/cli_command/test_attach.py
@@ -12,32 +12,30 @@ from mock import patch
 # Test Attach and Subscribe are the same
 class TestAttachCommand(TestCliProxyCommand):
     command_class = managercli.AttachCommand
+    tempdir = None
+    tempfiles = []
 
     @classmethod
     def setUpClass(cls):
         # Create temp file(s) for processing pool IDs
-        cls.tempfiles = [tempfile.mkstemp(), tempfile.mkstemp(), tempfile.mkstemp()]
+        cls.tempdir = tempfile.TemporaryDirectory()
+        cls.tempfiles = [
+            tempfile.mkstemp(dir=cls.tempdir.name),
+            tempfile.mkstemp(dir=cls.tempdir.name),
+            tempfile.mkstemp(dir=cls.tempdir.name),
+        ]
 
-        os.write(
-            cls.tempfiles[0][0],
-            "pool1 pool2   pool3 \npool4\npool5\r\npool6\t\tpool7\n  pool8\n\n\n".encode("utf-8"),
-        )
+        os.write(cls.tempfiles[0][0], b"pool1 pool2   pool3 \npool4\npool5\r\npool6\t\tpool7\n  pool8\n\n\n")
         os.close(cls.tempfiles[0][0])
-
-        os.write(
-            cls.tempfiles[1][0],
-            "pool1 pool2   pool3 \npool4\npool5\r\npool6\t\tpool7\n  pool8\n\n\n".encode("utf-8"),
-        )
+        os.write(cls.tempfiles[1][0], b"pool1 pool2   pool3 \npool4\npool5\r\npool6\t\tpool7\n  pool8\n\n\n")
         os.close(cls.tempfiles[1][0])
-
-        # The third temp file syspurposeionally left empty for testing empty sets of data.
+        # The third temp file intentionally left empty for testing empty sets of data
         os.close(cls.tempfiles[2][0])
 
     @classmethod
     def tearDownClass(cls):
-        # Unlink temp files
-        for f in cls.tempfiles:
-            os.unlink(f[1])
+        cls.tempdir = None
+        cls.tempfiles = []
 
     def setUp(self):
         super(TestAttachCommand, self).setUp()

--- a/test/cli_command/test_service_level.py
+++ b/test/cli_command/test_service_level.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 
 from ..test_managercli import TestCliProxyCommand
@@ -87,9 +86,8 @@ class TestServiceLevelCommand(TestCliProxyCommand):
         mock_syspurpose.read.return_value = Mock()
         mock_syspurpose.return_value = self.mock_sp_store()
 
-        mock_etc_rhsm_dir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, mock_etc_rhsm_dir)
-        mock_syspurpose_file = os.path.join(mock_etc_rhsm_dir, "syspurpose/syspurpose.json")
+        mock_etc_rhsm_dir = tempfile.TemporaryDirectory()
+        mock_syspurpose_file = os.path.join(mock_etc_rhsm_dir.name, "syspurpose/syspurpose.json")
         syspurposelib.USER_SYSPURPOSE = mock_syspurpose_file
 
         self.cc.store = self.mock_sp_store()

--- a/test/rhsmlib/facts/test_kpatch.py
+++ b/test/rhsmlib/facts/test_kpatch.py
@@ -15,7 +15,6 @@ import unittest
 
 from mock import patch
 import tempfile
-import shutil
 import os
 
 from rhsmlib.facts import kpatch
@@ -23,16 +22,15 @@ from rhsmlib.facts import kpatch
 
 class TestKPatchCollector(unittest.TestCase):
     def setUp(self):
-        self.DIR_WITH_INSTALLED_KPATCH_MODULES = tempfile.mkdtemp()
+        self.dir_installed = tempfile.TemporaryDirectory()
+        self.DIR_WITH_INSTALLED_KPATCH_MODULES = self.dir_installed.name
         os.mkdir(os.path.join(self.DIR_WITH_INSTALLED_KPATCH_MODULES, "3.10.0-1062.el7.x86_64"))
         os.mkdir(os.path.join(self.DIR_WITH_INSTALLED_KPATCH_MODULES, "3.10.0-1062.1.1.el7.x86_64"))
         os.mkdir(os.path.join(self.DIR_WITH_INSTALLED_KPATCH_MODULES, "3.10.0-1062.1.2.el7.x86_64"))
-        self.DIRS_WITH_LOADED_MODULE = ["/path/to/not-existing-directory", tempfile.mkdtemp()]
-        os.mkdir(os.path.join(self.DIRS_WITH_LOADED_MODULE[1], "3.10.0-1062.el7.x86_64"))
 
-    def tearDown(self):
-        shutil.rmtree(self.DIRS_WITH_LOADED_MODULE[1])
-        shutil.rmtree(self.DIR_WITH_INSTALLED_KPATCH_MODULES)
+        self.dir_loaded = tempfile.TemporaryDirectory()
+        self.DIRS_WITH_LOADED_MODULE = ["/path/to/not-existing-directory", self.dir_loaded.name]
+        os.mkdir(os.path.join(self.DIRS_WITH_LOADED_MODULE[1], "3.10.0-1062.el7.x86_64"))
 
     @patch("shutil.which")
     def test_kpatch_is_not_installed(self, which):

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -17,7 +17,6 @@ from datetime import datetime, timedelta
 import io
 import mock
 import random
-import tempfile
 
 from rhsm import config
 from subscription_manager.cert_sorter import CertSorter
@@ -36,7 +35,6 @@ from subscription_manager.cache import (
     ContentAccessModeCache,
 )
 from subscription_manager.facts import Facts
-from subscription_manager.lock import ActionLock
 from rhsm.certificate import GMT
 from rhsm.certificate2 import Version
 from subscription_manager.certdirectory import EntitlementDirectory, ProductDirectory
@@ -138,10 +136,6 @@ config.CFG = StubConfig()
 
 # we are not actually reading test/rhsm.conf, it's just a placeholder
 config.CFG.read("test/rhsm.conf")
-
-
-class MockActionLock(ActionLock):
-    PATH = tempfile.mkstemp()[1]
 
 
 class StubProduct(Product):

--- a/test/test_lock.py
+++ b/test/test_lock.py
@@ -3,7 +3,6 @@ import unittest
 import os
 import subprocess
 import sys
-import shutil
 import tempfile
 import threading
 import time
@@ -20,9 +19,8 @@ class TestLock(unittest.TestCase):
         self.other_process = None
 
     def _lock_path(self):
-        tmp_dir = tempfile.mkdtemp(suffix="-lock", prefix="subman-unit-tests-")
-        self.addCleanup(shutil.rmtree, tmp_dir, ignore_errors=True)
-        return os.path.join(tmp_dir, self.lf_name)
+        self.lock_directory = tempfile.TemporaryDirectory()
+        return os.path.join(self.lock_directory.name, self.lf_name)
 
     # For thread.Timer()
     def _kill_other_process(self, other_process):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -3,7 +3,7 @@ import random
 from . import fixture
 from . import stubs
 
-from tempfile import mkdtemp
+import tempfile
 
 from mock import Mock, patch
 from rhsm.utils import (
@@ -856,8 +856,8 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
 
     def setUp(self):
         super(TestGetProcessNamesAndIsProcessRunning, self).setUp()
-        self.root_dir = mkdtemp()
-        self.proc_root = os.path.join(self.root_dir, "proc")
+        self.root_dir = tempfile.TemporaryDirectory()
+        self.proc_root = os.path.join(self.root_dir.name, "proc")
         os.mkdir(self.proc_root)
         # self.addCleanup(rmtree, self.root_dir)
         self.fake_pids = set()
@@ -918,7 +918,7 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
         this would be the place to do it
         """
         mock_proc_dirs = os.listdir(self.proc_root)
-        new_open = self.redirect_open(self.root_dir)
+        new_open = self.redirect_open(self.root_dir.name)
         os_patch = patch("subscription_manager.utils.os.listdir")
         m = os_patch.start()
         m.return_value = mock_proc_dirs
@@ -979,7 +979,7 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
         fake_process_name = "magic_process"
         self.create_fake_process_status(name=fake_process_name)
         ld = os.listdir(self.proc_root)
-        new_open = self.redirect_open(self.root_dir)
+        new_open = self.redirect_open(self.root_dir.name)
         os_patch = patch("subscription_manager.utils.os.listdir")
         m = os_patch.start()
         m.return_value = ld
@@ -1001,7 +1001,7 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
         ld = os.listdir(self.proc_root)
         errors = {"1337": IOError("Cannot access bad_path"), "8675309": Exception("AHHHH")}
         ld.extend(errors.keys())
-        new_open = self.redirect_open(self.root_dir, path_to_error=errors)
+        new_open = self.redirect_open(self.root_dir.name, path_to_error=errors)
         os_patch = patch("subscription_manager.utils.os.listdir")
         m = os_patch.start()
         m.return_value = ld


### PR DESCRIPTION
* Card ID: ENT-4664

By using high-level NamedTemporaryFile and TemporaryDirectory we can
prevent files from being left in /tmp, as they are deleted automatically
as soon as their objects are deleted.