### PR TITLE
2097679: Fixed script hang in non-interactive execution

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -58,6 +58,18 @@ command.
 .B subscription-manager
 has specific options available for each command, depending on what operation is being performed. Subscription Manager commands are related to the different subscription operations:
 
+.PP
+.B Note:
+Please note that using commands that require providing a username using 
+.B --username
+, a password using 
+.B --password 
+, an organization using 
+.B --org 
+, or environments using 
+.B --environments 
+must be passed as system arguments in a non-interactive session.
+
 .IP
 1. register
 
@@ -161,6 +173,17 @@ Disables progress messages that are being displayed when waiting for server resp
 The
 .B register
 command registers a new system to the subscription management service.
+.PP
+.B Note:
+Please note that using commands that require providing a username using 
+.B --username
+, a password using 
+.B --password 
+, an organization using 
+.B --org 
+, or environments using 
+.B --environments 
+must be passed as system arguments in a non-interactive session.
 
 .TP
 .B --username=USERNAME

--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -44,6 +44,7 @@ from subscription_manager.utils import (
     print_error,
     get_supported_resources,
     is_simple_content_access,
+    is_interactive,
 )
 from subscription_manager.cli_command.environments import check_set_environment_names
 
@@ -387,6 +388,12 @@ class RegisterCommand(UserPassCommand):
         """
         By breaking this code out, we can write cleaner tests
         """
+        if not is_interactive():
+            system_exit(
+                os.EX_USAGE,
+                _("Error: --environments is a required parameter in non-interactive mode."),
+            )
+
         if self.cp.has_capability(MULTI_ENV):
             environment = input(_("Environments: ")).replace(" ", "")
         else:
@@ -462,7 +469,13 @@ class RegisterCommand(UserPassCommand):
             )
         )
 
-        # Read the owner key from stdin
+        # Read the owner key from stdin or raise a system error if in a non-interactive session.
+        if not is_interactive():
+            system_exit(
+                os.EX_USAGE,
+                _("Error: --org is a required parameter in non-interactive mode."),
+            )
+
         owner_key = None
         while not owner_key:
             owner_key = input(_("Organization: "))

--- a/src/subscription_manager/cli_command/user_pass.py
+++ b/src/subscription_manager/cli_command/user_pass.py
@@ -16,9 +16,12 @@
 #
 import getpass
 import readline
+import os
 
 from subscription_manager.cli_command.cli import CliCommand
+from subscription_manager.cli import system_exit
 from subscription_manager.i18n import ugettext as _
+from subscription_manager.utils import is_interactive
 
 
 class UserPassCommand(CliCommand):
@@ -52,8 +55,20 @@ class UserPassCommand(CliCommand):
         """
         Safely get a username and password from the tty, without echoing.
         if either username or password are provided as arguments, they will
-        not be prompted for.
+        not be prompted for. In a non-interactive session, the system exits with an error.
         """
+        if not is_interactive():
+            if not username:
+                system_exit(
+                    os.EX_USAGE,
+                    _("Error: --username is a required parameter in non-interactive mode."),
+                )
+            if not password:
+                system_exit(
+                    os.EX_USAGE,
+                    _("Error: --password is a required parameter in non-interactive mode."),
+                )
+
         while not username:
             username = input(_("Username: "))
             readline.clear_history()

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -622,3 +622,11 @@ def is_process_running(process_to_find):
         if process_to_find == process_name:
             return True
     return False
+
+
+def is_interactive() -> bool:
+    """
+    Check if the process is running in an interactive session.
+    :return: True, when the process is running in an interactive session; Otherwise returns False
+    """
+    return sys.stdin and sys.stdin.isatty()


### PR DESCRIPTION
- Resolved the script hanging issue caused by the script waiting on user inputs for information not specified through command line arguments by checking if the session is interactive and raising an error detailing the missing command line argument if not.
- Updated the man page "commands and options" section with a note to document this behavior.
- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2097679
- Card ID: ENT-5117