### PR TITLE
[1.28.32] rpmlint fixes

### DIFF
--- a/build_ext/build_ext/lint.py
+++ b/build_ext/build_ext/lint.py
@@ -21,7 +21,8 @@ from distutils.spawn import spawn
 from distutils.text_file import TextFile
 
 from build_ext.utils import Utils, BaseCommand, memoize
-
+import os
+import subprocess
 # These dependencies aren't available in build environments.  We won't need any
 # linting functionality there though, so just create a dummy class so we can proceed.
 try:
@@ -88,8 +89,12 @@ class RpmLint(BaseCommand):
     description = "run rpmlint on spec files"
 
     def run(self):
-        for f in Utils.find_files_of_type('.', '*.spec'):
-            spawn(['rpmlint', '--file=rpmlint.config', f])
+        files = subprocess.run(['git', 'ls-files', '--full-name'],
+                               capture_output=True).stdout
+        files = files.decode().splitlines()
+        files = [x for x in files if x.endswith(".spec")]
+        for f in files:
+            spawn(['rpmlint', '--file=rpmlint.config', os.path.realpath(f)])
 
 
 class FileLint(BaseCommand):

--- a/build_ext/build_ext/lint.py
+++ b/build_ext/build_ext/lint.py
@@ -94,7 +94,7 @@ class RpmLint(BaseCommand):
         files = files.decode().splitlines()
         files = [x for x in files if x.endswith(".spec")]
         for f in files:
-            spawn(['rpmlint', '--file=rpmlint.config', os.path.realpath(f)])
+            spawn(["rpmlint", os.path.realpath(f)])
 
 
 class FileLint(BaseCommand):

--- a/rpmlint.config
+++ b/rpmlint.config
@@ -1,16 +1,6 @@
 # This seems ok to me
 addFilter('invalid-url')
 
-# All yum and dnf plugins seem to hardcode paths
-addFilter("hardcoded-library-path .*lib/yum-plugins/.*")
-addFilter("hardcoded-library-path .*lib/dnf-plugins/.*")
-
-# Filter out zypper plugins too!
-addFilter("hardcoded-library-path .*lib/zypp/plugins/.*")
-
-# Systemd tmpfiles are in /usr/lib
-addFilter("hardcoded-library-path .*lib/tmpfiles.d/.*")
-
 # Ignore failing suse specific checks
 setBadness("suse-dbus-unauthorized-service", 0)
 setBadness("polkit-unauthorized-privilege", 0)


### PR DESCRIPTION
Backport commit 4af3f18f50c2e30090f7ae28df2e8e45c695348c and 1400a3e2ec537e76801027bc6c9b82573c82bfef to fix the rpmlint test with rpmlint 2.x.

Similar to #3121, for the 1.28.32 branch.