### PR TITLE
ENT-5443 [2094942]: Fixed expected message for manual attach case

### DIFF
--- a/src/subscription_manager/cli_command/attach.py
+++ b/src/subscription_manager/cli_command/attach.py
@@ -154,8 +154,9 @@ class AttachCommand(CliCommand):
         owner_id = owner["key"]
         print(
             _(
-                "Ignoring request to attach. "
-                'It is disabled for org "{owner_id}" because of the content access mode setting.'
+                "Ignoring the request to attach. "
+                'Attaching subscriptions is disabled for organization "{owner_id}" '
+                "because Simple Content Access (SCA) is enabled."
             ).format(owner_id=owner_id)
         )
 


### PR DESCRIPTION
- Updated the expected message from a user's manual attach request (`--pool`) when SCA is enabled for the organization.
**Current error message:** 
`
Ignoring request to attach. It is disabled for org $ORGID because of the content access mode setting.
`
**Expected error message:**
`
Ignoring the request to attach. Attaching subscriptions is disabled for organization $ORGID because Simple Content Access (SCA) is enabled.
`

- Card ID: ENT-5443
- BZ 2094942: https://bugzilla.redhat.com/show_bug.cgi?id=2094942