### PR TITLE
Handle tests in containers better

### DIFF
--- a/test/fixture.py
+++ b/test/fixture.py
@@ -256,6 +256,13 @@ class SubManFixture(unittest.TestCase):
 
         set_up_mock_sp_store(syncedstore_mock)
 
+        # Do not read system files. Even if the tests run in container environment,
+        # report that we are running on bare metal.
+        self.in_container_patcher = patch("rhsm.config.in_container")
+        in_container_mock = self.in_container_patcher.start()
+        in_container_mock.return_value = False
+        self.addCleanup(self.in_container_patcher.stop)
+
         self.files_to_cleanup = []
 
     def tearDown(self):

--- a/test/test_cp_provider.py
+++ b/test/test_cp_provider.py
@@ -29,6 +29,12 @@ class CPProviderTests(unittest.TestCase):
         """
         self.cp_provider = CPProvider()
 
+        # Do not try to perform TCP/TLS handshake during testing
+        self.conn_connect_patcher = patch("http.client.HTTPSConnection.connect")
+        conn_connect_mock = self.conn_connect_patcher.start()
+        conn_connect_mock.return_value = None
+        self.addCleanup(self.conn_connect_patcher.stop)
+
     def test_create_cp_provider(self):
         """
         Simple test of creating instance


### PR DESCRIPTION
When tests were run in container, without having sub-man packages installed, two things happened:

- Container detection kicked in and prevented CPProvider from being created. NOTE: rhsm/unit/test_config.py::InContainerTests do not inherit from fixture.py::SubManFixture and are not affected by this patch.

- TCP handshake was attempted by opening a connection. Because the connection requires RHSM certificates to be installed on the system, this step crashed, when subscription-manager-rhsm-certificates (e.g., /etc/rhsm/ca/ directory) was not present.