### PR TITLE
ENT-5106: Type-hint subscription_manager/ files

### DIFF
--- a/src/plugins/dnf/product-id.py
+++ b/src/plugins/dnf/product-id.py
@@ -13,6 +13,7 @@
 #
 
 import logging
+from typing import Set
 
 from subscription_manager.productid import ProductManager
 from subscription_manager.utils import chroot
@@ -202,7 +203,7 @@ class DnfProductManager(ProductManager):
     def read_productid_cache(self):
         return self.__read_cache_file(self.PRODUCTID_CACHE_FILE)
 
-    def get_active(self):
+    def get_active(self) -> Set[str]:
         """
         Find the list of repos that provide packages that are actually installed.
         """

--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -167,10 +167,10 @@ class _CertFactory:
         else:
             return alt_name.decode("utf-8")
 
-    def _read_issuer(self, x509: _certificate.X509) -> str:
+    def _read_issuer(self, x509: _certificate.X509) -> dict:
         return x509.get_issuer()
 
-    def _read_subject(self, x509: _certificate.X509) -> str:
+    def _read_subject(self, x509: _certificate.X509) -> dict:
         return x509.get_subject()
 
     def _create_identity_cert(
@@ -504,9 +504,9 @@ class Certificate:
         serial: Optional[int] = None,
         start: Optional[datetime.datetime] = None,
         end: Optional[datetime.datetime] = None,
-        subject: Optional[str] = None,
+        subject: Optional[str] = dict,
         pem: Optional[str] = None,
-        issuer: Optional[str] = None,
+        issuer: Optional[str] = dict,
     ):
         # The rhsm._certificate X509 object for this certificate.
         # WARNING: May be None in tests
@@ -531,8 +531,8 @@ class Certificate:
         self.valid_range = DateRange(self.start, self.end)
         self.pem: Optional[str] = pem
 
-        self.subject: Optional[str] = subject
-        self.issuer: Optional[str] = issuer
+        self.subject: Optional[dict] = subject
+        self.issuer: Optional[dict] = issuer
 
     def is_valid(self, on_date: Optional[datetime.datetime] = None):
         gmt = datetime.datetime.utcnow()
@@ -615,14 +615,14 @@ class EntitlementCertificate(ProductCertificate):
     def __init__(
         self,
         order: Optional["Order"] = None,
-        content: Optional["Content"] = None,
+        content: Optional[List["Content"]] = None,
         pool: Optional["Pool"] = None,
         extensions: Optional[Extensions] = None,
         **kwargs,
     ):
         ProductCertificate.__init__(self, **kwargs)
         self.order: Optional[Order] = order
-        self.content: Optional[Content] = content
+        self.content: Optional[List[Content]] = content
         self.pool: Optional[Pool] = pool
         self.extensions: Optional[Extensions] = extensions
         self._path_tree_object = None

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -25,7 +25,7 @@ import socket
 import sys
 import time
 import traceback
-from typing import Optional, Any, Union, List, Dict, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 from pathlib import Path
 import re
 import enum
@@ -547,7 +547,7 @@ class ContentConnection(BaseConnection):
             handler="/", cert_dir=cert_dir, user_agent=user_agent, **kwargs
         )
 
-    def get_versions(self, path: str, cert_key_pairs: list = None) -> Union[dict, None]:
+    def get_versions(self, path: str, cert_key_pairs: Iterable[Tuple[str, str]] = None) -> Union[dict, None]:
         """
         Get list of available release versions from the given path
         :param path: path, where is simple text file containing supported release versions
@@ -1722,7 +1722,7 @@ class UEPConnection(BaseConnection):
         method = "/consumers/%s/packages" % self.sanitize(consumer_uuid)
         return self.conn.request_put(method, pkg_dicts, description=_("Updating profile information"))
 
-    def updateCombinedProfile(self, consumer_uuid: str, profile: dict) -> dict:
+    def updateCombinedProfile(self, consumer_uuid: str, profile: List[Dict]) -> dict:
         """
         Updates the costumers' combined profile containing package profile,
         enabled repositories and dnf modules.

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -78,7 +78,7 @@ class CloudFactsCollector(collector.FactsCollector):
 
         facts: Dict[str, Union[str, None]] = {}
         if metadata_str is not None:
-            values: dict[str, Union[str, None]] = self.parse_json_content(metadata_str)
+            values: Dict[str, Union[str, None]] = self.parse_json_content(metadata_str)
 
             # Add these three attributes to system facts
             if "instanceId" in values:

--- a/src/rhsmlib/file_monitor.py
+++ b/src/rhsmlib/file_monitor.py
@@ -11,6 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 import threading
+from typing import Dict
 
 from rhsm.config import get_config_parser
 from rhsmlib.services import config
@@ -55,14 +56,14 @@ class FilesystemWatcher(object):
     # Timeout of loop in milliseconds
     TIMEOUT = 2000
 
-    def __init__(self, dir_watches):
+    def __init__(self, dir_watches: Dict[str, "DirectoryWatch"]):
         """
         :param dir_watches: dictionary of directories to watch (see DirectoryWatch class below)
         """
-        self.dir_watches = dir_watches
-        self.should_stop = False
+        self.dir_watches: Dict[str, DirectoryWatch] = dir_watches
+        self.should_stop: bool = False
 
-    def stop(self):
+    def stop(self) -> None:
         """
         Calling this method stops infinity loop of FileSystemWatcher
         """

