### PR TITLE
2097672: [RFE] [1.28] Improve the message, when SCA is enabled

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -307,7 +307,7 @@ class CliCommand(AbstractCLICommand):
 
         self.correlation_id = generate_correlation_id()
 
-    def _print_ignore_auto_attach_mesage(self):
+    def _print_ignore_auto_attach_message(self):
         """
         This message is shared by attach command and register command, because
         both commands can do auto-attach.
@@ -320,8 +320,9 @@ class CliCommand(AbstractCLICommand):
         owner_id = owner['key']
         print(
             _(
-                'Ignoring request to auto-attach. '
-                'It is disabled for org "{owner_id}" because of the content access mode setting.'
+                "Ignoring request to auto-attach. "
+                'Attaching subscriptions is disabled for organization "{owner_id}" '
+                "because of the content access mode setting."
             ).format(owner_id=owner_id)
         )
 
@@ -1882,7 +1883,7 @@ class RegisterCommand(UserPassCommand):
         # Do not try to do auto-attach, when simple content access mode is used
         # Only print info message to stdout
         if is_simple_content_access(uep=self.cp, identity=self.identity):
-            self._print_ignore_auto_attach_mesage()
+            self._print_ignore_auto_attach_message()
             return
 
         if 'serviceLevel' not in consumer and self.options.service_level:
@@ -2457,7 +2458,7 @@ class AttachCommand(CliCommand):
         #
         if is_simple_content_access(uep=self.cp, identity=self.identity):
             if self.auto_attach is True:
-                self._print_ignore_auto_attach_mesage()
+                self._print_ignore_auto_attach_message()
             else:
                 self._print_ignore_attach_message()
             return 0


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2097672
* Origin PR for main: #3116
  * Not possible to do simple cherry-pick
* Card ID: ENT-5115
* Changed warning message according suggestion in BZ bug report.
* Refactored code a little (fixed typo in method name)