### PR TITLE
2096852: [1.28] Fixed script hang in non-interactive execution

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -58,6 +58,18 @@ command.
 .B subscription-manager
 has specific options available for each command, depending on what operation is being performed. Subscription Manager commands are related to the different subscription operations:
 
+.PP
+.B Note:
+Please note that using commands that require providing a username using 
+.B --username
+, a password using 
+.B --password 
+, an organization using 
+.B --org 
+, or environments using 
+.B --environments 
+must be passed as system arguments in a non-interactive session.
+
 .IP
 1. register
 
@@ -157,6 +169,18 @@ Specifies a list of domain suffixes which should bypass the HTTP proxy.
 The
 .B register
 command registers a new system to the subscription management service.
+
+.PP
+.B Note:
+Please note that using commands that require providing a username using 
+.B --username
+, a password using 
+.B --password 
+, an organization using 
+.B --org 
+, or environments using 
+.B --environments 
+must be passed as system arguments in a non-interactive session.
 
 .TP
 .B --username=USERNAME

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -626,3 +626,11 @@ def is_process_running(process_to_find):
         if process_to_find == process_name:
             return True
     return False
+
+
+def is_interactive() -> bool:
+    """
+    Check if the process is running in an interactive session.
+    :return: True, when the process is running in an interactive session; Otherwise returns False
+    """
+    return sys.stdin and sys.stdin.isatty()


### PR DESCRIPTION
- Resolved the script hanging issue caused by the script waiting on user inputs for information not specified through command line arguments by checking if the session is interactive and raising an error detailing the missing command line argument if not.
- Updated the man page "commands and options" and "register" sections with a note to document this behavior.
- Manual backport of changes made in https://github.com/candlepin/subscription-manager/pull/3148
  - Original commit: cedc35f890ff3938d3a9bb14c3c80de4d197113e
  ... and in https://github.com/candlepin/subscription-manager/pull/3153
- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2096852
- Card ID: ENT-5117