### PR TITLE
libdnf: fix return value of `findProductId()`

### DIFF
--- a/src/plugins/libdnf/product-id.h
+++ b/src/plugins/libdnf/product-id.h
@@ -81,7 +81,7 @@ void getActiveReposFromInstalledPkgs(DnfContext *dnfContext, const GPtrArray *en
 void getActive(DnfContext *dnfContext, const GPtrArray *enabledRepoAndProductIds,
         GPtrArray *activeRepoAndProductIds);
 int decompress(gzFile input, GString *output);
-int findProductId(GString *certContent, GString *result);
+gboolean findProductId(GString *certContent, GString *result);
 int fetchProductId(DnfRepo *repo, RepoProductId *repoProductId);
 int installProductId(RepoProductId *repoProductId, ProductDb *productDb, const char *product_cert_dir);
 void writeRepoMap(ProductDb *productDb);

--- a/src/plugins/libdnf/test-product-id.c
+++ b/src/plugins/libdnf/test-product-id.c
@@ -172,8 +172,8 @@ void testFindProductIdInCorrectPEM(handleFixture *fixture, gconstpointer ignored
     (void)ignored;
     GString *result = g_string_new("");
     GString *certContent = g_string_new(CORRECT_PEM_CERT);
-    int ret = findProductId(certContent, result);
-    g_assert_cmpint(ret, ==, 1);
+    gboolean ret = findProductId(certContent, result);
+    g_assert_cmpint(ret, ==, TRUE);
     g_assert_cmpstr(result->str, ==, "69");
     g_string_free(certContent, TRUE);
     g_string_free(result, TRUE);
@@ -185,8 +185,8 @@ void testFindProductIdInCorruptedPEM(handleFixture *fixture, gconstpointer ignor
     (void)ignored;
     GString *result = g_string_new("");
     GString *certContent = g_string_new(CORRUPTED_PEM_CERT);
-    int ret = findProductId(certContent, result);
-    g_assert_cmpint(ret, ==, -1);
+    gboolean ret = findProductId(certContent, result);
+    g_assert_cmpint(ret, ==, FALSE);
     g_assert_cmpstr(result->str, ==, "");
     g_string_free(certContent, TRUE);
     g_string_free(result, TRUE);
@@ -198,8 +198,8 @@ void testFindProductIdInConsumerPEM(handleFixture *fixture, gconstpointer ignore
     (void)ignored;
     GString *result = g_string_new("");
     GString *certContent = g_string_new(CONSUMER_CERT);
-    int ret = findProductId(certContent, result);
-    g_assert_cmpint(ret, ==, -1);
+    gboolean ret = findProductId(certContent, result);
+    g_assert_cmpint(ret, ==, FALSE);
     g_assert_cmpstr(result->str, ==, "");
     g_string_free(certContent, TRUE);
     g_string_free(result, TRUE);


### PR DESCRIPTION
`findProductId()` returns an int, either -1 or 1 depending on whether it was possible to find the product ID in the specified certificate. The problem with this kind of return value is that's very easy to mistake for a boolean, and indeed `installProductId()` has a boolean-like check that it is always true, no matter the return value of `findProductId()`.

As a fix, change the return type of `findProductId()` to gboolean, with true returned whether the search succeeded:
- reduce the scope of the `ret_val` variable, so there are less chances to use it wrongly
- make `ret_val` false by default, only changing it to true in the only place where it needs to be like that
- adapt the tests accordingly

Reported-by: Matyas Horky