### PR TITLE
ENT-5510: [1.28] Fix issues with proxy and cockpit interaction

### DIFF
--- a/cockpit/src/subscriptions-client.js
+++ b/cockpit/src/subscriptions-client.js
@@ -262,6 +262,13 @@ client.registerSystem = (subscriptionDetails, update_progress) => {
         if (path) {
             connection_options.handler = dbus_str(path);
         }
+    } else {
+        // When user decide to not use proxy settings (checkbox "Use proxy server" is not checked),
+        // then set empty strings to all proxy options and do not use values from configuration file
+        connection_options.proxy_hostname = dbus_str('');
+        connection_options.proxy_port = dbus_str('');
+        connection_options.proxy_user = dbus_str('');
+        connection_options.proxy_password = dbus_str('');
     }
 
     // proxy is optional

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -181,18 +181,22 @@ class BaseConnection(object):
         else:
             info = utils.get_env_proxy_info()
 
-            self.proxy_hostname = proxy_hostname or \
-                                  config.get('server', 'proxy_hostname') or \
-                                  info['proxy_hostname']
-            self.proxy_port = proxy_port or \
-                              config.get('server', 'proxy_port') or \
-                              info['proxy_port']
-            self.proxy_user = proxy_user or \
-                              config.get('server', 'proxy_user') or \
-                              info['proxy_username']
-            self.proxy_password = proxy_password or \
-                                  config.get('server', 'proxy_password') or \
-                                  info['proxy_password']
+            if proxy_hostname is not None:
+                self.proxy_hostname = proxy_hostname
+            else:
+                self.proxy_hostname = config.get('server', 'proxy_hostname') or info['proxy_hostname']
+            if proxy_port is not None:
+                self.proxy_port = proxy_port
+            else:
+                self.proxy_port = config.get('server', 'proxy_port') or info['proxy_port']
+            if proxy_user is not None:
+                self.proxy_user = proxy_user
+            else:
+                self.proxy_user = config.get('server', 'proxy_user') or info['proxy_username']
+            if proxy_password is not None:
+                self.proxy_password = proxy_password
+            else:
+                self.proxy_password = config.get('server', 'proxy_password') or info['proxy_password']
 
         self.cert_file = cert_file
         self.key_file = key_file

--- a/test/rhsm/unit/test_connection.py
+++ b/test/rhsm/unit/test_connection.py
@@ -140,43 +140,139 @@ class ConnectionTests(unittest.TestCase):
     def test_clean_up_prefix(self):
         self.assertTrue(self.cp.handler == "/Test/")
 
+    @staticmethod
+    def mock_config_without_proxy_settings(section, name):
+        """
+        Mock configuration file (rhsm.conf) not including any proxy setting. Without this
+        mock conf some unit tests for environment variable will not work for situation, when
+        rhsm.conf on the system contains some proxy settings.
+        :param section: name of ini file section
+        :param name: name of ini option
+        :return: value for given section and option
+        """
+        if (section, name) == ('server', 'no_proxy'):
+            return ''
+        if (section, name) == ('server', 'proxy_hostname'):
+            return ''
+        if (section, name) == ('server', 'proxy_port'):
+            return ''
+        if (section, name) == ('server', 'proxy_user'):
+            return ''
+        if (section, name) == ('server', 'proxy_password'):
+            return ''
+        return None
+
     def test_https_proxy_info_allcaps(self):
         with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host:4444'}):
-            uep = UEPConnection(username="dummy", password="dummy",
-                 handler="/Test/", insecure=True)
-            self.assertEqual("u", uep.proxy_user)
-            self.assertEqual("p", uep.proxy_password)
-            self.assertEqual("host", uep.proxy_hostname)
-            self.assertEqual(int("4444"), uep.proxy_port)
+            with patch.object(connection.config, 'get', self.mock_config_without_proxy_settings):
+                uep = UEPConnection(username="dummy", password="dummy",
+                    handler="/Test/", insecure=True)
+                self.assertEqual("u", uep.proxy_user)
+                self.assertEqual("p", uep.proxy_password)
+                self.assertEqual("host", uep.proxy_hostname)
+                self.assertEqual(int("4444"), uep.proxy_port)
 
     def test_order(self):
         # should follow the order: HTTPS, https, HTTP, http
         with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host:4444',
                                        'http_proxy': 'http://notme:orme@host:2222'}):
-            uep = UEPConnection(username="dummy", password="dummy",
-                 handler="/Test/", insecure=True)
-            self.assertEqual("u", uep.proxy_user)
-            self.assertEqual("p", uep.proxy_password)
-            self.assertEqual("host", uep.proxy_hostname)
-            self.assertEqual(int("4444"), uep.proxy_port)
+            with patch.object(connection.config, 'get', self.mock_config_without_proxy_settings):
+                uep = UEPConnection(username="dummy", password="dummy",
+                    handler="/Test/", insecure=True)
+                self.assertEqual("u", uep.proxy_user)
+                self.assertEqual("p", uep.proxy_password)
+                self.assertEqual("host", uep.proxy_hostname)
+                self.assertEqual(int("4444"), uep.proxy_port)
 
     def test_no_port(self):
         with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host'}):
