### PR TITLE
2125227: Fixed incorrect registration warning with yum/dnf

### DIFF
--- a/src/plugins/dnf/subscription-manager.py
+++ b/src/plugins/dnf/subscription-manager.py
@@ -82,9 +82,9 @@ class SubscriptionManager(dnf.Plugin):
             if os.getuid() == 0:
                 # Try to update entitlement certificates and redhat.repo file
                 self._update(cache_only)
+                self._warn_or_give_usage_message()
             else:
                 logger.info(_("Not root, Subscription Management repositories not updated"))
-            self._warn_or_give_usage_message()
             self._warn_expired()
         except Exception as e:
             log.error(str(e))


### PR DESCRIPTION
- Updated dnf plugin to no longer display registration warnings to non-root guest users.

**before fix dnf/yum usage as non-root user:**
```
$ yum install haproxy
Not root, Subscription Management repositories not updated
This system is not registered with an entitlement server. You can use subscription-manager to register.
Error: This command has to be run with superuser privileges (under the root user on most systems).
```

**after fix dnf/yum usage as root user:**
```
$ yum install haproxy
Not root, Subscription Management repositories not updated
Error: This command has to be run with superuser privileges (under the root user on most systems).
```

- Card ID: ENT-5412
- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2125227
