### PR TITLE
2111035: Do not allow reusing TCP connection for rhsm.service

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -59,6 +59,8 @@ except ImportError:
 config = get_config_parser()
 MULTI_ENV = "multi_environment"
 
+REUSE_CONNECTION = True
+
 
 def safe_int(value, safe_value=None):
     try:
@@ -753,7 +755,10 @@ class BaseRestLib(object):
         # Do TCP and TLS handshake here before we make any request
         conn.connect()
         log.debug(f"Created connection: {conn.sock}")
-        self.__conn = conn
+
+        # Store connection object only in the case, when it is not forbidden
+        if REUSE_CONNECTION is True:
+            self.__conn = conn
 
         return conn
 

--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -19,6 +19,8 @@ import threading
 
 from rhsmlib.dbus import constants
 
+from rhsm import connection
+
 from gi.repository import GLib
 from functools import partial
 from rhsmlib.services import config
@@ -64,6 +66,12 @@ class Server(object):
         The object_classes argument is a list.  The list can contain either a class or a tuple consisting
         of a class and a dictionary of arguments to send that class's constructor.
         """
+
+        # Do not allow reusing connection, because server uses multiple threads. If reusing connection
+        # was used, then two threads could try to use the connection in the almost same time.
+        # It means that one thread could send request and the second one could send second request
+        # before the first thread received response. This could lead to raising exception CannotSendRequest.
+        connection.REUSE_CONNECTION = False
 
         init_logger(parser)
 


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2111035
* The rhsm.service usually opens new TCP connection for each
  D-Bus method call, but when rhsm.service tries to do some
  REST API call due to i-notify event, then multiple threads
  can try to do two REST API calls on the same connection
  in almost the same time. This caused raising
  CannotSendRequest, because one thread sent HTTP request
  and the second thread sent another HTTP request on the
  same HTTP connection before first thread received response.
* Partially fixes another BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2101510