### PR TITLE
2097672: [1.28] Fixed expected message for manual attach case

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -2437,8 +2437,9 @@ class AttachCommand(CliCommand):
         owner_id = owner['key']
         print(
             _(
-                'Ignoring request to attach. '
-                'It is disabled for org "{owner_id}" because of the content access mode setting.'
+                "Ignoring the request to attach. "
+                'Attaching subscriptions is disabled for organization "{owner_id}" '
+                "because Simple Content Access (SCA) is enabled."
             ).format(owner_id=owner_id)
         )
 


### PR DESCRIPTION
- Updated the expected message from a user's manual attach request (--pool) when SCA is enabled for the organization.
- Manual backport of changes made in https://github.com/candlepin/subscription-manager/pull/3143
    - Original commit: 4d89c1b1544b969941000d273dcc05ae23448d99
- Card ID: ENT-5443
- BZ 2097672: https://bugzilla.redhat.com/show_bug.cgi?id=2097672