### PR TITLE
2101510: [1.28] Fix D-Bus Register() and update entitlement certs

### DIFF
--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -211,6 +211,13 @@ class DomainSocketRegisterDBusObject(base_object.BaseObject):
             log.debug('Auto-attaching due to enable_content option')
             attach_service = AttachService(cp)
             enabled_content = attach_service.attach_auto()
+            if len(enabled_content) > 0:
+                log.debug("Updating entitlement certificates")
+                # FIXME: The enabled_content contains all data necessary for generating entitlement
+                # certificate and private key. Thus we could save few REST API calls, when the data was used.
+                EntCertActionInvoker().update()
+            else:
+                log.debug("Skipping updating entitlement certificates, because no content was enabled")
         elif content_access_mode == 'org_environment':
             log.debug('Refreshing due to enabled_content option and simple content access mode')
             entitlement_service = EntitlementService(cp)

--- a/test/rhsmlib_test/test_register.py
+++ b/test/rhsmlib_test/test_register.py
@@ -44,7 +44,7 @@ from rhsmlib.services import register, exceptions
 
 from test import subman_marker_dbus
 
-CONSUMER_CONTENT_JSON = '''{"hypervisorId": null,
+CONSUMER_CONTENT_JSON = '''{"hypervisorId": "foo",
         "serviceLevel": "",
         "autoheal": true,
         "idCert": {
@@ -82,6 +82,158 @@ CONSUMER_CONTENT_JSON = '''{"hypervisorId": null,
         {"releaseVer": null}, "entitlementStatus": "valid", "name":
         "test.example.com", "created": "2016-06-02T15:16:51+0000",
         "contentTags": null, "dev": false}'''
+
+CONSUMER_CONTENT_JSON_SCA = """{"hypervisorId": null,
+        "serviceLevel": "",
+        "autoheal": true,
+        "idCert": {
+          "key": "FAKE_KEY",
+          "cert": "FAKE_CERT",
+          "serial" : {
+            "id" : 5196045143213189102,
+            "revoked" : false,
+            "collected" : false,
+            "expiration" : "2033-04-25T18:03:06+0000",
+            "serial" : 5196045143213189102,
+            "created" : "2017-04-25T18:03:06+0000",
+            "updated" : "2017-04-25T18:03:06+0000"
+          },
+          "id" : "8a8d011e5ba64700015ba647fbd20b88",
+          "created" : "2017-04-25T18:03:07+0000",
+          "updated" : "2017-04-25T18:03:07+0000"
+        },
+        "owner": {
+          "href": "/owners/admin",
+          "displayName": "Admin Owner",
+          "id": "ff808081550d997c01550d9adaf40003",
+          "key": "admin",
+          "contentAccessMode": "org_environment"
+        },
+        "href": "/consumers/c1b8648c-6f0a-4aa5-b34e-b9e62c0e4364",
+        "facts": {}, "id": "ff808081550d997c015511b0406d1065",
+        "uuid": "c1b8648c-6f0a-4aa5-b34e-b9e62c0e4364",
+        "guestIds": null, "capabilities": null,
+        "environment": null, "installedProducts": null,
+        "canActivate": false, "type": {"manifest": false,
+        "id": "1000", "label": "system"}, "annotations": null,
+        "username": "admin", "updated": "2016-06-02T15:16:51+0000",
+        "lastCheckin": null, "entitlementCount": 0, "releaseVer":
+        {"releaseVer": null}, "entitlementStatus": "valid", "name":
+        "test.example.com", "created": "2016-06-02T15:16:51+0000",
+        "contentTags": null, "dev": false}"""
+
+ENABLED_CONTENT = """[ {
+  "created" : "2022-06-30T13:24:33+0000",
+  "updated" : "2022-06-30T13:24:33+0000",
+  "id" : "16def3d98d6549f8a3649f723a76991c",
+  "consumer" : {
+    "id" : "4028face81aa047e0181b4c8e1170bdc",
+    "uuid" : "8503a41a-6ce2-480c-bc38-b67d6aa6dd20",
+    "name" : "thinkpad-t580",
+    "href" : "/consumers/8503a41a-6ce2-480c-bc38-b67d6aa6dd20"
+  },
+  "pool" : {
+    "created" : "2022-06-28T11:14:35+0000",
+    "updated" : "2022-06-30T13:24:33+0000",
+    "id" : "4028face81aa047e0181aa052f740360",
+    "type" : "NORMAL",
+    "owner" : {
+      "id" : "4028face81aa047e0181aa0490e30002",
+      "key" : "admin",
+      "displayName" : "Admin Owner",
+      "href" : "/owners/admin",
+      "contentAccessMode" : "entitlement"
+    },
+    "activeSubscription" : true,
+    "sourceEntitlement" : null,
+    "quantity" : 5,
+    "startDate" : "2022-06-23T13:14:26+0000",
+    "endDate" : "2023-06-23T13:14:26+0000",
+    "attributes" : [ ],
+    "restrictedToUsername" : null,
+    "contractNumber" : "0",
+    "accountNumber" : "6547096716",
+    "orderNumber" : "order-23226139",
+    "consumed" : 1,
+    "exported" : 0,
+    "branding" : [ ],
+    "calculatedAttributes" : {
+      "compliance_type" : "Standard"
+    },
+    "upstreamPoolId" : "upstream-05736148",
+    "upstreamEntitlementId" : null,
+    "upstreamConsumerId" : null,
+    "productName" : "SP Server Standard (U: Development, R: SP Server)",
+    "productId" : "sp-server-dev",
+    "productAttributes" : [ {
+      "name" : "management_enabled",
+      "value" : "1"
+    }, {
+      "name" : "usage",
+      "value" : "Development"
+    }, {
+      "name" : "roles",
+      "value" : "SP Server"
+    }, {
+      "name" : "variant",
+      "value" : "ALL"
+    }, {
+      "name" : "sockets",
+      "value" : "128"
+    }, {
+      "name" : "support_level",
+      "value" : "Standard"
+    }, {
+      "name" : "support_type",
+      "value" : "L1-L3"
+    }, {
+      "name" : "arch",
+      "value" : "ALL"
+    }, {
+      "name" : "type",
+      "value" : "MKT"
+    }, {
+      "name" : "version",
+      "value" : "1.0"
+    } ],
+    "stackId" : null,
+    "stacked" : false,
+    "sourceStackId" : null,
+    "developmentPool" : false,
+    "href" : "/pools/4028face81aa047e0181aa052f740360",
+    "derivedProductAttributes" : [ ],
+    "derivedProductId" : null,
+    "derivedProductName" : null,
+    "providedProducts" : [ {
+      "productId" : "99000",
+      "productName" : "SP Server Bits"
+    } ],
+    "derivedProvidedProducts" : [ ],
+    "subscriptionSubKey" : "master",
+    "subscriptionId" : "srcsub-45255972",
+    "locked" : false
+  },
+  "quantity" : 1,
+  "certificates" : [ {
+    "created" : "2022-06-30T13:24:33+0000",
+    "updated" : "2022-06-30T13:24:33+0000",
+    "id" : "4028face81aa047e0181b4c8e4b90be1",
+    "key" : "-----BEGIN PRIVATE KEY-----REDACTED-----END PRIVATE KEY-----",
+    "cert" : "-----BEGIN CERTIFICATE-----REDACTED-----END RSA SIGNATURE-----",
+    "serial" : {
+      "created" : "2022-06-30T13:24:33+0000",
+      "updated" : "2022-06-30T13:24:33+0000",
+      "id" : 3712610178651551557,
+      "serial" : 3712610178651551557,
+      "expiration" : "2023-06-23T13:14:26+0000",
+      "revoked" : false
+    }
+  } ],
+  "startDate" : "2022-06-23T13:14:26+0000",
+  "endDate" : "2023-06-23T13:14:26+0000",
+  "href" : null
+} ]
+"""
 
 # Following consumer do not contain information about content access mode
 OLD_CONSUMER_CONTENT_JSON = '''{"hypervisorId": null,
@@ -624,6 +776,14 @@ class DomainSocketRegisterDBusObjectTest(DBusObjectTest, InjectionMockingTest):
         self.mock_cert_invoker = cert_invoker_patcher.start().return_value
         self.addCleanup(cert_invoker_patcher.stop)
 
+        attach_patcher = mock.patch("rhsmlib.dbus.objects.register.AttachService")
+        self.mock_attach_invoker = attach_patcher.start()
+        self.addCleanup(attach_patcher.stop)
+
+        ent_cert_service_patcher = mock.patch("rhsmlib.dbus.objects.register.EntitlementService")
+        self.mock_ent_cert_service_invoker = ent_cert_service_patcher.start()
+        self.addCleanup(ent_cert_service_patcher.stop)
+
     def injection_definitions(self, *args, **kwargs):
         if args[0] == inj.IDENTITY:
             return self.mock_identity
@@ -725,20 +885,92 @@ class DomainSocketRegisterDBusObjectTest(DBusObjectTest, InjectionMockingTest):
         dbus_method_args = ['admin', 'admin', 'admin', {}, {}, '']
         self.dbus_request(assertions, self._build_interface().Register, dbus_method_args)
 
-    def test_can_get_orgs_over_domain_socket(self):
-        expected_owners = json.loads(OWNERS_CONTENT_JSON)
-        expected_consumer = json.loads(CONSUMER_CONTENT_JSON)
+    def test_can_register_over_domain_socket_no_enabled_content(self):
+        """
+        Test calling Register method with argument "enable_content", when
+        access mode is entitlement and no content is enabled (e.g. due to
+        no installed product certs.)
+        """
 
         def assertions(*args):
-            # Be sure we are persisting the consumer cert
+            expected_consumer = json.loads(CONSUMER_CONTENT_JSON)
+            # Test that enabled content (with empty list) was injected to consumer object
+            expected_consumer["enabledContent"] = []
+            self.assertEqual(json.loads(args[0]), expected_consumer)
+
+        self.mock_identity.is_valid.return_value = False
+        self.mock_identity.uuid = "INVALIDCONSUMERUUID"
+
+        self.mock_register.register.return_value = json.loads(CONSUMER_CONTENT_JSON)
+
+        # Return empty list of consumed entitlement certificates (e.g. no installed product certs)
+        mock_attach_service_instance = mock.Mock(name="Mock of AttachService instance")
+        mock_attach_service_instance.attach_auto = mock.Mock(name="Mock of AttachService.attach_auto()")
+        # Empty list of consumed ent. certs.
+        mock_attach_service_instance.attach_auto.return_value = []
+        self.mock_attach_invoker.return_value = mock_attach_service_instance
+
+        dbus_method_args = ["admin", "admin", "admin", {"enable_content": "1"}, {}, ""]
+        self.dbus_request(assertions, self._build_interface().Register, dbus_method_args)
+
+    def test_can_register_over_domain_socket_enable_content(self):
+        """
+        Test calling Register method with argument "enable_content", when
+        access mode is entitlement and some content is enabled during auto-attach
+        """
+        enabled_content = json.loads(ENABLED_CONTENT)
+
+        def assertions(*args):
+            consumer = json.loads(args[0])
+            expected_consumer = json.loads(CONSUMER_CONTENT_JSON)
+            # Test that enabled content was injected to consumer object
+            expected_consumer["enabledContent"] = enabled_content
+            self.assertEqual(consumer, expected_consumer)
+
+        self.mock_identity.is_valid.return_value = False
+        self.mock_identity.uuid = "INVALIDCONSUMERUUID"
+
+        self.mock_register.register.return_value = json.loads(CONSUMER_CONTENT_JSON)
+
+        # Return list of consumed entitlement certificates
+        mock_attach_service_instance = mock.Mock(name="Mock of AttachService instance")
+        mock_attach_service_instance.attach_auto = mock.Mock(name="Mock of AttachService.attach_auto()")
+        mock_attach_service_instance.attach_auto.return_value = enabled_content
+        self.mock_attach_invoker.return_value = mock_attach_service_instance
+
+        dbus_method_args = ["admin", "admin", "admin", {"enable_content": "1"}, {}, ""]
+        self.dbus_request(assertions, self._build_interface().Register, dbus_method_args)
+
+    def test_can_register_over_domain_socket_enable_content_sca(self):
+        """
+        Test calling Register method with argument "enable_content", when
+        SCA mode is used
+        """
+
+        def assertions(*args):
+            # Be sure we are persisting the consumer cert and nothing is injected
+            # to consumer object, when SCA mode is used
+            expected_consumer = json.loads(CONSUMER_CONTENT_JSON_SCA)
+            self.assertEqual(json.loads(args[0]), expected_consumer)
+
+        self.mock_identity.is_valid.return_value = False
+        self.mock_identity.uuid = "INVALIDCONSUMERUUID"
+
+        self.mock_register.register.return_value = json.loads(CONSUMER_CONTENT_JSON_SCA)
+
+        dbus_method_args = ["admin", "admin", "admin", {"enable_content": "1"}, {}, ""]
+        self.dbus_request(assertions, self._build_interface().Register, dbus_method_args)
+
+    def test_can_get_orgs_over_domain_socket(self):
+        def assertions(*args):
+            # Be sure the returned json contains list of orgs
+            expected_owners = json.loads(OWNERS_CONTENT_JSON)
             self.assertEqual(json.loads(args[0]), expected_owners)
 
         self.mock_identity.is_valid.return_value = False
-        self.mock_identity.uuid = 'INVALIDCONSUMERUUID'
+        self.mock_identity.uuid = "INVALIDCONSUMERUUID"
 
-        self.mock_register.register.return_value = expected_consumer
-
-        dbus_method_args = ['admin', 'admin', {}, '']
+        dbus_method_args = ["admin", "admin", {}, ""]
         self.dbus_request(assertions, self._build_interface().GetOrgs, dbus_method_args)
 
     def test_can_register_over_domain_socket_with_activation_keys(self):


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2101510
* Backport of PR #3080
  * It wasn't possible to do simple cherry-pick
* Card ID: ENT-5185
* When D-Bus method Register() was called with argument
  enable_content == True and entitlement mode was used, then
  entitlement certificates were not installed on the system
* Added several unit tests