-            uep = UEPConnection(username="dummy", password="dummy",
-                 handler="/Test/", insecure=True)
-            self.assertEqual("u", uep.proxy_user)
-            self.assertEqual("p", uep.proxy_password)
-            self.assertEqual("host", uep.proxy_hostname)
-            self.assertEqual(3128, uep.proxy_port)
+            with patch.object(connection.config, 'get', self.mock_config_without_proxy_settings):
+                uep = UEPConnection(username="dummy", password="dummy",
+                    handler="/Test/", insecure=True)
+                self.assertEqual("u", uep.proxy_user)
+                self.assertEqual("p", uep.proxy_password)
+                self.assertEqual("host", uep.proxy_hostname)
+                self.assertEqual(3128, uep.proxy_port)
 
     def test_no_user_or_password(self):
         with patch.dict('os.environ', {'HTTPS_PROXY': 'http://host:1111'}):
-            uep = UEPConnection(username="dummy", password="dummy",
-                 handler="/Test/", insecure=True)
-            self.assertEqual(None, uep.proxy_user)
-            self.assertEqual(None, uep.proxy_password)
-            self.assertEqual("host", uep.proxy_hostname)
-            self.assertEqual(int("1111"), uep.proxy_port)
+            with patch.object(connection.config, 'get', self.mock_config_without_proxy_settings):
+                uep = UEPConnection(username="dummy", password="dummy",
+                    handler="/Test/", insecure=True)
+                self.assertEqual(None, uep.proxy_user)
+                self.assertEqual(None, uep.proxy_password)
+                self.assertEqual("host", uep.proxy_hostname)
+                self.assertEqual(int("1111"), uep.proxy_port)
+
+    def test_proxy_via_api(self):
+        """
+        Test that API trumps env var and config.
+        """
+        host = self.cp.host
+        port = self.cp.ssl_port
+
+        # Mock some proxy values in configuration file
+        def mock_config(section, name):
+            if (section, name) == ('server', 'hostname'):
+                return host
+            if (section, name) == ('server', 'port'):
+                return port
+            if (section, name) == ('server', 'proxy_hostname'):
+                return 'foo.example.com'
+            if (section, name) == ('server', 'proxy_port'):
+                return '3311'
+            if (section, name) == ('server', 'proxy_user'):
+                return 'proxyuser'
+            if (section, name) == ('server', 'proxy_password'):
+                return 'proxypassword'
+            return None
+
+        with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host',
+                                       'NO_PROXY': 'foo.example.com'}):
+            with patch.object(connection.config, 'get', mock_config):
+                uep = UEPConnection(username='dummy', password='dummy',
+                                    handler='/test', insecure=True,
+                                    proxy_hostname='proxy.example.org', proxy_port='3030',
+                                    proxy_user='foo_user', proxy_password='secret')
+                self.assertEqual(uep.proxy_hostname, 'proxy.example.org')
+                self.assertEqual(uep.proxy_port, '3030')
+                self.assertEqual(uep.proxy_user, 'foo_user')
+                self.assertEqual(uep.proxy_password, 'secret')
+
+    def test_empty_proxy_via_api(self):
+        """
+        Test that API trumps env var and config despite API uses empty strings.
+        """
+        host = self.cp.host
+        port = self.cp.ssl_port
+
+        # Mock some proxy values in configuration file
+        def mock_config(section, name):
+            if (section, name) == ('server', 'hostname'):
+                return host
+            if (section, name) == ('server', 'port'):
+                return port
+            if (section, name) == ('server', 'proxy_hostname'):
+                return 'foo.example.com'
+            if (section, name) == ('server', 'proxy_port'):
+                return '3311'
+            if (section, name) == ('server', 'proxy_user'):
+                return 'proxyuser'
+            if (section, name) == ('server', 'proxy_password'):
+                return 'proxypassword'
+            return None
+
+        with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host',
+                                       'NO_PROXY': 'foo.example.com'}):
+            with patch.object(connection.config, 'get', mock_config):
+                uep = UEPConnection(username='dummy', password='dummy',
+                                    handler='/test', insecure=True,
+                                    proxy_hostname='', proxy_port='',
+                                    proxy_user='', proxy_password='')
+                self.assertEqual(uep.proxy_hostname, '')
+                self.assertEqual(uep.proxy_port, '')
+                self.assertEqual(uep.proxy_user, '')
+                self.assertEqual(uep.proxy_password, '')
 
     def test_no_proxy_via_api(self):
         """Test that API trumps env var and config."""


### PR DESCRIPTION
- Resolved issue where proxy settings set in rhsm.conf were still being used by cockpit when cockpit disabled using proxy settings for registration, resulting in registration errors.
- Manual backport of changes made by Jiri in https://github.com/candlepin/subscription-manager/pull/2580
- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1956654
- Card ID: ENT-5510