### PR TITLE
Update repository documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,74 @@
+# Installation
+
+The subscription-manager codebase is on [GitHub](https://github.com/candlepin/subscription-manager).
+The project is built for the latest versions of Fedora (and submitted to Fedora Updates), CentOS Stream and RHEL.
+
+To install subscription-manager, run
+
+```bash
+sudo dnf install subscription-manager
+```
+
+## Developer installation
+
+The process below has been tested on Fedora 36.
+Other Fedora versions or distributions may require some adaptation.
+
+1. First you need to install RPM packages to build and run subscription-manager binaries:
+
+   ```bash
+   sudo dnf install git gcc python3-devel openssl-devel glib2-devel \
+       python3-rpm python3-librepo libdnf-devel cmake
+   ```
+
+   <!-- libdnf-devel, cmake are required to build product-id plugin -->
+
+2. Install Fedora's subscription-manager RPM and packages required to run the test suite:
+
+   ***NOTE**: Installing `subscription-manager` package is strictly not necessary, but it will pull down all dependencies and create all the files used by subscription-manager.*
+
+   ```bash
+   sudo dnf install subscription-manager dbus-daemon \
+       glibc-langpacks-de glibc-langpacks-ja
+   ```
+
+3. Install Python packages in virtual environment to prevent polluting userspace:
+ 
+   ***NOTE**: This step is optional.*
+
+   ```bash
+   sudo dnf install python3-pip
+   mkdir -p ~/.venvs/
+   python3 -m venv --system-site-packages ~/.venvs/subscription-manager
+   source ~/.venvs/subscription-manager/bin/activate
+   python3 -m pip install wheel
+   ```
+
+4. Clone the repository:
+
+   ```bash
+   git clone https://github.com/candlepin/subscription-manager.git
+   cd subscription-manager/
+   ```
+
+5. Build the project:
+
+   ```
+   ./setup.py build
+   ./setup.py build_ext --inplace
+   ```
+
+6. Test your local installation:
+
+   ```bash
+   sudo PYTHONPATH=./src python3 -m subscription_manager.scripts.subscription_manager
+   ```
+
+   You can setup an alias in `.bashrc` (or equivalent), so you can run it more easily:
+
+   ```bash
+   alias subscription-manager="sudo \
+       PYTHONPATH=/path/to/subscription-manager/src \
+       ~/.venvs/subscription-manager/bin/python3 \
+       -m subscription_manager.scripts.subscription_manager"
+   ```

--- a/README.md
+++ b/README.md
@@ -2,38 +2,19 @@ subscription-manager
 ====================
 
 The Subscription Manager package provides programs and libraries
-to allow users to manage subscriptions and yum repositories
-from the  Candlepin.
+to allow users to manage subscriptions and DNF repositories
+from the Candlepin.
 
- - http://candlepinproject.org/
- - https://fedorahosted.org/subscription-manager/
- - https://github.com/candlepin/subscription-Manager
+ - https://candlepinproject.org/
+ - https://github.com/candlepin/subscription-manager
 
 Local Installation
 ------------------
 
 In order to build, develop, and test locally, please follow
-[instructions at candlepinproject.org](http://www.candlepinproject.org/docs/subscription-manager/installation.html#installation-of-upstream-from-source-code).
+[INSTALL.md](INSTALL.md).
 
-For instructions on building the debian-packages of this project, see instructions in contrib/debian/README.source.
-
-Due to unintuitive behavior with `sys.path`
-(see https://github.com/asottile/scratch/wiki/PythonPathSadness),
-`python src/subscription_manager/scripts/subscription_manager.py` does not work
-as expected. One can run the script like this instead:
-
-```bash
-PYTHONPATH=./src python -m subscription_manager.scripts.subscription_manager
-```
-
-Similar for other bin scripts:
-
-```bash
-PYTHONPATH=./src python -m subscription_manager.scripts.rct
-# ... etc.
-```
-
-(You can also just export `PYTHONPATH` instead of setting it in each command).
+For instructions on building the debian-packages of this project, see instructions in [contrib/debian/README.source](contrib/debian/README.source).
 
 To ignore bulk commits that only change the format of the code, not the code
 itself (e.g. `black`ing whole codebase), add `.git-blame-ignore-revs` to your
@@ -42,84 +23,6 @@ git configuration:
 ```bash
 git config blame.ignoreRevsFile .git-blame-ignore-revs
 ```
-
-Pipenv
-------
-
-There is experimental support for installation of subscription-manager using
-Pipenv. We tested installing subscription-manager using Pipenv only on following
-operating systems:
-
-* Fedora 30
-* RHEL/CentOS 7
-* RHEL/CentOS 8
-
-We tested pipenv with Python 2 and Python 3. It is necessary to install following
-packages to your system, because binary module have to be compiled in virtual
-environment:
-
-### Python 2
-
-```bash
-dnf install -y pipenv gcc make python2-devel \
-    openssl-devel libnl3-devel
-```
-
-### Python 3
-
-```bash
-dnf install -y pipenv gcc make python3-devel \
-    openssl-devel libnl3-devel
-```
-
-You can create virtual environment using following steps:
-
-1. Create virtual environment using Python 2 or Python 3 and it is necessary to
-   use `--site-packages` argument, because virtual environment has to
-   use `rpm` Python package installed in your system. It is not possible
-   to install `rpm` Python package to virtual environment using pip/pipenv.
-
-   Python 2:
-
-   ```bash
-   pipenv --site-packages --two
-   ```
-
-   Python 3:
-
-   ```bash
-   pipenv --site-packages --three
-   ```
-
-2. Install required Python packages defined in `Pipfile` into virtual environment:
-
-   ```bash
-   pipevn install
-   ```
-
-3. Start virtual environment:
-
-   ```bash
-   pipenv shell
-   ```
-
-4. Build binary modules in virtual environment:
-
-   ```bash
-   python ./setup.py build
-   ```
-
-5. Install subscription-manager into virtual environment:
-
-   ```bash
-   python ./setup.py install
-   ```
-
-6. It should be possible to run subscription-manager in virtual environment
-
-   ```bash
-   sudo subscription-manager version
-   ```
 
 Development of the Subscription-Manager Deployment Ansible role
 ---------------------------------------------------------------

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,7 +1,5 @@
 # TESTING
 
-- [subscription-manager](#subscription-manager)
-
 ## subscription-manager
 
 ```bash
@@ -38,6 +36,12 @@ pytest -k cache
 pytest -k cache --no-summary
 ```
 
+To run tests in virtual machine or container without GUI, where DBus is not running, you can start it on-demand:
+
+```bash
+dbus-run-session pytest
+```
+
 ### Plugins
 
 - To disable pytest-randomly plugin, run
@@ -67,27 +71,10 @@ coverage html
 coverage xml
 ```
 
----
+## Further reading
 
-Following text may not be up to date.
+### Candlepin server
 
-# Testing of the game
-
-- [System testing](#system-testing)
-
-
-## System testing
-
-If you want to test subscription-manager in real life
-there is a few players in this game:
-
-- [candlepin server](#candlepin-server)
-- [tested machine](#tested-vm)
-- [proxy server](#proxy-server)
-- [RHSM services](#rhsm-services)
-
-### Initialization
-#### Candlepin server
 It is necessary to clone `candlepin` repo.
 
 ```shell
@@ -98,71 +85,6 @@ export CANDLEPIN_VAGRANT_NO_NFS=1
 export CANDLEPIN_DEPLOY_ARGS="-gTa"
 vagrant up
 ```
-See `README.md` in the repo for more details.
+
+See `README.md` in the repo or [their documentation](https://www.candlepinproject.org/docs/candlepin/developer_deployment.html) for more details.
 An URL of this server is `candlepin.example.com` by default.
-
-#### tested VM
-There is an env variable `SUBMAN_WITH_SYSTEM_TESTS` that enables system tests when a VM is provisioned.
-
-```shell
-cd ~/src/subscription-manager
-export SUBMAN_WITH_SYSTEM_TESTS=1
-vagrant up
-```
-An URL of this VM is `centos7.subman.example.com` by default.
-
-#### Proxy server
-This is an optional player. If you want to run test cases when a proxy is used it is necessary to use some proxy server.
-There is a vagrant box in Vagrantfile to make VM with squid auth proxy server.
-See in `vagrant/roles/proxy-server/default/main.yml` for username, password and more details.
-
-An URL of this server is `proxy-server.subman.example.com` and `squid` is listening on a port `3128`.
-
-```shell
-cd ~/src/subscription-manager
-vagrant up proxy-server
-```
-
-#### RHSM services
-
-RHSM services is a bunch of websocket services that offers a way to perfom some task inside a tested machine.
-The service is provisioned once you set a variable `SUBMAN_WITH_SYSTEM_TESTS=1` for `vagrant up`. 
-See [previous comment](#tested-vm).
-
-A base URL of the services is `ws:/centos7.subman.example.com:9091`. 
-
-There are a few services at the moment implemented:
-
-
-
-- a monitor of file changes
-
-  | what?      | that's it!                                                                                   |
-  |------------|----------------------------------------------------------------------------------------------|
-  | base url   | `ws://centos7.subman.example.com:9091/monitor/`                                              |
-  | an example | `ws://centos7.subman.example.com:9091/monitor//etc/rhsm/rhsm.conf`                           |
-  |            | `ws://centos7.subman.example.com:9091/monitor/etc/rhsm/rhsm.conf`                            |
-
-  > if you send something back to the connection it gives you back an actual content of the file
-
-- an execution of some command
-
-  | what?      | that's it!                                                                   |
-  |------------|------------------------------------------------------------------------------|
-  | base url   | `ws://centos7.subman.example.com:9091/execute/`                              |
-  | an example | `ws://centos7.subman.example.com:9091/execute//usr/bin/subscription-manager` |
-  |            | `ws://centos7.subman.example.com:9091/execute/usr/bin/subscription-manager`  |
-
-  > it is necessary to send args of the command after a connection is openned to execute the command 
-  
-  > for example: `register --username TEST --password PSWD --auto-attach`
-
-##### It is a systemd service
-
-See `/etc/systemd/system/rhsm-services` for more details.
-
-You can see a status of the services:
-
-```shell
-systemctl status rhsm-services
-```


### PR DESCRIPTION
- INSTALL.md updates original text from [candlepinproject.org/pull/263 ](https://github.com/candlepin/candlepinproject.org/pull/263) and moves it here to be closer to the source code.
- README.md links to this file and removes some obviously deprecated notes; but there is a space to make more changes.
- TESTING.md now does not contain notes on removed Vagrant setup; we may want to link to README.containers.md or draft something new instead.