--- a/src/rhsmlib/services/syspurpose.py
+++ b/src/rhsmlib/services/syspurpose.py
@@ -16,6 +16,7 @@ This module provides service for system purpose
 """
 
 import logging
+from typing import Dict
 
 from rhsm.connection import UEPConnection
 
@@ -41,7 +42,7 @@ class Syspurpose(object):
         self.owner = None
         self.valid_fields = None
 
-    def get_syspurpose_status(self, on_date: str = None) -> str:
+    def get_syspurpose_status(self, on_date: str = None) -> Dict:
         """
         Get syspurpose status from candlepin server
         :param on_date: Date of the status

--- a/src/subscription_manager/base_plugin.py
+++ b/src/subscription_manager/base_plugin.py
@@ -11,6 +11,10 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+from typing import Optional, Set, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from subscription_manager.plugins import PluginConfig
 
 
 class SubManPlugin(object):
@@ -19,25 +23,24 @@ class SubManPlugin(object):
     Plugins need to subclass SubManPlugin() to be found
     """
 
-    name = None
-    conf = None
+    name: str = None
+    conf: "PluginConfig" = None
     # if all_slots is set, the plugin will get registered to all slots
     # it is up to the plugin to handle providing callables
-    all_slots = None
+    all_slots: Set[str] = None
 
-    # did we have hooks that match provided slots? aka
-    # is this plugin going to be used
-    found_slots_for_hooks = False
+    # did we have hooks that match provided slots? aka is this plugin going to be used
+    found_slots_for_hooks: bool = False
 
-    def __init__(self, conf=None):
+    def __init__(self, conf: Optional["PluginConfig"] = None):
         if conf:
             self.conf = conf
         if self.conf is None:
             raise TypeError("SubManPlugin can not be constructed with conf=None")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name or self.__class__.__name__
 
     @classmethod
-    def get_plugin_key(cls):
+    def get_plugin_key(cls) -> str:
         return ".".join([cls.__module__, cls.__name__])

--- a/src/subscription_manager/cli_command/cli.py
+++ b/src/subscription_manager/cli_command/cli.py
@@ -17,6 +17,7 @@
 import logging
 import os
 import sys
+from typing import Optional
 
 import rhsm.config
 import rhsm.connection as connection
@@ -257,7 +258,7 @@ class CliCommand(AbstractCLICommand):
         self.server_versions = get_server_versions(cp, exception_on_timeout=False)
         log.debug("Server Versions: {versions}".format(versions=self.server_versions))
 
-    def main(self, args=None):
+    def main(self, args=None) -> Optional[int]:
 
         # TODO: For now, we disable the CLI entirely. We may want to allow some commands in the future.
         if rhsm.config.in_container():
@@ -269,7 +270,7 @@ class CliCommand(AbstractCLICommand):
                 ),
             )
 
-        config_changed = False
+        config_changed: bool = False
 
         # In testing we sometimes specify args, otherwise use the default:
         if args is None:

--- a/src/subscription_manager/factlib.py
+++ b/src/subscription_manager/factlib.py
@@ -14,6 +14,12 @@
 # in this software or its documentation.
 #
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rhsm.connection import UEPConnection
+    from subscription_manager.cp_provider import CPProvider
+    from subscription_manager.facts import Facts
 
 from .certlib import Locker, ActionReport
 from subscription_manager import injection as inj
@@ -33,10 +39,10 @@ class FactsActionInvoker(object):
     def __init__(self):
         self.locker = Locker()
 
-    def update(self):
+    def update(self) -> "FactsActionReport":
         return self.locker.run(self._do_update)
 
-    def _do_update(self):
+    def _do_update(self) -> "FactsActionReport":
         action = FactsActionCommand()
         return action.perform()
 
@@ -56,7 +62,7 @@ class FactsActionReport(ActionReport):
         self._updates = []
         self._status = None
 
-    def updates(self):
+    def updates(self) -> int:
         """How many facts were updated."""
         return len(self.fact_updates)
 
@@ -75,13 +81,13 @@ class FactsActionCommand(object):
     """
 
     def __init__(self):
-        cp_provider = inj.require(inj.CP_PROVIDER)
-        self.uep = cp_provider.get_consumer_auth_cp()
+        cp_provider: CPProvider = inj.require(inj.CP_PROVIDER)
+        self.uep: UEPConnection = cp_provider.get_consumer_auth_cp()
         self.report = FactsActionReport()
-        self.facts = inj.require(inj.FACTS)
-        self.facts_client = inj.require(inj.FACTS)
+        self.facts: Facts = inj.require(inj.FACTS)
+        self.facts_client: Facts = inj.require(inj.FACTS)
 
-    def perform(self):
+    def perform(self) -> "FactsActionReport":
         # figure out the diff between latest facts and
         # report that as updates
 

--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -19,6 +19,8 @@ from threading import local
 import os
 
 # Localization domain:
+from typing import Optional, Tuple
+
 APP = "rhsm"
 # Directory where translations are deployed:
 DIR = "/usr/share/locale/"
@@ -67,7 +69,7 @@ def configure_i18n():
         Locale.set(lang)
 
 
-def configure_gettext():
+def configure_gettext() -> None:
     """Configure gettext for all RHSM-related code.
 
     Since Glade internally uses gettext, we need to use the C-level bindings in locale to adjust the encoding.
@@ -79,14 +81,14 @@ def configure_gettext():
     locale.bind_textdomain_codeset(APP, "UTF-8")
 
 
-def ugettext(*args, **kwargs):
+def ugettext(*args, **kwargs) -> str:
     if hasattr(LOCALE, "lang") and LOCALE.lang is not None:
         return LOCALE.lang.gettext(*args, **kwargs)
     else:
         return TRANSLATION.gettext(*args, **kwargs)
 
 
-def ungettext(*args, **kwargs):
+def ungettext(*args, **kwargs) -> str:
     if hasattr(LOCALE, "lang") and LOCALE.lang is not None:
         return LOCALE.lang.ngettext(*args, **kwargs)
     else:
@@ -101,12 +103,12 @@ class Locale(object):
     translations = {}
 
     @classmethod
-    def is_locale_supported(cls, language):
+    def is_locale_supported(cls, language: str) -> bool:
         """
         Is translation for given locale supported?
         :param language: String with locale code e.g. de_DE, de_DE.UTF-8
