### PR TITLE
Fix order of language variables

### DIFF
--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -57,7 +57,7 @@ class TestI18N(unittest.TestCase):
     @patch("subscription_manager.i18n.Locale")
     def test_configure_i18n_lang_none(self, locale):
         """
-        Ensure the method i18n does not pass a None from the environment to Locale
+        Ensure the we use a proper language code instead of callng Locale.set with None
         :return:
         """
         with patch.dict(os.environ, clear=True):
@@ -66,4 +66,4 @@ class TestI18N(unittest.TestCase):
             except Exception:
                 self.fail()
 
-        locale.set.assert_not_called()
+        locale.set.assert_called_with("C")


### PR DESCRIPTION
Previous to this change we were reading the language that we should
translate to from the `LANG` env var, disregarding other locale related
variables of higher precedence like `LC_MESSAGES` and `LC_ALL`.  This change
fixes that by getting the language to translate to from
`locale.setlocale()` which is calculated from all of the relevant user
environment variables.

* Remove the warning about using a fallback of `C.UTF-8` if the user's
  environment variables did not specify a language code valid for the
  system.

* Retrieve the language to translate to using
  `locale.setlocale("LC_MESSAGES")`.  This is better than using
  `os.environ.get("LANG")` because `setlocale()` accounts for all of the
  environment variables that are part of deciding which language the
  system gettext will use, not just `LANG`.  This aligns with various
  standards and conventions in the *NIX world.

* Remove the workarounds for setting language to `None`.  This case could
  occur when we directly tried to get the language from the environment
  variables.  With the new code we first set up the locale system by
  calling `locale.setlocale(locale.LC_ALL, locale="")` and then
  determine the langauge code using `setlocale()` a second time.
  `setlocale()` will make sure that we receive a valid language code
  after that setup has been performed.

* An example in the docstring for `configure_i18n()` should have used
 ` es_ES.UTF-8` as the locale setting.

* Reword docstring for `configure_gettext()` since we no longer use glade.

* Update unittest that checks we do not call `Locale.set()` with `None`
Also update comments and docstrings.

@ptoscano  : This is the language issue I was talking about when we met in person.  LANG ends up being used to determine the translation to use instead of LC_MESSAGES or LC_ALL, both of which should take precedence.

Also, please test this before merging.  I held off on opening the PR because I thought that `setlocale()` was returning something that the `Locale.set()` method wouldn't like but on testing it again today, I couldn't figure out what that might be... `setlocale()` returns a string in the standard `{LANGUAGE}_{COUNTRYCODE}.{ENCODING}` format which `Locale.set()` wants so I think I was wrong before but maybe I'm missing something today.

EDIT: I think what I saw before is that `selocale(locale.LC_ALL)` returns a string containing all of the locale settings, which is not what we want.  However, `setlocale(locale.LC_MESSAGES)` return only the language code used for translations, which is what we need here.

##### REPRODUCER
If you run
```
# LC_ALL=C.UTF-8 LANG=fr_FR.UTF-8 subscription-manager
```
then some messages end up translated into French instead of being the strings hardcoded into the code.  Since `LC_ALL` is supposed to take precedence over `LANG` according to POSIX, GNU coding standards, gettext documentation, etc, this is buggy behaviour.  We have been calling `subscription-manager` from within a program and screenscraping the output for a few tasks so errant translations cause us problems. (We have since worked around this by setting `LANG` and `LANGUAGE` in addition to `LC_ALL`).