### PR TITLE
build: switch rpmlint check to rpmlint 2.x

### DIFF
--- a/build_ext/build_ext/lint.py
+++ b/build_ext/build_ext/lint.py
@@ -70,7 +70,7 @@ class RpmLint(BaseCommand):
         files = files.decode().splitlines()
         files = [x for x in files if x.endswith(".spec")]
         for f in files:
-            spawn(['rpmlint', '--file=rpmlint.config', os.path.realpath(f)])
+            spawn(['rpmlint', os.path.realpath(f)])
 
 
 class AstVisitor(object):

--- a/rpmlint.config
+++ b/rpmlint.config
@@ -1,15 +1,6 @@
 # This seems ok to me
 addFilter('invalid-url')
 
-# All dnf plugins seem to hardcode paths
-addFilter("hardcoded-library-path .*lib/dnf-plugins/.*")
-
-# Filter out zypper plugins too!
-addFilter("hardcoded-library-path .*lib/zypp/plugins/.*")
-
-# Systemd tmpfiles are in /usr/lib
-addFilter("hardcoded-library-path .*lib/tmpfiles.d/.*")
-
 # Ignore failing suse specific checks
 setBadness("suse-dbus-unauthorized-service", 0)
 setBadness("polkit-unauthorized-privilege", 0)


### PR DESCRIPTION
rpmlint 2.x changes almost radically the command line option, forcing to switch to the new format in case we do not want to do "autodetection" (which is not a good idea in the long term, anyway).

This also needs to adapt the configuration with the filters/badness, removing filters that do not apply anymore: they either are no more issues in the spec file (dnf plugin & tmpfiles.d paths), or rpmlint does not complain about them (the zypper plugin path).

(cherry picked from commit 4af3f18f50c2e30090f7ae28df2e8e45c695348c)

Backport of one commit from #3064 to fix the Jenkins-based stylish.