### PR TITLE
2093291: Make locking more reliable

### DIFF
--- a/src/subscription_manager/lock.py
+++ b/src/subscription_manager/lock.py
@@ -15,11 +15,12 @@
 #
 import fcntl
 import os
+import tempfile
 from threading import RLock as Mutex
 import time
+from typing import Union, Optional, TextIO
 
 import logging
-from typing import Optional, TextIO
 
 log = logging.getLogger(__name__)
 
@@ -34,56 +35,92 @@ class LockFile(object):
         self.pid: Optional[int] = None
         self.fp: Optional[TextIO] = None
 
-    def open(self):
+    def open(self, blocking: bool = False) -> None:
+        """
+        Try to open lock file, write PID to the lock file and finally lock the file
+        :param blocking: When it is set to True, then file locking blocks
+        """
         if self.notcreated():
             self.fp = open(self.path, "w")
             self.setpid()
             self.close()
         self.fp = open(self.path, "r+")
         fd: int = self.fp.fileno()
-        fcntl.flock(fd, fcntl.LOCK_EX)
+        if blocking is True:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        else:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
 
-    def getpid(self) -> int:
-        if self.pid is None:
+    def getpid(self) -> Union[int, None]:
+        """
+        Try to get PID from the locked file
+        """
+        if self.pid is None and self.fp is not None:
             content: str = self.fp.read().strip()
             if content:
                 self.pid = int(content)
         return self.pid
 
     def setpid(self) -> None:
+        """
+        Try to set PID. When the self.fp is not set, then exception is raised.
+        """
         self.fp.seek(0)
         content = str(os.getpid())
         self.fp.write(content)
         self.fp.flush()
 
     def mypid(self) -> bool:
+        """
+        If the PID in the locked file is PID of current process, then return True.
+        Otherwise, return False.
+        """
         return os.getpid() == self.getpid()
 
     def valid(self) -> bool:
+        """
+        Check if the process with PID is still running
+        """
         status: bool = False
         try:
             os.kill(self.getpid(), 0)
+        except Exception as err:
+            log.debug(f"Unable to send 0 signal to process: {err}")
+        else:
             status = True
-        except Exception:
-            pass
         return status
 
     def delete(self) -> None:
+        """
+        Try to delete lock file
+        """
         if self.mypid() or not self.valid():
             self.close()
             os.unlink(self.path)
 
     def close(self) -> None:
+        """
+        Try to close lock file
+        """
+        if self.fp is None:
+            self.pid = None
+            return
         try:
             fd: int = self.fp.fileno()
             fcntl.flock(fd, fcntl.LOCK_UN)
+        except Exception as err:
+            log.debug(f"Unable to unlock file {self.path}: {err}")
+        try:
             self.fp.close()
-        except Exception:
-            pass
+        except Exception as err:
+            log.debug(f"Unable to close file {self.path}: {err}")
         self.pid = None
         self.fp = None
 
     def notcreated(self) -> bool:
+        """
+        Check if lock file already exists
+        """
         return not os.path.exists(self.path)
 
     def __del__(self) -> None:
@@ -104,29 +141,53 @@ class Lock(object):
         try:
             if not os.path.exists(lock_dir):
                 os.makedirs(lock_dir)
-            self.lockdir = lock_dir
-        except Exception:
+            else:
+                # When lock directory exists, then check if the owner is
+                # the same as current user. Otherwise, try to create some temporary
+                # file to check if user can write to given directory. When the
+                # file system is mounted as read-only, then root cannot write to
+                # the directory despite it is super-user. In that case exception
+                # PermissionError will be raised.
+                if os.getuid() != os.stat(lock_dir).st_uid:
+                    temp_file = tempfile.NamedTemporaryFile(dir=lock_dir)
+                    temp_file.close()
+        except PermissionError as err:
+            log.info(f"Unable to create lock/write to directory {lock_dir}: {err}")
+            raise err
+        except Exception as err:
+            log.debug(f"Unable to create lock directory {lock_dir}: {err}")
             self.lockdir = None
+        else:
+            self.lockdir = lock_dir
 
