### PR TITLE
2134165: [1.28] Fixed incorrect registration warning with yum/dnf

### DIFF
--- a/src/dnf-plugins/subscription-manager.py
+++ b/src/dnf-plugins/subscription-manager.py
@@ -83,9 +83,9 @@ class SubscriptionManager(dnf.Plugin):
             if os.getuid() == 0:
                 # Try to update entitlement certificates and redhat.repo file
                 self._update(cache_only)
+                self._warn_or_give_usage_message()
             else:
-                logger.info(_('Not root, Subscription Management repositories not updated'))
-            self._warn_or_give_usage_message()
+                logger.info(_("Not root, Subscription Management repositories not updated"))
             self._warn_expired()
         except Exception as e:
             log.error(str(e))


### PR DESCRIPTION
- Updated dnf plugin to no longer display registration warnings to non-root guest users.
- Backport of changes made in https://github.com/candlepin/subscription-manager/pull/3146
    - Original commit: 71410e3f2616c45022666955a49cd22c9397a746
- Card ID: ENT-5412
- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2134165