-        :return: True if the locale is supported by rhsm. Otherwise return False
         """
+        lang: Optional[gettext.GNUTranslations]
         try:
             lang = gettext.translation(APP, DIR, languages=[language])
         except IOError:
@@ -118,14 +120,14 @@ class Locale(object):
             return False
 
     @classmethod
-    def _find_lang_alternative(cls, language):
+    def _find_lang_alternative(cls, language: str) -> Tuple[gettext.GNUTranslations, Optional[str]]:
         """
         Try to find alternative for given language
         :param language: string with code of language e.g. de_LU
         :return: Instance of gettext.translation and code of new_language
         """
-        lang = None
-        new_language = None
+        lang: Optional[gettext.GNUTranslations] = None
+        new_language: Optional[str] = None
         # For similar case: 'de'
         if "_" not in language:
             new_language = language + "_" + language.upper()
@@ -144,7 +146,7 @@ class Locale(object):
         return lang, new_language
 
     @classmethod
-    def set(cls, language):
+    def set(cls, language: str) -> None:
         """
         Set language used by gettext and ungettext method. This method is
         intended for changing language on the fly, because rhsm service can
@@ -154,7 +156,7 @@ class Locale(object):
                 (e.g. de, de_DE, de_DE.utf-8, de_DE.UTF-8)
         """
         global LOCALE
-        lang = None
+        lang: gettext.GNUTranslations = None
 
         if language != "":
             if language in cls.translations.keys():

--- a/src/subscription_manager/i18n_argparse.py
+++ b/src/subscription_manager/i18n_argparse.py
@@ -19,7 +19,7 @@ Make argparse friendlier to i18n/l10n
 
 Just use this instead of argparse, the interface should be the same.
 
-For some backgorund, see:
+For some background, see:
 http://bugs.python.org/issue4319
 """
 import argparse
@@ -36,10 +36,10 @@ USAGE = _("%(prog)s [OPTIONS]")
 
 
 class ArgumentParser(_ArgumentParser):
-    def print_help(self):
+    def print_help(self) -> None:
         sys.stdout.write(self.format_help())
 
-    def error(self, msg):
+    def error(self, msg: str) -> None:
         """
         Override default error handler to localize
 

--- a/src/subscription_manager/injection.py
+++ b/src/subscription_manager/injection.py
@@ -12,6 +12,8 @@
 # in this software or its documentation.
 #
 # Supported Features:
+from typing import Dict
+
 IDENTITY = "IDENTITY"
 CERT_SORTER = "CERT_SORTER"
 PRODUCT_DATE_RANGE_CALCULATOR = "PRODUCT_DATE_RANGE_CALCULATOR"
@@ -49,9 +51,9 @@ class FeatureBroker(object):
     """
 
     def __init__(self):
-        self.providers = {}
+        self.providers: Dict[str, object] = {}
 
-    def provide(self, feature, provider):
+    def provide(self, feature: str, provider: object) -> None:
         """
         Provide an implementation for a feature.
 
@@ -62,7 +64,7 @@ class FeatureBroker(object):
         """
         self.providers[feature] = provider
 
-    def require(self, feature, *args, **kwargs):
+    def require(self, feature: str, *args, **kwargs) -> object:
         """
         Require an implementation for a feature. Can be used to create objects
         without requiring an exact implementation to use.
@@ -84,7 +86,7 @@ class FeatureBroker(object):
         return self.providers[feature]
 
 
-def nonSingleton(other):
+def nonSingleton(other: type) -> object:
     """
     Creates a factory method for a class. Passes args to the constructor
     in order to create a new object every time it is required.
@@ -103,12 +105,15 @@ FEATURES = FeatureBroker()
 
 # Small wrapper functions to make usage look a little cleaner, can use these
 # instead of the global:
-def require(feature, *args, **kwargs):
+def require(feature: str, *args, **kwargs):
+    # NOTE This function is not type hinted for a reason. Putting anything here
+    #      makes IDEs and type checkers question what we are doing, it's better
+    #      to assign all types where this function is called.
     global FEATURES
     return FEATURES.require(feature, *args, **kwargs)
 
 
-def provide(feature, provider, singleton=False):
+def provide(feature: str, provider: object, singleton: bool = False) -> None:
     global FEATURES
     if not singleton and isinstance(provider, type):
         provider = nonSingleton(provider)

--- a/src/subscription_manager/installedproductslib.py
+++ b/src/subscription_manager/installedproductslib.py
@@ -8,10 +8,17 @@
 # NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-#
+from typing import TYPE_CHECKING
 
 from subscription_manager import injection as inj
 from subscription_manager import certlib
+
+if TYPE_CHECKING:
+    from rhsm.connection import UEPConnection
+
+    from subscription_manager.cache import InstalledProductsManager
+    from subscription_manager.cp_provider import CPProvider
+    from subscription_manager.identity import Identity
 
 
 class InstalledProductsActionInvoker(certlib.BaseActionInvoker):
