### PR TITLE
[1.29.30] 2151829: do not detect containers in OCP as such

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -17,6 +17,7 @@
 
 import sys
 import os
+import logging
 from iniparse import SafeConfigParser
 from iniparse.compat import NoOptionError, InterpolationMissingOptionError, NoSectionError
 import re
@@ -99,6 +100,9 @@ DEFAULTS = {
 }
 
 
+log = logging.getLogger(__name__)
+
+
 def in_container():
     """
     Are we running in a docker container or not?
@@ -107,8 +111,28 @@ def in_container():
     # off
     if os.environ.get("SMDEV_CONTAINER_OFF", ""):
         return False
+
+    def in_ocp() -> bool:
+        """
+        Is the system running as pod in OCP (OpenShift Container Platform)?
+
+        Check some of the canonical environment variables set by Kubernets
+        (on which OCP is based):
+        https://kubernetes.io/docs/concepts/containers/container-environment/
+        in particular, look for the "kubernetes" default service
+
+        "container=oci" is generally set by Red Hat-based containers.
+        """
+        return (
+            os.environ.get("KUBERNETES_PORT", "") != ""
+            and os.environ.get("KUBERNETES_SERVICE_HOST", "") != ""
+            and os.environ.get("KUBERNETES_SERVICE_PORT", "") != ""
+            and os.environ.get("container", "") == "oci"
+        )
+
     # Known locations to check for as an easy way to detect whether
-    # we are running in a container
+    # we are running in a container; note that pods in OCP are not
+    # considered containers but standalone systems
     locations = [
         # podman:
         # https://github.com/containers/podman/issues/6192
@@ -123,6 +147,11 @@ def in_container():
     ]
     for fn in locations:
         if os.path.exists(fn):
+            log.debug(f"in_container(): found '{fn}', may be a container")
+            is_ocp = in_ocp()
+            if is_ocp:
+                log.debug("in_container(): found kubernetes/OCP environment, not considering container")
+                return False
             return True
     return False
 

--- a/test/rhsm/unit/test_config.py
+++ b/test/rhsm/unit/test_config.py
@@ -412,3 +412,30 @@ class InContainerTests(unittest.TestCase):
         with patch.dict(os.environ, {"SMDEV_CONTAINER_OFF": "True"}):
             self.assertFalse(in_container())
         self.assertEqual(in_container(), really_in_container)
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("os.path.exists")
+    def test_existing_dotcontainer(self, exists_mock):
+        def exists_file(path):
+            return path == "/run/.containerenv"
+
+        exists_mock.side_effect = exists_file
+        self.assertTrue(in_container())
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("os.path.exists")
+    def test_existing_dotdockerenv(self, exists_mock):
+        def exists_file(path):
+            return path == "/.dockerenv"
+
+        exists_mock.side_effect = exists_file
+        self.assertTrue(in_container())
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("os.path.exists")
+    def test_existing_rhsm_host(self, exists_mock):
+        def exists_file(path):
+            return path == "/etc/rhsm-host/"
+
+        exists_mock.side_effect = exists_file
+        self.assertTrue(in_container())

--- a/test/rhsm/unit/test_config.py
+++ b/test/rhsm/unit/test_config.py
@@ -439,3 +439,21 @@ class InContainerTests(unittest.TestCase):
 
         exists_mock.side_effect = exists_file
         self.assertTrue(in_container())
+
+    @patch.dict(
+        "os.environ",
+        {
+            "KUBERNETES_PORT": "tcp://10.0.0.1:443",
+            "KUBERNETES_SERVICE_HOST": "10.0.0.1",
+            "KUBERNETES_SERVICE_PORT": "443",
+            "container": "oci",
+        },
+        clear=True,
+    )
+    @patch("os.path.exists")
+    def test_ocp(self, exists_mock):
+        def exists_file(path):
+            return path == "/run/.containerenv"
+
+        exists_mock.side_effect = exists_file
+        self.assertFalse(in_container())


### PR DESCRIPTION
Containers/pods running in OCP (OpenShift Container Platform) need to be
considered as standalone systems, that can either register by themselves
or can get credentials using a mounted secret object to access an
already subscribed content.

Hence, tweak the container detection a bit: in case we are detecting the
system runs in a container, checks for Kubernetes/OCP environment
variables as canary way to detect this situation, and switch back to
"not container".

The tests were extended for the untested cases, to be able to easily add a new test case for the changes.

The effect of this PR is that it is possible to run `subscription-manager` commands in a Red Hat based container (RHEL, CentOS, etc) that runs as pod in OpenShift Container Platform. Other container usages (e.g. running a RHEL system directly with podman with no mounts for entitlements) will still produce:
```
subscription-manager is disabled when running inside a container. Please refer to your host system for subscription management.
```

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2151829
Card ID: ENT-5340

Backport of PR #3171 to 1.29.30.