### PR TITLE
[2126981] ENT-5345: improve various error messages

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -432,12 +432,23 @@ class UnknownContentException(ConnectionException):
     [200, 202, 204, 401, 403, 410, 429, 500, 502, 503, 504]
     """
 
-    def __init__(self, code: int) -> None:
+    def __init__(self, code: int, content_type: Optional[str] = None, content: Optional[str] = None) -> None:
         self.code = code
+        self.content_type = content_type
+        self.content = content
+
+    @property
+    def title(self) -> str:
+        return httplib.responses.get(self.code, "Unknown")
 
     def __str__(self) -> str:
-        error_title = httplib.responses.get(self.code, "Unknown")
-        return "HTTP error (%s - %s)" % (self.code, error_title)
+        s = f"Unknown content error (HTTP {self.code} - {self.title}"
+        if self.content_type is not None:
+            s += f", type {self.content_type}"
+        if self.content is not None:
+            s += f", len {len(self.content)}"
+        s += ")"
+        return s
 
 
 class RemoteServerException(ConnectionException):
@@ -1235,7 +1246,11 @@ class BaseRestLib(object):
 
                 else:
                     # unexpected with no valid content
-                    raise UnknownContentException(response["status"])
+                    raise UnknownContentException(
+                        response["status"],
+                        response.get("headers", {}).get("Content-Type"),
+                        response.get("content"),
+                    )
 
     @staticmethod
     def _parse_msg_from_error_response_body(body: dict) -> str:

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -136,9 +136,10 @@ class ConnectionSetupException(ConnectionException):
 class BadCertificateException(ConnectionException):
     """Thrown when an error parsing a certificate is encountered."""
 
-    def __init__(self, cert_path: str) -> None:
+    def __init__(self, cert_path: str, ssl_exc: ssl.SSLError) -> None:
         """Pass the full path to the bad certificate."""
         self.cert_path = cert_path
+        self.ssl_exc = ssl_exc
 
     def __str__(self) -> str:
         return "Bad certificate at %s" % self.cert_path
@@ -673,8 +674,8 @@ class BaseRestLib(object):
                     cert_path = os.path.join(self.ca_dir, cert_file)
                     context.load_verify_locations(cert_path)
                     loaded_ca_certs.append(cert_file)
-        except ssl.SSLError:
-            raise BadCertificateException(cert_path)
+        except ssl.SSLError as exc:
+            raise BadCertificateException(cert_path, exc)
         except OSError as e:
             raise ConnectionSetupException(e.strerror)
 

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -671,11 +671,8 @@ class BaseRestLib(object):
             for cert_file in os.listdir(self.ca_dir):
                 if cert_file.endswith(".pem"):
                     cert_path = os.path.join(self.ca_dir, cert_file)
-                    # FIXME: method load_verify_locations() does not return anything
-                    res = context.load_verify_locations(cert_path)
+                    context.load_verify_locations(cert_path)
                     loaded_ca_certs.append(cert_file)
-                    if res == 0:
-                        raise BadCertificateException(cert_path)
         except ssl.SSLError:
             raise BadCertificateException(cert_path)
         except OSError as e:

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -425,7 +425,7 @@ class GoneException(RestlibException):
         self.deleted_id = deleted_id
 
 
-class NetworkException(ConnectionException):
+class UnknownContentException(ConnectionException):
     """
     Thrown when the response of a request has no valid json content
     and the http status code is anything other than the following:
@@ -1235,7 +1235,7 @@ class BaseRestLib(object):
 
                 else:
                     # unexpected with no valid content
-                    raise NetworkException(response["status"])
+                    raise UnknownContentException(response["status"])
 
     @staticmethod
     def _parse_msg_from_error_response_body(body: dict) -> str:

--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -185,8 +185,8 @@ class AbstractSyspurposeCommand(CliCommand):
             # When system is registered, then try to get valid fields from cache file
             try:
                 valid_fields = get_syspurpose_valid_fields(uep=self.cp, identity=self.identity)
-            except ProxyException:
-                system_exit(os.EX_UNAVAILABLE, _("Proxy connection failed, please check your settings."))
+            except ProxyException as exc:
+                system_exit(os.EX_UNAVAILABLE, exc)
         elif self.options.username and self.options.password and self.cp is not None:
             # Try to get current organization key. It is property of OrgCommand.
             # Every Syspurpose command has to be subclass of OrgCommand too
