### PR TITLE
[1.28] Cloud-what: Make saving token file more robust

### DIFF
--- a/src/cloud_what/_base_provider.py
+++ b/src/cloud_what/_base_provider.py
@@ -202,11 +202,14 @@ class BaseCloudProvider(object):
 
         log.debug(f'Writing {self.CLOUD_PROVIDER_ID} token to file {self.TOKEN_CACHE_FILE}')
 
-        with open(self.TOKEN_CACHE_FILE, "w") as token_cache_file:
-            json.dump(token_cache_content, token_cache_file)
-
-        # Only owner (root) should be able to read the token file
-        os.chmod(self.TOKEN_CACHE_FILE, 0o600)
+        try:
+            with open(self.TOKEN_CACHE_FILE, "w") as token_cache_file:
+                json.dump(token_cache_content, token_cache_file)
+        except IOError as err_msg:
+            log.error(f'Unable to write token to cache file: {self.TOKEN_CACHE_FILE}: {err_msg}')
+        else:
+            # Only owner (root) should be able to read the token file
+            os.chmod(self.TOKEN_CACHE_FILE, 0o600)
 
     @staticmethod
     def _is_in_memory_cache_valid(cache, ctime: float, ttl: float) -> bool:


### PR DESCRIPTION
* When it is not possible to write token to cache file, then cloud-what is able to resurrect gracefully.
* This change fixes few unit tests, when /var/cache/cloud-what/ exists and non-root user is not able to read/write to this directory.

Cherry-picked from 5989527fc027d031cd8332b9c265dc25df243a13