### PR TITLE
ENT-4286: Simplify exception reporting with system_exit()

### DIFF
--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -23,7 +23,6 @@ from rhsm.connection import ProxyException
 from subscription_manager import syspurposelib
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand, ERR_NOT_REGISTERED_CODE, ERR_NOT_REGISTERED_MSG
-from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ungettext, ugettext as _
 from subscription_manager.syspurposelib import get_syspurpose_valid_fields
 from subscription_manager.utils import friendly_join
@@ -199,8 +198,7 @@ class AbstractSyspurposeCommand(CliCommand):
                 log.warning(
                     "Unable to get list of valid fields using REST API: {rest_err}".format(rest_err=rest_err)
                 )
-                mapped_message: str = ExceptionMapper().get_message(rest_err)
-                system_exit(os.EX_SOFTWARE, mapped_message)
+                system_exit(os.EX_SOFTWARE, rest_err)
             except ProxyException:
                 system_exit(os.EX_UNAVAILABLE, _("Proxy connection failed, please check your settings."))
             else:
@@ -448,8 +446,7 @@ class AbstractSyspurposeCommand(CliCommand):
                 log.error(
                     "Error: Unable to retrieve {attr} from server: {err}".format(attr=self.attr, err=err)
                 )
-                mapped_message: str = ExceptionMapper().get_message(err)
-                system_exit(os.EX_SOFTWARE, mapped_message)
+                system_exit(os.EX_SOFTWARE, err)
             else:
                 log.debug(
                     "Error: Unable to retrieve {attr} from server: {err}".format(attr=self.attr, err=err)
@@ -507,6 +504,6 @@ class AbstractSyspurposeCommand(CliCommand):
             advice = SP_ADVICE.format(command=command)
             value = result[attr]
             msg = _(SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice))
-            system_exit(os.EX_SOFTWARE, msgs=msg)
+            system_exit(os.EX_SOFTWARE, msg)
         else:
             print(success_msg)

--- a/src/subscription_manager/cli_command/cli.py
+++ b/src/subscription_manager/cli_command/cli.py
@@ -32,7 +32,6 @@ from rhsmlib.services import config
 
 from subscription_manager.cli import AbstractCLICommand, InvalidCLIOptionError, system_exit
 from subscription_manager.entcertlib import EntCertActionInvoker
