### PR TITLE
[1.28] Enhancement and fix for containerized pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,12 +18,7 @@ jobs:
         include:
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
-            pytest_args: '--deselect test/rhsmlib_test/test_hwprobe.py::HardwareProbeTest::test_networkinfo --deselect test/rhsmlib_test/test_facts.py::TestFactsDBusObject::test_GetFacts'
-            # The 'test_networkinfo' breaks in CentOS container because it has IPv6 disabled.
-            # Because of a bug in Python, collecting 'socket.AF_INET6' via 'socket.getaddrinfo()' causes
-            # segfaults instead of exceptions. This deselect is a workaround until it is fixed or until
-            # we switch to a different way of collecting network facts.
-            # 'test_GetFacts' triggers full fact collection and causes the same error.
+            pytest_args: ''
           - name: "CentOS Stream 8"
             image: "quay.io/centos/centos:stream8"
             pytest_args: ''

--- a/scripts/container-pre-test.sh
+++ b/scripts/container-pre-test.sh
@@ -1,22 +1,19 @@
 #!/bin/bash
 
+# Install essential packages
+dnf --setopt install_weak_deps=False install -y \
+  dnf-plugins-core git gcc cmake python3 python3-devel python3-pip
+
 source /etc/os-release
 # These repositories are required for the 'libdnf-devel' package.
 # Fedora has it available out of the box.
 # RHEL needs it to be enabled via 'subscription-manager repos'.
-if [[ $ID == "centos" ]]; then
-  dnf --setopt install_weak_deps=False install -y dnf-plugins-core
-  if [[ $VERSION == "8" ]]; then
-    dnf config-manager --set-enabled powertools
-  fi
-  if [[ $VERSION == "9" ]]; then
-    dnf config-manager --enable crb
-  fi
+if [[ $ID == "centos" && $VERSION == "8" ]]; then
+    dnf config-manager --enable powertools
 fi
-
-# Install essential packages
-dnf --setopt install_weak_deps=False install -y \
-  git gcc cmake python3 python3-devel python3-pip
+if [[ $ID == "centos" && $VERSION == "9" ]]; then
+    dnf config-manager --enable crb
+fi
 
 # Install system, build and runtime packages
 dnf --setopt install_weak_deps=False install -y \


### PR DESCRIPTION
First commit addresses one test that was being skipped on Fedora images. By including dnf-plugins-core package there as well, we can run it.

Second commit removes the excluded tests on CentOS 9 Stream, as https://bugzilla.redhat.com/show_bug.cgi?id=2167468 is now fixed.

Backport of PR #3214.