### PR TITLE
Run multiple Python versions in CI

### DIFF
--- a/.github/workflows/stylish.yml
+++ b/.github/workflows/stylish.yml
@@ -5,34 +5,68 @@ on:
   workflow_dispatch:
 
 jobs:
-  stylish:
-    name: "black & flake8 & rpmlint"
+  check-spec:
+    name: rpmlint
     runs-on: ubuntu-latest
     container:
       image: fedora:latest
 
     steps:
-    - name: Base setup
-      run: |
-        dnf --setopt install_weak_deps=False install -y \
-            git-core \
-            python3-flake8 \
-            python3-pip \
-            rpmlint
+      - name: Install packages
+        run: |
+          dnf --setopt instal_week_deps=False install -y git-core rpmlint
 
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - uses: psf/black@stable
-      with:
-        version: "22.3.0"
+      - name: Run rpmlint
+        run: |
+          rpmlint subscription-manager.spec
 
-    - name: Setup flake8 annotations
-      uses: rbialon/flake8-annotations@v1
+  check-python:
+    name: "black & flake8"
+    runs-on: ubuntu-latest
 
-    - name: Run flake8
-      run: |
-        flake8
+    strategy:
+      fail-fast: false
+      matrix:
+        # By using '-dev' suffix, Actions picks up the latest release,
+        # including alpha, beta and rc versions.
+        include:
+          - python-version: "3.6"
+            use-annotations: false
+          - python-version: "3.7"
+            use-annotations: false
+          - python-version: "3.8"
+            use-annotations: false
+          - python-version: "3.9"
+            use-annotations: false
+          - python-version: "3.10"
+            use-annotations: true
+          - python-version: "3.11-dev"
+            use-annotations: false
 
-    - name: Run rpmlint
-      run: |
-        rpmlint subscription-manager.spec
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install packages
+        run: |
+          python3 -m pip install --upgrade pip wheel
+          python3 -m pip install -r test-requirements.txt
+
+      - name: flake8-annotations
+        uses: rbialon/flake8-annotations@v1
+        if: ${{ matrix.use-annotations }}
+
+      - name: Run Black
+        run: |
+          black . --diff
+
+      - name: Run flake8
+        run: |
+          flake8


### PR DESCRIPTION
Previously, everything was run in a Fedora container. This new version
splits rpmlint from the rest, which gives us a few advantages.

The first is speed. We don't have to spin up several Fedora containers
now, which makes the results visible in 30-40 seconds, instead of a
minute or two.

The second is pip caching, which is supported by actions/setup-python.
This also contributes to the speedup.

The last thing is the fact that we don't have to do anything to make
all the different Python versions work. It could be difficult to handle
installation and setup of all the Python versions.

One disadvantage is that now we rely on Ubuntu system and not RHEL-based
system. I don't think this makes it less reliable though, as it is only
linting and no libraries we use have to be installed.