@@ -19,7 +26,7 @@ class InstalledProductsActionInvoker(certlib.BaseActionInvoker):
     products on this system periodically.
     """
 
-    def _do_update(self):
+    def _do_update(self) -> "InstalledProductsActionReport":
         action = InstalledProductsActionCommand()
         return action.perform()
 
@@ -32,12 +39,12 @@ class InstalledProductsActionCommand(object):
 
     def __init__(self):
         self.report = InstalledProductsActionReport()
-        self.cp_provider = inj.require(inj.CP_PROVIDER)
-        self.uep = self.cp_provider.get_consumer_auth_cp()
+        self.cp_provider: CPProvider = inj.require(inj.CP_PROVIDER)
+        self.uep: UEPConnection = self.cp_provider.get_consumer_auth_cp()
 
-    def perform(self):
-        mgr = inj.require(inj.INSTALLED_PRODUCTS_MANAGER)
-        consumer_identity = inj.require(inj.IDENTITY)
+    def perform(self) -> "InstalledProductsActionReport":
+        mgr: InstalledProductsManager = inj.require(inj.INSTALLED_PRODUCTS_MANAGER)
+        consumer_identity: Identity = inj.require(inj.IDENTITY)
 
         ret = mgr.update_check(self.uep, consumer_identity.uuid)
         self.report._status = ret
@@ -45,4 +52,4 @@ class InstalledProductsActionCommand(object):
 
 
 class InstalledProductsActionReport(certlib.ActionReport):
-    name = "Installed Products"
+    name: str = "Installed Products"

--- a/src/subscription_manager/isodate.py
+++ b/src/subscription_manager/isodate.py
@@ -12,8 +12,6 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-#
-
 
 import datetime
 import dateutil.parser
@@ -22,9 +20,9 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def _parse_date_dateutil(date):
+def _parse_date_dateutil(date: str) -> datetime.datetime:
     try:
-        dt = dateutil.parser.parse(date)
+        dt: datetime.datetime = dateutil.parser.parse(date)
         # the datetime.datetime objects returned by dateutil use the own
         # dateutil.tz.tzutc object for UTC, rather than the datetime own;
         # switch the tzinfo object of UTC dates to datetime.timezone.utc:

--- a/src/subscription_manager/jsonwrapper.py
+++ b/src/subscription_manager/jsonwrapper.py
@@ -13,41 +13,43 @@
 #
 
 # This module contains wrappers for JSON returned from the CP server.
+from typing import Dict, List, Optional, Union
+
 from subscription_manager.utils import is_true_value
 
 
 class PoolWrapper(object):
-    def __init__(self, pool_json):
-        self.data = pool_json
+    def __init__(self, pool_json: dict):
+        self.data: dict = pool_json
 
-    def get_id(self):
+    def get_id(self) -> str:
         return self.data.get("id")
 
-    def is_virt_only(self):
-        attributes = self.data["attributes"]
-        virt_only = False
+    def is_virt_only(self) -> bool:
+        attributes: dict = self.data["attributes"]
+        virt_only: bool = False
         for attribute in attributes:
-            name = attribute["name"]
-            value = attribute["value"]
+            name: str = attribute["name"]
+            value: str = attribute["value"]
             if name == "virt_only":
                 virt_only = is_true_value(value)
                 break
 
         return virt_only
 
-    def management_enabled(self):
+    def management_enabled(self) -> bool:
         return is_true_value(self._get_attribute_value("productAttributes", "management_enabled"))
 
-    def get_stacking_id(self):
+    def get_stacking_id(self) -> str:
         return self._get_attribute_value("productAttributes", "stacking_id")
 
-    def get_service_level(self):
+    def get_service_level(self) -> str:
         return self._get_attribute_value("productAttributes", "support_level")
 
-    def get_service_type(self):
+    def get_service_type(self) -> str:
         return self._get_attribute_value("productAttributes", "support_type")
 
-    def get_product_attributes(self, *attribute_names):
+    def get_product_attributes(self, *attribute_names: Union[str, List[str]]) -> Dict[str, object]:
         attrs = {}
 
         if "productAttributes" not in self.data:
@@ -59,13 +61,13 @@ class PoolWrapper(object):
             attrs[attr_name] = None
 
         for attr in self.data["productAttributes"]:
-            name = attr["name"]
+            name: str = attr["name"]
             if name in attribute_names:
                 attrs[name] = attr["value"]
         return attrs
 
-    def get_suggested_quantity(self):
-        result = None
+    def get_suggested_quantity(self) -> Optional[int]:
+        result: Optional[int] = None
 
         try:
             result = int(self.data["calculatedAttributes"]["suggested_quantity"])
@@ -74,10 +76,10 @@ class PoolWrapper(object):
 
         return result
 
-    def get_pool_type(self):
+    def get_pool_type(self) -> str:
         return (self.data.get("calculatedAttributes") or {}).get("compliance_type", "")
 
-    def _get_attribute_value(self, attr_list_name, attr_name):
+    def _get_attribute_value(self, attr_list_name: str, attr_name: str) -> Optional[str]:
         product_attrs = self.data[attr_list_name]
         for attribute in product_attrs:
             name = attribute["name"]
@@ -86,6 +88,6 @@ class PoolWrapper(object):
                 return value
         return None
 
-    def get_provided_products(self):
+    def get_provided_products(self) -> Dict[str, str]:
         products = self.data.get("providedProducts", [])
         return {prod.get("productId"): prod.get("productName") for prod in products}

--- a/src/subscription_manager/listing.py
+++ b/src/subscription_manager/listing.py
@@ -10,24 +10,25 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-#
+
+from typing import List, Optional
 
 
 class ListingFile(object):
-    def __init__(self, data=None):
-        self.data = data
-        self.releases = []
+    def __init__(self, data: Optional[str] = None):
+        self.data: Optional[str] = data
+        self.releases: List[str] = []
 
         self.parse()
 
-    def get_releases(self):
+    def get_releases(self) -> List[str]:
         return self.releases
 
-    def parse(self):
+    def parse(self) -> None:
         if not self.data:
             return
 
-        lines = self.data.split("\n")
+        lines: List[str] = self.data.split("\n")
 
         for line in lines:
             line = line.strip()

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -16,6 +16,11 @@
 import logging
 import sys
 
+from typing import List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from subscription_manager.cli_command.cli import CliCommand
+
 from subscription_manager import managerlib
 from subscription_manager.cli import CLI
 from subscription_manager.cli_command.addons import AddonsCommand
@@ -52,7 +57,7 @@ log = logging.getLogger(__name__)
 
 class ManagerCLI(CLI):
     def __init__(self):
-        commands = [
+        commands: List[CliCommand] = [
             RegisterCommand,
             UnRegisterCommand,
             AddonsCommand,
@@ -82,11 +87,11 @@ class ManagerCLI(CLI):
         ]
         CLI.__init__(self, command_classes=commands)
 
-    def main(self):
+    def main(self) -> Optional[int]:
         managerlib.check_identity_cert_perms()
-        ret = CLI.main(self)
+        ret: Optional[int] = CLI.main(self)
         # Try to enable all yum plugins (subscription-manager and plugin-id)
-        enabled_yum_plugins = YumPluginManager.enable_pkg_plugins()
+        enabled_yum_plugins: List[str] = YumPluginManager.enable_pkg_plugins()
         if len(enabled_yum_plugins) > 0:
             print("\n" + _("WARNING") + "\n\n" + YumPluginManager.warning_message(enabled_yum_plugins) + "\n")
         # Try to close all connections

--- a/src/subscription_manager/overrides.py
+++ b/src/subscription_manager/overrides.py
@@ -11,11 +11,18 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-#
+
+from typing import Dict, List, Optional, TYPE_CHECKING
+
 from subscription_manager import injection as inj
 from subscription_manager.repolib import RepoActionInvoker
 
 import logging
+
+if TYPE_CHECKING:
+    from rhsm.connection import UEPConnection
+    from subscription_manager.cache import OverrideStatusCache
+    from subscription_manager.cp_provider import CPProvider
 
 log = logging.getLogger(__name__)
 
@@ -24,59 +31,59 @@ log = logging.getLogger(__name__)
 
 class Overrides(object):
     def __init__(self):
-        self.cp_provider = inj.require(inj.CP_PROVIDER)
+        self.cp_provider: CPProvider = inj.require(inj.CP_PROVIDER)
 
-        self.cache = inj.require(inj.OVERRIDE_STATUS_CACHE)
+        self.cache: OverrideStatusCache = inj.require(inj.OVERRIDE_STATUS_CACHE)
         self.repo_lib = RepoActionInvoker(cache_only=True)
 
-    def get_overrides(self, consumer_uuid):
+    def get_overrides(self, consumer_uuid: str) -> List["Override"]:
         return self._build_from_json(self.cache.load_status(self._getuep(), consumer_uuid))
 
-    def add_overrides(self, consumer_uuid, overrides):
+    def add_overrides(self, consumer_uuid, overrides) -> List["Override"]:
         return self._build_from_json(self._getuep().setContentOverrides(consumer_uuid, self._add(overrides)))
 
-    def remove_overrides(self, consumer_uuid, overrides):
+    def remove_overrides(self, consumer_uuid, overrides) -> List["Override"]:
         return self._delete_overrides(consumer_uuid, self._remove(overrides))
 
-    def remove_all_overrides(self, consumer_uuid, repos):
+    def remove_all_overrides(self, consumer_uuid, repos) -> List["Override"]:
         return self._delete_overrides(consumer_uuid, self._remove_all(repos))
 
-    def update(self, overrides):
+    def update(self, overrides: List["Override"]) -> None:
         self.cache.server_status = [override.to_json() for override in overrides]
         self.cache.write_cache()
         self.repo_lib.update()
 
-    def _delete_overrides(self, consumer_uuid, override_data):
+    def _delete_overrides(self, consumer_uuid: str, override_data: List[dict]):
         return self._build_from_json(self._getuep().deleteContentOverrides(consumer_uuid, override_data))
 
-    def _add(self, overrides):
+    def _add(self, overrides: List) -> List[dict]:
         return [override.to_json() for override in overrides]
 
-    def _remove(self, overrides):
+    def _remove(self, overrides: List) -> List[dict]:
         return [{"contentLabel": override.repo_id, "name": override.name} for override in overrides]
 
-    def _remove_all(self, repos):
+    def _remove_all(self, repos: List[dict]) -> Optional[List[dict]]:
         if repos:
             return [{"contentLabel": repo} for repo in repos]
         else:
             return None
 
-    def _build_from_json(self, override_json):
+    def _build_from_json(self, override_json: List[dict]) -> List["Override"]:
         return [Override.from_json(override_dict) for override_dict in override_json]
 
-    def _getuep(self):
+    def _getuep(self) -> "UEPConnection":
         return self.cp_provider.get_consumer_auth_cp()
 
 
 class Override(object):
-    def __init__(self, repo_id, name, value=None):
-        self.repo_id = repo_id
-        self.name = name
-        self.value = value
+    def __init__(self, repo_id: str, name: str, value: Optional[object] = None):
+        self.repo_id: str = repo_id
+        self.name: str = name
+        self.value: Optional[object] = value
 
     @classmethod
-    def from_json(cls, json_obj):
+    def from_json(cls, json_obj: Dict[str, str]):
         return cls(json_obj["contentLabel"], json_obj["name"], json_obj["value"])
 
-    def to_json(self):
+    def to_json(self) -> Dict[str, str]:
         return {"contentLabel": self.repo_id, "name": self.name, "value": self.value}

--- a/src/subscription_manager/packageprofilelib.py
+++ b/src/subscription_manager/packageprofilelib.py
@@ -9,6 +9,13 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
+from typing import Literal, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rhsm.connection import UEPConnection
+    from subscription_manager.identity import Identity
+    from subscription_manager.cache import ProfileManager
+    from subscription_manager.cp_provider import CPProvider
 
 from subscription_manager import injection as inj
 from subscription_manager import certlib
@@ -19,7 +26,7 @@ class PackageProfileActionInvoker(certlib.BaseActionInvoker):
     periodically.
     """
 