+    # FIXME: Following code is absolutely stochastic and there has to be some black magic, because
+    # it is miracle that it works and it does not block any application using this code.
+    # It seems that nothing uses blocking keyed argument. Thus only default equal None is used.
     def acquire(self, blocking: Optional[bool] = None) -> Optional[bool]:
         """Behaviour here is modeled after threading.RLock.acquire.
 
-        If 'blocking' is False, we return True if we didn't need to block and we acquired the lock.
-        We return False if couldn't acquire the lock and would have
+        If 'blocking' is False, we return True if we didn't need to block, and we acquired the lock.
+        We return False, if we couldn't acquire the lock and would have
         had to wait and block.
 
-        if 'blocking' is None, we return None when we acquire the lock, otherwise block until we do.
+        If 'blocking' is None, we return None when we acquire the lock, otherwise block until we do.
 
-        if 'blocking' is True, we behave the same as with blocking=None, except we return True.
+        If 'blocking' is True, we behave the same as with blocking=None, except we return True.
+
         """
 
         if self.lockdir is None:
             return None
         f = LockFile(self.path)
+        log.debug(f"Locking file: {self.path}")
         try:
             try:
                 while True:
-                    f.open()
+                    # FIXME: if you set blocking to True, then this code would work anyway.
+                    # It is absolutely unclear, how it is possible, because fcntl.flock()
+                    # should block in this case. The blocking is set to False here to be sure
+                    # that the code will be still functional, when the magic would be over.
+                    f.open(blocking=False)
                     f.getpid()
                     if f.mypid():
                         self.P()
@@ -146,9 +207,7 @@ class Lock(object):
                 self.P()
                 f.setpid()
             except OSError as e:
-                log.exception(e)
-                # FIXME Stop printing this
-                print("could not create lock")
+                log.exception(f"Could not lock file: {self.path}", exc_info=e)
         finally:
             f.close()
 
@@ -165,8 +224,10 @@ class Lock(object):
         self.V()
         if self.acquired():
             return
+        log.debug(f"Unlocking file {self.path}")
         f = LockFile(self.path)
         try:
+            # FIXME: it does not make any sense to try to lock file again here
             f.open()
             f.delete()
         finally:
@@ -215,7 +276,34 @@ class Lock(object):
 
 class ActionLock(Lock):
 
+    # Standard path of lock file
     PATH = "/run/rhsm/cert.pid"
 
-    def __init__(self):
-        super(ActionLock, self).__init__(self.PATH)
+    # This path is used, when standard directory is read-only and environment
+    # variable XDG_RUNTIME_DIR is defined
+    USER_PATH = "{XDG_RUNTIME_DIR}/rhsm/cert.pid"
+
+    def __init__(self) -> None:
+        try:
+            super(ActionLock, self).__init__(self.PATH)
+        except PermissionError:
+            # When it is not possible to create lock in standard directory, then
+            # try to use one in user directory
+            user_path = self._get_user_lock_dir()
+            if user_path is not None:
+                super(ActionLock, self).__init__(user_path)
+            else:
+                log.error("Unable to create lock directory in user runtime directory")
+
+    def _get_user_lock_dir(self) -> Union[None, str]:
+        """
+        Try to get lock directory in user runtime directory (typically /run/user/${UID}/)
+        """
+        if "XDG_RUNTIME_DIR" in os.environ:
+            xdg_runtime_dir = os.environ["XDG_RUNTIME_DIR"]
+            user_path = self.USER_PATH.format(XDG_RUNTIME_DIR=xdg_runtime_dir)
+        else:
+            log.debug("Environment variable XDG_RUNTIME_DIR not defined")
+            return None
+        log.info(f"Trying to use user lock directory: {user_path} (influenced by $XDG_RUNTIME_DIR)")
+        return user_path


### PR DESCRIPTION
* Card ID: ENT-5077
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2093291
* When the /run is mounted read-only, then try to create lock
  file in /run/users, which should never be mounted as
  read-only. The path to user's runtime directory should be
  defined in $XDG_RUNTIME_DIR
* Added some doc strings and type hints for LockFile class
  and added more debug prints
* Added some unit tests