### PR TITLE
ENT-5532: Call rhsm-package-profile-uploader with --force-upload

### DIFF
--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -52,7 +52,6 @@ typedef enum {
 #define WORKER LIBEXECDIR"/rhsmcertd-worker"
 #define WORKER_NAME WORKER
 #define PACKAGE_PROFILE_UPLOADER LIBEXECDIR"/rhsm-package-profile-uploader"
-#define PACKAGE_PROFILE_UPLOADER_NAME PACKAGE_PROFILE_UPLOADER
 #define INITIAL_DELAY_SECONDS 120
 #define DEFAULT_AUTO_REG_INTERVAL_SECONDS 3600 /* 1 hour */
 #define DEFAULT_CERT_INTERVAL_SECONDS 14400    /* 4 hours */
@@ -250,13 +249,15 @@ long long gen_random(long long max) {
 /**
  * Try to run Python script package-profile-uploader. This script tries to upload DNF profile
  * to server, when server supports profile. New process is spawned in blocking way.
+ * Note: this script is spawned with --force-upload. Thus report_package_config configuration
+ * option is ignored and this configuration option should be checked before using this approach.
  * @return Return true, when uploading was successful. Otherwise, return false.
  */
 static gboolean
 upload_package_profile ()
 {
     gboolean ret;
-    const char * argv[] = {PACKAGE_PROFILE_UPLOADER, NULL};
+    const char * argv[] = {PACKAGE_PROFILE_UPLOADER, "--force-upload", NULL};
     gchar *standard_output = NULL;
     gchar *standard_error = NULL;
     gint wait_status = 0;

--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -221,7 +221,7 @@ class RegisterCommand(UserPassCommand):
             try:
                 profile_mgr = inj.require(inj.PROFILE_MANAGER)
                 # 767265: always force an upload of the packages when registering
-                profile_mgr.update_check(self.cp, consumer["uuid"], True)
+                profile_mgr.update_check(self.cp, consumer["uuid"], force=True)
             except RemoteServerException as err:
                 # When it is not possible to upload profile ATM, then print only error about this
                 # to rhsm.log. The rhsmcertd will try to upload it next time.
@@ -243,7 +243,10 @@ class RegisterCommand(UserPassCommand):
             if is_process_running("rhsmcertd", rhsmcertd_pid) is True:
                 # This will only send SIGUSR1 signal, which triggers gathering and uploading
                 # of DNF profile by rhsmcertd. We try to "outsource" this activity to rhsmcertd
-                # server to not block registration process
+                # server to not block registration process.
+                # Note: rhsmcertd tries to upload profile using Python script and this script
+                # is always triggered with --force-upload CLI option. We ignore report_package_config
+                # configure option here due to BZ: 767265
                 log.debug("Sending SIGUSR1 signal to rhsmcertd process")
                 try:
                     os.kill(rhsmcertd_pid, signal.SIGUSR1)


### PR DESCRIPTION
* Card ID: ENT-5532
* When configuration option report_package_config is set to 0, then package profile should not be usually reported. It only has to be reported during registration regardless the value of report_package_config option. For this reason the rhsm-package-profile-uploader is always spawned with --force-upload CLI option.
* Note: if you want to use this approach for other cases, then it is necessary to check if value of report_package_config is equal and then it is possible to send SIGUSR1 signal to rhsmcertd.
* Small changes:
  - Removed unused definition in rhsmcertd.c
  - Emphasize that update_check() is called with force=True