### PR TITLE
spec: remove redundant License from python3-cloud-what

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -350,9 +350,6 @@ entitlements, certificates, and access to content.
 Summary: Python package for detection of public cloud provider
 %if 0%{?suse_version}
 Group: Productivity/Networking/System
-License: GPL-2.0
-%else
-License: GPLv2
 %endif
 Requires: python3-requests
 %ifarch %{dmidecode_arches}


### PR DESCRIPTION
After the removal of the cockpit plugin (which is LGPL), all the
remaining bits are GPL-2, which is already specified for the source.

Hence, remove the License tag from python3-cloud-what, as it is exactly
as the License already specified.