-    def _do_update(self):
+    def _do_update(self) -> "PackageProfileActionReport":
         action = PackageProfileActionCommand()
         return action.perform()
 
@@ -32,13 +39,13 @@ class PackageProfileActionCommand(object):
 
     def __init__(self):
         self.report = PackageProfileActionReport()
-        self.cp_provider = inj.require(inj.CP_PROVIDER)
-        self.uep = self.cp_provider.get_consumer_auth_cp()
+        self.cp_provider: CPProvider = inj.require(inj.CP_PROVIDER)
+        self.uep: UEPConnection = self.cp_provider.get_consumer_auth_cp()
 
-    def perform(self, force_upload=False):
-        profile_mgr = inj.require(inj.PROFILE_MANAGER)
-        consumer_identity = inj.require(inj.IDENTITY)
-        ret = profile_mgr.update_check(self.uep, consumer_identity.uuid, force=force_upload)
+    def perform(self, force_upload: bool = False) -> "PackageProfileActionReport":
+        profile_mgr: ProfileManager = inj.require(inj.PROFILE_MANAGER)
+        consumer_identity: Identity = inj.require(inj.IDENTITY)
+        ret: Literal[0, 1] = profile_mgr.update_check(self.uep, consumer_identity.uuid, force=force_upload)
         self.report._status = ret
         return self.report
 

