### PR TITLE
utils: import pkg_resources only when needed

### DIFF
--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -24,7 +24,6 @@ import signal
 import socket
 import syslog
 import uuid
-import pkg_resources
 
 import urllib
 from rhsm.https import ssl
@@ -255,6 +254,8 @@ def get_client_versions():
     try:
         sm_version = subscription_manager.version.pkg_version
         if sm_version is None or sm_version == "None":
+            import pkg_resources
+
             sm_version = pkg_resources.require("subscription-manager")[0].version
     except Exception as e:
         log.debug("Client Versions: Unable to check client versions")


### PR DESCRIPTION
Merely importing "pkg_resources" will perform its initialization, which is not exactly lightweight. "pkg_resources" is used to get the version of subscription-manager as installed, in case there is no valid version in the internal "version" module, which usually happens in developer-only setups.

Since the build system takes care of filling "pkg_version" in the "version" module, a distro build of subscription-manager does not need to query "pkg_resources" for the version. Hence, import "pkg_resources" only when we actually need to use it for getting the version.