### PR TITLE
[1.28] Remove deprecated function call in i18n

### DIFF
--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -95,7 +95,6 @@ def configure_gettext():
     """
     gettext.bindtextdomain(APP, DIR)
     gettext.textdomain(APP)
-    gettext.bind_textdomain_codeset(APP, 'UTF-8')
     locale.bind_textdomain_codeset(APP, 'UTF-8')
 
 


### PR DESCRIPTION
This function has been deprecated since Python 3.8 and was removed in Python 3.11.

Adapted from commit 32beefe1e5b2e520d7091819ccab72ab33391724