--- a/src/subscription_manager/printing_utils.py
+++ b/src/subscription_manager/printing_utils.py
@@ -14,6 +14,7 @@
 import fnmatch
 import re
 import logging
+from typing import Callable, List
 
 from subscription_manager.unicode_width import textual_width as utf8_width
 from subscription_manager.utils import get_terminal_width
@@ -27,11 +28,11 @@ FONT_RED = "\033[31m"
 FONT_NORMAL = "\033[0m"
 
 
-def ljust_wide(in_str, padding):
+def ljust_wide(in_str: str, padding: int):
     return in_str + " " * (padding - utf8_width(in_str))
 
 
-def columnize(caption_list, callback, *args, **kwargs):
+def columnize(caption_list: List[str], callback: Callable, *args, **kwargs) -> str:
     """
     Take a list of captions and values and columnize the output so that
     shorter captions are padded to be the same length as the longest caption.
@@ -43,21 +44,21 @@ def columnize(caption_list, callback, *args, **kwargs):
     The callback gives us the ability to do things like replacing None values
     with the string "None" (see none_wrap_columnize_callback()).
     """
-    indent = kwargs.get("indent", 0)
-    caption_list = [" " * indent + caption for caption in caption_list]
-    columns = get_terminal_width()
-    padding = sorted(map(utf8_width, caption_list))[-1] + 1
+    indent: int = kwargs.get("indent", 0)
+    caption_list: List[str] = [" " * indent + caption for caption in caption_list]
+    columns: int = get_terminal_width()
+    padding: int = sorted(map(utf8_width, caption_list))[-1] + 1
     if columns:
         padding = min(padding, int(columns / 2))
-    padded_list = []
+    padded_list: List[str] = []
     for caption in caption_list:
-        lines = format_name(caption, indent, padding - 1).split("\n")
+        lines: List[str] = format_name(caption, indent, padding - 1).split("\n")
         lines[-1] = ljust_wide(lines[-1], padding) + "%s"
-        fixed_caption = "\n".join(lines)
+        fixed_caption: str = "\n".join(lines)
         padded_list.append(fixed_caption)
 
     lines = list(zip(padded_list, args))
-    output = []
+    output: List[str] = []
     for (caption, value) in lines:
         kwargs["caption"] = caption
         if isinstance(value, dict):
@@ -80,7 +81,7 @@ def columnize(caption_list, callback, *args, **kwargs):
     return "\n".join(output)
 
 
-def format_name(name, indent, max_length):
+def format_name(name: str, indent: int, max_length: int) -> str:
     """
     Formats a potentially long name for multi-line display, giving
     it a columned effect.  Assumes the first line is already
@@ -89,6 +90,7 @@ def format_name(name, indent, max_length):
     if not name or not max_length or (max_length - indent) <= 2 or not isinstance(name, str):
         return name
     if not isinstance(name, str):
+        # FIXME This is not necessary in Python 3 code
         name = name.decode("utf-8")
     words = name.split()
     lines = []
@@ -134,11 +136,11 @@ def format_name(name, indent, max_length):
     return "\n".join(lines)
 
 
-def highlight_by_filter_string_columnize_cb(template_str, *args, **kwargs):
+def highlight_by_filter_string_columnize_cb(template_str: str, *args, **kwargs) -> str:
     """
     Takes a template string and arguments and highlights word matches