@@ -199,8 +199,8 @@ class AbstractSyspurposeCommand(CliCommand):
                     "Unable to get list of valid fields using REST API: {rest_err}".format(rest_err=rest_err)
                 )
                 system_exit(os.EX_SOFTWARE, rest_err)
-            except ProxyException:
-                system_exit(os.EX_UNAVAILABLE, _("Proxy connection failed, please check your settings."))
+            except ProxyException as exc:
+                system_exit(os.EX_UNAVAILABLE, exc)
             else:
                 if "systemPurposeAttributes" in server_response:
                     server_response = post_process_received_data(server_response)

--- a/src/subscription_manager/cli_command/cli.py
+++ b/src/subscription_manager/cli_command/cli.py
@@ -398,8 +398,8 @@ class CliCommand(AbstractCLICommand):
                         os.EX_CONFIG,
                         _("Error: CA certificate for subscription service has not been installed."),
                     )
-                except ProxyException:
-                    system_exit(os.EX_UNAVAILABLE, _("Proxy connection failed, please check your settings."))
+                except ProxyException as exc:
+                    system_exit(os.EX_UNAVAILABLE, exc)
 
         else:
             self.cp = None

--- a/src/subscription_manager/cli_command/cli.py
+++ b/src/subscription_manager/cli_command/cli.py
@@ -23,6 +23,7 @@ import rhsm.connection as connection
 import subscription_manager.injection as inj
 
 from rhsm.certificate import CertificateException
+from rhsm.certificate2 import CertificateLoadingError
 from rhsm.connection import ProxyException
 from rhsm.https import ssl
 import rhsm.utils
@@ -415,7 +416,7 @@ class CliCommand(AbstractCLICommand):
 
             if return_code is not None:
                 return return_code
-        except (CertificateException, ssl.SSLError) as e:
+        except (CertificateException, CertificateLoadingError, ssl.SSLError) as e:
             log.error(e)
             system_exit(os.EX_SOFTWARE, _("System certificates corrupted. Please reregister."))
         except connection.GoneException as ge:

--- a/src/subscription_manager/cli_command/cli.py
+++ b/src/subscription_manager/cli_command/cli.py
@@ -416,7 +416,9 @@ class CliCommand(AbstractCLICommand):
 
             if return_code is not None:
                 return return_code
-        except (CertificateException, CertificateLoadingError, ssl.SSLError) as e:
+        except CertificateLoadingError as exc:
+            system_exit(os.EX_SOFTWARE, exc)
+        except (CertificateException, ssl.SSLError) as e:
             log.error(e)
             system_exit(os.EX_SOFTWARE, _("System certificates corrupted. Please reregister."))
         except connection.GoneException as ge:

--- a/src/subscription_manager/cli_command/service_level.py
+++ b/src/subscription_manager/cli_command/service_level.py
@@ -147,11 +147,8 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
                 log.error("Error: Unable to retrieve service levels: {err}".format(err=re_err))
 
                 system_exit(os.EX_SOFTWARE, re_err)
-            except ProxyException:
-                system_exit(
-                    os.EX_UNAVAILABLE,
-                    _("Proxy connection failed, please check your settings."),
-                )
+            except ProxyException as exc:
+                system_exit(os.EX_UNAVAILABLE, exc)
 
     def set(self):
         if self.cp.has_capability("syspurpose"):

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -26,6 +26,7 @@ from subscription_manager.i18n import ugettext as _
 SOCKET_MESSAGE = _(
     "Network error, unable to connect to server. Please see /var/log/rhsm/rhsm.log for more information."
 )
+CONNECTION_MESSAGE = _("Connection error: {message} (error code {code})")
 NETWORK_MESSAGE = _(
     "Network error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information."
 )
