### PR TITLE
cockpit: disable the reference branch for sub-man-cockpit

### DIFF
--- a/integration-tests/run
+++ b/integration-tests/run
@@ -26,8 +26,10 @@ SUBMAN_TAR=$(CURDIR)/dist/subscription-manager.tar.gz
 SMBEXT_TAR=$(CURDIR)/dist/subscription-manager-build-extra.tar.gz
 
 check: prepare
-	# make sure CWD is the cockpit source dir
-	cd $(SUB_MAN_COCKPIT) && test/common/run-tests
+	# make sure CWD is the cockpit source dir;
+	# set the reference branch to empty (i.e. none), otherwise run-tests
+	# will try to use the currently tested sub-man branch in sub-man-cockpit
+	cd $(SUB_MAN_COCKPIT) && test/common/run-tests --base ''
 
 reset:
 	rm -f $(SUBMAN_TAR) $(SMBEXT_TAR)


### PR DESCRIPTION
By default, cockpit's run-tests tries to get the list of tests that
changed in the branch being tested; since we run the test suite of
subscription-manager-cockpit from the local clone of it, that repository
will definitely not contain subscription-manager branches.

As a possible solution, disable the reference branch for run-tests
(using an empty string): we are not changing sub-man-cockpit tests from
this repository, so there are definitely no changes in its tests.