-    when the value contains a match to the filter_string.This occurs
-    only when the row caption exists in the match columns.  Mainly this
+    when the value contains a match to the filter_string. This occurs
+    only when the row caption exists in the match columns. Mainly this
     is a callback meant to be used by columnize().
     """
     filter_string = kwargs.get("filter_string")
@@ -170,7 +172,7 @@ def highlight_by_filter_string_columnize_cb(template_str, *args, **kwargs):
     return template_str % tuple(arglist)
 
 
-def none_wrap_columnize_callback(template_str, *args, **kwargs):
+def none_wrap_columnize_callback(template_str: str, *args, **kwargs) -> str:
     """
     Takes a template string and arguments and replaces any None arguments
     with the word "None" before rendering the template.  Mainly this is
@@ -184,7 +186,7 @@ def none_wrap_columnize_callback(template_str, *args, **kwargs):
     return template_str % tuple(arglist)
 
 
-def echo_columnize_callback(template_str, *args, **kwargs):
+def echo_columnize_callback(template_str: str, *args, **kwargs) -> str:
     """
     Just takes a template string and arguments and renders it.  Mainly
     this is a callback meant to be used by columnize().

--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -17,6 +17,8 @@ from gzip import GzipFile
 import logging
 import os
 
+from typing import Callable, Dict, List, Literal, Optional, Union
+
 # for labelCompare
 import rpm
 
@@ -46,6 +48,7 @@ class DatabaseDirectory(Directory):
 class ProductIdRepoMap(utils.DefaultDict):
     def __init__(self, *args, **kwargs):
         self.default_factory = list
+        # FIXME Missing super() call
 
 
 class ProductDatabase(object):
@@ -54,24 +57,24 @@ class ProductDatabase(object):
         self.content = ProductIdRepoMap()
         self.create()
 
-    def add(self, product, repo):
+    def add(self, product: str, repo: str) -> None:
         self.content[product].append(repo)
 
     # TODO: need way to delete one prod->repo map
-    def delete(self, product):
+    def delete(self, product: str) -> None:
         try:
             del self.content[product]
         except Exception:
             pass
 
-    def find_repos(self, product):
+    def find_repos(self, product) -> Optional[str]:
         return self.content.get(product, None)
 
-    def create(self):
+    def create(self) -> None:
         if not os.path.exists(self.__fn()):
             self.write()
 
-    def read(self):
+    def read(self) -> None:
         f = open(self.__fn())
         try:
             d = json.load(f)
@@ -81,7 +84,7 @@ class ProductDatabase(object):
             pass
         f.close()
 
-    def populate_content(self, db_dict):
+    def populate_content(self, db_dict: Dict[str, str]):
         """Populate map with info from a productid -> [repoids] map.
 
         Note this needs to support the old form of
@@ -93,7 +96,7 @@ class ProductDatabase(object):
             else:
                 self.content[productid] = repo_data
 
-    def write(self):
+    def write(self) -> None:
         f = open(self.__fn(), "w")
         try:
             json.dump(self.content, f, indent=2, default=json.encode)
@@ -101,14 +104,16 @@ class ProductDatabase(object):
             pass
         f.close()
 
-    def __fn(self):
+    def __fn(self) -> str:
         return self.dir.abspath("productid.js")
 
 
 class ComparableMixin(object):
     """Needs compare_keys to be implemented."""
 
-    def _compare(self, keys, method):
+    # FIXME self.compare_keys should be defined here, raising NotImplementedError
+
+    def _compare(self, keys: List, method: Callable) -> Union[Literal[NotImplemented], bool]:
         return method(keys[0], keys[1]) if keys else NotImplemented
 
     def __eq__(self, other):

--- a/src/subscription_manager/reasons.py
+++ b/src/subscription_manager/reasons.py
@@ -11,6 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+from typing import Dict, List
 
 from subscription_manager.i18n import ugettext as _
 
@@ -25,19 +26,19 @@ class Reasons(object):
         self.reasons = reasons
         self.sorter = sorter
 
-    def get_subscription_reasons(self, sub_id):
+    def get_subscription_reasons(self, sub_id) -> List[str]:
         """
         returns reasons for sub_id, or empty list
         if there are none.
         """
         return self.get_subscription_reasons_map().get(sub_id, [])
 
-    def get_subscription_reasons_map(self):
+    def get_subscription_reasons_map(self) -> Dict[str, List[str]]:
         """
         returns a dictionary that maps
         valid entitlements to lists of reasons.
         """
-        result = {}
+        result: Dict[str, List[str]] = {}
         for s in self.sorter.valid_entitlement_certs:
             result[s.subject["CN"]] = []
 
@@ -59,7 +60,7 @@ class Reasons(object):
                     result[s_id].append(reason["message"])
         return result
 
-    def get_name_message_map(self):
+    def get_name_message_map(self) -> Dict[str, List[str]]:
         result = {}
         for reason in self.reasons:
             reason_name = reason["attributes"]["name"]
@@ -70,7 +71,7 @@ class Reasons(object):
             result[reason_name].append(reason["message"])
         return result
 
-    def get_reason_ids_map(self):
+    def get_reason_ids_map(self) -> Dict[str, List[str]]:
         result = {}
         for reason in self.reasons:
             if "attributes" in reason and "product_id" in reason["attributes"]:
@@ -87,14 +88,14 @@ class Reasons(object):
                 )
         return result
 
-    def get_stack_subscriptions(self, stack_id):
+    def get_stack_subscriptions(self, stack_id) -> List[str]:
         result = set([])
         for s in self.sorter.valid_entitlement_certs:
             if s.order.stacking_id and s.order.stacking_id == stack_id:
                 result.add(s.subject["CN"])
         return list(result)
 
