### PR TITLE
Call parent methods in DBusServerStubProvider

### DIFF
--- a/test/rhsmlib/base.py
+++ b/test/rhsmlib/base.py
@@ -115,6 +115,8 @@ class DBusServerStubProvider(SubManFixture):
             **cls.dbus_class_kwargs,
         )
 
+        super().setUpClass()
+
     @classmethod
     def tearDownClass(cls) -> None:
         # Unload current DBus class
@@ -127,9 +129,13 @@ class DBusServerStubProvider(SubManFixture):
             except AttributeError as exc:
                 raise RuntimeError(f"Object {patch} cannot be stopped.") from exc
 
+        super().tearDownClass()
+
     def tearDown(self) -> None:
         # Always reset the locale to default value.
         # Some tests (Attach, for example) are passing non-english language
         # strings to DBus methods, which are changing the global locale
         # settings. This teardown makes sure the language will always be reset.
         Locale.set(self.LOCALE)
+
+        super().tearDown()


### PR DESCRIPTION
This small patch ensures all injections have been initialized before running the test suite. Without them, inheriting from SubManFixture would have no effect.

This is an addition to #3181, found during its #3176 backport to 1.28.