-from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.utils import (
     generate_correlation_id,
@@ -70,10 +69,8 @@ def handle_exception(msg, ex):
     log.error(msg)
     log.exception(ex)
 
-    exception_mapper = ExceptionMapper()
-
-    mapped_message: str = exception_mapper.get_message(ex)
-    system_exit(os.EX_SOFTWARE, mapped_message)
+    # Directly pass the exception to system_exit for exception message formatting and exit.
+    system_exit(os.EX_SOFTWARE, ex)
 
 
 class CliCommand(AbstractCLICommand):

--- a/src/subscription_manager/cli_command/environments.py
+++ b/src/subscription_manager/cli_command/environments.py
@@ -27,7 +27,6 @@ from subscription_manager.cli_command.cli import (
 )
 from subscription_manager.cli_command.org import OrgCommand
 from subscription_manager.cli_command.list import ENVIRONMENT_LIST
-from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.i18n import ungettext
 from subscription_manager.printing_utils import columnize, echo_columnize_callback
@@ -107,8 +106,7 @@ class EnvironmentsCommand(OrgCommand):
             log.exception(re)
             log.error("Error: Unable to retrieve environment list from server: {re}".format(re=re))
 
-            mapped_message: str = ExceptionMapper().get_message(re)
-            system_exit(os.EX_SOFTWARE, mapped_message)
+            system_exit(os.EX_SOFTWARE, re)
         except Exception as e:
             handle_exception(_("Error: Unable to retrieve environment list from server"), e)
 

--- a/src/subscription_manager/cli_command/facts.py
+++ b/src/subscription_manager/cli_command/facts.py
@@ -22,7 +22,6 @@ import subscription_manager.injection as inj
 
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand
-from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
@@ -76,7 +75,6 @@ class FactsCommand(CliCommand):
             except connection.RestlibException as re:
                 log.exception(re)
 
-                mapped_message: str = ExceptionMapper().get_message(re)
-                system_exit(os.EX_SOFTWARE, mapped_message)
+                system_exit(os.EX_SOFTWARE, re)
             log.debug("Succesfully updated the system facts.")
             print(_("Successfully updated the system facts."))

--- a/src/subscription_manager/cli_command/identity.py
+++ b/src/subscription_manager/cli_command/identity.py
@@ -28,7 +28,6 @@ from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import handle_exception
 from subscription_manager.cli_command.environments import MULTI_ENV
 from subscription_manager.cli_command.user_pass import UserPassCommand
-from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.i18n import ungettext
 from subscription_manager.utils import get_current_owner, get_supported_resources
@@ -139,7 +138,6 @@ class IdentityCommand(UserPassCommand):
             log.exception(re)
             log.error("Error: Unable to generate a new identity for the system: {re}".format(re=re))
 
-            mapped_message: str = ExceptionMapper().get_message(re)
-            system_exit(os.EX_SOFTWARE, mapped_message)
+            system_exit(os.EX_SOFTWARE, re)
         except Exception as e:
             handle_exception(_("Error: Unable to generate a new identity for the system"), e)

--- a/src/subscription_manager/cli_command/override.py
+++ b/src/subscription_manager/cli_command/override.py
@@ -20,7 +20,6 @@ import rhsm.connection as connection
 
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand
-from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.overrides import Overrides, Override
 from subscription_manager.printing_utils import columnize, echo_columnize_callback
@@ -159,8 +158,7 @@ class OverrideCommand(CliCommand):
                 if ex.code == 400:
                     # blocklisted overrides specified.
                     # Print message and return a less severe code.
-                    mapped_message: str = ExceptionMapper().get_message(ex)
-                    system_exit(1, mapped_message)
+                    system_exit(1, ex)
                 else:
                     raise ex
 

--- a/src/subscription_manager/cli_command/owners.py
+++ b/src/subscription_manager/cli_command/owners.py
@@ -23,7 +23,6 @@ from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import handle_exception
 from subscription_manager.cli_command.list import ORG_LIST
 from subscription_manager.cli_command.user_pass import UserPassCommand
-from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.printing_utils import columnize, echo_columnize_callback
 
@@ -66,7 +65,6 @@ class OwnersCommand(UserPassCommand):
             log.exception(re)
             log.error("Error: Unable to retrieve org list from server: {re}".format(re=re))
 
-            mapped_message: str = ExceptionMapper().get_message(re)
-            system_exit(os.EX_SOFTWARE, mapped_message)
+            system_exit(os.EX_SOFTWARE, re)
         except Exception as e:
             handle_exception(_("Error: Unable to retrieve org list from server"), e)

--- a/src/subscription_manager/cli_command/refresh.py
+++ b/src/subscription_manager/cli_command/refresh.py
@@ -22,7 +22,6 @@ import rhsm.connection as connection
 
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand, handle_exception
-from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
@@ -41,8 +40,7 @@ class RefreshCommand(CliCommand):
             refresh_service.refresh(force=self.options.force)
         except connection.RestlibException as re:
             log.error(re)
-            mapped_message: str = ExceptionMapper().get_message(re)
-            system_exit(os.EX_SOFTWARE, mapped_message)
+            system_exit(os.EX_SOFTWARE, re)
         except Exception as e:
             handle_exception(
                 _("Unable to perform refresh due to the following exception: {e}").format(e=e), e

--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -37,7 +37,6 @@ from subscription_manager.cli_command.environments import MULTI_ENV
 from subscription_manager.cli_command.list import show_autosubscribe_output
 from subscription_manager.cli_command.user_pass import UserPassCommand
 from subscription_manager.entcertlib import CONTENT_ACCESS_CERT_CAPABILITY
-from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.utils import (
     restart_virt_who,
@@ -204,8 +203,7 @@ class RegisterCommand(UserPassCommand):
             # set during service.register() call
             attach.AttachService(self.cp).attach_auto(service_level=None)
         except connection.RestlibException as rest_lib_err:
-            mapped_message: str = ExceptionMapper().get_message(rest_lib_err)
-            print_error(mapped_message)
+            print_error(rest_lib_err)
         except Exception:
             log.exception("Auto-attach failed")
             raise
@@ -308,8 +306,7 @@ class RegisterCommand(UserPassCommand):
         except (connection.RestlibException, exceptions.ServiceError) as re:
             log.exception(re)
 
-            mapped_message: str = ExceptionMapper().get_message(re)
-            system_exit(os.EX_SOFTWARE, mapped_message)
+            system_exit(os.EX_SOFTWARE, re)
         except Exception as e:
             handle_exception(_("Error during registration: {e}").format(e=e), e)
         else:

--- a/src/subscription_manager/cli_command/remove.py
+++ b/src/subscription_manager/cli_command/remove.py
@@ -23,7 +23,6 @@ from rhsmlib.services import entitlement
 
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand, handle_exception
-from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ungettext, ugettext as _
 from subscription_manager.utils import unique_list_items
 
@@ -165,8 +164,7 @@ class RemoveCommand(CliCommand):
             except connection.RestlibException as err:
                 log.error(err)
 
-                mapped_message: str = ExceptionMapper().get_message(err)
-                system_exit(os.EX_SOFTWARE, mapped_message)
+                system_exit(os.EX_SOFTWARE, err)
             except Exception as e:
                 handle_exception(
                     _("Unable to perform remove due to the following exception: {e}").format(e=e), e

--- a/src/subscription_manager/cli_command/service_level.py
+++ b/src/subscription_manager/cli_command/service_level.py
@@ -30,7 +30,6 @@ from subscription_manager.cli_command.cli import (
     handle_exception,
 )
 from subscription_manager.cli_command.org import OrgCommand
-from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.i18n import ugettext as _
 
 from syspurpose.files import SyncedStore
@@ -124,8 +123,7 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
             log.exception(re)
             log.error("Error: Unable to retrieve service levels: {re}".format(re=re))
 
-            mapped_message: str = ExceptionMapper().get_message(re)
-            system_exit(os.EX_SOFTWARE, mapped_message)
+            system_exit(os.EX_SOFTWARE, re)
         except Exception as e:
             handle_exception(_("Error: Unable to retrieve service levels."), e)
         else:
@@ -148,8 +146,7 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
                 log.exception(re_err)
                 log.error("Error: Unable to retrieve service levels: {err}".format(err=re_err))
 
-                mapped_message: str = ExceptionMapper().get_message(re_err)
-                system_exit(os.EX_SOFTWARE, mapped_message)
+                system_exit(os.EX_SOFTWARE, re_err)
             except ProxyException:
                 system_exit(
                     os.EX_UNAVAILABLE,
@@ -237,7 +234,6 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
                     os.EX_UNAVAILABLE, _("Error: The service-level command is not supported by the server.")
                 )
             elif e.code == 404:
-                mapped_message: str = ExceptionMapper().get_message(e)
-                system_exit(os.EX_DATAERR, mapped_message)
+                system_exit(os.EX_DATAERR, e)
             else:
                 raise e

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -299,7 +299,7 @@ class TestCliProxyCommand(TestCliCommand):
 
 class TestSystemExit(unittest.TestCase):
     def test_a_msg(self):
-        msg = "some message"
+        msg: str = "some message"
         with Capture() as cap:
             try:
                 system_exit(1, msg)
@@ -307,62 +307,33 @@ class TestSystemExit(unittest.TestCase):
                 pass
         self.assertEqual("%s\n" % msg, cap.err)
 
-    def test_msgs(self):
-        msgs = ["a", "b", "c"]
-        with Capture() as cap:
-            try:
-                system_exit(1, msgs)
-            except SystemExit:
-                pass
-        self.assertEqual("%s\n" % ("\n".join(msgs)), cap.err)
-
-    def test_msg_and_exception(self):
-        msgs = ["a", ValueError()]
-        with Capture() as cap:
-            try:
-                system_exit(1, msgs)
-            except SystemExit:
-                pass
-        self.assertEqual("%s\n\n" % msgs[0], cap.err)
-
-    def test_msg_and_exception_no_str(self):
-        class NoStrException(Exception):
-            pass
-
-        msgs = ["a", NoStrException()]
-        with Capture() as cap:
-            try:
-                system_exit(1, msgs)
-            except SystemExit:
-                pass
-        self.assertEqual("%s\n\n" % msgs[0], cap.err)
-
     def test_msg_unicode(self):
-        msgs = ["\u2620 \u2603 \u203D"]
+        msg: str = "\u2620 \u2603 \u203D"
         with Capture() as cap:
             try:
-                system_exit(1, msgs)
+                system_exit(1, msg)
             except SystemExit:
                 pass
-        captured = cap.err
-        self.assertEqual("%s\n" % msgs[0], captured)
+        captured: str = cap.err
+        self.assertEqual("%s\n" % msg, captured)
 
-    def test_msg_and_exception_str(self):
-        class StrException(Exception):
-            def __init__(self, msg):
-                self.msg = msg
-
-            def __str__(self):
-                return self.msg
-
-        msg = "bar"
-        msgs = ["a", StrException(msg)]
+    def test_only_exception(self):
+        ex: ValueError = ValueError("test message")
         with Capture() as cap:
             try:
-                system_exit(1, msgs)
+                system_exit(1, ex)
             except SystemExit:
                 pass
-        self.assertEqual("%s\n%s\n" % ("a", msg), cap.err)
+        self.assertEqual("%s\n" % str(ex), cap.err)
+
+    def test_only_exception_unicode(self):
+        ex: ValueError = ValueError("\u2620 \u2603 \u203D")
+        with Capture() as cap:
+            try:
+                system_exit(1, ex)
+            except SystemExit:
+                pass
+        self.assertEqual("%s\n" % str(ex), cap.err)
 
 
 class HandleExceptionTests(unittest.TestCase):


### PR DESCRIPTION
Card ID: ENT-4286
- Updated system_exit() function to directly accept an exception to
format the exception message using ExceptionMapper before printing it.
- Updated various exception handlers to directly pass exceptions
to system_exit() where ExceptionMapper was used to
format the message of that exception.
- Removed list of exceptions and messages support
and removed related test cases for system_exit() function.
- Added new unit tests for system_exit() function.