### PR TITLE
Enhancement and fix for containerized pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,13 +18,7 @@ jobs:
         include:
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
-            pytest_args: '--deselect test/rhsmlib/facts/test_hwprobe.py::HardwareProbeTest::test_networkinfo --deselect test/rhsmlib/test_facts.py::TestFactsDBusObject::test_GetFacts'
-            # The 'test_networkinfo' breaks in CentOS container because it has IPv6 disabled.
-            # Because of a bug in Python, collecting 'socket.AF_INET6' via 'socket.getaddrinfo()' causes
-            # segfaults instead of exceptions when the IPv6 network is not available.
-            # This deselect is a workaround until it is fixed or until we switch to a different way of
-            # collecting network facts.
-            # 'test_GetFacts' triggers full fact collection and causes the same error.
+            pytest_args: ''
           - name: "Fedora latest"
             image: "fedora:latest"
             pytest_args: ''

--- a/scripts/container-pre-test.sh
+++ b/scripts/container-pre-test.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
+# Install essential packages
+dnf --setopt install_weak_deps=False install -y \
+  dnf-plugins-core git gcc cmake python3 python3-devel python3-pip
+
 source /etc/os-release
 # These repositories are required for the 'libdnf-devel' package.
 # Fedora has it available out of the box.
 # RHEL needs it to be enabled via 'subscription-manager repos'.
 if [[ $ID == "centos" && $VERSION == "9" ]]; then
-  dnf --setopt install_weak_deps=False install -y dnf-plugins-core
   dnf config-manager --enable crb
 fi
-
-# Install essential packages
-dnf --setopt install_weak_deps=False install -y \
-  git gcc cmake python3 python3-devel python3-pip
 
 # Install system, build and runtime packages
 dnf --setopt install_weak_deps=False install -y \


### PR DESCRIPTION
First commit addresses one test that was being skipped on Fedora images. By including dnf-plugins-core package there as well, we can run it.

Second commit removes the excluded tests on CentOS 9 Stream, as https://bugzilla.redhat.com/show_bug.cgi?id=2167468 is now fixed.