### PR TITLE
Catch generic `OSError` during `HTTPSConnection.connect()`

### DIFF
--- a/src/subscription_manager/cli_command/cli.py
+++ b/src/subscription_manager/cli_command/cli.py
@@ -24,7 +24,7 @@ import subscription_manager.injection as inj
 
 from rhsm.certificate import CertificateException
 from rhsm.certificate2 import CertificateLoadingError
-from rhsm.connection import ProxyException
+from rhsm.connection import ProxyException, ConnectionOSErrorException
 from rhsm.https import ssl
 import rhsm.utils
 from rhsm.utils import cmd_name, ServerUrlParseError, remove_scheme
@@ -399,7 +399,7 @@ class CliCommand(AbstractCLICommand):
                         os.EX_CONFIG,
                         _("Error: CA certificate for subscription service has not been installed."),
                     )
-                except ProxyException as exc:
+                except (ProxyException, ConnectionOSErrorException) as exc:
                     system_exit(os.EX_UNAVAILABLE, exc)
 
         else:

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -61,6 +61,7 @@ PRODUCT_CERTIFICATE_LOADING_PATH_ERROR = _("Bad product certificate: {file}: [{l
 CERTIFICATE_LOADING_PATH_ERROR = _("Bad certificate: {file}: [{library}] {message}")
 CERTIFICATE_LOADING_PEM_ERROR = _("Bad certificate: [{library}] {message}\n{data}")
 CERTIFICATE_LOADING_ERROR = _("Bad certificate: [{library}] {message}")
+CONNECTION_UNREACHABLE_MESSAGE = _("Unable to reach the server at {host}: {message}")
 
 # TRANSLATORS: example: "You don't have permission to perform this action (HTTP error code 403: Forbidden)"
 # (the part before the opening bracket originates on the server)
@@ -95,6 +96,10 @@ class ExceptionMapper(object):
             httplib.BadStatusLine: (REMOTE_SERVER_MESSAGE, self.format_using_template),
             TokenAuthUnsupportedException: (TOKEN_AUTH_UNSUPPORTED_MESSAGE, self.format_using_template),
             CertificateLoadingError: (None, self.format_cert_loading_error),
+            connection.ConnectionOSErrorException: (
+                CONNECTION_UNREACHABLE_MESSAGE,
+                self.format_connection_unreachable,
+            ),
         }
 
     def format_using_template(self, _: Exception, message: str) -> str:
@@ -171,6 +176,12 @@ class ExceptionMapper(object):
         if exc.pem is not None:
             return CERTIFICATE_LOADING_PEM_ERROR.format(**fmtargs)
         return CERTIFICATE_LOADING_ERROR.format(**fmtargs)
+
+    def format_connection_unreachable(
+        self, exc: connection.ConnectionOSErrorException, message_template: str
+    ):
+        host = f"{exc.host}:{exc.port}{exc.handler}"
+        return message_template.format(host=host, message=str(exc.exc))
 
     def get_message(self, exception) -> str:
         """Get string representation of an exception.

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -38,7 +38,7 @@ from subscription_manager import injection as inj
 # we may want to import some of the other items for
 # compatibility.
 from rhsm.utils import parse_url
-from rhsm.connection import ProxyException
+from rhsm.connection import ProxyException, ConnectionOSErrorException
 
 import subscription_manager.version
 from rhsm.connection import RestlibException, GoneException
@@ -162,7 +162,7 @@ def is_valid_server_info(conn):
         # Indicates a missing CA certificate, which callers may need to
         # notify the user of:
         raise MissingCaCertException(e)
-    except ProxyException:
+    except (ProxyException, ConnectionOSErrorException):
         raise
     except Exception as e:
         log.exception(e)

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -15,7 +15,13 @@ import unittest
 
 from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.certdirectory import DEFAULT_PRODUCT_CERT_DIR
-from rhsm.connection import RestlibException, BadCertificateException, ProxyException, UnknownContentException
+from rhsm.connection import (
+    RestlibException,
+    BadCertificateException,
+    ProxyException,
+    UnknownContentException,
+    ConnectionOSErrorException,
+)
 from rhsm.https import httplib, ssl
 from rhsm.certificate2 import CertificateLoadingError
 
@@ -254,5 +260,20 @@ class TestExceptionMapper(unittest.TestCase):
         err = CertificateLoadingError(expected_library, expected_reason)
         self.assertEqual(
             f"Bad certificate: [{expected_library}] {expected_reason}",
+            mapper.get_message(err),
+        )
+
+    def test_connectionoserror(self):
+        expected_message = "Expected MESSAGE"
+        expected_hostname = "hostname"
+        expected_port = 1234
+        expected_handler = "/foo"
+        mapper = ExceptionMapper()
+
+        genericerr = OSError(expected_message)
+        err = ConnectionOSErrorException(expected_hostname, expected_port, expected_handler, genericerr)
+        self.assertEqual(
+            f"Unable to reach the server at {expected_hostname}:{expected_port}{expected_handler}: "
+            f"{expected_message}",
             mapper.get_message(err),
         )


### PR DESCRIPTION
In case `HTTPSConnection.connect()` fails for reasons different than syscall failures, the raisen `OSError` has the `errno` field set to `None`; this typically happens for proxy/tunnel connection failures.

Since we want to diagnose those cases accurately, then
- introduce a new exception, `ConnectionOSErrorException`, to represent this situation
- catch the specific situation we want from `HTTPSConnection.connect()`, passing through the other exceptions as done so far
- format `ConnectionOSErrorException` properly

This can be tested by e.g. trying to register by specifying a wrong `server.hostname` and connecting via proxy:
```bash
# subscription-manager config --server.hostname=this.doesnot.exists.NO
# subscription-manager register --proxy=http://valid-proxy-hostname:port
```