### PR TITLE
Catch also CertificateLoadingError for identity cert loading

### DIFF
--- a/src/subscription_manager/identity.py
+++ b/src/subscription_manager/identity.py
@@ -23,6 +23,7 @@ from subscription_manager.certdirectory import Path
 
 from rhsmlib.services import config
 from rhsm.certificate import CertificateException
+from rhsm.certificate2 import CertificateLoadingError
 
 conf = config.Config(get_config_parser())
 log = logging.getLogger(__name__)
@@ -137,7 +138,7 @@ class Identity(object):
                 self.consumer = self._get_consumer_identity()
             # XXX shouldn't catch the global exception here, but that's what
             # existsAndValid did, so this is better.
-            except (CertificateException, IOError) as err:
+            except (CertificateException, CertificateLoadingError, IOError) as err:
                 self.consumer = None
                 err_msg = err
                 msg = "Reload of consumer identity cert %s raised an exception with msg: %s" % (


### PR DESCRIPTION
They are now raisen in case of loading failure of certificates.

This avoids tracebacks when trying to do operations that load the identity certificate, in case it is not valid:
- register a system
- corrupt `/etc/pki/consumer/cert.pem` in any way so it is no more valid
- run e.g. `subscription-manager clean`
             
Fixes commit 05f20b9713e4bb629243da947da9d53226ba9877.