### PR TITLE
Drop libnotify-devel usage

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,7 +20,6 @@ RUN dnf install -y \
     glibc-langpack-ja \
     json-c-devel \
     libdnf-devel \
-    libnotify-devel \
     make \
     openssl \
     openssl-devel \

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -187,7 +187,6 @@ BuildRequires: openssl-devel
 BuildRequires: gcc
 BuildRequires: %{py_package_prefix}-setuptools
 BuildRequires: gettext
-BuildRequires: libnotify-devel
 
 %if 0%{?suse_version}
 BuildRequires: distribution-release


### PR DESCRIPTION
It was used by the GUI, which was removed long ago. Hence, drop the
libnotify-devel `BuildRequires` from the spec file, and from the
`Containerfile` too.