### PR TITLE
[1.28] 2166317: gui: do not use an empty environment string

### DIFF
--- a/src/subscription_manager/gui/registergui.py
+++ b/src/subscription_manager/gui/registergui.py
@@ -1946,6 +1946,8 @@ class AsyncBackend(object):
         """
         method run in the worker thread.
         """
+        # Avoid passing empty strings as environments
+        environments = env if env else None
         try:
             # We've got several steps here that all happen in this thread
             #
@@ -1991,7 +1993,7 @@ class AsyncBackend(object):
 
             cp = self.backend.cp_provider.get_basic_auth_cp()
             retval = cp.registerConsumer(name=name, facts=facts_dict,
-                                         owner=owner, environments=env,
+                                         owner=owner, environments=environments,
                                          keys=activation_keys,
                                          installed_products=installed_mgr.format_for_server(),
                                          role=syspurpose.get('role'),


### PR DESCRIPTION
Make sure that the string for 'environments' passed to registerConsumer() is not empty (using None in that case): because of the multi-environment work (4b2c3334eb44a0dc28b9859d53ddc72c60092d76), an empty string is split as list of environments, trying to send a single empty environment when registering.