### PR TITLE
Test updates for the 1.28 branch

### DIFF
--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -152,8 +152,8 @@ class SubscriptionsCase(MachineCase):
         m.write("/etc/insights-client/insights-client.conf",
 """
 [insights-client]
-gpg=False
 auto_config=False
+auto_update=False
 base_url=localhost:8888/r/insights
 cert_verify=False
 username=admin
@@ -358,9 +358,6 @@ class TestSubscriptions(SubscriptionsCase):
         b.click('footer button.apply')
         with b.wait_timeout(360):
             b.wait_not_present('.pf-c-modal-box')
-
-        # HACK - this should eventually not be necessary
-        m.execute("insights-client --check-results")
 
         b.wait_visible("#overview a[href='http://cloud.redhat.com/insights/inventory/123-nice-id']")
         b.wait_visible("#overview a:contains('3 hits, including important')")

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -427,11 +427,7 @@ class TestSubscriptions(SubscriptionsCase):
         m.execute("systemctl start insights-client; while systemctl --quiet is-active insights-client; do sleep 1; done",
                   timeout=360)
 
-        # We can't rely on the insights-client actually succeeding.
-        # It seems to randomly run out of its TasksMax=20 limit, for
-        # example.
-        if m.execute("systemctl is-failed insights-client || true").strip() != "failed":
-            b.wait_not_present("button .pf-c-button__icon svg[fill='orange']")
+        b.wait_not_present("button .pf-c-button__icon svg[fill='orange']")
 
         b.click("button:contains('Unregister')")
         b.wait_not_in_text("#overview", "Insights")

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -149,20 +149,20 @@ class SubscriptionsCase(MachineCase):
         # Wait for the web service to be accessible
         machine_python(self.machine, WAIT_SCRIPT, CANDLEPIN_URL)
 
+        hostname = m.execute("hostname").rstrip()
+
         m.write("/etc/insights-client/insights-client.conf",
-"""
+f"""
 [insights-client]
 auto_config=False
 auto_update=False
-base_url=localhost:8888/r/insights
-cert_verify=False
+base_url={hostname}:8443/r/insights
+cert_verify=/var/lib/insights/mock-certs/ca.crt
 username=admin
 password=foobar
 """)
 
         m.upload(["files/mock-insights"], "/var/tmp")
-        # this re-uses cockpit ws certificate, so ensure that it exists
-        m.execute("systemctl start cockpit")
         m.spawn("/var/tmp/mock-insights", "mock-insights")
 
         # HACK: older c-ws versions always log an assertion; https://github.com/cockpit-project/cockpit/pull/16765

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -386,6 +386,14 @@ class TestSubscriptions(SubscriptionsCase):
         m = self.machine
         b = self.browser
 
+        # HACK - https://bugzilla.redhat.com/show_bug.cgi?id=2062136
+        #
+        # We rely on insights-client.service to be working, let's not
+        # get distracted by SELinux.  Denials will still be logged and
+        # tracked as known issues even when not enforcing.
+        #
+        m.execute("setenforce 0")
+
         self.login_and_go("/subscriptions")
 
         b.click("button:contains('Register')")

--- a/test/files/mock-insights
+++ b/test/files/mock-insights
@@ -39,12 +39,6 @@ class handler(BaseHTTPRequestHandler):
             self.wfile.write(b"lub-dup")
             return
 
-        m = self.match("/r/insights/v1/static/core/insights-core.egg")
-        if m:
-            self.send_response(304)
-            self.end_headers()
-            return
-
         m = self.match("/r/insights/v1/static/uploader.v2.json")
         if m:
             # This is not a valid response and will cause the client

--- a/test/files/mock-insights
+++ b/test/files/mock-insights
@@ -10,10 +10,10 @@
 #
 # You need these in your insights-client.conf:
 #
-# gpg=False
 # auto_config=False
-# base_url=127.0.0.1:8888/r/insights
-# insecure_connection=True
+# auto_update=False
+# base_url=127.0.0.1:8443/r/insights
+# cert_verify=/var/lib/insights/mock-certs/ca.crt
 # username=admin
 # password=foobar
 
@@ -22,6 +22,7 @@ import json
 import os
 import re
 import ssl
+import subprocess
 
 systems = {}
 
@@ -133,25 +134,22 @@ class handler(BaseHTTPRequestHandler):
 
 
 def insights_server(port):
+    # Let's put the certs into /var/lib/insights so that SELinux
+    # allows insights-client to actually read ca.crt when running as a
+    # systemd service.
+    certdir = "/var/lib/insights/mock-certs"
+    if not os.path.exists(certdir):
+        os.makedirs(certdir)
+        subprocess.check_call(["sscg"], cwd=certdir)
+
     httpd = HTTPServer(('', port), handler)
-    certfile = '/etc/cockpit/ws-certs.d/0-self-signed.cert'
-    keyfile = '/etc/cockpit/ws-certs.d/0-self-signed.key'
     ssl_args = {
-        'certfile': certfile,
+        'certfile': f'{certdir}/service.pem',
+        'keyfile': f'{certdir}/service-key.pem',
         'server_side': True,
     }
-    # take into account a behaviour change in the way cockpit generates its
-    # self-signed bits:
-    # - cockpit < 242: the .cert file contains both certificate *and* key
-    # - cockpit >= 242: separate .cert and .key files
-    # hence, if the separate .key file exists, use it as keyfile,
-    # otherwise use the .cert for that
-    if os.path.isfile(keyfile):
-        ssl_args['keyfile'] = keyfile
-    else:
-        ssl_args['keyfile'] = certfile
     httpd.socket = ssl.wrap_socket(httpd.socket, **ssl_args)
     httpd.serve_forever()
 
 
-insights_server(8888)
+insights_server(8443)


### PR DESCRIPTION
With a recent rhel-8-7 refresh, the subscription-manager-1.28 branch seems to need some of the updates we did on main for newer versions of Insights.

rhel-8-7 update: https://github.com/cockpit-project/bots/pull/3818
