### PR TITLE
ENT-4286: Additional fix for exception handling

### DIFF
--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -46,6 +46,7 @@ from subscription_manager.utils import (
     is_interactive,
 )
 from subscription_manager.cli_command.environments import check_set_environment_names
+from subscription_manager.exceptions import ExceptionMapper
 
 log = logging.getLogger(__name__)
 
@@ -203,7 +204,8 @@ class RegisterCommand(UserPassCommand):
             # set during service.register() call
             attach.AttachService(self.cp).attach_auto(service_level=None)
         except connection.RestlibException as rest_lib_err:
-            print_error(rest_lib_err)
+            mapped_message: str = ExceptionMapper().get_message(rest_lib_err)
+            print_error(mapped_message)
         except Exception:
             log.exception("Auto-attach failed")
             raise


### PR DESCRIPTION
- Reverted the removal of a mapped message with ExceptionMapper in cli_command/register.py
- Resolves additional issue discovered in previously merged PR: https://github.com/candlepin/subscription-manager/pull/3152
- Card ID: ENT-4286