### PR TITLE
2121350: Implement "force" register option in rhsm dbus python binding

### DIFF
--- a/test/rhsmlib/dbus/test_register.py
+++ b/test/rhsmlib/dbus/test_register.py
@@ -14,6 +14,8 @@ import contextlib
 import json
 import mock
 import socket
+import dbus
+
 
 from rhsm import connection
 
@@ -370,6 +372,12 @@ class DomainSocketRegisterDBusObjectTest(DBusServerStubProvider):
         cls.patches["register"] = register_patch.start()
         cls.addClassCleanup(register_patch.stop)
 
+        unregister_patch = mock.patch(
+            "rhsmlib.services.unregister.UnregisterService.unregister", name="unregister"
+        )
+        cls.patches["unregister"] = unregister_patch.start()
+        cls.addClassCleanup(unregister_patch.stop)
+
         is_registered_patch = mock.patch(
             "rhsmlib.dbus.base_object.BaseObject.is_registered",
             name="is_registered",
@@ -412,6 +420,26 @@ class DomainSocketRegisterDBusObjectTest(DBusServerStubProvider):
 
         result = self.obj.Register.__wrapped__(self.obj, "org", "username", "password", {}, {}, self.LOCALE)
         self.assertEqual(expected, json.loads(result))
+
+    def test_Register__with_force_option(self):
+        expected = json.loads(CONSUMER_CONTENT_JSON)
+        self.patches["register"].return_value = expected
+        self.patches["unregister"].return_value = None
+        self.patches["is_registered"].return_value = True
+
+        result = self.obj.Register.__wrapped__(
+            self.obj, "org", "username", "password", {"force": True}, {}, self.LOCALE
+        )
+        self.assertEqual(expected, json.loads(result))
+
+    def test_Register__already_registered(self):
+        expected = json.loads(CONSUMER_CONTENT_JSON)
+        self.patches["register"].return_value = expected
+        self.patches["unregister"].return_value = None
+        self.patches["is_registered"].return_value = True
+
+        with self.assertRaisesRegex(dbus.DBusException, "This system is already registered."):
+            self.obj.Register.__wrapped__(self.obj, "org", "username", "password", {}, {}, self.LOCALE)
 
     def test_Register__enable_content(self):
         """Test including 'enable_content' in entitlement mode with no content."""
@@ -471,6 +499,37 @@ class DomainSocketRegisterDBusObjectTest(DBusServerStubProvider):
             "username",
             ["key1", "key2"],
             {},
+            {"host": "localhost", "port": "8443", "handler": "/candlepin"},
+            self.LOCALE,
+        )
+        self.assertEqual(expected, json.loads(result))
+
+    def test_RegisterWithActivationKeys__already_registered(self):
+        expected = json.loads(CONSUMER_CONTENT_JSON)
+        self.patches["is_registered"].return_value = True
+        self.patches["register"].return_value = expected
+
+        with self.assertRaisesRegex(dbus.DBusException, "This system is already registered."):
+            self.obj.RegisterWithActivationKeys.__wrapped__(
+                self.obj,
+                "username",
+                ["key1", "key2"],
+                {},
+                {"host": "localhost", "port": "8443", "handler": "/candlepin"},
+                self.LOCALE,
+            )
+
+    def test_RegisterWithActivationKeys__with_force_option(self):
+        expected = json.loads(CONSUMER_CONTENT_JSON)
+        self.patches["is_registered"].return_value = True
+        self.patches["unregister"].return_value = None
+        self.patches["register"].return_value = expected
+
+        result = self.obj.RegisterWithActivationKeys.__wrapped__(
+            self.obj,
+            "username",
+            ["key1", "key2"],
+            {"force": True},
             {"host": "localhost", "port": "8443", "handler": "/candlepin"},
             self.LOCALE,
         )


### PR DESCRIPTION
- Card ID: ENT-5350
- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2121350
- Implemented missing behavior of the "force" option in Dbus API by unregistering the system if already registered and re-registering the system.


### Testing
This implementation can be tested in either Python or CLI by sending a register command with the "force" option enabled to the rhsm dbus python binding as seen below:

**Testing with a shell script**
- Use this script: https://github.com/jirihnidek/rhsm-dbus-examples/blob/main/register-org-username-password-force.sh

**Testing with a python script** 
- Modified script from original BZ reproduction steps:
```python
import dbus

REGISTER_OPTS_DICT = dbus.Dictionary({"force": True}, signature="ss")
system_bus = dbus.SystemBus()
register_server = system_bus.get_object("com.redhat.RHSM1", "/com/redhat/RHSM1/RegisterServer")
address = register_server.Start("C", dbus_interface="com.redhat.RHSM1.RegisterServer")
private_bus = dbus.connection.Connection(address)
register_object = private_bus.get_object("com.redhat.RHSM1", "/com/redhat/RHSM1/Register")
connection_opts = {
    "host": "<stage_server_address>"
}
connection_opts = dbus.Dictionary(connection_opts, signature="ss")

# Register w/ username and password
register_object.Register(
    "<org_id>",
    "<username>",
    "<password>",
    REGISTER_OPTS_DICT,
    connection_opts,
    "C",
    dbus_interface="com.redhat.RHSM1.Register",
)

# Register w/ activation keys
register_object.RegisterWithActivationKeys(
    "<org_id>",
    [<list_of_activation_keys>],
    REGISTER_OPTS_DICT,
    connection_opts,
    "C",
    dbus_interface="com.redhat.RHSM1.Register",
)
```