@@ -60,6 +61,7 @@ class ExceptionMapper(object):
 
         self.message_map = {
             socket_error: (SOCKET_MESSAGE, self.format_using_template),
+            ConnectionError: (CONNECTION_MESSAGE, self.format_generic_oserror),
             Disconnected: (SOCKET_MESSAGE, self.format_using_template),
             connection.ProxyException: (PROXY_MESSAGE, self.format_using_template),
             connection.NetworkException: (NETWORK_MESSAGE, self.format_using_template),
@@ -89,6 +91,9 @@ class ExceptionMapper(object):
     def format_using_error(self, exc: Exception, _: str) -> str:
         """Return string representation of the error."""
         return str(exc)
+
+    def format_generic_oserror(self, exc: Exception, message_template: str):
+        return message_template.format(message=exc.strerror, code=exc.errno)
 
     def format_bad_ca_cert_exception(
         self, bad_ca_cert_error: connection.BadCertificateException, message_template: str

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -17,7 +17,9 @@ from socket import error as socket_error, gaierror as socket_gaierror
 from rhsm.https import ssl, httplib
 
 from rhsm import connection, utils
+from rhsm.certificate2 import CertificateLoadingError
 
+from subscription_manager.certdirectory import DEFAULT_PRODUCT_CERT_DIR
 from subscription_manager.cp_provider import TokenAuthUnsupportedException
 from subscription_manager.entcertlib import Disconnected
 
@@ -55,6 +57,10 @@ RATE_LIMIT_MESSAGE = _("The server rate limit has been exceeded, please try agai
 RATE_LIMIT_EXPIRATION = _(
     "The server rate limit has been exceeded, please try again later. (Expires in %s seconds)"
 )
+PRODUCT_CERTIFICATE_LOADING_PATH_ERROR = _("Bad product certificate: {file}: [{library}] {message}")
+CERTIFICATE_LOADING_PATH_ERROR = _("Bad certificate: {file}: [{library}] {message}")
+CERTIFICATE_LOADING_PEM_ERROR = _("Bad certificate: [{library}] {message}\n{data}")
+CERTIFICATE_LOADING_ERROR = _("Bad certificate: [{library}] {message}")
 
 # TRANSLATORS: example: "You don't have permission to perform this action (HTTP error code 403: Forbidden)"
 # (the part before the opening bracket originates on the server)
@@ -88,6 +94,7 @@ class ExceptionMapper(object):
             connection.RateLimitExceededException: (None, self.format_rate_limit_exception),
             httplib.BadStatusLine: (REMOTE_SERVER_MESSAGE, self.format_using_template),
             TokenAuthUnsupportedException: (TOKEN_AUTH_UNSUPPORTED_MESSAGE, self.format_using_template),
+            CertificateLoadingError: (None, self.format_cert_loading_error),
         }
 
     def format_using_template(self, _: Exception, message: str) -> str:
@@ -145,6 +152,23 @@ class ExceptionMapper(object):
             return RATE_LIMIT_EXPIRATION % str(rate_limit_exception.retry_after)
         else:
             return RATE_LIMIT_MESSAGE
+
+    def format_cert_loading_error(self, exc: CertificateLoadingError, _: str):
+        fmtargs = {
+            "library": exc.liberr,
+            "message": exc.reasonerr,
+        }
+        if exc.path is not None:
+            fmtargs["file"] = exc.path
+        if exc.pem is not None:
+            fmtargs["data"] = terminal_printable_content(exc.pem)
+        if exc.path is not None:
+            if exc.path.startswith(DEFAULT_PRODUCT_CERT_DIR):
+                return PRODUCT_CERTIFICATE_LOADING_PATH_ERROR.format(**fmtargs)
+            return CERTIFICATE_LOADING_PATH_ERROR.format(**fmtargs)
+        if exc.pem is not None:
+            return CERTIFICATE_LOADING_PEM_ERROR.format(**fmtargs)
+        return CERTIFICATE_LOADING_ERROR.format(**fmtargs)
 
     def get_message(self, exception) -> str:
         """Get string representation of an exception.

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -13,7 +13,7 @@
 # in this software or its documentation.
 #
 import inspect
-from socket import error as socket_error
+from socket import error as socket_error, gaierror as socket_gaierror
 from rhsm.https import ssl, httplib
 
 from rhsm import connection, utils
@@ -26,6 +26,7 @@ from subscription_manager.i18n import ugettext as _
 SOCKET_MESSAGE = _(
     "Network error, unable to connect to server. Please see /var/log/rhsm/rhsm.log for more information."
 )
+GAI_MESSAGE = _("Network error: {message} (error code {code})")
 CONNECTION_MESSAGE = _("Connection error: {message} (error code {code})")
 NETWORK_MESSAGE = _(
     "Network error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information."
@@ -61,6 +62,7 @@ class ExceptionMapper(object):
 
         self.message_map = {
             socket_error: (SOCKET_MESSAGE, self.format_using_template),
+            socket_gaierror: (GAI_MESSAGE, self.format_generic_oserror),
             ConnectionError: (CONNECTION_MESSAGE, self.format_generic_oserror),
             Disconnected: (SOCKET_MESSAGE, self.format_using_template),
             connection.ProxyException: (PROXY_MESSAGE, self.format_using_template),

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -31,7 +31,11 @@ CONNECTION_MESSAGE = _("Connection error: {message} (error code {code})")
 NETWORK_MESSAGE = _(
     "Network error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information."
 )
-PROXY_MESSAGE = _("Proxy error, unable to connect to proxy server.")
+PROXY_ADDRESS_REASON_OSERROR_MESSAGE = _(
+    "Proxy error: unable to connect to {hostname}: {message} (error code {code})"
+)
+PROXY_ADDRESS_REASON_MESSAGE = _("Proxy error: unable to connect to {hostname}: {message}")
+PROXY_ADDRESS_MESSAGE = _("Proxy error: unable to connect to {hostname}")
 UNAUTHORIZED_MESSAGE = _("Unauthorized: Invalid credentials for request.")
 TOKEN_AUTH_UNSUPPORTED_MESSAGE = _("Token authentication not supported by the entitlement server")
 FORBIDDEN_MESSAGE = _("Forbidden: Invalid credentials for request.")
@@ -65,7 +69,7 @@ class ExceptionMapper(object):
             socket_gaierror: (GAI_MESSAGE, self.format_generic_oserror),
             ConnectionError: (CONNECTION_MESSAGE, self.format_generic_oserror),
             Disconnected: (SOCKET_MESSAGE, self.format_using_template),
-            connection.ProxyException: (PROXY_MESSAGE, self.format_using_template),
+            connection.ProxyException: (None, self.format_proxy_exception),
             connection.NetworkException: (NETWORK_MESSAGE, self.format_using_template),
             connection.UnauthorizedException: (UNAUTHORIZED_MESSAGE, self.format_using_template),
             connection.ForbiddenException: (FORBIDDEN_MESSAGE, self.format_using_template),
@@ -96,6 +100,22 @@ class ExceptionMapper(object):
 
     def format_generic_oserror(self, exc: Exception, message_template: str):
         return message_template.format(message=exc.strerror, code=exc.errno)
+
+    def format_proxy_exception(self, exc: connection.ProxyException, _: str) -> str:
+        proxy_address = exc.address
+        # catches gaierror and socket.error
+        if isinstance(exc.exc, OSError):
+            return PROXY_ADDRESS_REASON_OSERROR_MESSAGE.format(
+                hostname=proxy_address,
+                message=exc.exc.strerror,
+                code=exc.exc.errno,
+            )
+        if exc.exc is not None:
+            return PROXY_ADDRESS_REASON_MESSAGE.format(
+                hostname=proxy_address,
+                message=exc.exc,
+            )
+        return PROXY_ADDRESS_MESSAGE.format(hostname=proxy_address)
 
     def format_bad_ca_cert_exception(
         self, bad_ca_cert_error: connection.BadCertificateException, message_template: str

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -70,7 +70,7 @@ class ExceptionMapper(object):
             ConnectionError: (CONNECTION_MESSAGE, self.format_generic_oserror),
             Disconnected: (SOCKET_MESSAGE, self.format_using_template),
             connection.ProxyException: (None, self.format_proxy_exception),
-            connection.NetworkException: (NETWORK_MESSAGE, self.format_using_template),
+            connection.UnknownContentException: (NETWORK_MESSAGE, self.format_using_template),
             connection.UnauthorizedException: (UNAUTHORIZED_MESSAGE, self.format_using_template),
             connection.ForbiddenException: (FORBIDDEN_MESSAGE, self.format_using_template),
             connection.RemoteServerException: (REMOTE_SERVER_MESSAGE, self.format_using_template),

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -37,7 +37,7 @@ REMOTE_SERVER_MESSAGE = _(
     "Remote server error. Please check the connection details, "
     "or see /var/log/rhsm/rhsm.log for more information."
 )
-BAD_CA_CERT_MESSAGE = _("Bad CA certificate: %s")
+BAD_CA_CERT_MESSAGE = _("Bad CA certificate: {file}: {reason}")
 EXPIRED_ID_CERT_MESSAGE = _("Your identity certificate has expired")
 SSL_MESSAGE = _("Unable to verify server's identity: %s")
 PERROR_EMPTY_MESSAGE = _("Server URL can not be empty")
@@ -90,8 +90,12 @@ class ExceptionMapper(object):
         """Return string representation of the error."""
         return str(exc)
 
-    def format_bad_ca_cert_exception(self, bad_ca_cert_error, message_template):
-        return message_template % bad_ca_cert_error.cert_path
+    def format_bad_ca_cert_exception(
+        self, bad_ca_cert_error: connection.BadCertificateException, message_template: str
+    ):
+        return message_template.format(
+            file=bad_ca_cert_error.cert_path, reason=str(bad_ca_cert_error.ssl_exc)
+        )
 
     def format_ssl_error(self, ssl_error, message_template):
         return message_template % ssl_error

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -13,6 +13,7 @@
 #
 
 import collections
+import io
 import logging
 import os
 import pprint
@@ -630,3 +631,18 @@ def is_interactive() -> bool:
     :return: True, when the process is running in an interactive session; Otherwise returns False
     """
     return sys.stdin and sys.stdin.isatty()
+
+
+def terminal_printable_content(content: str) -> str:
+    """
+    Get the content of the reply in a way suitable to print on terminal;
+    in particular, this means that any non-printable character
+    (excluding new lines and tabs) is replaced with "<$code>".
+    """
+    buf = io.StringIO()
+    for c in content:
+        if c.isprintable() or c == "\n" or c == "\t":
+            buf.write(c)
+        else:
+            buf.write(f"<{ord(c)}>")
+    return buf.getvalue()

--- a/test/rhsm/unit/test_certificate2.py
+++ b/test/rhsm/unit/test_certificate2.py
@@ -23,6 +23,7 @@ from rhsm.certificate2 import (
     IdentityCertificate,
     Product,
     ProductCertificate,
+    CertificateLoadingError,
 )
 
 from mock import patch
@@ -85,7 +86,7 @@ class V1EntCertTests(unittest.TestCase):
         self.assertRaises(CertificateException, create_from_pem, "")
 
     def test_junk_contents_throws_exception(self):
-        self.assertRaises(CertificateException, create_from_pem, "DOESTHISLOOKLIKEACERTTOYOU?")
+        self.assertRaises(CertificateLoadingError, create_from_pem, "DOESTHISLOOKLIKEACERTTOYOU?")
 
     def test_factory_method_on_ent_cert(self):
         self.assertEqual("1.0", str(self.ent_cert.version))

--- a/test/rhsm/unit/test_connection.py
+++ b/test/rhsm/unit/test_connection.py
@@ -26,7 +26,7 @@ from rhsm.connection import (
     BadCertificateException,
     RestlibException,
     GoneException,
-    NetworkException,
+    UnknownContentException,
     RemoteServerException,
     drift_check,
     ExpiredIdentityCertException,
@@ -654,7 +654,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
             response["headers"] = headers
         self.restlib.validateResponse(response, self.request_type, self.handler)
 
-    # All empty responses that aren't 200/204 raise a NetworkException
+    # All empty responses that aren't 200/204 raise a UnknownContentException
     def test_200_empty(self):
         # this should just not raise any exceptions
         self.vr("200", "")
@@ -690,12 +690,12 @@ class RestlibValidateResponseTests(unittest.TestCase):
     #     self.vr("301", "")
 
     def test_400_empty(self):
-        # FIXME: not sure 400 makes sense as "NetworkException"
-        #        we check for NetworkException in several places in
+        # FIXME: not sure 400 makes sense as "UnknownContentException"
+        #        we check for UnknownContentException in several places in
         #        addition to RestlibException and RemoteServerException
         #        I think maybe a 400 ("Bad Request") should be a
         #        RemoteServerException
-        self.assertRaises(NetworkException, self.vr, "400", "")
+        self.assertRaises(UnknownContentException, self.vr, "400", "")
 
     def test_401_empty(self):
         try:
@@ -874,7 +874,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
             self.fail("RemoteServerException expected")
 
     def test_599_empty(self):
-        self.assertRaises(NetworkException, self.vr, "599", "")
+        self.assertRaises(UnknownContentException, self.vr, "599", "")
 
 
 class RestlibTests(unittest.TestCase):

--- a/test/rhsm/unit/test_connection.py
+++ b/test/rhsm/unit/test_connection.py
@@ -956,6 +956,7 @@ class BadCertificateExceptionTest(ExceptionTest):
 
     def _create_exception(self, *args, **kwargs):
         kwargs["cert_path"] = "/etc/sdfsd"
+        kwargs["ssl_exc"] = ssl.SSLError(5, "some ssl error")
         return self.exception(*args, **kwargs)
 
 

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -12,7 +12,8 @@
 import unittest
 
 from subscription_manager.exceptions import ExceptionMapper
-from rhsm.connection import RestlibException
+from rhsm.connection import RestlibException, BadCertificateException
+from rhsm.https import ssl
 
 
 class MyRuntimeErrorBase(RuntimeError):
@@ -96,3 +97,11 @@ class TestExceptionMapper(unittest.TestCase):
 
         err = OldStyleClass()
         self.assertEqual(expected_message, mapper.get_message(err))
+
+    def test_bad_certificate_exception(self):
+        expected_message = "Expected MESSAGE"
+        mapper = ExceptionMapper()
+
+        sslerr = ssl.SSLError(5, expected_message)
+        err = BadCertificateException("foo.pem", sslerr)
+        self.assertEqual(f"Bad CA certificate: foo.pem: {expected_message}", mapper.get_message(err))

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -10,6 +10,7 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
 import errno
+import socket
 import unittest
 
 from subscription_manager.exceptions import ExceptionMapper
@@ -115,5 +116,16 @@ class TestExceptionMapper(unittest.TestCase):
         err = ConnectionRefusedError(expected_errno, expected_message)
         self.assertEqual(
             f"Connection error: {expected_message} (error code {expected_errno})",
+            mapper.get_message(err),
+        )
+
+    def test_socket_gaierror(self):
+        expected_message = "Expected MESSAGE"
+        expected_errno = socket.EAI_NONAME
+        mapper = ExceptionMapper()
+
+        err = socket.gaierror(expected_errno, expected_message)
+        self.assertEqual(
+            f"Network error: {expected_message} (error code {expected_errno})",
             mapper.get_message(err),
         )

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -14,8 +14,10 @@ import socket
 import unittest
 
 from subscription_manager.exceptions import ExceptionMapper
+from subscription_manager.certdirectory import DEFAULT_PRODUCT_CERT_DIR
 from rhsm.connection import RestlibException, BadCertificateException, ProxyException, UnknownContentException
 from rhsm.https import httplib, ssl
+from rhsm.certificate2 import CertificateLoadingError
 
 
 class MyRuntimeErrorBase(RuntimeError):
@@ -192,5 +194,52 @@ class TestExceptionMapper(unittest.TestCase):
         err = UnknownContentException(expected_http_code)
         self.assertEqual(
             f"Unknown server reply (HTTP error code {expected_http_code}: {expected_http_string})",
+            mapper.get_message(err),
+        )
+
+    def test_certificateloadingerror_product_certificate(self):
+        expected_library = "X509"
+        expected_reason = "Expected MESSAGE"
+        expected_path = f"{DEFAULT_PRODUCT_CERT_DIR}/foo.pem"
+        mapper = ExceptionMapper()
+
+        err = CertificateLoadingError(expected_library, expected_reason, path=expected_path)
+        self.assertEqual(
+            f"Bad product certificate: {expected_path}: [{expected_library}] {expected_reason}",
+            mapper.get_message(err),
+        )
+
+    def test_certificateloadingerror_other_certificate(self):
+        expected_library = "X509"
+        expected_reason = "Expected MESSAGE"
+        expected_path = "/tmp/foo.pem"
+        mapper = ExceptionMapper()
+
+        err = CertificateLoadingError(expected_library, expected_reason, path=expected_path)
+        self.assertEqual(
+            f"Bad certificate: {expected_path}: [{expected_library}] {expected_reason}",
+            mapper.get_message(err),
+        )
+
+    def test_certificateloadingerror_pem_data(self):
+        expected_library = "X509"
+        expected_reason = "Expected MESSAGE"
+        expected_data = "DOESTHISLOOKLIKEACERT?"
+        mapper = ExceptionMapper()
+
+        err = CertificateLoadingError(expected_library, expected_reason, pem=expected_data)
+        self.assertEqual(
+            f"Bad certificate: [{expected_library}] {expected_reason}\n{expected_data}",
+            mapper.get_message(err),
+        )
+
+    def test_certificateloadingerror_unknown(self):
+        expected_library = "X509"
+        expected_reason = "Expected MESSAGE"
+        mapper = ExceptionMapper()
+
+        err = CertificateLoadingError(expected_library, expected_reason)
+        self.assertEqual(
+            f"Bad certificate: [{expected_library}] {expected_reason}",
             mapper.get_message(err),
         )

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -9,6 +9,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
+import errno
 import unittest
 
 from subscription_manager.exceptions import ExceptionMapper
@@ -105,3 +106,14 @@ class TestExceptionMapper(unittest.TestCase):
         sslerr = ssl.SSLError(5, expected_message)
         err = BadCertificateException("foo.pem", sslerr)
         self.assertEqual(f"Bad CA certificate: foo.pem: {expected_message}", mapper.get_message(err))
+
+    def test_connectionerror(self):
+        expected_message = "Expected MESSAGE"
+        expected_errno = errno.ECONNREFUSED
+        mapper = ExceptionMapper()
+
+        err = ConnectionRefusedError(expected_errno, expected_message)
+        self.assertEqual(
+            f"Connection error: {expected_message} (error code {expected_errno})",
+            mapper.get_message(err),
+        )

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -402,8 +402,8 @@ class HandleExceptionTests(unittest.TestCase):
         except SystemExit as e:
             self.assertEqual(e.code, os.EX_SOFTWARE)
 
-    def test_he_network_exception(self):
-        e = connection.NetworkException(1337)
+    def test_he_unknowncontent_exception(self):
+        e = connection.UnknownContentException(1337)
         try:
             handle_exception("huh", e)
         except SystemExit as e:

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -388,7 +388,8 @@ class HandleExceptionTests(unittest.TestCase):
             self.assertEqual(e.code, os.EX_SOFTWARE)
 
     def test_he_bad_certificate(self):
-        e = connection.BadCertificateException("/road/to/nowhwere")
+        sslerr = ssl.SSLError(5, "some ssl error")
+        e = connection.BadCertificateException("/road/to/nowhwere", sslerr)
         try:
             handle_exception("huh", e)
         except SystemExit as e:

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -725,7 +725,7 @@ class RepoUpdateActionTests(fixture.SubManFixture):
     def test_with_ssl_verify_ProxyException(self, mock_get_consumer_auth_cp):
         """Test that proxy exception is handled and does not use SSL verification."""
         mock_cp = Mock()
-        mock_cp.has_capability = Mock(side_effect=rhsm.connection.ProxyException)
+        mock_cp.has_capability = Mock(side_effect=rhsm.connection.ProxyException(hostname="host", port=1234))
         mock_get_consumer_auth_cp.return_value = mock_cp
 
         update_action = RepoUpdateActionCommand()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -29,6 +29,7 @@ from subscription_manager.utils import (
     is_simple_content_access,
     is_process_running,
     get_process_names,
+    terminal_printable_content,
 )
 from .stubs import StubProductCertificate, StubProduct, StubEntitlementCertificate
 from .fixture import SubManFixture
@@ -1011,3 +1012,22 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
         res = get_process_names()
         res = list(res)
         self.assertEqual(res, [fake_process_name], "Expected an empty list, Actual: %s" % res)
+
+
+class TestTerminalPrintableContent(fixture.SubManFixture):
+    TEST_DATA = [
+        # empty string
+        ("", ""),
+        ("foo", "foo"),
+        ("foo\nbar", "foo\nbar"),
+        ("foo καινούργιο", "foo καινούργιο"),
+        ("foo 😃", "foo 😃"),
+        ("foo\tbar", "foo\tbar"),
+        # no terminal escape codes, please
+        ("\033[93mfoo\033[0m", "<27>[93mfoo<27>[0m"),
+    ]
+
+    def test_data(self):
+        for data in self.TEST_DATA:
+            with self.subTest(data=data):
+                self.assertEqual(data[1], terminal_printable_content(data[0]))


### PR DESCRIPTION
Some of the messages that subscription-manager prints in certain error situations, mostly related to networking, are generic and unhelpful. This  means that the users have little idea of what went wrong, and in certain cases even looking at the log file (`rhsm.log`) does not provide more clues. Since subscription-manager actually has more details on the failures, let's make it print what it knows about a certain failure.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2126981
Card ID: ENT-5345

### Internal changes

Some internal classes, mostly in `rhsm.connection`, were extended to carry more details/info. Those new bits are used later on to produce more detailed error messages.

There were changes in the C `_certificates` extension: in particular, a new exception, `CertificateLoadingError`, is added for certificate loading failures from OpenSSL.

Please refer to the individual commits for more detailed explanations on the changes.

### The changed messages

#### Network error, unable to connect to server. Please see ...

This represents a number of network related issues.

For any error related to the network name resolution, the proposed error message is:
> Network error: \<error message\> (error code \<error code\>)

for example:
> Network error: Name or service not known (error code -2)

For any error related to the network connection itself, the proposed error message is:
> Connection error: \<error message\> (error code \<error code\>)

for example:
> Connection error: Connection refused (error code 111)

In both cases, the error message/code is as reported by the low level network bits in the Linux stack.

***NB:*** the "old" error message is still (theoretically) in use, and thus not removed. This is because it is mapped to the `socket.error` exception, which in Python 3.3 became an alias for `OSError`: since `OSError` is very broad, it is hard to determine whether the current mappings done by `ExceptionMapper` cover all the cases handled by `ExceptionMapper`.

#### Network error. Please check the connection details, ...

Despite the "network” mention, this represents a reply from the server in case the content cannot be parsed as JSON, and the HTTP error code is different than 200, 202, 204, 304, 401, 403, 404, 410, 429, 500, 502, 503, 504.

In case there is a content in the server reply, the proposed error message is:
> Unknown server reply (HTTP error code \<error code\>: \<error message\>):
> \<content\>

for example:
> Unknown server reply (HTTP error code 400: Bad Request):
> \<html\>
> \<body\>
> [etc]

In case there is no content in the server reply, the proposed error message is:
> Unknown server reply (HTTP error code \<error code\>: \<error message\>)

for example:
> Unknown server reply (HTTP error code 400: Bad Request)

#### Proxy connection failed, please check your settings.

This represents errors related to the connection to the proxy server.

For any error related to the network name resolution of the proxy server, the proposed error message is:
> Proxy error: proxy_hostname:proxy_port: \<error message\> (error code \<error code\>)

for example:
> Proxy error: proxy_hostname:proxy_port: Name or service not known (error code -2)

For any error related to the connection to the proxy server, the proposed error message is:
> Proxy error: unable to connect to proxy_hostname:proxy_port: \<error message\> (error code \<error code\>)

for example:
> Proxy error: unable to connect to proxy_hostname:proxy_port: Connection refused (error code 111)

The error message/code is as reported by the low level network bits in the Linux stack.

#### Unable to reach the server at \<host\>:\<port\>/\<path\>

This error is printed when the initial connection to the entitlement server cannot be established; usually they refer to proxy errors.

For any error related to the connection to the proxy server, the proposed error message is:
> Unable to reach the server at hostname:port/path: \<error message\>

for example:
> Unable to reach the server at hostname:port/path: Tunnel connection failed: 500 Unable to connect
> Unable to reach the server at hostname:port/path: Tunnel connection failed: 407 Proxy Authentication Required

#### Bad CA certificate: \<file\>

This error is printed when any of the .pem files in the CA directory of subscription-manager (the default is /etc/rhsm/ca/) is not a valid PEM file with certificates. This generally should not happen, unless a custom faulty certificate is added to that directory.

The proposed error message is:
> Bad CA certificate: \<file\>: \<error message\>

for example:
> Bad CA certificate: \<file\>: [X509] no certificate or crl found (_ssl.c:3771)

The error message is what is reported by the Python ssl module or OpenSSL directly.

#### System certificates corrupted. Please reregister.

This error is printed when any of the products .pem files in /etc/pki/product-default/ is not a valid PEM file with certificates. This generally should not happen, as the certificates in that directory are provided by Red Hat.

The proposed error message is:
> Bad product certificate: \<file\>: \<error message\>

for example:
> Bad product certificate: \<file\>: [X509] no certificate or crl found (_ssl.c:3771)

The error message is what is reported by OpenSSL directly.

***NB:*** since the code involved in this is not used only to load product certificates, there are few more messages related to certificate loading failures.
