### PR TITLE
[1.28] ENT-5541: Publish PR coverage

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,6 +8,10 @@ jobs:
   pytest:
     name: "pytest"
 
+    permissions:
+      issues: write
+      pull-requests: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -33,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}
+      volumes:
+        - /tmp:/tmp
 
     steps:
       - name: "Checkout repository"
@@ -45,7 +51,21 @@ jobs:
       - name: "Run pytest"
         env:
           SUBMAN_TEST_IN_CONTAINER: "1"
-          PYTEST_ADDOPTS: "--color=yes --code-highlight=yes --showlocals"
+          PYTEST_ADDOPTS:
+            "--color=yes --code-highlight=yes --showlocals
+            --cov 'src/' --cov-report 'term:skip-covered'
+            --cov-report 'xml:/tmp/coverage.xml' --junitxml '/tmp/pytest.xml'"
         run: |
           dbus-run-session \
             python3 -m pytest ${{ matrix.pytest_args }}
+
+      - name: "Publish coverage"
+        uses: MishaKav/pytest-coverage-comment@main
+        if: |
+          github.event.pull_request.head.repo.full_name == github.repository
+          && matrix.name == 'Fedora latest'
+        with:
+          title: "Coverage (computed on ${{ matrix.name }})"
+          report-only-changed-files: true
+          pytest-xml-coverage-path: /tmp/coverage.xml
+          junitxml-path: /tmp/pytest.xml

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,7 +11,7 @@ pytest<7
 pytest-randomly
 pytest-timeout
 pytest-forked
-coverage
+pytest-cov
 polib
 pyinotify
 simplejson


### PR DESCRIPTION
* Card ID: ENT-5541

Publish coverage report as a comment under the PR.
- To send the comment only once, not for every matrix system, only 'Fedora latest' is used as a data source.
- Because of how GitHub permissions work, the comment is only sent if the PR originates from a feature branch; nothing will be sent for a PR originating from some fork. Full coverage is still displayed in CI output, it is just not sent as a comment.
- Package 'pytest-cov' is used instead of 'coverage'. It is still using coverage in a background, but it runs it as a pytest addon instead, allowing us to pass its arguments into pytest, instead of wrapping whole pytest call inside of a coverage invocation.

(Cherry-picked from ea495a6)