### PR TITLE
2108549: do not detect containers in OCP as such

### DIFF
--- a/test/rhsm/unit/test_config.py
+++ b/test/rhsm/unit/test_config.py
@@ -412,3 +412,30 @@ class InContainerTests(unittest.TestCase):
         with patch.dict(os.environ, {"SMDEV_CONTAINER_OFF": "True"}):
             self.assertFalse(in_container())
         self.assertEqual(in_container(), really_in_container)
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("os.path.exists")
+    def test_existing_dotcontainer(self, exists_mock):
+        def exists_file(path):
+            return path == "/run/.containerenv"
+
+        exists_mock.side_effect = exists_file
+        self.assertTrue(in_container())
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("os.path.exists")
+    def test_existing_dotdockerenv(self, exists_mock):
+        def exists_file(path):
+            return path == "/.dockerenv"
+
+        exists_mock.side_effect = exists_file
+        self.assertTrue(in_container())
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("os.path.exists")
+    def test_existing_rhsm_host(self, exists_mock):
+        def exists_file(path):
+            return path == "/etc/rhsm-host/"
+
+        exists_mock.side_effect = exists_file
+        self.assertTrue(in_container())

--- a/test/rhsm/unit/test_config.py
+++ b/test/rhsm/unit/test_config.py
@@ -439,3 +439,21 @@ class InContainerTests(unittest.TestCase):
 
         exists_mock.side_effect = exists_file
         self.assertTrue(in_container())
+
+    @patch.dict(
+        "os.environ",
+        {
+            "KUBERNETES_PORT": "tcp://10.0.0.1:443",
+            "KUBERNETES_SERVICE_HOST": "10.0.0.1",
+            "KUBERNETES_SERVICE_PORT": "443",
+            "container": "oci",
+        },
+        clear=True,
+    )
+    @patch("os.path.exists")
+    def test_ocp(self, exists_mock):
+        def exists_file(path):
+            return path == "/run/.containerenv"
+
+        exists_mock.side_effect = exists_file
+        self.assertFalse(in_container())


### PR DESCRIPTION
Containers/pods running in OCP (OpenShift Container Platform) need to be
considered as standalone systems, that can either register by themselves
or can get credentials using a mounted secret object to access an
already subscribed content.

Hence, tweak the container detection a bit: in case we are detecting the
system runs in a container, checks for Kubernetes/OCP environment
variables as canary way to detect this situation, and switch back to
"not container".

The tests were extended for the untested cases, to be able to easily add a new test case for the changes.

The effect of this PR is that it is possible to run `subscription-manager` commands in a Red Hat based container (RHEL, CentOS, etc) that runs as pod in OpenShift Container Platform. Other container usages (e.g. running a RHEL system directly with podman with no mounts for entitlements) will still produce:
```
subscription-manager is disabled when running inside a container. Please refer to your host system for subscription management.
```

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2108549
Card ID: ENT-5340