### PR TITLE
Ensure tests don't fail when run under root

### DIFF
--- a/test/syspurpose/test_utils.py
+++ b/test/syspurpose/test_utils.py
@@ -28,6 +28,7 @@ class UtilsTests(unittest.TestCase):
     def tearDown(self):
         utils.HOST_CONFIG_DIR = "/etc/rhsm-host/"
 
+    @unittest.skipIf(os.getuid() == 0, "Test cannot be run under root.")
     def test_create_dir(self):
         """
         Verify that the create_dir utility method creates directories as we expect.

--- a/test/test_logutil.py
+++ b/test/test_logutil.py
@@ -10,6 +10,8 @@ from . import stubs
 
 from rhsm import logutil
 
+import unittest
+
 
 # no NullHandler in 2.6, include our own
 class NullHandler(logging.Handler):
@@ -186,6 +188,7 @@ class TestLogutil(fixture.SubManFixture):
         logutil.USER_LOGFILE_DIR = old_dir_path
         logutil.USER_LOGFILE_PATH = old_file_path
 
+    @unittest.skipIf(os.getuid() == 0, "Test cannot be run under root.")
     @mock.patch("os.getuid")
     def test_not_possible_to_create_root_log_dir_due_to_access_perm(self, MockGetUID):
         """
@@ -223,6 +226,7 @@ class TestLogutil(fixture.SubManFixture):
         logutil.LOGFILE_DIR = old_dir_path
         logutil.LOGFILE_PATH = old_file_path
 
+    @unittest.skipIf(os.getuid() == 0, "Test cannot be run under root.")
     @mock.patch("os.getuid")
     def test_not_possible_to_create_user_log_dir_due_to_access_perm(self, MockGetUID):
         """
@@ -260,6 +264,7 @@ class TestLogutil(fixture.SubManFixture):
         logutil.USER_LOGFILE_DIR = old_dir_path
         logutil.USER_LOGFILE_PATH = old_file_path
 
+    @unittest.skipIf(os.getuid() == 0, "Test cannot be run under root.")
     @mock.patch("os.getuid")
     def test_wrong_rhsm_log_priv(self, MockGetUID):
         """


### PR DESCRIPTION
Several tests fail when 'pytest' is run under root, even if they work
correctly when run as non-root user. By adding the new pytest marker
we can ensure that these tests are skipped, instead of raising false
alarms.

---

The usecase of these changes is rather small, this PR can be closed
if deemed not necessary. But recently I needed to run tests on RHEL
VM to find a bug source, and they kept failing. I could have created
non-root account, but setting it up would take a time in which I could
have solved the issue.