-    def get_reason_id(self, reason):
+    def get_reason_id(self, reason) -> str:
         # returns ent/prod/stack id
         # ex: Subscription 123456
         if "product_id" in reason["attributes"]:
@@ -108,7 +109,7 @@ class Reasons(object):
             # Reason has no id attr
             return _("Unknown")
 
-    def get_product_reasons(self, prod):
+    def get_product_reasons(self, prod) -> List[str]:
         """
         Returns a list of reason messages that
         apply to the installed product
@@ -142,7 +143,7 @@ class Reasons(object):
                     result.add(reason["message"])
         return list(result)
 
-    def get_product_subscriptions(self, prod):
+    def get_product_subscriptions(self, prod) -> List[str]:
         """
         Returns a list of subscriptions that provide
         the product.

--- a/src/subscription_manager/rhelproduct.py
+++ b/src/subscription_manager/rhelproduct.py
@@ -24,21 +24,27 @@ import re
 #       may or may not be a RHEL "branded" Product. See rhelentbranding for
 #       code that handles finding and comparing RHEL "branded" Product objects.
 #
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from rhsm.certificate2 import Product
+
+
 class RHELProductMatcher(object):
     """Check a Product object to see if it is a RHEL product.
 
     Compares the provided tags to see if any provide 'rhel-VERSION'.
     """
 
-    def __init__(self, product=None):
-        self.product = product
+    def __init__(self, product: Optional["Product"] = None):
+        self.product: Optional[Product] = product
         # Match "rhel-6" or "rhel-11" or "rhel-alt-7" (bz1510024)
         # but not "rhel-6-server" or "rhel-6-server-highavailabilty"
         # NOTE: we considered rhel(-[\w\d]+)?-\d+$ but decided against it
         # due to possibility of unintentional matches
         self.pattern = r"rhel(-alt)?-\d+$|rhel-5-workstation$"
 
-    def is_rhel(self):
+    def is_rhel(self) -> bool:
         """return true if this is a rhel product cert"""
 
         return any([re.match(self.pattern, tag) for tag in self.product.provided_tags])

--- a/src/subscription_manager/unicode_width.py
+++ b/src/subscription_manager/unicode_width.py
@@ -76,7 +76,10 @@ have the same width so we need helper functions for displaying them.
 
 
 # Renamed but still pretty much JA's port of MK's code
-def _interval_bisearch(value, table):
+from typing import Sequence, Tuple
+
+
+def _interval_bisearch(value: int, table: Sequence[Tuple[int, int]]) -> bool:
     """Binary search in an interval table.
 
     :arg value: numeric value to search for
@@ -192,7 +195,7 @@ _COMBINING = (
 # Handling of control chars rewritten.  Rest is JA's port of MK's C code.
 # -Toshio Kuratomi
 # NOTE: Removed unused functionality (see note in docstring) - subscription-manager developers
-def _ucp_width(ucs):
+def _ucp_width(ucs: int) -> int:
     """Get the :term:`textual width` of a ucs character
 
     :arg ucs: integer representing a single unicode :term:`code point`
@@ -238,7 +241,7 @@ def _ucp_width(ucs):
 
 # Wholly rewritten by me (LGPLv2+) -Toshio Kuratomi
 # NOTE: Removed unused functionality (see note in docstring) - subscription-manager developers
-def textual_width(msg):
+def textual_width(msg: str) -> int:
     """Get the :term:`textual width` of a string
 
     :arg msg: :class:`str` string or byte :class:`bytes` to get the width of

--- a/src/subscription_manager/validity.py
+++ b/src/subscription_manager/validity.py
@@ -13,23 +13,30 @@
 #
 
 import logging
+from typing import Optional, TYPE_CHECKING
 
 from rhsm.certificate import DateRange
 import subscription_manager.injection as inj
 from subscription_manager.isodate import parse_date
 
+if TYPE_CHECKING:
+    from rhsm.connection import UEPConnection
+
+    from subscription_manager.cache import ProductStatusCache
+    from subscription_manager.identity import Identity
+
 log = logging.getLogger(__name__)
 
 
 class ValidProductDateRangeCalculator(object):
-    def __init__(self, uep=None):
+    def __init__(self, uep: Optional["UEPConnection"] = None):
         uep = uep or inj.require(inj.CP_PROVIDER).get_consumer_auth_cp()
-        self.identity = inj.require(inj.IDENTITY)
+        self.identity: Identity = inj.require(inj.IDENTITY)
         if self.identity.is_valid():
-            self.prod_status_cache = inj.require(inj.PROD_STATUS_CACHE)
-            self.prod_status = self.prod_status_cache.load_status(uep, self.identity.uuid)
+            self.prod_status_cache: ProductStatusCache = inj.require(inj.PROD_STATUS_CACHE)
+            self.prod_status: dict = self.prod_status_cache.load_status(uep, self.identity.uuid)
 
-    def calculate(self, product_hash):
+    def calculate(self, product_hash: str) -> Optional[DateRange]:
         """
         Calculate the valid date range for the specified product based on
         today's date.


### PR DESCRIPTION
* Card ID: ENT-5106

- Along with type hints, some typos in comments have been fixed and some import statements were reordered.

Unfortunately, it is a large PR due to the card scope. Most of the files should be easy to review though, as frequently there were only some minor changes.

Because type hints of function arguments and return values are evaluated at runtime, some have been put into quotes as strings -- they are not being loaded, they are imported only when `TYPE_CHECKING` is True. Variable arguments are not evaluated at runtime, so they do not need to be stringified.