### PR TITLE
Fix failures of D-Bus' Register tests

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -78,7 +78,6 @@ RUN pip3 install -r dev-requirements.txt && \
 
 RUN chown -R user:user /build
 USER user
-ENV DBUS_SESSION_BUS_ADDRESS='unix:path=/tmp/bus'
 RUN echo "export SMDEV_CONTAINER_OFF='True'" >> /home/user/.bashrc && \
     echo "export SMDEV_CONTAINER_OFF='True'" >> /home/user/.zshrc
 WORKDIR /build/subscription-manager

--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -29,7 +29,6 @@ echo "Using container name: $TAG"
 if [ -d $WORKSPACE@tmp ]; then
     podman run -it \
       -u $JUID:$JGID \
-      -v /run/user/$JUID/bus:/tmp/bus \
       -w $WORKSPACE \
       -v $WORKSPACE:$WORKSPACE:rw,z \
       -v $WORKSPACE@tmp:$WORKSPACE@tmp:rw,z \
@@ -42,7 +41,6 @@ if [ -d $WORKSPACE@tmp ]; then
 else
     podman run -it \
       -u $JUID:$JGID \
-      -v /run/user/$JUID/bus:/tmp/bus \
       -w $WORKSPACE \
       -v $WORKSPACE:$WORKSPACE:rw,z \
       --name "$TAG" \

--- a/jenkins/unit.sh
+++ b/jenkins/unit.sh
@@ -22,7 +22,7 @@ python3 setup.py build
 python3 setup.py build_ext --inplace
 
 # make sure we have a dbus session for the dbus tests
-dbus-run-session coverage run -m pytest -v
+dbus-run-session coverage run -m pytest -vvl
 RETVAL="$?"
 coverage report
 coverage xml

--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -253,6 +253,17 @@ class DomainSocketServer(object):
     to open another server on a domain socket, gets socket information back, and then connects and sends
     the register command (with the credentials) to the server on the domain socket."""
 
+    # FIXME Use `dir` instead.
+    # `tmpdir` behaves differently from `dir` on old versions of dbus
+    # (earlier than 1.12.24 and 1.14.4).
+    # In newer versions we are not getting abstract socket anymore.
+    _server_socket_iface: str = "unix:tmpdir="
+    _server_socket_path: str = "/run"
+
+    @property
+    def _server_socket(self):
+        return self._server_socket_iface + self._server_socket_path
+
     @staticmethod
     def connection_added(domain_socket_server, service_class, object_list, conn):
         obj = service_class(
@@ -317,7 +328,7 @@ class DomainSocketServer(object):
 
     def run(self):
         try:
-            self._server = dbus.server.Server("unix:tmpdir=/run")
+            self._server = dbus.server.Server(self._server_socket)
 
             for clazz in self.object_classes:
                 self._server.on_connection_added.append(

--- a/test/rhsmlib/base.py
+++ b/test/rhsmlib/base.py
@@ -29,6 +29,8 @@ from subscription_manager.i18n import Locale
 import rhsmlib.dbus.base_object
 from rhsmlib.dbus import constants
 
+from test import subman_marker_dbus
+
 # Set DBus mainloop early in test run (test import time!)
 dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 log = logging.getLogger(__name__)
@@ -66,6 +68,7 @@ class InjectionMockingTest(unittest.TestCase):
         raise NotImplementedError("Subclasses should define injected objects")
 
 
+@subman_marker_dbus
 class DBusServerStubProvider(unittest.TestCase):
     """Special class used start a DBus server.
 

--- a/test/rhsmlib/dbus/test_register.py
+++ b/test/rhsmlib/dbus/test_register.py
@@ -12,12 +12,16 @@
 # in this software or its documentation.
 import contextlib
 import json
+import tempfile
+from typing import Optional
+
 import mock
 import socket
 
 from rhsm import connection
 
 import rhsmlib.dbus.exceptions
+from rhsmlib.dbus.server import DomainSocketServer
 from rhsmlib.dbus.objects import RegisterDBusObject, DomainSocketRegisterDBusObject
 
 from test.rhsmlib.base import DBusServerStubProvider
@@ -315,6 +319,21 @@ OWNERS_CONTENT_JSON = """[
 class RegisterDBusObjectTest(DBusServerStubProvider):
     dbus_class = RegisterDBusObject
     dbus_class_kwargs = {}
+    socket_dir: Optional[tempfile.TemporaryDirectory] = None
+
+    def setUp(self) -> None:
+        self.socket_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.socket_dir.cleanup)
+
+        socket_path_patch = mock.patch.object(DomainSocketServer, "_server_socket_path", self.socket_dir.name)
+        socket_path_patch.start()
+        # `tmpdir` behaves differently from `dir` on old versions of dbus
+        # (earlier than 1.12.24 and 1.14.4).
+        # In newer versions we are not getting abstract socket anymore.
+        socket_iface_patch = mock.patch.object(DomainSocketServer, "_server_socket_iface", "unix:dir=")
+        socket_iface_patch.start()
+
+        super().setUp()
 
     def tearDown(self) -> None:
         """Make sure the domain server is stopped once the test ends."""
@@ -324,7 +343,7 @@ class RegisterDBusObjectTest(DBusServerStubProvider):
         super().tearDown()
 
     def test_Start(self):
-        substring = "/run/dbus.*"
+        substring = self.socket_dir.name + "/dbus.*"
         result = self.obj.Start.__wrapped__(self.obj, self.LOCALE)
         self.assertRegex(result, substring)
 
@@ -341,10 +360,7 @@ class RegisterDBusObjectTest(DBusServerStubProvider):
 
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
-            # The socket returned for connection is an abstract socket, so we
-            # have to begin the name with a NUL byte to get into that namespace.
-            # See http://blog.eduardofleury.com/archives/2007/09/13.
-            sock.connect("\0" + address)
+            sock.connect(address)
         finally:
             sock.close()
 


### PR DESCRIPTION
Our test that checks if it is possible to connect to newly created socket started failing with 'Permission denied' when the code tried to use it. Pytest cannot write into '/run', moving it to '/tmp' solves the issue.