### PR TITLE
Remove 'mock' from test-requirements.txt

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -33,7 +33,6 @@ RUN dnf install -y \
     python3-iniparse \
     python3-inotify \
     python3-librepo \
-    python3-mock \
     python3-pip \
     python3-polib \
     python3-pytest \

--- a/build_ext/setup.py
+++ b/build_ext/setup.py
@@ -18,7 +18,6 @@ test_require = [
     "pytest",
     "pytest-randomly",
     "pytest-timeout",
-    "mock",
 ]
 
 install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -235,7 +235,6 @@ install_requires = [
 
 test_require = (
     [
-        "mock",
         "pytest",
         "pytest-randomly",
         "pytest-timeout",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,4 +17,3 @@ coverage
 polib
 pyinotify
 simplejson
-mock

--- a/test/cli_command/test_addons.py
+++ b/test/cli_command/test_addons.py
@@ -8,7 +8,7 @@ from subscription_manager import managercli
 
 from ..fixture import Capture
 
-from mock import patch
+from unittest.mock import patch
 
 
 class TestAddonsCommand(TestCliCommand):

--- a/test/cli_command/test_attach.py
+++ b/test/cli_command/test_attach.py
@@ -6,7 +6,7 @@ import tempfile
 from ..test_managercli import TestCliProxyCommand
 from subscription_manager import managercli
 
-from mock import patch
+from unittest.mock import patch
 
 
 # Test Attach and Subscribe are the same

--- a/test/cli_command/test_config.py
+++ b/test/cli_command/test_config.py
@@ -8,7 +8,7 @@ from subscription_manager.cli_command import config as config_command
 
 from ..fixture import Capture
 
-from mock import patch
+from unittest.mock import patch
 
 
 class TestConfigCommand(TestCliCommand):

--- a/test/cli_command/test_import_cert.py
+++ b/test/cli_command/test_import_cert.py
@@ -4,7 +4,7 @@ import sys
 from ..test_managercli import TestCliCommand
 from subscription_manager import managercli
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 
 class TestImportCertCommand(TestCliCommand):

--- a/test/cli_command/test_list.py
+++ b/test/cli_command/test_list.py
@@ -9,7 +9,7 @@ from subscription_manager.injection import provide, CERT_SORTER
 from ..stubs import StubProductCertificate, StubEntitlementCertificate, StubProduct, StubCertSorter, StubPool
 from ..fixture import Capture
 
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 
 
 class TestListCommand(TestCliProxyCommand):

--- a/test/cli_command/test_override.py
+++ b/test/cli_command/test_override.py
@@ -7,7 +7,7 @@ from subscription_manager.overrides import Override
 
 from ..fixture import Capture
 
-from mock import patch
+from unittest.mock import patch
 
 
 class TestOverrideCommand(TestCliProxyCommand):

--- a/test/cli_command/test_refresh.py
+++ b/test/cli_command/test_refresh.py
@@ -1,6 +1,6 @@
 from ..fixture import SubManFixture
 from ..test_managercli import TestCliProxyCommand
-from mock import Mock
+from unittest.mock import Mock
 from subscription_manager import managercli
 from subscription_manager.cache import ContentAccessCache, ContentAccessModeCache
 from subscription_manager.injection import provide, CONTENT_ACCESS_CACHE, CONTENT_ACCESS_MODE_CACHE

--- a/test/cli_command/test_register.py
+++ b/test/cli_command/test_register.py
@@ -4,7 +4,7 @@ from ..test_managercli import TestCliProxyCommand
 from subscription_manager import syspurposelib
 from subscription_manager import managercli
 
-from mock import patch
+from unittest.mock import patch
 
 
 class TestRegisterCommand(TestCliProxyCommand):

--- a/test/cli_command/test_release.py
+++ b/test/cli_command/test_release.py
@@ -2,7 +2,7 @@ from ..test_managercli import TestCliProxyCommand
 from subscription_manager import managercli
 from subscription_manager.cli_command import release
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 
 class TestReleaseCommand(TestCliProxyCommand):

--- a/test/cli_command/test_repos.py
+++ b/test/cli_command/test_repos.py
@@ -7,7 +7,7 @@ from subscription_manager.repolib import Repo
 
 from ..fixture import Capture, Matcher, set_up_mock_sp_store
 
-from mock import patch, Mock, call
+from unittest.mock import patch, Mock, call
 
 
 class TestReposCommand(TestCliCommand):

--- a/test/cli_command/test_role.py
+++ b/test/cli_command/test_role.py
@@ -8,7 +8,7 @@ import subscription_manager.injection as inj
 from ..stubs import StubUEP
 from ..fixture import Capture, SubManFixture
 
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 
 
 class TestSyspurposeCommand(TestCliProxyCommand):

--- a/test/cli_command/test_service_level.py
+++ b/test/cli_command/test_service_level.py
@@ -8,7 +8,7 @@ from subscription_manager import managercli
 from ..stubs import StubConsumerIdentity, StubUEP
 from ..fixture import set_up_mock_sp_store
 
-from mock import patch, Mock, call
+from unittest.mock import patch, Mock, call
 
 
 class TestServiceLevelCommand(TestCliProxyCommand):

--- a/test/cli_command/test_status.py
+++ b/test/cli_command/test_status.py
@@ -4,7 +4,7 @@ from rhsm.certificate2 import CONTENT_ACCESS_CERT_TYPE
 from ..stubs import StubConsumerIdentity, StubUEP
 from ..fixture import SubManFixture, Capture
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 
 MOCK_SERVICE_STATUS_SCA = {

--- a/test/cloud_what/test_aws.py
+++ b/test/cloud_what/test_aws.py
@@ -17,7 +17,7 @@ Module for testing AWS part of Python package cloud_what
 """
 
 import unittest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 import tempfile
 import time
 

--- a/test/cloud_what/test_azure.py
+++ b/test/cloud_what/test_azure.py
@@ -17,7 +17,7 @@ Module for testing Azure part of Python package cloud_what
 """
 
 import unittest
-from mock import patch, Mock, call
+from unittest.mock import patch, Mock, call
 import json
 import requests
 

--- a/test/cloud_what/test_cloud_what.py
+++ b/test/cloud_what/test_cloud_what.py
@@ -17,7 +17,7 @@ Unit testing of public part of cloud_what
 """
 
 import unittest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from cloud_what.providers import aws, azure, gcp
 from cloud_what.provider import detect_cloud_provider, get_cloud_provider, DetectionMethod

--- a/test/cloud_what/test_gcp.py
+++ b/test/cloud_what/test_gcp.py
@@ -17,7 +17,7 @@ Module for testing GCP part of Python package cloud_what
 """
 
 import unittest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 import json
 
 from cloud_what.providers import gcp

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -15,7 +15,7 @@ try:
 except AttributeError:
     pass
 
-from mock import Mock, MagicMock, NonCallableMock, patch, mock_open
+from unittest.mock import Mock, MagicMock, NonCallableMock, patch, mock_open
 from contextlib import contextmanager
 
 from . import stubs
@@ -169,7 +169,7 @@ class SubManFixture(unittest.TestCase):
         cli.conf = config.Config(self.mock_cfg_parser)
         self.addCleanup(unstub_conf)
 
-        facts_host_patcher = patch("rhsmlib.dbus.facts.FactsClient", auto_spec=True)
+        facts_host_patcher = patch("rhsmlib.dbus.facts.FactsClient", autospec=True)
         self.mock_facts_host = facts_host_patcher.start()
         self.mock_facts_host.return_value.GetFacts.return_value = self.set_facts()
 

--- a/test/rhsm/functional/test_connection.py
+++ b/test/rhsm/functional/test_connection.py
@@ -27,7 +27,7 @@ from rhsm.connection import (
     ForbiddenException,
     RestlibException,
 )
-from mock import patch
+from unittest.mock import patch
 
 
 def random_string(name, target_length=32):
@@ -213,7 +213,7 @@ class BindRequestTests(unittest.TestCase):
 
     @patch.object(Restlib, "validateResponse")
     @patch("rhsm.connection.drift_check", return_value=False)
-    @patch("httplib.HTTPSConnection", auto_spec=True)
+    @patch("httplib.HTTPSConnection", autospec=True)
     def test_bind_no_args(self, mock_conn, mock_drift, mock_validate):
 
         self.cp.bind(self.consumer_uuid)
@@ -228,7 +228,7 @@ class BindRequestTests(unittest.TestCase):
 
     @patch.object(Restlib, "validateResponse")
     @patch("rhsm.connection.drift_check", return_value=False)
-    @patch("httplib.HTTPSConnection", auto_spec=True)
+    @patch("httplib.HTTPSConnection", autospec=True)
     def test_bind_by_pool(self, mock_conn, mock_drift, mock_validate):
         # this test is just to verify we make the httplib connection with
         # right args, we don't validate the bind here

--- a/test/rhsm/functional/test_profile.py
+++ b/test/rhsm/functional/test_profile.py
@@ -14,7 +14,7 @@ import unittest
 
 from rhsm.profile import Package, RPMProfile, get_profile, InvalidProfileType
 from rhsm import ourjson as json
-from mock import Mock
+from unittest.mock import Mock
 
 from test import subman_marker_functional
 

--- a/test/rhsm/unit/test_certificate2.py
+++ b/test/rhsm/unit/test_certificate2.py
@@ -26,7 +26,7 @@ from rhsm.certificate2 import (
     CertificateLoadingError,
 )
 
-from mock import patch
+from unittest.mock import patch
 
 
 class V1ProductCertTests(unittest.TestCase):

--- a/test/rhsm/unit/test_config.py
+++ b/test/rhsm/unit/test_config.py
@@ -21,7 +21,7 @@ import os
 from tempfile import NamedTemporaryFile
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 from rhsm.config import RhsmConfigParser, RhsmHostConfigParser, in_container
 
 TEST_CONFIG = """

--- a/test/rhsm/unit/test_connection.py
+++ b/test/rhsm/unit/test_connection.py
@@ -41,7 +41,7 @@ from rhsm.connection import (
 from subscription_manager.cache import ContentAccessCache
 import subscription_manager.injection as inj
 
-from mock import Mock, mock, patch, mock_open
+from unittest.mock import Mock, patch, mock_open
 from datetime import date
 from time import strftime, gmtime
 from rhsm import ourjson as json
@@ -189,7 +189,7 @@ class ConnectionTests(unittest.TestCase):
     def test_get_environment_by_name_requires_owner(self):
         self.assertRaises(Exception, self.cp.getEnvironment, None, {"name": "env name"})
 
-    @mock.patch("locale.getlocale")
+    @patch("locale.getlocale")
     def test_has_proper_language_header_utf8(self, mock_locale):
         # First test it with Japanese
         mock_locale.return_value = ("ja_JP", "UTF-8")
@@ -203,7 +203,7 @@ class ConnectionTests(unittest.TestCase):
         self.cp.conn._set_accept_language_in_header()
         self.assertEqual(self.cp.conn.headers["Accept-Language"], "es-es")
 
-    @mock.patch("locale.getlocale")
+    @patch("locale.getlocale")
     def test_has_proper_language_header_not_utf8(self, mock_locale):
         mock_locale.return_value = ("ja_JP", "")
         self.cp.conn.headers = {}

--- a/test/rhsm/unit/test_profile.py
+++ b/test/rhsm/unit/test_profile.py
@@ -12,8 +12,8 @@
 
 import tempfile
 import unittest
-import mock
-from mock import patch
+from unittest import mock
+from unittest.mock import patch
 
 from rhsm.profile import ModulesProfile, EnabledReposProfile
 

--- a/test/rhsm/unit/test_utils.py
+++ b/test/rhsm/unit/test_utils.py
@@ -2,7 +2,7 @@ import threading
 import time
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 from rhsm.utils import (
     remove_scheme,
     get_env_proxy_info,

--- a/test/rhsmlib/base.py
+++ b/test/rhsmlib/base.py
@@ -22,7 +22,7 @@ import dbus.lowlevel
 import dbus.bus
 import dbus.mainloop.glib
 import logging
-import mock
+from unittest import mock
 
 from subscription_manager.i18n import Locale
 

--- a/test/rhsmlib/dbus/test_attach.py
+++ b/test/rhsmlib/dbus/test_attach.py
@@ -14,7 +14,7 @@ from typing import Any, Dict
 
 import dbus
 import json
-import mock
+from unittest import mock
 
 from rhsmlib.dbus.objects import AttachDBusObject
 

--- a/test/rhsmlib/dbus/test_consumer.py
+++ b/test/rhsmlib/dbus/test_consumer.py
@@ -13,7 +13,7 @@
 
 from rhsmlib.dbus.objects.consumer import ConsumerDBusObject
 
-import mock
+from unittest import mock
 from test.rhsmlib.base import DBusServerStubProvider
 
 

--- a/test/rhsmlib/dbus/test_entitlement.py
+++ b/test/rhsmlib/dbus/test_entitlement.py
@@ -10,7 +10,7 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-import mock
+from unittest import mock
 import json
 
 from rhsmlib.dbus.objects import EntitlementDBusObject

--- a/test/rhsmlib/dbus/test_facts.py
+++ b/test/rhsmlib/dbus/test_facts.py
@@ -10,7 +10,7 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-import mock
+from unittest import mock
 
 from rhsmlib.dbus.facts.base import AllFacts
 

--- a/test/rhsmlib/dbus/test_products.py
+++ b/test/rhsmlib/dbus/test_products.py
@@ -10,7 +10,7 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-import mock
+from unittest import mock
 import json
 import datetime
 

--- a/test/rhsmlib/dbus/test_register.py
+++ b/test/rhsmlib/dbus/test_register.py
@@ -15,7 +15,7 @@ import json
 import tempfile
 from typing import Optional
 
-import mock
+from unittest import mock
 import socket
 import dbus
 

--- a/test/rhsmlib/dbus/test_service_wrapper.py
+++ b/test/rhsmlib/dbus/test_service_wrapper.py
@@ -13,7 +13,7 @@
 import unittest
 
 import dbus
-import mock
+from unittest import mock
 
 from rhsmlib.dbus import service_wrapper, constants
 
@@ -41,7 +41,7 @@ class ServiceWrapperTest(unittest.TestCase):
     @mock.patch("rhsmlib.dbus.service_wrapper.server.Server")
     def test_loads_an_object_class(self, mock_serve):
         # Just use some class we have available
-        service_wrapper.main(["cmd_name", "mock.MagicMock"])
+        service_wrapper.main(["cmd_name", "unittest.mock.MagicMock"])
         mock_serve.assert_called_with(
             bus_class=dbus.SystemBus, bus_name=constants.BUS_NAME, object_classes=[mock.MagicMock]
         )

--- a/test/rhsmlib/dbus/test_unregister.py
+++ b/test/rhsmlib/dbus/test_unregister.py
@@ -11,7 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 import dbus
-import mock
+from unittest import mock
 
 from rhsmlib.dbus.objects import UnregisterDBusObject
 

--- a/test/rhsmlib/facts/test_cloud_facts.py
+++ b/test/rhsmlib/facts/test_cloud_facts.py
@@ -12,8 +12,8 @@
 # in this software or its documentation.
 
 import unittest
-import mock
-from mock import patch, Mock
+from unittest import mock
+from unittest.mock import patch, Mock
 
 import socket
 import requests

--- a/test/rhsmlib/facts/test_collector.py
+++ b/test/rhsmlib/facts/test_collector.py
@@ -14,7 +14,7 @@
 import unittest
 
 import platform
-import mock
+from unittest import mock
 from test.fixture import open_mock
 
 from rhsmlib.facts import collector, firmware_info

--- a/test/rhsmlib/facts/test_host_collector.py
+++ b/test/rhsmlib/facts/test_host_collector.py
@@ -13,7 +13,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from rhsmlib.facts import host_collector
 

--- a/test/rhsmlib/facts/test_hwprobe.py
+++ b/test/rhsmlib/facts/test_hwprobe.py
@@ -14,9 +14,9 @@ import unittest
 
 import io
 
-from mock import patch
-from mock import Mock
-from mock import mock_open
+from unittest.mock import patch
+from unittest.mock import Mock
+from unittest.mock import mock_open
 
 import test.fixture
 from test.fixture import OPEN_FUNCTION

--- a/test/rhsmlib/facts/test_insights.py
+++ b/test/rhsmlib/facts/test_insights.py
@@ -15,7 +15,7 @@ import unittest
 
 from test.fixture import open_mock_many
 from rhsmlib.facts import insights
-from mock import patch
+from unittest.mock import patch
 import tempfile
 
 INSIGHT_FUTURE_UUID = "250878c1-a8a2-4c44-8a29-5736dc4094c7"

--- a/test/rhsmlib/facts/test_kpatch.py
+++ b/test/rhsmlib/facts/test_kpatch.py
@@ -13,7 +13,7 @@
 
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 import tempfile
 import os
 

--- a/test/rhsmlib/facts/test_pkg_arches.py
+++ b/test/rhsmlib/facts/test_pkg_arches.py
@@ -1,7 +1,7 @@
 import unittest
 
 from rhsmlib.facts import pkg_arches
-from mock import patch
+from unittest.mock import patch
 
 
 class TestSupportedArchesCollector(unittest.TestCase):

--- a/test/rhsmlib/facts/test_virt.py
+++ b/test/rhsmlib/facts/test_virt.py
@@ -13,7 +13,7 @@
 import unittest
 
 import test.fixture
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from rhsmlib.facts import virt, firmware_info
 

--- a/test/rhsmlib/services/test_attach.py
+++ b/test/rhsmlib/services/test_attach.py
@@ -10,7 +10,7 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-import mock
+from unittest import mock
 
 from test.rhsmlib.base import InjectionMockingTest
 

--- a/test/rhsmlib/services/test_consumer.py
+++ b/test/rhsmlib/services/test_consumer.py
@@ -11,7 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
-import mock
+from unittest import mock
 
 from rhsmlib.services import consumer
 

--- a/test/rhsmlib/services/test_entitlement.py
+++ b/test/rhsmlib/services/test_entitlement.py
@@ -11,7 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 import datetime
-import mock
+from unittest import mock
 
 from test.rhsmlib.base import InjectionMockingTest
 

--- a/test/rhsmlib/services/test_products.py
+++ b/test/rhsmlib/services/test_products.py
@@ -10,7 +10,7 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-import mock
+from unittest import mock
 import datetime
 
 from test.rhsmlib.base import InjectionMockingTest

--- a/test/rhsmlib/services/test_register.py
+++ b/test/rhsmlib/services/test_register.py
@@ -11,7 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
-import mock
+from unittest import mock
 import json
 
 import subscription_manager.injection as inj

--- a/test/rhsmlib/services/test_unregister.py
+++ b/test/rhsmlib/services/test_unregister.py
@@ -12,7 +12,7 @@
 # in this software or its documentation.
 #
 
-import mock
+from unittest import mock
 
 from test.rhsmlib.base import InjectionMockingTest
 

--- a/test/rhsmlib/test_file_monitor.py
+++ b/test/rhsmlib/test_file_monitor.py
@@ -13,7 +13,7 @@
 
 from rhsmlib import file_monitor
 import configparser
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from test import fixture
 from threading import Thread
 import subprocess

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -15,7 +15,7 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
 import io
-import mock
+from unittest import mock
 import random
 
 from rhsm import config

--- a/test/syspurpose/test_syspurposefiles.py
+++ b/test/syspurpose/test_syspurposefiles.py
@@ -15,7 +15,7 @@ from ..fixture import Capture
 import io
 import json
 import os
-import mock
+from unittest import mock
 import tempfile
 import unittest
 

--- a/test/syspurpose/test_utils.py
+++ b/test/syspurpose/test_utils.py
@@ -17,7 +17,7 @@ import io
 import os
 import errno
 import json
-import mock
+from unittest import mock
 import tempfile
 import unittest
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -9,7 +9,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
-from mock import patch, call, Mock
+from unittest.mock import patch, call, Mock
 
 from subscription_manager import api
 from subscription_manager.repolib import Repo

--- a/test/test_auto_registration.py
+++ b/test/test_auto_registration.py
@@ -18,7 +18,7 @@ Module for testing automatic registration on public cloud
 
 import unittest
 import base64
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from subscription_manager.scripts.rhsmcertd_worker import _collect_cloud_info
 from .rhsmlib.facts.test_cloud_facts import AWS_METADATA

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -18,7 +18,7 @@ import shutil
 import socket
 import tempfile
 import time
-from mock import Mock, patch, mock_open
+from unittest.mock import Mock, patch, mock_open
 
 # used to get a user readable cfg class for test cases
 from .stubs import (

--- a/test/test_cert_sorter.py
+++ b/test/test_cert_sorter.py
@@ -30,7 +30,7 @@ import subscription_manager.cert_sorter
 from subscription_manager.cert_sorter import CertSorter, UNKNOWN
 from subscription_manager.cache import EntitlementStatusCache
 from datetime import timedelta, datetime
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from rhsm import ourjson as json
 
 

--- a/test/test_certdirectory.py
+++ b/test/test_certdirectory.py
@@ -16,7 +16,7 @@ import unittest
 import tempfile
 import os
 
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from shutil import rmtree
 
 from .stubs import StubProduct, StubEntitlementCertificate, StubProductCertificate

--- a/test/test_certlib.py
+++ b/test/test_certlib.py
@@ -13,7 +13,7 @@
 #
 import threading
 
-from mock import patch
+from unittest.mock import patch
 
 from . import fixture
 

--- a/test/test_certmgr.py
+++ b/test/test_certmgr.py
@@ -14,7 +14,7 @@
 
 from datetime import datetime, timedelta
 
-import mock
+from unittest import mock
 from . import stubs
 
 from rhsm import ourjson as json

--- a/test/test_container_content_plugin.py
+++ b/test/test_container_content_plugin.py
@@ -10,7 +10,7 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
 
-import mock
+from unittest import mock
 
 from . import fixture
 import tempfile

--- a/test/test_cp_provider.py
+++ b/test/test_cp_provider.py
@@ -13,7 +13,7 @@
 #
 import unittest
 
-from mock import patch, mock
+from unittest.mock import patch, Mock
 
 from subscription_manager.cp_provider import CPProvider
 
@@ -132,7 +132,7 @@ class CPProviderTests(unittest.TestCase):
         Test of getting connection to candlepin server using keycloack authentication
         """
         no_auth_connection = self.cp_provider.get_no_auth_cp()
-        no_auth_connection.has_capability = mock.Mock(return_value=True)
+        no_auth_connection.has_capability = Mock(return_value=True)
         # TOKEN is base64 encoded following json document
         # {"typ":"bearer", "preferred_username": "foo"}
         connection = self.cp_provider.get_keycloak_auth_cp(
@@ -146,7 +146,7 @@ class CPProviderTests(unittest.TestCase):
         """
         # Create no auth connection and fake getting capabilities
         no_auth_connection = self.cp_provider.get_no_auth_cp()
-        no_auth_connection.has_capability = mock.Mock(return_value=True)
+        no_auth_connection.has_capability = Mock(return_value=True)
         # Then try to create keycloak connection
         # TOKEN is base64 encoded following json document
         # {"typ":"bearer", "preferred_username": "foo"}

--- a/test/test_entbranding.py
+++ b/test/test_entbranding.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from . import fixture
 from . import stubs

--- a/test/test_entcertlib.py
+++ b/test/test_entcertlib.py
@@ -12,7 +12,7 @@
 # in this software or its documentation.
 #
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from datetime import timedelta, datetime
 
 from .stubs import StubEntitlementCertificate, StubProduct, StubEntitlementDirectory

--- a/test/test_facts.py
+++ b/test/test_facts.py
@@ -1,6 +1,6 @@
 import tempfile
 import shutil
-from mock import patch
+from unittest.mock import patch
 
 from . import fixture
 from subscription_manager import facts

--- a/test/test_format_time.py
+++ b/test/test_format_time.py
@@ -4,7 +4,7 @@ import locale
 
 from datetime import datetime
 from dateutil.tz import tzutc, tzstr
-from mock import patch
+from unittest.mock import patch
 
 from subscription_manager import managerlib
 

--- a/test/test_healinglib.py
+++ b/test/test_healinglib.py
@@ -12,7 +12,7 @@
 # in this software or its documentation.
 #
 
-import mock
+from unittest import mock
 
 from . import fixture
 

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 import unittest
 

--- a/test/test_identitycertlib.py
+++ b/test/test_identitycertlib.py
@@ -10,7 +10,7 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
 
-import mock
+from unittest import mock
 
 from . import fixture
 

--- a/test/test_logutil.py
+++ b/test/test_logutil.py
@@ -1,6 +1,6 @@
 import logging
 
-import mock
+from unittest import mock
 import tempfile
 import os
 

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -15,7 +15,7 @@ from subscription_manager.cli_command import cli
 from .stubs import StubEntitlementCertificate, StubUEP, StubProductDirectory, StubCertSorter
 from .fixture import FakeException, FakeLogger, SubManFixture, Capture
 
-from mock import patch
+from unittest.mock import patch
 
 # for some exceptions
 from rhsm import connection

--- a/test/test_managerlib.py
+++ b/test/test_managerlib.py
@@ -38,7 +38,7 @@ from .modelhelpers import create_pool
 from subscription_manager import managerlib
 import rhsm
 from rhsm.certificate import create_from_pem, DateRange, GMT
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 cfg = rhsm.config.get_config_parser()
 ENT_CONFIG_DIR = cfg.get("rhsm", "entitlementCertDir")

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from . import fixture
 

--- a/test/test_model_ent_cert.py
+++ b/test/test_model_ent_cert.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from . import fixture
 

--- a/test/test_ostree_content_plugin.py
+++ b/test/test_ostree_content_plugin.py
@@ -11,7 +11,7 @@
 # ignores wrong content type
 import configparser
 
-import mock
+from unittest import mock
 from . import fixture
 
 from subscription_manager.model import EntitlementSource, Entitlement, find_content

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -14,7 +14,7 @@
 import unittest
 
 import os
-import mock
+from unittest import mock
 import io
 
 from subscription_manager import plugins

--- a/test/test_printing_utils.py
+++ b/test/test_printing_utils.py
@@ -13,7 +13,7 @@ from subscription_manager.printing_utils import (
     FONT_NORMAL,
 )
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 
 class TestFormatName(unittest.TestCase):

--- a/test/test_productid.py
+++ b/test/test_productid.py
@@ -11,7 +11,7 @@ from subscription_manager import certdirectory
 
 from rhsm.certificate2 import Product
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from .fixture import SubManFixture
 
 

--- a/test/test_rct_cert_command.py
+++ b/test/test_rct_cert_command.py
@@ -13,7 +13,7 @@
 #
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 from rhsm.certificate import CertificateException
 from rct.cert_commands import RCTCertCommand
 from subscription_manager.cli import InvalidCLIOptionError

--- a/test/test_rct_manifest_command.py
+++ b/test/test_rct_manifest_command.py
@@ -14,7 +14,7 @@
 import unittest
 
 import errno
-import mock
+from unittest import mock
 import os
 import io
 import tempfile

--- a/test/test_reasons.py
+++ b/test/test_reasons.py
@@ -14,7 +14,7 @@
 import unittest
 
 from .stubs import StubEntitlementCertificate, StubProduct
-from mock import Mock
+from unittest.mock import Mock
 from subscription_manager.reasons import Reasons
 
 INST_PID_1 = "100000000000002"  # awesomeos 64

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -13,7 +13,7 @@
 #
 import os
 
-from mock import Mock, NonCallableMock, patch, MagicMock
+from unittest.mock import Mock, NonCallableMock, patch, MagicMock
 
 from .stubs import StubUEP
 

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -12,7 +12,7 @@
 # in this software or its documentation.
 #
 
-import mock
+from unittest import mock
 import http.client
 import socket
 from rhsm.https import ssl

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -20,7 +20,7 @@ from importlib import reload
 from . import fixture
 
 from iniparse import RawConfigParser, SafeConfigParser
-from mock import Mock, patch, MagicMock, mock_open
+from unittest.mock import Mock, patch, MagicMock, mock_open
 import tempfile
 from iniparse import ConfigParser
 

--- a/test/test_syspurposelib.py
+++ b/test/test_syspurposelib.py
@@ -1,5 +1,5 @@
 from .fixture import SubManFixture, open_mock
-import mock
+from unittest import mock
 from subscription_manager import syspurposelib
 from subscription_manager.syspurposelib import SyspurposeSyncActionCommand, SyspurposeSyncActionReport
 import json

--- a/test/test_syspurposestore_interface.py
+++ b/test/test_syspurposestore_interface.py
@@ -19,7 +19,7 @@ import unittest
 from .fixture import set_up_mock_sp_store
 
 import os
-import mock
+from unittest import mock
 
 
 class SyspurposeStoreInterfaceTests(unittest.TestCase):

--- a/test/test_unregistration.py
+++ b/test/test_unregistration.py
@@ -17,7 +17,7 @@ import rhsm.connection as connection
 from .stubs import StubUEP
 from .fixture import SubManFixture
 from subscription_manager import managercli
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 
 class CliUnRegistrationTests(SubManFixture):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,7 +5,7 @@ from . import stubs
 
 import tempfile
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from rhsm.utils import (
     ServerUrlParseErrorEmpty,
     ServerUrlParseErrorNone,

--- a/test/test_validity.py
+++ b/test/test_validity.py
@@ -12,7 +12,7 @@
 # in this software or its documentation.
 #
 
-from mock import Mock, NonCallableMock
+from unittest.mock import Mock, NonCallableMock
 from datetime import datetime
 
 from .fixture import SubManFixture


### PR DESCRIPTION
Mock is a library that backports unittest.mock package into old Python versions (until 3.3). Our minimal Python version is 3.6, we do not need this anymore.