### PR TITLE
[1.29.30] 2142611: Clear progress messages properly

### DIFF
--- a/src/rhsm/utils.py
+++ b/src/rhsm/utils.py
@@ -457,7 +457,7 @@ class StatusMessage:
     def clean(self):
         if self.quiet:
             return
-        print(" " * len(self.text), end="\r")
+        print("\033[0K", end="\r")
 
     def __enter__(self):
         self.print()
@@ -542,15 +542,6 @@ class LiveStatusMessage(StatusMessage):
             yield self.frames[self._loops % len(self.frames)]
 
     @property
-    def max_text_width(self) -> int:
-        """Get the length of the longest line possible.
-
-        This is used so we can properly clean the console when we exit.
-        """
-        max_frame_length: int = len(max(self.frames, key=len))
-        return len(self.text) + max_frame_length + 1
-
-    @property
     def cursor(self) -> bool:
         """Get cursor visibility state."""
         return self._cursor
@@ -604,7 +595,7 @@ class LiveStatusMessage(StatusMessage):
     def clean(self):
         if self.quiet:
             return
-        print(" " * self.max_text_width, end="\r")
+        print("\033[0K", end="\r")
 
     def loop(self):
         """Show pretty animation while we fetch data."""


### PR DESCRIPTION
* BZ: 2142611
* Card ID: ENT-5468

Multi-byte progress messages, such as Japanese, were not being cleared correctly. The number of characters was lower than the number of bytes written to the console, so we weren't clearing enough.

Escape code 0K should handle this properly, as it will delete all the content on current line.

Cherry picked from 62652ba.