### PR TITLE
integration-tests: support testing on the Python bridge

### DIFF
--- a/integration-tests/run
+++ b/integration-tests/run
@@ -45,13 +45,33 @@ $(SUBMAN_TAR):
 $(SMBEXT_TAR):
 	tar czf $(SMBEXT_TAR) build_ext
 
-$(VM_IMAGE): $(SUB_MAN_COCKPIT) $(SUBMAN_TAR) $(SMBEXT_TAR) integration-tests/vm.install
+# pybridge scenario: build and install the python bridge from cockpit repo
+ifeq ("$(TEST_SCENARIO)","pybridge")
+COCKPIT_PYBRIDGE_REF = main
+COCKPIT_WHEEL = cockpit-0-py3-none-any.whl
+
+$(COCKPIT_WHEEL):
+	# aka: pip wheel git+https://github.com/cockpit-project/cockpit.git@${COCKPIT_PYBRIDGE_REF}
+	rm -rf tmp/pybridge
+	git init tmp/pybridge
+	git -C tmp/pybridge remote add origin https://github.com/cockpit-project/cockpit
+	git -C tmp/pybridge fetch --depth=1 origin ${COCKPIT_PYBRIDGE_REF}
+	git -C tmp/pybridge reset --hard FETCH_HEAD
+	cp "$$(tmp/pybridge/tools/make-wheel)" $(SUB_MAN_COCKPIT)
+
+
+VM_DEPENDS = $(COCKPIT_WHEEL)
+VM_CUSTOMIZE_FLAGS = --install $(COCKPIT_WHEEL)
+endif
+
+
+$(VM_IMAGE): $(SUB_MAN_COCKPIT) $(SUBMAN_TAR) $(SMBEXT_TAR) integration-tests/vm.install $(VM_DEPENDS)
 	rm -f $(VM_IMAGE)
 	# setup the test image from subscription-manager-cockpit without
 	# a custom subscription-manager, which will be installed manually
 	TEST_SCENARIO=system make -C $(SUB_MAN_COCKPIT) prepare-check
 	# install the custom subscription-manager on the test image
-	cd $(SUB_MAN_COCKPIT) && bots/image-customize -v $(TEST_OS) \
+	cd $(SUB_MAN_COCKPIT) && bots/image-customize -v $(VM_CUSTOMIZE_FLAGS) $(TEST_OS) \
           -u $(SUBMAN_TAR):/var/tmp/ \
           -u $(SMBEXT_TAR):/var/tmp/ \
           -s ../../integration-tests/vm.install


### PR DESCRIPTION
The Python bridge is our new experimental cockpit-bridge, with the pybridge scenario we can test if it's compatible with subscription manager.

Locally I saw some tests fail on which I assume is:

```
> debug: Opening private bus interface at unix:path=/run/dbus-Fbs7wCDj8a,guid=997177f8c3946d27deb11ddf63e15f8c
> debug: registering using activation key
> error: error registering
> log: Error parsing D-Bus error message:  Unexpected token 'I', "Introspect"... is not valid JSON
> log: Returning original error message:
> debug: Result of registration:
> debug: stopping registration server
> warning: Introspection data for method com.redhat.RHSM1.Register RegisterWithActivationKeys not available
```

```
> debug: Opening private bus interface at unix:path=/run/dbus-vBZaHewidm,guid=0ef2fb000ea7aead12c9073b63e16065
> debug: registering using username and password
> log: registration_options:
> error: error registering
> log: Error parsing D-Bus error message:  Unexpected token 'I', "Introspect"... is not valid JSON
> log: Returning original error message:
> debug: Result of registration:
> debug: stopping registration server
> warning: Introspection data for method com.redhat.RHSM1.Register Register not available
> debug: requesting update of subscription status
> debug: requesting update of syspurpose status
> debug: Other state: unknown
```

Some sort of introspection going wrong @allisonkarlitskaya 