### PR TITLE
[1.28] New dmidecode-based DMI facts collector; use it on aarch64

### DIFF
--- a/src/cloud_what/setup.py
+++ b/src/cloud_what/setup.py
@@ -48,6 +48,6 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    install_requires=['dmidecode', 'requests'],
+    install_requires=['requests'],
 
 )

--- a/src/rhsmlib/facts/dmidecodeparser.py
+++ b/src/rhsmlib/facts/dmidecodeparser.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+
+"""
+This module contains a minimal ad-hoc parser for the output of `dmidecode`.
+
+Tailored for the rest of the subscription-manager code, not general enough.
+"""
+
+import collections
+import contextlib
+import enum
+import logging
+import os
+import re
+import shutil
+import subprocess
+from typing import Dict, List, Union
+
+log = logging.getLogger(__name__)
+
+
+class DmidecodeParser:
+    """
+    Simple parser for the dmidecode output.
+
+    This class provides a simple way to parse the output of the dmidecode(1)
+    tool, either by running dmidecode(1) directly, or by reading its output
+    from a text file.
+
+    This parser only parses the output and collects the various entries,
+    so they can be queried as needed.
+    """
+
+    @enum.unique
+    class DmiTypes(enum.Enum):
+        """
+        The known DMI types.
+
+        The values represent the actual values in the SMBIOS specification,
+        so it possible to use this enum to avoid specifying them when
+        looking up sections.
+        """
+
+        BIOS_INFORMATION = 0
+        SYSTEM_INFORMATION = 1
+        BASEBOARD_INFORMATION = 2
+        SYSTEM_ENCLOSURE_OR_CHASSIS = 3
+        PROCESSOR_INFORMATION = 4
+        MEMORY_CONTROLLER_INFORMATION = 5
+        MEMORY_MODULE_INFORMATION = 6
+        CACHE_INFORMATION = 7
+        PORT_CONNECTOR_INFORMATION = 8
+        SYSTEM_SLOTS = 9
+        ON_BOARD_DEVICES_INFORMATION = 10
+        OEM_STRINGS = 11
+        SYSTEM_CONFIGURATION_OPTIONS = 12
+        BIOS_LANGUAGE_INFORMATION = 13
+        GROUP_ASSOCIATIONS = 14
+        SYSTEM_EVENT_LOG = 15
+        PHYSICAL_MEMORY_ARRAY = 16
+        MEMORY_DEVICE = 17
+        THIRTYTWO_BIT_MEMORY_ERROR_INFORMATION = 18
+        MEMORY_ARRAY_MAPPED_ADDRESS = 19
+        MEMORY_DEVICE_MAPPED_ADDRESS = 20
+        BUILT_IN_POINTING_DEVICE = 21
+        PORTABLE_BATTERY = 22
+        SYSTEM_RESET = 23
+        HARDWARE_SECURITY = 24
+        SYSTEM_POWER_CONTROLS = 25
+        VOLTAGE_PROBE = 26
+        COOLING_DEVICE = 27
+        TEMPERATURE_PROBE = 28
+        ELECTRICAL_CURRENT_PROBE = 29
+        OUT_OF_BAND_REMOTE_ACCESS = 30
+        BOOT_INTEGRITY_SERVICES_ENTRY_POINT = 31
+        SYSTEM_BOOT_INFORMATION = 32
+        SIXTYFOUR_BIT_MEMORY_ERROR_INFORMATION = 33
+        MANAGEMENT_DEVICE = 34
+        MANAGEMENT_DEVICE_COMPONENT = 35
+        MANAGEMENT_DEVICE_THRESHOLD_DATA = 36
+        MEMORY_CHANNEL = 37
+        IPMI_DEVICE_INFORMATION = 38
+        SYSTEM_POWER_SUPPLY = 39
+        ADDITIONAL_INFORMATION = 40
+        ONBOARD_DEVICES_EXTENDED_INFORMATION = 41
+        MANAGEMENT_CONTROLLER_HOST_INTERFACE = 42
+        TPM_DEVICE = 43
+        PROCESSOR_ADDITIONAL_INFORMATION = 44
+
+    def __init__(self):
+        self._data: Dict[int, Dict[str, Union[str, List[str]]]] = {}
+        self._dmi_types = collections.defaultdict(dict)
+
+    def parse(self):
+        """
+        Run `dmidecode` and parses its output.
+
+        In case `dmidecode` is not available, cannot be executed, or it exits
+        with failure, a warning is logged.
+        """
+        path = shutil.which("dmidecode")
+        if path is None:
+            log.warning("'dmidecode' is not available. No DMI info will be collected.")
+            return
+
+        env = dict(os.environ)
+        env.update({"LANGUAGE": "en_US.UTF-8"})
+
+        try:
+            proc = subprocess.Popen(
+                [path], env=env, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+            self._parse_lines(proc.stdout)
+        except subprocess.SubprocessError:
+            error = proc.stderr.read()
+            log.warning(f"Error with dmidecode subprocess: {error}")
+
+    def parse_file(self, filename):
+        """
+        Parse the output of `dmidecode` previously saved into the specified
+        file.
+        """
+        with open(filename, "r") as f:
+            self._parse_lines(f)
+
+    def _parse_lines(self, fd):
+        """
+        The actual parsing of the `dmidecode` output.
+
+        'fd' is a file object, so anything where it is possible to read line
+        by line (using readline()).
+        """
+
+        class ParsingState(enum.Enum):
+            """
+            Helper enum representing the current state in the parsing.
+            """
+
+            NONE = enum.auto()  # not in any section
+            IN_SECTION = enum.auto()  # within the header of a section
+            IN_RECORD = enum.auto()  # within a record of a section
+            IN_BLOCK = enum.auto()  # within a block of a record
+
+        def is_value_specified(v):
+            """
+            Is a value actually specified/available?
+
+            This is needed because dmidecode prints "Not Specified"/etc
+            instead of omitting a value that is not specified as DMI string
+            (le sigh).
+            """
+            return (
+                value != "Not Specified" and
+                value != "Not Available" and
+                value != "Unknown" and
+                value != "Unspecified"
+            )
+
+        state = ParsingState.NONE
+        current_handle = None
+        current_key = None
+        # regex to parse the start of a section in the output; example:
+        #   Handle 0x0000, DMI type 222, 14 bytes
+        re_handle = re.compile(r"^Handle\s+([^,]+),\s+DMI\s+type\s+(\d+),\s+(\d+)\s+bytes$")
+
+        while True:
+            # the output of dmidecode is read and parsed line by line;
+            # this is done to avoid reading & keeping in memory the whole
+            # output, as it can be big (depending on the available hardware,
+            # usually)
+            line = fd.readline()
+            if not line:
+                break
+
+            line = line.rstrip()
+            # empty line: not in a section
+            if len(line) == 0:
+                # reset all the state variables, and continue with the next
+                # line
+                state = ParsingState.NONE
+                current_handle = None
+                current_key = None
+                continue
+
+            # this may be the start of a section
+            if line.startswith("Handle "):
+                m = re_handle.fullmatch(line)
+                if m:
+                    # it really is a section, so get the various details,
+                    # and prepare the internal structures for it
+                    state = ParsingState.IN_SECTION
+                    current_handle = int(m[1], base=16)
+                    current_dmi_type = int(m[2])
+                    self._data[current_handle] = dict()
+                    handles = self._dmi_types[current_dmi_type].get("handles", [])
+                    handles.append(current_handle)
+                    self._dmi_types[current_dmi_type]["handles"] = handles
+                    continue
+
+            # we are in a section, in particular in the beginning of it
+            # (after the "Handle: header): the line is the name of the section,
+            # so skip it, and assume that records will follow
+            if state == ParsingState.IN_SECTION:
+                state = ParsingState.IN_RECORD
+                continue
+
+            # we are in a record, or in the block of a record: they are handled
+            # in a single case because, since we parse line by line, we cannot
+            # know when a block ends (and a new record starts)
+            if state == ParsingState.IN_RECORD or state == ParsingState.IN_BLOCK:
+                # a block
+                if line.startswith("\t\t"):
+                    if state == ParsingState.IN_RECORD:
+                        # had a value, drop it
+                        with contextlib.suppress(KeyError):
+                            del self._data[current_handle][current_key]
+                    value = line[2:]
+                    # if the current record had already a value, turn it into
+                    # a list, and append the new value to it; this way, each
+                    # line in the block will be a new item in the list which
+                    # is the value of this record
+                    try:
+                        current_value = self._data[current_handle][current_key]
+                        if not isinstance(current_value, list):
+                            current_value = [current_value]
+                        current_value.append(value)
+                        self._data[current_handle][current_key] = current_value
+                    except KeyError:
+                        self._data[current_handle][current_key] = value
+                    state = ParsingState.IN_BLOCK
+                # a record (and not a block, as that is checked earlier)
+                elif line.startswith("\t"):
+                    # usually a record is a line e.g.
+                    #   Foo: value
+                    # so split by the first colon, ignoring potentially
+                    # wrong lines
+                    parts = line[1:].split(":", maxsplit=1)
+                    if len(parts) != 2:
+                        continue
+                    current_key = parts[0]
+                    value = parts[1].lstrip()
+                    if is_value_specified(value):
+                        self._data[current_handle][current_key] = value
+                    state = ParsingState.IN_RECORD
+
+    def get_sections(self, dmi_type: Union[int, DmiTypes]) -> List[Dict[str, Union[str, List[str]]]]:
+        """
+        Get a list of sections for the specified DMI type.
+
+        'dmi_type' can be either an item of the DmiTypes enum, or the integer
+        value of a DMI type.
+        """
+        if isinstance(dmi_type, self.DmiTypes):
+            dmi_type = dmi_type.value
+
+        return [self._data[h] for h in self._dmi_types[dmi_type]["handles"]]
+
+    def get_key(self, dmi_type: Union[int, DmiTypes], key: str) -> Union[str, List[str]]:
+        """
+        Get the value of a specific key of a specified DMI type.
+
+        In case there are more sections of the specified DMI type, this will
+        lookup in the first section printed by dmidecode. This function
+        is more or less like a convenience wrapper.
+
+        KeyError is raisen if there is no section of the specified DMI type,
+        or that section does not have the specified key.
+        """
+        values = self.get_sections(dmi_type)
+        return values[0][key]

--- a/src/rhsmlib/facts/dmidecodeparser.py
+++ b/src/rhsmlib/facts/dmidecodeparser.py
@@ -151,7 +151,7 @@ class DmidecodeParser:
             IN_RECORD = enum.auto()  # within a record of a section
             IN_BLOCK = enum.auto()  # within a block of a record
 
-        def is_value_specified(v):
+        def is_value_specified(possible_value: str) -> bool:
             """
             Is a value actually specified/available?
 
@@ -160,10 +160,10 @@ class DmidecodeParser:
             (le sigh).
             """
             return (
-                value != "Not Specified" and
-                value != "Not Available" and
-                value != "Unknown" and
-                value != "Unspecified"
+                possible_value != "Not Specified" and
+                possible_value != "Not Available" and
+                possible_value != "Unknown" and
+                possible_value != "Unspecified"
             )
 
         state = ParsingState.NONE

--- a/src/rhsmlib/facts/dmiinfo.py
+++ b/src/rhsmlib/facts/dmiinfo.py
@@ -18,6 +18,7 @@ from __future__ import print_function, division, absolute_import
 Note: This module will fail to import if dmidecode fails to import.
       firmware_info.py expects that and handles it, and any other
       module that imports it should handle an import error as well."""
+import contextlib
 import logging
 import os
 import six
@@ -27,6 +28,7 @@ from subscription_manager.i18n import ugettext as _
 log = logging.getLogger(__name__)
 
 from rhsmlib.facts import collector
+from rhsmlib.facts.dmidecodeparser import DmidecodeParser
 
 FIRMWARE_DUMP_FILENAME = "dmi.dump"
 
@@ -129,3 +131,99 @@ class DmiFirmwareInfoCollector(collector.FactsCollector):
         if dmiwarnings:
             log.warn(_("Error reading system DMI information: %s"), dmiwarnings, exc_info=True)
             dmidecode.clear_warnings()
+
+
+class DmidecodeFactCollector(collector.FactsCollector):
+    def __init__(self, prefix=None, testing=None, collected_hw_info=None):
+        super(DmidecodeFactCollector, self).__init__(
+            prefix=prefix, testing=testing, collected_hw_info=collected_hw_info
+        )
+
+        self._dmidecode_output = None
+
+    def set_dmidecode_output(self, filename):
+        self._dmidecode_output = filename
+
+    def get_all(self):
+        """
+        Collect facts from the dmidecode output, if available.
+
+        There are different quirks done to make the facts returned closer
+        to the way python-dmidecode used to return them.
+        """
+        parser = DmidecodeParser()
+        try:
+            if self._dmidecode_output is not None:
+                parser.parse_file(self._dmidecode_output)
+            else:
+                parser.parse()
+        except Exception as exc:
+            log.warning("Failed to parse the dmidecode output: {exc}")
+            log.exception(exc)
+            return {}
+
+        dmiinfo = {}
+        socket_designations = 0
+        # map the various DMI types to the various subtags of "dmi" facts;
+        # there can be multiple types for the same subtag, as python-dmidecode
+        # aggregated them
+        tags = {
+            DmidecodeParser.DmiTypes.BIOS_INFORMATION: "dmi.bios.",
+            DmidecodeParser.DmiTypes.BIOS_LANGUAGE_INFORMATION: "dmi.bios.",
+            DmidecodeParser.DmiTypes.PROCESSOR_INFORMATION: "dmi.processor.",
+            DmidecodeParser.DmiTypes.BASEBOARD_INFORMATION: "dmi.baseboard.",
+            DmidecodeParser.DmiTypes.SYSTEM_ENCLOSURE_OR_CHASSIS: "dmi.chassis.",
+            DmidecodeParser.DmiTypes.SYSTEM_SLOTS: "dmi.slot.",
+            DmidecodeParser.DmiTypes.SYSTEM_INFORMATION: "dmi.system.",
+            DmidecodeParser.DmiTypes.SYSTEM_CONFIGURATION_OPTIONS: "dmi.system.",
+            DmidecodeParser.DmiTypes.MEMORY_DEVICE: "dmi.memory.",
+            DmidecodeParser.DmiTypes.PHYSICAL_MEMORY_ARRAY: "dmi.memory.",
+            DmidecodeParser.DmiTypes.PORT_CONNECTOR_INFORMATION: "dmi.connector.",
+        }
+        for dmi_type, facts_tag in tags.items():
+            try:
+                sections = parser.get_sections(dmi_type)
+            except KeyError:
+                continue
+            # quirk: use the last handle (likely the one with an higher value)
+            # in a similar way to what python-dmidecode did
+            section = sections[-1]
+            for key, value in section.items():
+                if not isinstance(value, str):
+                    # we are skipping lists
+                    continue
+
+                nkey = "".join([facts_tag, key.lower()]).replace(" ", "_")
+                nvalue = value
+                if nvalue.startswith("0x"):
+                    # quirk: hex value, lowercase it like python-dmidecode did
+                    nvalue = value.lower()
+                elif key == "UUID":
+                    # quirk: UUID, uppercase it like python-dmidecode did
+                    nvalue = value.upper()
+                dmiinfo[nkey] = nvalue
+
+        try:
+            sections = parser.get_sections(DmidecodeParser.DmiTypes.PROCESSOR_INFORMATION)
+        except KeyError:
+            pass
+        else:
+            socket_designations = sum(1 for s in sections for k in s.keys() if k == "Socket Designation")
+            # Populate how many socket descriptions we have in a faux-fact,
+            # so we can use it to munge lscpu info later if needed.
+            if socket_designations > 0:
+                dmiinfo["dmi.meta.cpu_socket_count"] = str(socket_designations)
+
+        try:
+            sections = parser.get_sections(DmidecodeParser.DmiTypes.MEMORY_DEVICE)
+        except KeyError:
+            pass
+        else:
+            # quirk: set dmi.memory.size based on the first "useful" value
+            # among all the memory devices available
+            with contextlib.suppress(StopIteration, KeyError):
+                dmiinfo["dmi.memory.size"] = next(
+                    s["Size"] for s in sections if s["Size"] != "No Module Installed"
+                )
+
+        return dmiinfo

--- a/src/rhsmlib/facts/dmiinfo.py
+++ b/src/rhsmlib/facts/dmiinfo.py
@@ -15,122 +15,14 @@ from __future__ import print_function, division, absolute_import
 #
 """Load and collect DMI data.
 
-Note: This module will fail to import if dmidecode fails to import.
-      firmware_info.py expects that and handles it, and any other
-      module that imports it should handle an import error as well."""
+"""
 import contextlib
 import logging
-import os
-import six
-
-from subscription_manager.i18n import ugettext as _
 
 log = logging.getLogger(__name__)
 
 from rhsmlib.facts import collector
 from rhsmlib.facts.dmidecodeparser import DmidecodeParser
-
-FIRMWARE_DUMP_FILENAME = "dmi.dump"
-
-
-class DmiFirmwareInfoCollector(collector.FactsCollector):
-    def __init__(self, prefix=None, testing=None, collected_hw_info=None):
-        super(DmiFirmwareInfoCollector, self).__init__(
-            prefix=prefix,
-            testing=testing,
-            collected_hw_info=collected_hw_info
-        )
-
-        self._socket_designation = []
-        self._socket_counter = 0
-
-        self.dump_file = None
-        if testing and prefix:
-            self.dump_file = os.path.join(prefix, FIRMWARE_DUMP_FILENAME)
-
-    def use_dump_file(self, dmidecode):
-        """Set this instances to use a dmidecode dump file.
-
-        WARNING: This involves settings a module global
-        attribute in 'dmidecode', not just for this class
-        or object, but for the lifetime of the dmidecode module.
-
-        To 'unset' it, it can be set back to '/dev/mem', or
-        re set it to another dump file."""
-        if os.access(self.dump_file, os.R_OK):
-            dmidecode.set_dev(self.dump_file)
-
-    # This needs all of the previously collected hwinfo, so it can decide
-    # what is bogus enough that the DMI info is better.
-    def get_all(self):
-        try:
-            import dmidecode
-        except ImportError:
-            log.warn("Unable to load dmidecode module. No DMI info will be collected")
-            raise
-
-        dmiinfo = {}
-        try:
-            # When alternative memory device file was specified for this class, then
-            # try to use it. Otherwise current device file will be used.
-            if self.dump_file is not None:
-                self.use_dump_file(dmidecode)
-            log.debug("Using dmidecode dump file: %s" % dmidecode.get_dev())
-            dmi_data = {
-                "dmi.bios.": self._read_dmi(dmidecode.bios),
-                "dmi.processor.": self._read_dmi(dmidecode.processor),
-                "dmi.baseboard.": self._read_dmi(dmidecode.baseboard),
-                "dmi.chassis.": self._read_dmi(dmidecode.chassis),
-                "dmi.slot.": self._read_dmi(dmidecode.slot),
-                "dmi.system.": self._read_dmi(dmidecode.system),
-                "dmi.memory.": self._read_dmi(dmidecode.memory),
-                "dmi.connector.": self._read_dmi(dmidecode.connector),
-            }
-
-            for tag, func in list(dmi_data.items()):
-                dmiinfo = self._get_dmi_data(func, tag, dmiinfo)
-        except Exception as e:
-            log.warn(_("Error reading system DMI information: %s"), e, exc_info=True)
-        finally:
-            self.log_warnings(dmidecode)
-        return dmiinfo
-
-    def _read_dmi(self, func):
-        try:
-            return func()
-        except Exception as e:
-            log.warn(_("Error reading system DMI information with %s: %s"), func, e)
-            return {}
-
-    def _get_dmi_data(self, func, tag, ddict):
-        for key, value in list(func.items()):
-            for key1, value1 in list(value['data'].items()):
-                # FIXME: this loses useful data...
-                if not isinstance(value1, six.text_type) and not isinstance(value1, six.binary_type):
-                    # we are skipping things like int and bool values, as
-                    # well as lists and dicts
-                    continue
-
-                # keep track of any cpu socket info we find, we have to do
-                # it here, since we flatten it and lose the info creating nkey
-                if tag == 'dmi.processor.' and key1 == 'Socket Designation':
-                    self._socket_designation.append(value1)
-
-                nkey = ''.join([tag, key1.lower()]).replace(" ", "_")
-                ddict[nkey] = six.text_type(value1, 'utf-8')
-
-        # Populate how many socket descriptions we saw in a faux-fact, so we can
-        # use it to munge lscpu info later if needed.
-        if self._socket_designation:
-            ddict['dmi.meta.cpu_socket_count'] = str(len(self._socket_designation))
-
-        return ddict
-
-    def log_warnings(self, dmidecode):
-        dmiwarnings = dmidecode.get_warnings()
-        if dmiwarnings:
-            log.warn(_("Error reading system DMI information: %s"), dmiwarnings, exc_info=True)
-            dmidecode.clear_warnings()
 
 
 class DmidecodeFactCollector(collector.FactsCollector):

--- a/src/rhsmlib/facts/firmware_info.py
+++ b/src/rhsmlib/facts/firmware_info.py
@@ -130,11 +130,7 @@ def get_firmware_collector(arch, prefix=None, testing=None,
         log.debug("Looking in file structure for UUID for arch '%s'" % arch)
         firmware_provider_class = UuidFirmwareInfoCollector
     else:
-        try:
-            import dmidecode  # noqa
-            firmware_provider_class = dmiinfo.DmiFirmwareInfoCollector
-        except:
-            firmware_provider_class = NullFirmwareInfoCollector
+        firmware_provider_class = dmiinfo.DmidecodeFactCollector
 
     firmware_provider = firmware_provider_class(
         prefix=prefix,

--- a/src/rhsmlib/facts/firmware_info.py
+++ b/src/rhsmlib/facts/firmware_info.py
@@ -20,13 +20,8 @@ import logging
 
 from rhsmlib.facts import dmiinfo
 from rhsmlib.facts import collector
-from uuid import UUID
 
 ARCHES_WITHOUT_DMI = ["ppc64", "ppc64le", "s390x"]
-ARCHES_WITH_ALTERNATE_UUID_LOC = ["aarch64"]
-ARCH_UUID_LOCATION = {
-    "aarch64": "/sys/devices/virtual/dmi/id/product_uuid"
-}
 
 log = logging.getLogger(__name__)
 
@@ -42,35 +37,6 @@ class NullFirmwareInfoCollector(object):
 
     def get_all(self):
         return self.info
-
-
-class UuidFirmwareInfoCollector(collector.FactsCollector):
-    """
-    If we are on an arch where dmi.system.uuid is not collected
-    but is available in a directory, we will collect it here.
-    """
-
-    def __init__(self, prefix=None, testing=None, collected_hw_info=None):
-        super(UuidFirmwareInfoCollector, self).__init__(
-            prefix=prefix,
-            testing=testing,
-            collected_hw_info=collected_hw_info
-        )
-
-    def get_all(self):
-        uuidinfo = {}
-        try:
-            with open(ARCH_UUID_LOCATION[self.arch], 'r') as uuid_file:
-                uuid = uuid_file.read().strip()
-            if uuid:
-                UUID(uuid)
-                uuidinfo['dmi.system.uuid'] = uuid
-        except ValueError as err:
-            log.error('Wrong UUID value: %s read from: %s, error: %s' %
-                (uuid, ARCH_UUID_LOCATION[self.arch], err))
-        except Exception as e:
-            log.warning("Error reading system uuid information: %s", e, exc_info=True)
-        return uuidinfo
 
 
 class FirmwareCollector(collector.FactsCollector):
@@ -120,15 +86,12 @@ def get_firmware_collector(arch, prefix=None, testing=None,
     ie, DmiFirmwareInfoProvider on intel platforms, and a
     NullFirmwareInfoProvider otherwise.
     """
-    # we could potential consider /proc/sysinfo as a FirmwareInfoProvider
+    # we could potentially consider /proc/sysinfo as a FirmwareInfoProvider
     # but at the moment, it is just firmware/dmi stuff.
 
     if arch in ARCHES_WITHOUT_DMI:
         log.debug("Not looking for DMI info since it is not available on '%s'" % arch)
         firmware_provider_class = NullFirmwareInfoCollector
-    elif arch in ARCHES_WITH_ALTERNATE_UUID_LOC:
-        log.debug("Looking in file structure for UUID for arch '%s'" % arch)
-        firmware_provider_class = UuidFirmwareInfoCollector
     else:
         firmware_provider_class = dmiinfo.DmidecodeFactCollector
 

--- a/src/zypper/services/rhsm
+++ b/src/zypper/services/rhsm
@@ -232,11 +232,3 @@ if __name__ == '__main__':
         sys.stderr.write('\n')
 
     service.main()
-
-    # suppress python-dmidecode warnings
-    # TODO do this elsewhere?
-    try:
-        import dmidecode
-        dmidecode.clear_warnings()
-    except ImportError:
-        pass

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -18,6 +18,7 @@
 %if (0%{?rhel} >= 7 || 0%{?fedora})
 %global dmidecode_version >= 3.12.2-2
 %endif
+%global dmidecode_arches %{ix86} x86_64
 
 # We use the tmpfiles_create macro from systemd-rpm-macros rpm.
 # Because of an incorrect version labelling of that rpm in SLES 12 which
@@ -746,8 +747,8 @@ subscription-manager-initial-setup-addon, and subscription-manager-cockpit-plugi
 Summary: Python package for detection of public cloud provider
 License: GPLv2
 Requires: python3-requests
-%ifnarch aarch64 ppc ppc64 ppc64le s390 s390x
-Requires:  %{py_package_prefix}-dmidecode %{?dmidecode_version}
+%ifarch %{dmidecode_arches}
+Requires: dmidecode
 %endif
 
 %description -n python3-cloud-what

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -15,9 +15,6 @@
 %global use_container_plugin 1
 %endif
 
-%if (0%{?rhel} >= 7 || 0%{?fedora})
-%global dmidecode_version >= 3.12.2-2
-%endif
 %global dmidecode_arches %{ix86} x86_64
 
 # We use the tmpfiles_create macro from systemd-rpm-macros rpm.
@@ -292,6 +289,10 @@ Requires:  %{py_package_prefix}-ethtool
 Requires:  %{py_package_prefix}-iniparse
 Requires:  %{py_package_prefix}-decorator
 Requires:  virt-what
+%ifarch %{dmidecode_arches}
+Requires: dmidecode
+%endif
+
 %if 0%{?suse_version}
 Requires:  logrotate
 Requires:  cron
@@ -337,11 +338,6 @@ Requires:  usermode
 Requires: python3-gobject-base
 %else
 Requires:  %{?gtk3:gobject-introspection, pygobject3-base} %{!?gtk3:pygobject2}
-%endif
-# There's no dmi to read on these arches, so don't pull in this dep.
-# Additionally, dmidecode isn't packaged at all on SUSE
-%ifnarch aarch64 ppc ppc64 ppc64le s390 s390x
-Requires:  %{py_package_prefix}-dmidecode %{?dmidecode_version}
 %endif
 %endif
 

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -15,7 +15,7 @@
 %global use_container_plugin 1
 %endif
 
-%global dmidecode_arches %{ix86} x86_64
+%global dmidecode_arches %{ix86} x86_64 aarch64
 
 # We use the tmpfiles_create macro from systemd-rpm-macros rpm.
 # Because of an incorrect version labelling of that rpm in SLES 12 which

--- a/test/rhsmlib_test/dmidecodedata/aarch64-baremetal-1.txt
+++ b/test/rhsmlib_test/dmidecodedata/aarch64-baremetal-1.txt
@@ -1,0 +1,823 @@
+# dmidecode 3.3
+Getting SMBIOS data from sysfs.
+SMBIOS 3.2.0 present.
+Table at 0x9FF6840000.
+
+Handle 0x0000, DMI type 0, 26 bytes
+BIOS Information
+	Vendor: LENOVO
+	Version: hve104q-1.14
+	Release Date: 06/25/2020
+	Address: 0xF0000
+	Runtime Size: 64 kB
+	ROM Size: 8 MB
+	Characteristics:
+		PCI is supported
+		BIOS is upgradeable
+		Boot from CD is supported
+		Selectable boot is supported
+		ACPI is supported
+		Targeted content distribution is supported
+		UEFI is supported
+	BIOS Revision: 1.14
+	Firmware Revision: 1.8
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+	Manufacturer: Lenovo
+	Product Name: PPPPPPPPPP    
+	Version: 7X33A007NA          
+	Serial Number: SSSSSSSS                    
+	UUID: 11111111-2222-3333-4444-555555555555
+	Wake-up Type: Power Switch
+	SKU Number: LENOVO_MT_OR
+	Family: Lenovo ThinkSystem HR330A/HR350A
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+	Manufacturer: Lenovo
+	Product Name: PPPPPPPPPP     
+	Version: SB27A42903
+	Serial Number: SSSSSSSS                 
+	Asset Tag:                                                   
+	Features:
+		Board is a hosting board
+	Location In Chassis: Part Component
+	Chassis Handle: 0x0003
+	Type: Motherboard
+	Contained Object Handles: 0
+
+Handle 0x0003, DMI type 3, 22 bytes
+Chassis Information
+	Manufacturer: Lenovo
+	Type: Rack Mount Chassis
+	Lock: Not Present
+	Version: 7X33CTO1WW  
+	Serial Number: SSSSSSSS                                
+	Asset Tag:                                                   
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: None
+	OEM Information: 0x00000000
+	Height: Unspecified
+	Number Of Power Cords: 1
+	Contained Elements: 0
+	SKU Number: Not Specified
+
+Handle 0x0004, DMI type 4, 48 bytes
+Processor Information
+	Socket Designation: CPU 1
+	Type: Central Processor
+	Family: ARMv8
+	Manufacturer: Ampere(TM)
+	ID: 02 00 3F 50 00 00 00 00
+	Signature: Implementor 0x50, Variant 0x3, Architecture 15, Part 0x000, Revision 2
+	Version: eMAG 
+	Voltage: 0.9 V
+	External Clock: 3000 MHz
+	Max Speed: 3300 MHz
+	Current Speed: 3000 MHz
+	Status: Populated, Enabled
+	Upgrade: None
+	L1 Cache Handle: 0x0005
+	L2 Cache Handle: 0x0006
+	L3 Cache Handle: 0x0007
+	Serial Number: SSSSSSSS
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 32
+	Core Enabled: 32
+	Thread Count: 32
+	Characteristics:
+		64-bit capable
+		Multi-Core
+		Hardware Thread
+		Execute Protection
+		Enhanced Virtualization
+
+Handle 0x0005, DMI type 7, 27 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Not Socketed, Level 1
+	Operational Mode: Write Through
+	Location: Internal
+	Installed Size: 64 kB
+	Maximum Size: 64 kB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Parity
+	System Type: Other
+	Associativity: 8-way Set-associative
+
+Handle 0x0006, DMI type 7, 27 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Not Socketed, Level 2
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 256 kB
+	Maximum Size: 256 kB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Parity
+	System Type: Unified
+	Associativity: 32-way Set-associative
+
+Handle 0x0007, DMI type 7, 27 bytes
+Cache Information
+	Socket Designation: L3 Cache
+	Configuration: Enabled, Not Socketed, Level 3
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 32 MB
+	Maximum Size: 32 MB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Parity
+	System Type: Unified
+	Associativity: 32-way Set-associative
+
+Handle 0x0008, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: CON 32 - FRONT PANEL SATA0-3(HR350A)
+	Internal Connector Type: Other
+	External Reference Designator: SATA
+	External Connector Type: Other
+	Port Type: SATA
+
+Handle 0x0009, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: CON 36 - FRONT PANEL NVMe4-5(HR350A)
+	Internal Connector Type: Other
+	External Reference Designator: NVMe
+	External Connector Type: Other
+	Port Type: Other
+
+Handle 0x0010, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: CON 25 - FRONT PANEL VGA
+	Internal Connector Type: Other
+	External Reference Designator: Video
+	External Connector Type: DB-15 female
+	Port Type: Video Port
+
+Handle 0x0011, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: CON 39 - FRONT PANEL USB
+	Internal Connector Type: Other
+	External Reference Designator: USB 3,4
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0012, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Specified
+	Internal Connector Type: Other
+	External Reference Designator: CON 38 - REAR PANEL USB1,2
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0013, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Specified
+	Internal Connector Type: Other
+	External Reference Designator: CON 41 - REAR PANEL COM PORT
+	External Connector Type: DB-9 female
+	Port Type: Serial Port 16550 Compatible
+
+Handle 0x0014, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Specified
+	Internal Connector Type: Other
+	External Reference Designator: CON 52 - REAR PANEL VGA PORT
+	External Connector Type: DB-15 female
+	Port Type: Video Port
+
+Handle 0x0015, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Specified
+	Internal Connector Type: Other
+	External Reference Designator: CON 24 - REAR PANEL ETHERNET PORT
+	External Connector Type: RJ-45
+	Port Type: Network Port
+
+Handle 0x0016, DMI type 9, 17 bytes
+System Slot Information
+	Designation: Slot 1
+	Type: x8 PCI Express 3
+	Current Usage: In Use
+	Length: Long
+	ID: 1
+	Characteristics:
+		3.3 V is provided
+		PME signal is supported
+	Bus Address: 0002:01:00.0
+
+Handle 0x0017, DMI type 9, 17 bytes
+System Slot Information
+	Designation: Slot 2
+	Type: x16 PCI Express 3
+	Current Usage: In Use
+	Length: Long
+	ID: 2
+	Characteristics:
+		3.3 V is provided
+		PME signal is supported
+	Bus Address: 0000:01:00.0
+
+Handle 0x0018, DMI type 9, 17 bytes
+System Slot Information
+	Designation: Slot 3
+	Type: x8 PCI Express 3 x16
+	Current Usage: Available
+	Length: Long
+	ID: 3
+	Characteristics:
+		3.3 V is provided
+		PME signal is supported
+	Bus Address: 0003:00:00.0
+
+Handle 0x0020, DMI type 11, 5 bytes
+OEM Strings
+	String 1: hve104q-1.14
+
+Handle 0x0021, DMI type 12, 5 bytes
+System Configuration Options
+	Option 1: JP29: Close to clear NVPARAM and NVRAM sections
+	Option 2: JP30: Close to clear BIOS Administrator and User passwords
+	Option 3: JP32: Close to active hidden menu feature
+
+Handle 0x0022, DMI type 13, 22 bytes
+BIOS Language Information
+	Language Description Format: Long
+	Installable Languages: 1
+		en|US|iso8859-1
+	Currently Installed Language: en|US|iso8859-1
+
+Handle 0x0023, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: Multi-bit ECC
+	Maximum Capacity: 512 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 16
+
+Handle 0x0024, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x0000000090000000k
+	Ending Address: 0x00000000FFFFFFFFk
+	Range Size: 1792 MB
+	Physical Array Handle: 0x0023
+	Partition Width: 1
+
+Handle 0x0025, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x0000000880000000k
+	Ending Address: 0x0000000FFFFFFFFFk
+	Range Size: 30 GB
+	Physical Array Handle: 0x0023
+	Partition Width: 2
+
+Handle 0x0026, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x0000008800000000k
+	Ending Address: 0x0000009FFFFFFFFFk
+	Range Size: 96 GB
+	Physical Array Handle: 0x0023
+	Partition Width: 6
+
+Handle 0x0028, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 16 GB
+	Form Factor: DIMM
+	Set: Unknown
+	Locator: DIMM 1
+	Bank Locator: Bank 1
+	Type: DDR4
+	Type Detail: Unknown
+	Speed: 2667 MT/s
+	Manufacturer: Samsung
+	Serial Number: SSSSSSSS               
+	Asset Tag: Array 1 Asset Tag 1
+	Part Number: AAAAAAAAAAAAA-ZZ     
+	Rank: 2
+	Configured Memory Speed: 2667 MT/s
+	Minimum Voltage: 1.08 V
+	Maximum Voltage: 1.32 V
+	Configured Voltage: 1.2 V
+	Memory Technology: <OUT OF SPEC>
+	Memory Operating Mode Capability: None
+	Firmware Version: <BAD INDEX>
+	Module Manufacturer ID: Unknown
+	Module Product ID: Unknown
+	Memory Subsystem Controller Manufacturer ID: Unknown
+	Memory Subsystem Controller Product ID: Unknown
+	Non-Volatile Size: None
+	Volatile Size: None
+	Cache Size: None
+	Logical Size: None
+
+Handle 0x0029, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00090000000
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1792 MB
+	Physical Device Handle: 0x0028
+	Memory Array Mapped Address Handle: 0x0024
+	Partition Row Position: Unknown
+
+Handle 0x0030, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 2
+	Bank Locator: Bank 2
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0031, DMI type 126, 35 bytes
+Inactive
+
+Handle 0x0032, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 16 GB
+	Form Factor: DIMM
+	Set: Unknown
+	Locator: DIMM 3
+	Bank Locator: Bank 3
+	Type: DDR4
+	Type Detail: Unknown
+	Speed: 2667 MT/s
+	Manufacturer: Samsung
+	Serial Number: SSSSSSSS               
+	Asset Tag: Array 1 Asset Tag 3
+	Part Number: AAAAAAAAAAAAA-ZZ     
+	Rank: 2
+	Configured Memory Speed: 2667 MT/s
+	Minimum Voltage: 1.08 V
+	Maximum Voltage: 1.32 V
+	Configured Voltage: 1.2 V
+	Memory Technology: <OUT OF SPEC>
+	Memory Operating Mode Capability: None
+	Firmware Version: <BAD INDEX>
+	Module Manufacturer ID: Unknown
+	Module Product ID: Unknown
+	Memory Subsystem Controller Manufacturer ID: Unknown
+	Memory Subsystem Controller Product ID: Unknown
+	Non-Volatile Size: None
+	Volatile Size: None
+	Cache Size: None
+	Logical Size: None
+
+Handle 0x0033, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00C00000000
+	Ending Address: 0x00FFFFFFFFF
+	Range Size: 16 GB
+	Physical Device Handle: 0x0032
+	Memory Array Mapped Address Handle: 0x0025
+	Partition Row Position: Unknown
+
+Handle 0x0034, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 4
+	Bank Locator: Bank 4
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0035, DMI type 126, 35 bytes
+Inactive
+
+Handle 0x0036, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 16 GB
+	Form Factor: DIMM
+	Set: Unknown
+	Locator: DIMM 5
+	Bank Locator: Bank 5
+	Type: DDR4
+	Type Detail: Unknown
+	Speed: 2667 MT/s
+	Manufacturer: Samsung
+	Serial Number: SSSSSSSS               
+	Asset Tag: Array 1 Asset Tag 5
+	Part Number: AAAAAAAAAAAAA-ZZ     
+	Rank: 2
+	Configured Memory Speed: 2667 MT/s
+	Minimum Voltage: 1.08 V
+	Maximum Voltage: 1.32 V
+	Configured Voltage: 1.2 V
+	Memory Technology: <OUT OF SPEC>
+	Memory Operating Mode Capability: None
+	Firmware Version: <BAD INDEX>
+	Module Manufacturer ID: Unknown
+	Module Product ID: Unknown
+	Memory Subsystem Controller Manufacturer ID: Unknown
+	Memory Subsystem Controller Product ID: Unknown
+	Non-Volatile Size: None
+	Volatile Size: None
+	Cache Size: None
+	Logical Size: None
+
+Handle 0x0037, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x08800000000
+	Ending Address: 0x08BFFFFFFFF
+	Range Size: 16 GB
+	Physical Device Handle: 0x0036
+	Memory Array Mapped Address Handle: 0x0026
+	Partition Row Position: Unknown
+
+Handle 0x0038, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 6
+	Bank Locator: Bank 6
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0039, DMI type 126, 35 bytes
+Inactive
+
+Handle 0x0040, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 16 GB
+	Form Factor: DIMM
+	Set: Unknown
+	Locator: DIMM 7
+	Bank Locator: Bank 7
+	Type: DDR4
+	Type Detail: Unknown
+	Speed: 2667 MT/s
+	Manufacturer: Samsung
+	Serial Number: SSSSSSSS               
+	Asset Tag: Array 1 Asset Tag 7
+	Part Number: AAAAAAAAAAAAA-ZZ     
+	Rank: 2
+	Configured Memory Speed: 2667 MT/s
+	Minimum Voltage: 1.08 V
+	Maximum Voltage: 1.32 V
+	Configured Voltage: 1.2 V
+	Memory Technology: <OUT OF SPEC>
+	Memory Operating Mode Capability: None
+	Firmware Version: <BAD INDEX>
+	Module Manufacturer ID: Unknown
+	Module Product ID: Unknown
+	Memory Subsystem Controller Manufacturer ID: Unknown
+	Memory Subsystem Controller Product ID: Unknown
+	Non-Volatile Size: None
+	Volatile Size: None
+	Cache Size: None
+	Logical Size: None
+
+Handle 0x0041, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x08C00000000
+	Ending Address: 0x08FFFFFFFFF
+	Range Size: 16 GB
+	Physical Device Handle: 0x0040
+	Memory Array Mapped Address Handle: 0x0026
+	Partition Row Position: Unknown
+
+Handle 0x0042, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 8
+	Bank Locator: Bank 8
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0043, DMI type 126, 35 bytes
+Inactive
+
+Handle 0x0044, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 16 GB
+	Form Factor: DIMM
+	Set: Unknown
+	Locator: DIMM 9
+	Bank Locator: Bank 9
+	Type: DDR4
+	Type Detail: Unknown
+	Speed: 2667 MT/s
+	Manufacturer: Samsung
+	Serial Number: SSSSSSSS               
+	Asset Tag: Array 1 Asset Tag 9
+	Part Number: AAAAAAAAAAAAA-ZZ     
+	Rank: 2
+	Configured Memory Speed: 2667 MT/s
+	Minimum Voltage: 1.08 V
+	Maximum Voltage: 1.32 V
+	Configured Voltage: 1.2 V
+	Memory Technology: <OUT OF SPEC>
+	Memory Operating Mode Capability: None
+	Firmware Version: <BAD INDEX>
+	Module Manufacturer ID: Unknown
+	Module Product ID: Unknown
+	Memory Subsystem Controller Manufacturer ID: Unknown
+	Memory Subsystem Controller Product ID: Unknown
+	Non-Volatile Size: None
+	Volatile Size: None
+	Cache Size: None
+	Logical Size: None
+
+Handle 0x0045, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x09000000000
+	Ending Address: 0x093FFFFFFFF
+	Range Size: 16 GB
+	Physical Device Handle: 0x0044
+	Memory Array Mapped Address Handle: 0x0026
+	Partition Row Position: Unknown
+
+Handle 0x0046, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 10
+	Bank Locator: Bank 10
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0047, DMI type 126, 35 bytes
+Inactive
+
+Handle 0x0048, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 16 GB
+	Form Factor: DIMM
+	Set: Unknown
+	Locator: DIMM 11
+	Bank Locator: Bank 11
+	Type: DDR4
+	Type Detail: Unknown
+	Speed: 2667 MT/s
+	Manufacturer: Samsung
+	Serial Number: SSSSSSSS                
+	Asset Tag: Array 1 Asset Tag 11
+	Part Number: AAAAAAAAAAAAA-ZZ     
+	Rank: 2
+	Configured Memory Speed: 2667 MT/s
+	Minimum Voltage: 1.08 V
+	Maximum Voltage: 1.32 V
+	Configured Voltage: 1.2 V
+	Memory Technology: <OUT OF SPEC>
+	Memory Operating Mode Capability: None
+	Firmware Version: <BAD INDEX>
+	Module Manufacturer ID: Unknown
+	Module Product ID: Unknown
+	Memory Subsystem Controller Manufacturer ID: Unknown
+	Memory Subsystem Controller Product ID: Unknown
+	Non-Volatile Size: None
+	Volatile Size: None
+	Cache Size: None
+	Logical Size: None
+
+Handle 0x0049, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x09400000000
+	Ending Address: 0x097FFFFFFFF
+	Range Size: 16 GB
+	Physical Device Handle: 0x0048
+	Memory Array Mapped Address Handle: 0x0026
+	Partition Row Position: Unknown
+
+Handle 0x0050, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 12
+	Bank Locator: Bank 12
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0051, DMI type 126, 35 bytes
+Inactive
+
+Handle 0x0052, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 16 GB
+	Form Factor: DIMM
+	Set: Unknown
+	Locator: DIMM 13
+	Bank Locator: Bank 13
+	Type: DDR4
+	Type Detail: Unknown
+	Speed: 2667 MT/s
+	Manufacturer: Samsung
+	Serial Number: SSSSSSSS                
+	Asset Tag: Array 1 Asset Tag 13
+	Part Number: AAAAAAAAAAAAA-ZZ     
+	Rank: 2
+	Configured Memory Speed: 2667 MT/s
+	Minimum Voltage: 1.08 V
+	Maximum Voltage: 1.32 V
+	Configured Voltage: 1.2 V
+	Memory Technology: <OUT OF SPEC>
+	Memory Operating Mode Capability: None
+	Firmware Version: <BAD INDEX>
+	Module Manufacturer ID: Unknown
+	Module Product ID: Unknown
+	Memory Subsystem Controller Manufacturer ID: Unknown
+	Memory Subsystem Controller Product ID: Unknown
+	Non-Volatile Size: None
+	Volatile Size: None
+	Cache Size: None
+	Logical Size: None
+
+Handle 0x0053, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x09800000000
+	Ending Address: 0x09BFFFFFFFF
+	Range Size: 16 GB
+	Physical Device Handle: 0x0052
+	Memory Array Mapped Address Handle: 0x0026
+	Partition Row Position: Unknown
+
+Handle 0x0054, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 14
+	Bank Locator: Bank 14
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0055, DMI type 126, 35 bytes
+Inactive
+
+Handle 0x0056, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 16 GB
+	Form Factor: DIMM
+	Set: Unknown
+	Locator: DIMM 15
+	Bank Locator: Bank 15
+	Type: DDR4
+	Type Detail: Unknown
+	Speed: 2667 MT/s
+	Manufacturer: Samsung
+	Serial Number: SSSSSSSS                
+	Asset Tag: Array 1 Asset Tag 15
+	Part Number: AAAAAAAAAAAAA-ZZ     
+	Rank: 2
+	Configured Memory Speed: 2667 MT/s
+	Minimum Voltage: 1.08 V
+	Maximum Voltage: 1.32 V
+	Configured Voltage: 1.2 V
+	Memory Technology: <OUT OF SPEC>
+	Memory Operating Mode Capability: None
+	Firmware Version: <BAD INDEX>
+	Module Manufacturer ID: Unknown
+	Module Product ID: Unknown
+	Memory Subsystem Controller Manufacturer ID: Unknown
+	Memory Subsystem Controller Product ID: Unknown
+	Non-Volatile Size: None
+	Volatile Size: None
+	Cache Size: None
+	Logical Size: None
+
+Handle 0x0057, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x09C00000000
+	Ending Address: 0x09FFFFFFFFF
+	Range Size: 16 GB
+	Physical Device Handle: 0x0056
+	Memory Array Mapped Address Handle: 0x0026
+	Partition Row Position: Unknown
+
+Handle 0x0058, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0023
+	Error Information Handle: 0x0000
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 16
+	Bank Locator: Bank 16
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0059, DMI type 126, 35 bytes
+Inactive
+
+Handle 0x0060, DMI type 24, 5 bytes
+Hardware Security
+	Power-On Password Status: Disabled
+	Keyboard Password Status: Disabled
+	Administrator Password Status: Disabled
+	Front Panel Reset Status: Disabled
+
+Handle 0x0061, DMI type 32, 11 bytes
+System Boot Information
+	Status: No errors detected
+
+Handle 0x0062, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation: Onboard VGA
+	Type: Video
+	Status: Enabled
+	Type Instance: 1
+	Bus Address: 0000:00:00.0
+
+Handle 0x0063, DMI type 38, 18 bytes
+IPMI Device Information
+	Interface Type: SSIF (SMBus System Interface)
+	Specification Version: 2.0
+	I2C Slave Address: 0x10
+	NV Storage Device: Not Present
+	Base Address: 0x10 (SMBus)
+
+Handle 0x0078, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00880000000
+	Ending Address: 0x00BFFFFFFFF
+	Range Size: 14 GB
+	Physical Device Handle: 0x0028
+	Memory Array Mapped Address Handle: 0x0025
+	Partition Row Position: Unknown
+
+Handle 0x0079, DMI type 127, 4 bytes
+End Of Table
+

--- a/test/rhsmlib_test/dmidecodedata/aarch64-baremetal-2.txt
+++ b/test/rhsmlib_test/dmidecodedata/aarch64-baremetal-2.txt
@@ -1,0 +1,444 @@
+# dmidecode 3.3
+Getting SMBIOS data from sysfs.
+SMBIOS 3.0.0 present.
+Table at 0x83FF269000.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+	Vendor: American Megatrends Inc.
+	Version: ROD1002C
+	Release Date: 04/08/2016
+	Address: 0xF0000
+	Runtime Size: 64 kB
+	ROM Size: 1088 kB
+	Characteristics:
+		PCI is supported
+		BIOS is upgradeable
+		BIOS shadowing is allowed
+		Boot from CD is supported
+		Selectable boot is supported
+		BIOS ROM is socketed
+		EDD is supported
+		5.25"/1.2 MB floppy services are supported (int 13h)
+		3.5"/720 kB floppy services are supported (int 13h)
+		3.5"/2.88 MB floppy services are supported (int 13h)
+		Print screen service is supported (int 5h)
+		Serial services are supported (int 14h)
+		Printer services are supported (int 17h)
+		ACPI is supported
+		USB legacy is supported
+		BIOS boot specification is supported
+		Targeted content distribution is supported
+		UEFI is supported
+	BIOS Revision: 5.6
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+	Manufacturer: AMD
+	Product Name: PPPPPPPPPP
+	Version: To be filled by O.E.M.
+	Serial Number: SSSSSSSS
+	UUID: 11111111-2222-3333-4444-555555555555
+	Wake-up Type: Power Switch
+	SKU Number: To be filled by O.E.M.
+	Family: Seattle
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+	Manufacturer: Default string
+	Product Name: Default string
+	Version: Default string
+	Serial Number: Default string
+	Asset Tag: Default string
+	Features:
+		Board is a hosting board
+		Board is removable
+		Board is replaceable
+	Location In Chassis: Default string
+	Chassis Handle: 0x0000
+	Type: Motherboard
+	Contained Object Handles: 0
+
+Handle 0x0003, DMI type 3, 22 bytes
+Chassis Information
+	Manufacturer: Default string
+	Type: Desktop
+	Lock: Not Present
+	Version: Default string
+	Serial Number: Default string
+	Asset Tag: Default string
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: None
+	OEM Information: 0x00000000
+	Height: Unspecified
+	Number Of Power Cords: 1
+	Contained Elements: 0
+	SKU Number: Default string
+
+Handle 0x0004, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Default string
+	Internal Connector Type: None
+	External Reference Designator: Default string
+	External Connector Type: None
+	Port Type: None
+
+Handle 0x0005, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Default string
+	Internal Connector Type: None
+	External Reference Designator: Default string
+	External Connector Type: None
+	Port Type: None
+
+Handle 0x0006, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Default string
+	Internal Connector Type: None
+	External Reference Designator: Default string
+	External Connector Type: None
+	Port Type: None
+
+Handle 0x0007, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Default string
+	Internal Connector Type: None
+	External Reference Designator: Default string
+	External Connector Type: None
+	Port Type: None
+
+Handle 0x0008, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Default string
+	Internal Connector Type: None
+	External Reference Designator: Default string
+	External Connector Type: None
+	Port Type: None
+Handle 0x0009, DMI type 9, 17 bytes
+System Slot Information
+	Designation: Slot 1
+	Type: 32-bit PCI Express x1
+	Current Usage: Available
+	Length: Short
+	ID: 1
+	Characteristics:
+		3.3 V is provided
+		PME signal is supported
+	Bus Address: 0000:00:00.0
+
+Handle 0x000A, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1
+	Configuration: Enabled, Not Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 80 kB
+	Maximum Size: 80 kB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: None
+	Speed: Unknown
+	Error Correction Type: Multi-bit ECC
+	System Type: Unified
+	Associativity: Fully Associative
+
+Handle 0x000B, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2
+	Configuration: Enabled, Not Socketed, Level 2
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 1 MB
+	Maximum Size: 1 MB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: None
+	Speed: Unknown
+	Error Correction Type: Multi-bit ECC
+	System Type: Unified
+	Associativity: 4-way Set-associative
+
+Handle 0x000C, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L3
+	Configuration: Enabled, Not Socketed, Level 3
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 8000 kB
+	Maximum Size: 8000 kB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: None
+	Speed: Unknown
+	Error Correction Type: Multi-bit ECC
+	System Type: Unified
+	Associativity: 16-way Set-associative
+
+Handle 0x0010, DMI type 9, 17 bytes
+System Slot Information
+	Designation: Slot 1
+	Type: 32-bit PCI Express x1
+	Current Usage: Available
+	Length: Short
+	ID: 1
+	Characteristics:
+		3.3 V is provided
+		PME signal is supported
+	Bus Address: 0000:00:00.0
+
+Handle 0x0011, DMI type 9, 17 bytes
+System Slot Information
+	Designation: Slot 1
+	Type: 32-bit PCI Express x1
+	Current Usage: Available
+	Length: Short
+	ID: 1
+	Characteristics:
+		3.3 V is provided
+		PME signal is supported
+	Bus Address: 0000:00:00.0
+
+Handle 0x0012, DMI type 9, 17 bytes
+System Slot Information
+	Designation: Slot 1
+	Type: 32-bit PCI Express x1
+	Current Usage: Available
+	Length: Short
+	ID: 1
+	Characteristics:
+		3.3 V is provided
+		PME signal is supported
+	Bus Address: 0000:00:00.0
+
+Handle 0x0013, DMI type 9, 17 bytes
+System Slot Information
+	Designation: Slot 1
+	Type: 32-bit PCI Express x1
+	Current Usage: Available
+	Length: Short
+	ID: 1
+	Characteristics:
+		3.3 V is provided
+		PME signal is supported
+	Bus Address: 0000:00:00.0
+
+Handle 0x0014, DMI type 10, 6 bytes
+On Board Device Information
+	Type: Unknown
+	Status: Enabled
+	Description: Device 1
+
+Handle 0x0015, DMI type 11, 5 bytes
+OEM Strings
+	String 1: Default string
+
+Handle 0x0016, DMI type 12, 5 bytes
+System Configuration Options
+	Option 1: Default string
+
+Handle 0x0017, DMI type 13, 22 bytes
+BIOS Language Information
+	Language Description Format: Long
+	Installable Languages: 1
+		en|US|iso8859-1
+	Currently Installed Language: en|US|iso8859-1
+
+Handle 0x0028, DMI type 32, 11 bytes
+System Boot Information
+	Status: No errors detected
+
+Handle 0x0029, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation: Device 1
+	Type: Unknown
+	Status: Enabled
+	Type Instance: 1
+	Bus Address: 0000:00:00.0
+
+Handle 0x0030, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation: Device 2
+	Type: Unknown
+	Status: Enabled
+	Type Instance: 1
+	Bus Address: 0000:00:00.0
+
+Handle 0x0031, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation: Device 3
+	Type: Unknown
+	Status: Enabled
+	Type Instance: 1
+	Bus Address: 0000:00:00.0
+
+Handle 0x0035, DMI type 4, 48 bytes
+Processor Information
+	Socket Designation: P0
+	Type: Central Processor
+	Family: ARM
+	Manufacturer: AMD
+	ID: 00 00 00 00 10 00 2F 01
+	Version: N/A
+	Voltage: 1.0 V
+	External Clock: 100 MHz
+	Max Speed: 2000 MHz
+	Current Speed: 2000 MHz
+	Status: Populated, Enabled
+	Upgrade: Daughter Board
+	L1 Cache Handle: 0x000A
+	L2 Cache Handle: 0x000B
+	L3 Cache Handle: 0x000C
+	Serial Number: SSSSSSSS
+	Asset Tag: AssetTag Number
+	Part Number: Part Number
+	Core Count: 8
+	Core Enabled: 8
+	Thread Count: 8
+	Characteristics:
+		64-bit capable
+		Multi-Core
+		Execute Protection
+		Enhanced Virtualization
+
+Handle 0x0036, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: Multi-bit ECC
+	Maximum Capacity: 16 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 4
+
+Handle 0x0037, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x003FFFFFFFF
+	Range Size: 16 GB
+	Physical Array Handle: 0x0036
+	Partition Width: 255
+
+Handle 0x0038, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0036
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: Unknown
+	Set: None
+	Locator: DIMM 0 
+	Bank Locator: CHANNEL A      
+	Type: DDR3
+	Type Detail: None
+
+Handle 0x0039, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0036
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 8 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 1 
+	Bank Locator: CHANNEL A      
+	Type: DDR3
+	Type Detail: Synchronous Registered (Buffered)
+	Speed: 667 MT/s
+	Manufacturer: Micron
+	Serial Number: SSSSSSSS       
+	Asset Tag: A1_AssetTagNum1
+	Part Number: AAAAAAAAAAAAA-ZZ 
+	Rank: 2
+	Configured Memory Speed: 667 MT/s
+	Minimum Voltage: Unknown
+	Maximum Voltage: Unknown
+	Configured Voltage: 1.35 V
+
+Handle 0x003A, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0036
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: Unknown
+	Set: None
+	Locator: DIMM 0 
+	Bank Locator: CHANNEL B      
+	Type: DDR3
+	Type Detail: None
+
+Handle 0x003B, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0036
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 8 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 1 
+	Bank Locator: CHANNEL B      
+	Type: DDR3
+	Type Detail: Synchronous Registered (Buffered)
+	Speed: 667 MT/s
+	Manufacturer: Micron
+	Serial Number: SSSSSSSS       
+	Asset Tag: A1_AssetTagNum3
+	Part Number: AAAAAAAAAAAAA-ZZ 
+	Rank: 2
+	Configured Memory Speed: 667 MT/s
+	Minimum Voltage: Unknown
+	Maximum Voltage: Unknown
+	Configured Voltage: 1.35 V
+
+Handle 0x003C, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x000000003FF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0000
+	Memory Array Mapped Address Handle: 0x0000
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x003D, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x001FFFFFFFF
+	Range Size: 8 GB
+	Physical Device Handle: 0x0039
+	Memory Array Mapped Address Handle: 0x0037
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x003E, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x000000003FF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0000
+	Memory Array Mapped Address Handle: 0x0000
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x003F, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00200000000
+	Ending Address: 0x003FFFFFFFF
+	Range Size: 8 GB
+	Physical Device Handle: 0x003B
+	Memory Array Mapped Address Handle: 0x0037
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0046, DMI type 127, 4 bytes
+End Of Table
+

--- a/test/rhsmlib_test/dmidecodedata/aarch64-qemu-1.txt
+++ b/test/rhsmlib_test/dmidecodedata/aarch64-qemu-1.txt
@@ -1,0 +1,189 @@
+# dmidecode 3.3
+Getting SMBIOS data from sysfs.
+SMBIOS 3.0.0 present.
+Table at 0x13F550000.
+
+Handle 0x0100, DMI type 1, 27 bytes
+System Information
+	Manufacturer: QEMU
+	Product Name: PPPPPPPPPP
+	Version: virt-4.2
+	Serial Number: Not Specified
+	UUID: 11111111-2222-3333-4444-555555555555
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Not Specified
+
+Handle 0x0300, DMI type 3, 22 bytes
+Chassis Information
+	Manufacturer: QEMU
+	Type: Other
+	Lock: Not Present
+	Version: virt-4.2
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: Unknown
+	OEM Information: 0x00000000
+	Height: Unspecified
+	Number Of Power Cords: Unspecified
+	Contained Elements: 0
+	SKU Number: Not Specified
+
+Handle 0x0400, DMI type 4, 42 bytes
+Processor Information
+	Socket Designation: CPU 0
+	Type: Central Processor
+	Family: Other
+	Manufacturer: QEMU
+	ID: 00 00 00 00 00 00 00 00
+	Version: virt-4.2
+	Voltage: Unknown
+	External Clock: Unknown
+	Max Speed: 2000 MHz
+	Current Speed: 2000 MHz
+	Status: Populated, Enabled
+	Upgrade: Other
+	L1 Cache Handle: Not Provided
+	L2 Cache Handle: Not Provided
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 1
+	Core Enabled: 1
+	Thread Count: 1
+	Characteristics: None
+
+Handle 0x0401, DMI type 4, 42 bytes
+Processor Information
+	Socket Designation: CPU 1
+	Type: Central Processor
+	Family: Other
+	Manufacturer: QEMU
+	ID: 00 00 00 00 00 00 00 00
+	Version: virt-4.2
+	Voltage: Unknown
+	External Clock: Unknown
+	Max Speed: 2000 MHz
+	Current Speed: 2000 MHz
+	Status: Populated, Enabled
+	Upgrade: Other
+	L1 Cache Handle: Not Provided
+	L2 Cache Handle: Not Provided
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 1
+	Core Enabled: 1
+	Thread Count: 1
+	Characteristics: None
+
+Handle 0x0402, DMI type 4, 42 bytes
+Processor Information
+	Socket Designation: CPU 2
+	Type: Central Processor
+	Family: Other
+	Manufacturer: QEMU
+	ID: 00 00 00 00 00 00 00 00
+	Version: virt-4.2
+	Voltage: Unknown
+	External Clock: Unknown
+	Max Speed: 2000 MHz
+	Current Speed: 2000 MHz
+	Status: Populated, Enabled
+	Upgrade: Other
+	L1 Cache Handle: Not Provided
+	L2 Cache Handle: Not Provided
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 1
+	Core Enabled: 1
+	Thread Count: 1
+	Characteristics: None
+
+Handle 0x0403, DMI type 4, 42 bytes
+Processor Information
+	Socket Designation: CPU 3
+	Type: Central Processor
+	Family: Other
+	Manufacturer: QEMU
+	ID: 00 00 00 00 00 00 00 00
+	Version: virt-4.2
+	Voltage: Unknown
+	External Clock: Unknown
+	Max Speed: 2000 MHz
+	Current Speed: 2000 MHz
+	Status: Populated, Enabled
+	Upgrade: Other
+	L1 Cache Handle: Not Provided
+	L2 Cache Handle: Not Provided
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 1
+	Core Enabled: 1
+	Thread Count: 1
+	Characteristics: None
+
+Handle 0x1000, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: Other
+	Use: System Memory
+	Error Correction Type: Multi-bit ECC
+	Maximum Capacity: 4 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 1
+
+Handle 0x1100, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x1000
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: 4 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 0
+	Bank Locator: Not Specified
+	Type: RAM
+	Type Detail: Other
+	Speed: Unknown
+	Manufacturer: QEMU
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown
+	Configured Memory Speed: Unknown
+	Minimum Voltage: Unknown
+	Maximum Voltage: Unknown
+	Configured Voltage: Unknown
+
+Handle 0x2000, DMI type 32, 11 bytes
+System Boot Information
+	Status: No errors detected
+
+Handle 0x0000, DMI type 0, 26 bytes
+BIOS Information
+	Vendor: EFI Development Kit II / OVMF
+	Version: 0.0.0
+	Release Date: 02/06/2015
+	Address: 0xE8000
+	Runtime Size: 96 kB
+	ROM Size: 64 kB
+	Characteristics:
+		BIOS characteristics not supported
+		Targeted content distribution is supported
+		UEFI is supported
+		System is a virtual machine
+	BIOS Revision: 0.0
+
+Handle 0xFEFF, DMI type 127, 4 bytes
+End Of Table
+

--- a/test/rhsmlib_test/dmidecodedata/x86_64-aws-1.txt
+++ b/test/rhsmlib_test/dmidecodedata/x86_64-aws-1.txt
@@ -1,0 +1,218 @@
+# dmidecode 3.2
+Getting SMBIOS data from sysfs.
+SMBIOS 2.7 present.
+13 structures occupying 567 bytes.
+Table at 0xBFFF0000.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+	Vendor: Amazon EC2
+	Version: 1.0
+	Release Date: 10/16/2017
+	Address: 0xF0000
+	Runtime Size: 64 kB
+	ROM Size: 64 kB
+	Characteristics:
+		PCI is supported
+		EDD is supported
+		ACPI is supported
+		System is a virtual machine
+	BIOS Revision: 1.0
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+	Manufacturer: Amazon EC2
+	Product Name: PPPPPPPPPP
+	Version: Not Specified
+	Serial Number: SSSSSSSS
+	UUID: 11111111-2222-3333-4444-555555555555
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Not Specified
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+	Manufacturer: Amazon EC2
+	Product Name: Not Specified
+	Version: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: i-00d2efb1ec3832748
+	Features: None
+	Location In Chassis: Not Specified
+	Chassis Handle: 0x0003
+	Type: Other
+	Contained Object Handles: 0
+
+Handle 0x0003, DMI type 3, 21 bytes
+Chassis Information
+	Manufacturer: Amazon EC2
+	Type: Other
+	Lock: Not Present
+	Version: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Amazon EC2
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: None
+	OEM Information: 0x00000000
+	Height: Unspecified
+	Number Of Power Cords: 1
+	Contained Elements: 0
+
+Handle 0x0004, DMI type 4, 42 bytes
+Processor Information
+	Socket Designation: CPU 0
+	Type: Central Processor
+	Family: Xeon
+	Manufacturer: Intel(R) Corporation
+	ID: 54 06 05 00 FF FB EB BF
+	Signature: Type 0, Family 6, Model 85, Stepping 4
+	Flags:
+		FPU (Floating-point unit on-chip)
+		VME (Virtual mode extension)
+		DE (Debugging extension)
+		PSE (Page size extension)
+		TSC (Time stamp counter)
+		MSR (Model specific registers)
+		PAE (Physical address extension)
+		MCE (Machine check exception)
+		CX8 (CMPXCHG8 instruction supported)
+		APIC (On-chip APIC hardware supported)
+		SEP (Fast system call)
+		MTRR (Memory type range registers)
+		PGE (Page global enable)
+		MCA (Machine check architecture)
+		CMOV (Conditional move instruction supported)
+		PAT (Page attribute table)
+		PSE-36 (36-bit page size extension)
+		CLFSH (CLFLUSH instruction supported)
+		DS (Debug store)
+		ACPI (ACPI supported)
+		MMX (MMX technology supported)
+		FXSR (FXSAVE and FXSTOR instructions supported)
+		SSE (Streaming SIMD extensions)
+		SSE2 (Streaming SIMD extensions 2)
+		SS (Self-snoop)
+		HTT (Multi-threading)
+		TM (Thermal monitor supported)
+		PBE (Pending break enabled)
+	Version: Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+	Voltage: 1.6 V
+	External Clock: 100 MHz
+	Max Speed: 3500 MHz
+	Current Speed: 2500 MHz
+	Status: Populated, Enabled
+	Upgrade: Socket LGA3647-1
+	L1 Cache Handle: 0x0005
+	L2 Cache Handle: 0x0006
+	L3 Cache Handle: 0x0007
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 1
+	Core Enabled: 1
+	Thread Count: 2
+	Characteristics:
+		64-bit capable
+		Multi-Core
+		Hardware Thread
+		Execute Protection
+
+Handle 0x0005, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1-Cache
+	Configuration: Enabled, Not Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 1536 kB
+	Maximum Size: 1536 kB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Instruction
+	Associativity: 8-way Set-associative
+
+Handle 0x0006, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2-Cache
+	Configuration: Enabled, Not Socketed, Level 2
+	Operational Mode: Varies With Memory Address
+	Location: Internal
+	Installed Size: 24 MB
+	Maximum Size: 24 MB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Unified
+	Associativity: 16-way Set-associative
+
+Handle 0x0007, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L3-Cache
+	Configuration: Enabled, Not Socketed, Level 3
+	Operational Mode: Varies With Memory Address
+	Location: Internal
+	Installed Size: 33 MB
+	Maximum Size: 33 MB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Unified
+	Associativity: Fully Associative
+
+Handle 0x0008, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: Unknown
+	Maximum Capacity: 8 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 1
+
+Handle 0x0009, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0008
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 8 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: Not Specified
+	Bank Locator: Not Specified
+	Type: DDR4
+	Type Detail: Static Column Pseudo-static Synchronous Window DRAM
+	Speed: 2666 MT/s
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown
+	Configured Memory Speed: Unknown
+
+Handle 0x000A, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x0000000000000000k
+	Ending Address: 0x00000001FFFFFFFFk
+	Range Size: 8 GB
+	Physical Array Handle: 0x0008
+	Partition Width: 1
+
+Handle 0x000B, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x0000000000000000k
+	Ending Address: 0x00000001FFFFFFFFk
+	Range Size: 8 GB
+	Physical Device Handle: 0x0009
+	Memory Array Mapped Address Handle: 0x000A
+	Partition Row Position: 1
+
+Handle 0x000C, DMI type 127, 4 bytes
+End Of Table

--- a/test/rhsmlib_test/dmidecodedata/x86_64-baremetal-1.txt
+++ b/test/rhsmlib_test/dmidecodedata/x86_64-baremetal-1.txt
@@ -1,0 +1,677 @@
+# dmidecode 3.3
+Getting SMBIOS data from sysfs.
+SMBIOS 3.2.0 present.
+Table at 0x76B9F000.
+
+Handle 0x0000, DMI type 222, 14 bytes
+OEM-specific Type
+	Header and Data:
+		DE 0E 00 00 01 99 00 03 10 01 20 02 30 03
+	Strings:
+		Memory Init Complete
+		End of DXE Phase
+		BIOS Boot Complete
+
+Handle 0x0001, DMI type 14, 8 bytes
+Group Associations
+	Name: Intel(R) Silicon View Technology
+	Items: 1
+		0x0000 (OEM-specific)
+
+Handle 0x0002, DMI type 134, 13 bytes
+OEM-specific Type
+	Header and Data:
+		86 0D 02 00 27 09 21 20 00 00 00 00 00
+
+Handle 0x0003, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: None
+	Maximum Capacity: 32 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 2
+
+Handle 0x0004, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0003
+	Error Information Handle: Not Provided
+	Total Width: 64 bits
+	Data Width: 64 bits
+	Size: 32 GB
+	Form Factor: SODIMM
+	Set: None
+	Locator: ChannelA-DIMM0
+	Bank Locator: BANK 0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: 3200 MT/s
+	Manufacturer: SK Hynix
+	Serial Number: SSSSSSSS
+	Asset Tag: None
+	Part Number: AAAAAAAAAAAAA-ZZ    
+	Rank: 2
+	Configured Memory Speed: 2933 MT/s
+	Minimum Voltage: Unknown
+	Maximum Voltage: Unknown
+	Configured Voltage: 1.2 V
+	Memory Technology: DRAM
+	Memory Operating Mode Capability: Volatile memory
+	Firmware Version: Not Specified
+	Module Manufacturer ID: Bank 1, Hex 0xAD
+	Module Product ID: Unknown
+	Memory Subsystem Controller Manufacturer ID: Unknown
+	Memory Subsystem Controller Product ID: Unknown
+	Non-Volatile Size: None
+	Volatile Size: 32767 MB
+	Cache Size: None
+	Logical Size: None
+
+Handle 0x0005, DMI type 17, 84 bytes
+Memory Device
+	Array Handle: 0x0003
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: Unknown
+	Set: None
+	Locator: ChannelB-DIMM0
+	Bank Locator: BANK 2
+	Type: Unknown
+	Type Detail: None
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown
+	Configured Memory Speed: Unknown
+	Minimum Voltage: Unknown
+	Maximum Voltage: Unknown
+	Configured Voltage: Unknown
+	Memory Technology: <OUT OF SPEC>
+	Memory Operating Mode Capability: Volatile memory
+	Firmware Version: Not Specified
+	Module Manufacturer ID: Unknown
+	Module Product ID: Unknown
+	Memory Subsystem Controller Manufacturer ID: Unknown
+	Memory Subsystem Controller Product ID: Unknown
+	Non-Volatile Size: None
+	Volatile Size: None
+	Cache Size: None
+	Logical Size: None
+
+Handle 0x0006, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x007FFFFFFFF
+	Range Size: 32 GB
+	Physical Array Handle: 0x0003
+	Partition Width: 1
+
+Handle 0x0007, DMI type 221, 12 bytes
+OEM-specific Type
+	Header and Data:
+		DD 0C 07 00 01 01 00 02 00 00 14 12
+	Strings:
+		BIOS Guard
+
+Handle 0x0008, DMI type 221, 26 bytes
+OEM-specific Type
+	Header and Data:
+		DD 1A 08 00 03 01 00 09 00 3B 30 00 02 00 00 00
+		00 EC 00 03 00 01 08 00 00 00
+	Strings:
+		Reference Code - CPU
+		uCode Version
+		TXT ACM version
+
+Handle 0x0009, DMI type 221, 26 bytes
+OEM-specific Type
+	Header and Data:
+		DD 1A 09 00 03 01 00 09 00 3B 30 00 02 00 0E 00
+		00 01 00 03 04 0E 01 35 71 06
+	Strings:
+		Reference Code - ME
+		MEBx version
+		ME Firmware Version
+		Corporate SKU
+
+Handle 0x000A, DMI type 221, 54 bytes
+OEM-specific Type
+	Header and Data:
+		DD 36 0A 00 07 01 00 09 00 3B 30 00 02 03 FF FF
+		FF FF FF 04 00 FF FF FF 00 00 05 00 FF FF FF 00
+		00 06 00 02 0A 00 00 00 07 00 1B FF FF FF FF 08
+		00 00 FF FF FF FF
+	Strings:
+		Reference Code - CML PCH
+		PCH-CRID Status
+		Disabled
+		PCH-CRID Original Value
+		PCH-CRID New Value
+		OPROM - RST - RAID
+		ChipsetInit Base Version
+		ChipsetInit Oem Version
+
+Handle 0x000B, DMI type 221, 54 bytes
+OEM-specific Type
+	Header and Data:
+		DD 36 0B 00 07 01 00 09 00 3B 30 00 02 00 00 00
+		00 4A 00 03 00 09 00 3B 30 00 04 05 FF FF FF FF
+		FF 06 00 00 00 00 02 00 07 00 00 00 00 02 00 08
+		00 FF FF FF FF FF
+	Strings:
+		Reference Code - SA - System Agent
+		Reference Code - MRC
+		SA - PCIe Version
+		SA-CRID Status
+		Enabled 
+		SA-CRID Original Value
+		SA-CRID New Value
+		OPROM - VBIOS
+
+Handle 0x000C, DMI type 221, 12 bytes
+OEM-specific Type
+	Header and Data:
+		DD 0C 0C 00 01 01 00 04 00 00 00 00
+	Strings:
+		FSP Binary Version
+
+Handle 0x000D, DMI type 7, 27 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Not Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 384 kB
+	Maximum Size: 384 kB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Parity
+	System Type: Unified
+	Associativity: 8-way Set-associative
+
+Handle 0x000E, DMI type 7, 27 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Not Socketed, Level 2
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 1536 kB
+	Maximum Size: 1536 kB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Unified
+	Associativity: 4-way Set-associative
+
+Handle 0x000F, DMI type 7, 27 bytes
+Cache Information
+	Socket Designation: L3 Cache
+	Configuration: Enabled, Not Socketed, Level 3
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 12 MB
+	Maximum Size: 12 MB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Multi-bit ECC
+	System Type: Unified
+	Associativity: 16-way Set-associative
+
+Handle 0x0010, DMI type 4, 48 bytes
+Processor Information
+	Socket Designation: U3E1
+	Type: Central Processor
+	Family: Core i7
+	Manufacturer: Intel(R) Corporation
+	ID: 52 06 0A 00 FF FB EB BF
+	Signature: Type 0, Family 6, Model 165, Stepping 2
+	Flags:
+		FPU (Floating-point unit on-chip)
+		VME (Virtual mode extension)
+		DE (Debugging extension)
+		PSE (Page size extension)
+		TSC (Time stamp counter)
+		MSR (Model specific registers)
+		PAE (Physical address extension)
+		MCE (Machine check exception)
+		CX8 (CMPXCHG8 instruction supported)
+		APIC (On-chip APIC hardware supported)
+		SEP (Fast system call)
+		MTRR (Memory type range registers)
+		PGE (Page global enable)
+		MCA (Machine check architecture)
+		CMOV (Conditional move instruction supported)
+		PAT (Page attribute table)
+		PSE-36 (36-bit page size extension)
+		CLFSH (CLFLUSH instruction supported)
+		DS (Debug store)
+		ACPI (ACPI supported)
+		MMX (MMX technology supported)
+		FXSR (FXSAVE and FXSTOR instructions supported)
+		SSE (Streaming SIMD extensions)
+		SSE2 (Streaming SIMD extensions 2)
+		SS (Self-snoop)
+		HTT (Multi-threading)
+		TM (Thermal monitor supported)
+		PBE (Pending break enabled)
+	Version: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
+	Voltage: 0.8 V
+	External Clock: 100 MHz
+	Max Speed: 2700 MHz
+	Current Speed: 2700 MHz
+	Status: Populated, Enabled
+	Upgrade: Other
+	L1 Cache Handle: 0x000D
+	L2 Cache Handle: 0x000E
+	L3 Cache Handle: 0x000F
+	Serial Number: None
+	Asset Tag: None
+	Part Number: None
+	Core Count: 6
+	Core Enabled: 6
+	Thread Count: 12
+	Characteristics:
+		64-bit capable
+		Multi-Core
+		Hardware Thread
+		Execute Protection
+		Enhanced Virtualization
+		Power/Performance Control
+
+Handle 0x0011, DMI type 0, 26 bytes
+BIOS Information
+	Vendor: LENOVO
+	Version: N2VET38W (1.23 )
+	Release Date: 02/10/2022
+	Address: 0xE0000
+	Runtime Size: 128 kB
+	ROM Size: 32 MB
+	Characteristics:
+		PCI is supported
+		PNP is supported
+		BIOS is upgradeable
+		BIOS shadowing is allowed
+		Boot from CD is supported
+		Selectable boot is supported
+		EDD is supported
+		3.5"/720 kB floppy services are supported (int 13h)
+		Print screen service is supported (int 5h)
+		8042 keyboard services are supported (int 9h)
+		Serial services are supported (int 14h)
+		Printer services are supported (int 17h)
+		CGA/mono video services are supported (int 10h)
+		ACPI is supported
+		USB legacy is supported
+		BIOS boot specification is supported
+		Targeted content distribution is supported
+		UEFI is supported
+	BIOS Revision: 1.23
+	Firmware Revision: 1.11
+
+Handle 0x0012, DMI type 1, 27 bytes
+System Information
+	Manufacturer: LENOVO
+	Product Name: PPPPPPPPPP
+	Version: ThinkPad P1 Gen 3
+	Serial Number: SSSSSSSS
+	UUID: 11111111-2222-3333-4444-555555555555
+	Wake-up Type: Power Switch
+	SKU Number: LENOVO_MT_20TJ_BU_Think_FM_ThinkPad P1 Gen 3
+	Family: ThinkPad P1 Gen 3
+
+Handle 0x0013, DMI type 2, 15 bytes
+Base Board Information
+	Manufacturer: LENOVO
+	Product Name: PPPPPPPPPP
+	Version: Not Defined
+	Serial Number: SSSSSSSS
+	Asset Tag: Not Available
+	Features:
+		Board is a hosting board
+		Board is replaceable
+	Location In Chassis: Not Available
+	Chassis Handle: 0x0000
+	Type: Motherboard
+	Contained Object Handles: 0
+
+Handle 0x0014, DMI type 3, 22 bytes
+Chassis Information
+	Manufacturer: LENOVO
+	Type: Notebook
+	Lock: Not Present
+	Version: None
+	Serial Number: SSSSSSSS
+	Asset Tag: No Asset Information
+	Boot-up State: Unknown
+	Power Supply State: Unknown
+	Thermal State: Unknown
+	Security Status: Unknown
+	OEM Information: 0x00000000
+	Height: Unspecified
+	Number Of Power Cords: Unspecified
+	Contained Elements: 0
+	SKU Number: Not Specified
+
+Handle 0x0015, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Available
+	Internal Connector Type: None
+	External Reference Designator: USB 1
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0016, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Available
+	Internal Connector Type: None
+	External Reference Designator: USB 2
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0017, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Available
+	Internal Connector Type: None
+	External Reference Designator: USB 3
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0018, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Available
+	Internal Connector Type: None
+	External Reference Designator: USB 4
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0019, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x001A, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x001B, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x001C, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x001D, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x001E, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Available
+	Internal Connector Type: None
+	External Reference Designator: Ethernet
+	External Connector Type: RJ-45
+	Port Type: Network Port
+
+Handle 0x001F, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x0020, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Available
+	Internal Connector Type: None
+	External Reference Designator: Hdmi1
+	External Connector Type: Other
+	Port Type: Video Port
+
+Handle 0x0021, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x0022, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x0023, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x0024, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: Not Available
+	Internal Connector Type: None
+	External Reference Designator: Headphone/Microphone Combo Jack1
+	External Connector Type: Mini Jack (headphones)
+	Port Type: Audio Port
+
+Handle 0x0025, DMI type 126, 9 bytes
+Inactive
+
+Handle 0x0026, DMI type 9, 17 bytes
+System Slot Information
+	Designation: SimCard Slot
+	Type: Other
+	Current Usage: Available
+	Length: Other
+	Characteristics: None
+	Bus Address: 00ff:ff:1f.7
+
+Handle 0x0027, DMI type 12, 5 bytes
+System Configuration Options
+
+Handle 0x0028, DMI type 13, 22 bytes
+BIOS Language Information
+	Language Description Format: Abbreviated
+	Installable Languages: 1
+		en-US
+	Currently Installed Language: en-US
+
+Handle 0x0029, DMI type 22, 26 bytes
+Portable Battery
+	Location: Front
+	Manufacturer: SMP
+	Name: 5B10X19049
+	Design Capacity: 80400 mWh
+	Design Voltage: 15360 mV
+	SBDS Version: 03.01
+	Maximum Error: Unknown
+	SBDS Serial Number: 076F
+	SBDS Manufacture Date: 2021-08-05
+	SBDS Chemistry: LiP
+	OEM-specific Information: 0x00000000
+
+Handle 0x002A, DMI type 126, 26 bytes
+Inactive
+
+Handle 0x002B, DMI type 140, 15 bytes
+OEM-specific Type
+	Header and Data:
+		8C 0F 2B 00 4C 45 4E 4F 56 4F 0B 09 01 01 02
+	Strings:
+		1.23 
+		1.19 
+
+Handle 0x002C, DMI type 133, 5 bytes
+OEM-specific Type
+	Header and Data:
+		85 05 2C 00 01
+	Strings:
+		KHOIHGIUCCHHII
+
+Handle 0x002D, DMI type 135, 19 bytes
+OEM-specific Type
+	Header and Data:
+		87 13 2D 00 54 50 07 02 42 41 59 20 49 2F 4F 20
+		04 00 00
+
+Handle 0x002E, DMI type 130, 20 bytes
+OEM-specific Type
+	Header and Data:
+		82 14 2E 00 24 41 4D 54 01 00 01 00 01 A5 AF 02
+		C0 00 00 00
+
+Handle 0x002F, DMI type 131, 64 bytes
+OEM-specific Type
+	Header and Data:
+		83 40 2F 00 35 00 00 00 0E 00 00 00 00 00 01 00
+		F8 00 8E 06 00 00 00 00 09 C0 00 00 01 00 0E 00
+		71 06 35 00 00 00 00 00 FE 00 FF FF 00 00 00 00
+		00 00 00 00 E6 01 00 00 76 50 72 6F 00 00 00 00
+
+Handle 0x0030, DMI type 24, 5 bytes
+Hardware Security
+	Power-On Password Status: Disabled
+	Keyboard Password Status: Not Implemented
+	Administrator Password Status: Disabled
+	Front Panel Reset Status: Not Implemented
+
+Handle 0x0031, DMI type 132, 8 bytes
+OEM-specific Type
+	Header and Data:
+		84 08 31 00 02 D8 36 00
+
+Handle 0x0032, DMI type 14, 8 bytes
+Group Associations
+	Name: $MEI
+	Items: 1
+		0x0000 (OEM-specific)
+
+Handle 0x0033, DMI type 219, 106 bytes
+OEM-specific Type
+	Header and Data:
+		DB 6A 33 00 01 04 01 45 02 00 90 06 89 85 32 30
+		00 00 00 04 40 00 00 01 1F 00 00 C9 0B 40 44 02
+		FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF
+		FF FF FF FF FF FF FF FF 03 00 00 00 80 00 00 00
+		00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+		00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+		00 00 00 00 00 00 00 00 00 00
+	Strings:
+		MEI1
+		MEI2
+		MEI3
+		MEI4
+
+Handle 0x0034, DMI type 18, 23 bytes
+32-bit Memory Error Information
+	Type: OK
+	Granularity: Unknown
+	Operation: Unknown
+	Vendor Syndrome: Unknown
+	Memory Array Address: Unknown
+	Device Address: Unknown
+	Resolution: Unknown
+
+Handle 0x0035, DMI type 21, 7 bytes
+Built-in Pointing Device
+	Type: Track Point
+	Interface: PS/2
+	Buttons: 3
+
+Handle 0x0036, DMI type 21, 7 bytes
+Built-in Pointing Device
+	Type: Touch Pad
+	Interface: Other
+	Buttons: 2
+
+Handle 0x0037, DMI type 131, 22 bytes
+ThinkVantage Technologies
+	Version: 1
+	Diagnostics: No
+
+Handle 0x0038, DMI type 136, 6 bytes
+OEM-specific Type
+	Header and Data:
+		88 06 38 00 5A 5A
+
+Handle 0x0039, DMI type 15, 31 bytes
+System Event Log
+	Area Length: 482 bytes
+	Header Start Offset: 0x0000
+	Header Length: 16 bytes
+	Data Start Offset: 0x0010
+	Access Method: General-purpose non-volatile data functions
+	Access Address: 0x00F0
+	Status: Valid, Not Full
+	Change Token: 0x0000001D
+	Header Format: Type 1
+	Supported Log Type Descriptors: 4
+	Descriptor 1: POST error
+	Data Format 1: POST results bitmap
+	Descriptor 2: PCI system error
+	Data Format 2: None
+	Descriptor 3: System reconfigured
+	Data Format 3: None
+	Descriptor 4: Log area reset/cleared
+	Data Format 4: None
+
+Handle 0x003A, DMI type 140, 19 bytes
+OEM-specific Type
+	Header and Data:
+		8C 13 3A 00 4C 45 4E 4F 56 4F 0B 04 01 B2 00 4D
+		53 20 00
+
+Handle 0x003B, DMI type 140, 19 bytes
+OEM-specific Type
+	Header and Data:
+		8C 13 3B 00 4C 45 4E 4F 56 4F 0B 05 01 07 00 00
+		00 00 00
+
+Handle 0x003C, DMI type 140, 23 bytes
+OEM-specific Type
+	Header and Data:
+		8C 17 3C 00 4C 45 4E 4F 56 4F 0B 06 01 CB 06 51
+		44 03 60 00 00 00 00
+
+Handle 0x003D, DMI type 141, 18 bytes
+OEM-specific Type
+	Header and Data:
+		8D 12 3D 00 54 48 4E 4B 00 00 00 00 00 00 8F 34
+		00 00
+
+Handle 0x003E, DMI type 141, 18 bytes
+OEM-specific Type
+	Header and Data:
+		8D 12 3E 00 54 48 4E 4B 00 00 10 00 00 00 58 08
+		00 00
+
+Handle 0x003F, DMI type 141, 18 bytes
+OEM-specific Type
+	Header and Data:
+		8D 12 3F 00 54 48 4E 4B 00 00 30 00 00 00 00 00
+		00 00
+
+Handle 0x0040, DMI type 141, 18 bytes
+OEM-specific Type
+	Header and Data:
+		8D 12 40 00 54 48 4E 4B 00 00 40 00 00 00 32 00
+		00 00
+
+Handle 0x0041, DMI type 141, 30 bytes
+OEM-specific Type
+	Header and Data:
+		8D 1E 41 00 54 48 4E 4B 00 00 50 00 00 00 A7 77
+		B9 00 00 00 00 00 2A 15 DF 0D 00 00 00 00
+
+Handle 0x0042, DMI type 140, 15 bytes
+ThinkPad Embedded Controller Program
+	Version ID: N2VHT22W
+	Release Date: 03/10/2022
+
+Handle 0x0043, DMI type 140, 43 bytes
+OEM-specific Type
+	Header and Data:
+		8C 2B 43 00 4C 45 4E 4F 56 4F 0B 08 01 FF FF FF
+		FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF
+		FF FF FF FF FF FF FF FF FF FF FF
+
+Handle 0x0044, DMI type 135, 18 bytes
+OEM-specific Type
+	Header and Data:
+		87 12 44 00 54 50 07 01 01 00 00 00 06 00 00 00
+		06 00
+
+Handle 0xFEFF, DMI type 127, 4 bytes
+End Of Table
+

--- a/test/rhsmlib_test/dmidecodedata/x86_64-esx6.7-1.txt
+++ b/test/rhsmlib_test/dmidecodedata/x86_64-esx6.7-1.txt
@@ -1,0 +1,2109 @@
+# dmidecode 3.3
+Getting SMBIOS data from sysfs.
+SMBIOS 2.7 present.
+158 structures occupying 9702 bytes.
+Table at 0x0DF8601F.
+
+Handle 0x0000, DMI type 0, 26 bytes
+BIOS Information
+	Vendor: VMware, Inc.
+	Version: VMW71.00V.16707776.B64.2008070230
+	Release Date: 08/07/2020
+	ROM Size: 2 MB
+	Characteristics:
+		ISA is supported
+		PCI is supported
+		PNP is supported
+		BIOS is upgradeable
+		Targeted content distribution is supported
+		UEFI is supported
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+	Manufacturer: VMware, Inc.
+	Product Name: PPPPPPPPPP
+	Version: None
+	Serial Number: SSSSSSSS
+	UUID: 11111111-2222-3333-4444-555555555555
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Not Specified
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+	Manufacturer: Intel Corporation
+	Product Name: PPPPPPPPPP
+	Version: None
+	Serial Number: None
+	Asset Tag: Not Specified
+	Features: None
+	Location In Chassis: Not Specified
+	Chassis Handle: 0x0000
+	Type: Other
+	Contained Object Handles: 0
+
+Handle 0x0003, DMI type 3, 21 bytes
+Chassis Information
+	Manufacturer: No Enclosure
+	Type: Other
+	Lock: Not Present
+	Version: N/A
+	Serial Number: None
+	Asset Tag: No Asset Tag
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: None
+	OEM Information: 0x00000000
+	Height: Unspecified
+	Number Of Power Cords: Unspecified
+	Contained Elements: 0
+
+Handle 0x0004, DMI type 4, 48 bytes
+Processor Information
+	Socket Designation: CPU 0
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A0 06 03 00 FF FB 8B 0F
+	Version: Intel(R) Xeon(R) CPU E5-2620 v2 @ 2.10GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 2002 MHz
+	Current Speed: 2002 MHz
+	Status: Populated, Enabled
+	Upgrade: ZIF Socket
+	L1 Cache Handle: Not Provided
+	L2 Cache Handle: Not Provided
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 1
+	Core Enabled: 1
+	Characteristics:
+		64-bit capable
+		Execute Protection
+
+Handle 0x0005, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J19
+	Internal Connector Type: 9 Pin Dual Inline (pin 10 cut)
+	External Reference Designator: COM 1
+	External Connector Type: DB-9 male
+	Port Type: Serial Port 16550A Compatible
+
+Handle 0x0006, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J23
+	Internal Connector Type: 25 Pin Dual Inline (pin 26 cut)
+	External Reference Designator: Parallel
+	External Connector Type: DB-25 female
+	Port Type: Parallel Port ECP/EPP
+
+Handle 0x0007, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J11
+	Internal Connector Type: None
+	External Reference Designator: Keyboard
+	External Connector Type: Circular DIN-8 male
+	Port Type: Keyboard Port
+
+Handle 0x0008, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J12
+	Internal Connector Type: None
+	External Reference Designator: PS/2 Mouse
+	External Connector Type: Circular DIN-8 male
+	Port Type: Keyboard Port
+
+Handle 0x0009, DMI type 9, 17 bytes
+System Slot Information
+	Designation: PCI Slot J11
+	Type: 32-bit PCI
+	Current Usage: In Use
+	Length: Long
+	ID: 1
+	Characteristics:
+		5.0 V is provided
+		3.3 V is provided
+	Bus Address: 0000:00:0f.0
+
+Handle 0x000A, DMI type 9, 17 bytes
+System Slot Information
+	Designation: PCI Slot J12
+	Type: 32-bit PCI
+	Current Usage: Available
+	Length: Long
+	ID: 2
+	Characteristics:
+		5.0 V is provided
+		3.3 V is provided
+	Bus Address: 0000:00:10.0
+
+Handle 0x000B, DMI type 9, 17 bytes
+System Slot Information
+	Designation: PCI Slot J13
+	Type: 32-bit PCI
+	Current Usage: In Use
+	Length: Long
+	ID: 3
+	Characteristics:
+		5.0 V is provided
+		3.3 V is provided
+	Bus Address: 0000:00:11.0
+
+Handle 0x000C, DMI type 9, 17 bytes
+System Slot Information
+	Designation: PCI Slot J14
+	Type: 32-bit PCI
+	Current Usage: Available
+	Length: Long
+	ID: 4
+	Characteristics:
+		5.0 V is provided
+		3.3 V is provided
+	Bus Address: 0000:00:12.0
+
+Handle 0x000D, DMI type 9, 17 bytes
+System Slot Information
+	Designation: PCI Slot J15
+	Type: 32-bit PCI
+	Current Usage: Available
+	Length: Long
+	ID: 5
+	Characteristics:
+		5.0 V is provided
+		3.3 V is provided
+	Bus Address: 0000:00:13.0
+
+Handle 0x000E, DMI type 9, 17 bytes
+System Slot Information
+	Designation: PCI Slot J16
+	Type: 32-bit PCI
+	Current Usage: Available
+	Length: Long
+	ID: 6
+	Characteristics:
+		5.0 V is provided
+		3.3 V is provided
+	Bus Address: 0000:00:14.0
+
+Handle 0x000F, DMI type 10, 8 bytes
+On Board Device 1 Information
+	Type: Video
+	Status: Disabled
+	Description: VMware SVGA II
+On Board Device 2 Information
+	Type: Sound
+	Status: Disabled
+	Description: ES1371
+
+Handle 0x0010, DMI type 11, 5 bytes
+OEM Strings
+	String 1: [MS_VM_CERT/SHA1/27d66596a61c48dd3dc7216fd715126e33f59ae7]
+	String 2: Welcome to the Virtual Machine
+
+Handle 0x0011, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: None
+	Maximum Capacity: 2 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 64
+
+Handle 0x0012, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: 64 bits
+	Data Width: 64 bits
+	Size: 2 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #0
+	Bank Locator: RAM slot #0
+	Type: DRAM
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: VMware Virtual RAM
+	Serial Number: SSSSSSSS
+	Asset Tag: Not Specified
+	Part Number: AAAAAAAAAAAAA-ZZ
+	Rank: Unknown
+	Configured Memory Speed: Unknown
+	Minimum Voltage: Unknown
+	Maximum Voltage: Unknown
+	Configured Voltage: Unknown
+
+Handle 0x0013, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #1
+	Bank Locator: RAM slot #1
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0014, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #2
+	Bank Locator: RAM slot #2
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0015, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #3
+	Bank Locator: RAM slot #3
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0016, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #4
+	Bank Locator: RAM slot #4
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0017, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #5
+	Bank Locator: RAM slot #5
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0018, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #6
+	Bank Locator: RAM slot #6
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0019, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #7
+	Bank Locator: RAM slot #7
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x001A, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #8
+	Bank Locator: RAM slot #8
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x001B, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #9
+	Bank Locator: RAM slot #9
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x001C, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #10
+	Bank Locator: RAM slot #10
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x001D, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #11
+	Bank Locator: RAM slot #11
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x001E, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #12
+	Bank Locator: RAM slot #12
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x001F, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #13
+	Bank Locator: RAM slot #13
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0020, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #14
+	Bank Locator: RAM slot #14
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0021, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #15
+	Bank Locator: RAM slot #15
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0022, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #16
+	Bank Locator: RAM slot #16
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0023, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #17
+	Bank Locator: RAM slot #17
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0024, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #18
+	Bank Locator: RAM slot #18
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0025, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #19
+	Bank Locator: RAM slot #19
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0026, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #20
+	Bank Locator: RAM slot #20
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0027, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #21
+	Bank Locator: RAM slot #21
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0028, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #22
+	Bank Locator: RAM slot #22
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0029, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #23
+	Bank Locator: RAM slot #23
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x002A, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #24
+	Bank Locator: RAM slot #24
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x002B, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #25
+	Bank Locator: RAM slot #25
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x002C, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #26
+	Bank Locator: RAM slot #26
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x002D, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #27
+	Bank Locator: RAM slot #27
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x002E, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #28
+	Bank Locator: RAM slot #28
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x002F, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #29
+	Bank Locator: RAM slot #29
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0030, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #30
+	Bank Locator: RAM slot #30
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0031, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #31
+	Bank Locator: RAM slot #31
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0032, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #32
+	Bank Locator: RAM slot #32
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0033, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #33
+	Bank Locator: RAM slot #33
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0034, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #34
+	Bank Locator: RAM slot #34
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0035, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #35
+	Bank Locator: RAM slot #35
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0036, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #36
+	Bank Locator: RAM slot #36
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0037, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #37
+	Bank Locator: RAM slot #37
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0038, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #38
+	Bank Locator: RAM slot #38
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0039, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #39
+	Bank Locator: RAM slot #39
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x003A, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #40
+	Bank Locator: RAM slot #40
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x003B, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #41
+	Bank Locator: RAM slot #41
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x003C, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #42
+	Bank Locator: RAM slot #42
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x003D, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #43
+	Bank Locator: RAM slot #43
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x003E, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #44
+	Bank Locator: RAM slot #44
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x003F, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #45
+	Bank Locator: RAM slot #45
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0040, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #46
+	Bank Locator: RAM slot #46
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0041, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #47
+	Bank Locator: RAM slot #47
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0042, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #48
+	Bank Locator: RAM slot #48
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0043, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #49
+	Bank Locator: RAM slot #49
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0044, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #50
+	Bank Locator: RAM slot #50
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0045, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #51
+	Bank Locator: RAM slot #51
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0046, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #52
+	Bank Locator: RAM slot #52
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0047, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #53
+	Bank Locator: RAM slot #53
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0048, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #54
+	Bank Locator: RAM slot #54
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0049, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #55
+	Bank Locator: RAM slot #55
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x004A, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #56
+	Bank Locator: RAM slot #56
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x004B, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #57
+	Bank Locator: RAM slot #57
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x004C, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #58
+	Bank Locator: RAM slot #58
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x004D, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #59
+	Bank Locator: RAM slot #59
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x004E, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #60
+	Bank Locator: RAM slot #60
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x004F, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #61
+	Bank Locator: RAM slot #61
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0050, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #62
+	Bank Locator: RAM slot #62
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0051, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0011
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #63
+	Bank Locator: RAM slot #63
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0052, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #0
+	Bank Locator: NVD slot #0
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0053, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #1
+	Bank Locator: NVD slot #1
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0054, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #2
+	Bank Locator: NVD slot #2
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0055, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #3
+	Bank Locator: NVD slot #3
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0056, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #4
+	Bank Locator: NVD slot #4
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0057, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #5
+	Bank Locator: NVD slot #5
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0058, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #6
+	Bank Locator: NVD slot #6
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0059, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #7
+	Bank Locator: NVD slot #7
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x005A, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #8
+	Bank Locator: NVD slot #8
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x005B, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #9
+	Bank Locator: NVD slot #9
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x005C, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #10
+	Bank Locator: NVD slot #10
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x005D, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #11
+	Bank Locator: NVD slot #11
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x005E, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #12
+	Bank Locator: NVD slot #12
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x005F, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #13
+	Bank Locator: NVD slot #13
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0060, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #14
+	Bank Locator: NVD slot #14
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0061, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #15
+	Bank Locator: NVD slot #15
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0062, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #16
+	Bank Locator: NVD slot #16
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0063, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #17
+	Bank Locator: NVD slot #17
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0064, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #18
+	Bank Locator: NVD slot #18
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0065, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #19
+	Bank Locator: NVD slot #19
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0066, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #20
+	Bank Locator: NVD slot #20
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0067, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #21
+	Bank Locator: NVD slot #21
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0068, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #22
+	Bank Locator: NVD slot #22
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0069, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #23
+	Bank Locator: NVD slot #23
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x006A, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #24
+	Bank Locator: NVD slot #24
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x006B, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #25
+	Bank Locator: NVD slot #25
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x006C, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #26
+	Bank Locator: NVD slot #26
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x006D, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #27
+	Bank Locator: NVD slot #27
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x006E, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #28
+	Bank Locator: NVD slot #28
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x006F, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #29
+	Bank Locator: NVD slot #29
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0070, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #30
+	Bank Locator: NVD slot #30
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0071, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #31
+	Bank Locator: NVD slot #31
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0072, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #32
+	Bank Locator: NVD slot #32
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0073, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #33
+	Bank Locator: NVD slot #33
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0074, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #34
+	Bank Locator: NVD slot #34
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0075, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #35
+	Bank Locator: NVD slot #35
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0076, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #36
+	Bank Locator: NVD slot #36
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0077, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #37
+	Bank Locator: NVD slot #37
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0078, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #38
+	Bank Locator: NVD slot #38
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0079, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #39
+	Bank Locator: NVD slot #39
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x007A, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #40
+	Bank Locator: NVD slot #40
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x007B, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #41
+	Bank Locator: NVD slot #41
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x007C, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #42
+	Bank Locator: NVD slot #42
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x007D, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #43
+	Bank Locator: NVD slot #43
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x007E, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #44
+	Bank Locator: NVD slot #44
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x007F, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #45
+	Bank Locator: NVD slot #45
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0080, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #46
+	Bank Locator: NVD slot #46
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0081, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #47
+	Bank Locator: NVD slot #47
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0082, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #48
+	Bank Locator: NVD slot #48
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0083, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #49
+	Bank Locator: NVD slot #49
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0084, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #50
+	Bank Locator: NVD slot #50
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0085, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #51
+	Bank Locator: NVD slot #51
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0086, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #52
+	Bank Locator: NVD slot #52
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0087, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #53
+	Bank Locator: NVD slot #53
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0088, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #54
+	Bank Locator: NVD slot #54
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0089, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #55
+	Bank Locator: NVD slot #55
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x008A, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #56
+	Bank Locator: NVD slot #56
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x008B, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #57
+	Bank Locator: NVD slot #57
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x008C, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #58
+	Bank Locator: NVD slot #58
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x008D, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #59
+	Bank Locator: NVD slot #59
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x008E, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #60
+	Bank Locator: NVD slot #60
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x008F, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #61
+	Bank Locator: NVD slot #61
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0090, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #62
+	Bank Locator: NVD slot #62
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0091, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0000
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: NVD slot #63
+	Bank Locator: NVD slot #63
+	Type: Unknown
+	Type Detail: Unknown
+
+Handle 0x0092, DMI type 18, 23 bytes
+32-bit Memory Error Information
+	Type: OK
+	Granularity: Unknown
+	Operation: Unknown
+	Vendor Syndrome: Unknown
+	Memory Array Address: Unknown
+	Device Address: Unknown
+	Resolution: 0x00800000
+
+Handle 0x0093, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x0000009FFFF
+	Range Size: 640 kB
+	Physical Array Handle: 0x0011
+	Partition Width: 0
+
+Handle 0x0094, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x00000100000
+	Ending Address: 0x0000FFFFFFF
+	Range Size: 255 MB
+	Physical Array Handle: 0x0011
+	Partition Width: 0
+
+Handle 0x0095, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x0000009FFFF
+	Range Size: 640 kB
+	Physical Device Handle: 0x0012
+	Memory Array Mapped Address Handle: 0x0093
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0096, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00000100000
+	Ending Address: 0x0000FFFFFFF
+	Range Size: 255 MB
+	Physical Device Handle: 0x0012
+	Memory Array Mapped Address Handle: 0x0094
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0097, DMI type 23, 13 bytes
+System Reset
+	Status: Enabled
+	Watchdog Timer: Present
+	Boot Option: Do Not Reboot
+	Boot Option On Limit: Do Not Reboot
+	Reset Count: Unknown
+	Reset Limit: Unknown
+	Timer Interval: Unknown
+	Timeout: Unknown
+
+Handle 0x0098, DMI type 24, 5 bytes
+Hardware Security
+	Power-On Password Status: Disabled
+	Keyboard Password Status: Unknown
+	Administrator Password Status: Enabled
+	Front Panel Reset Status: Unknown
+
+Handle 0x0099, DMI type 30, 6 bytes
+Out-of-band Remote Access
+	Manufacturer Name: Intel
+	Inbound Connection: Enabled
+	Outbound Connection: Disabled
+
+Handle 0x009A, DMI type 32, 11 bytes
+System Boot Information
+	Status: No errors detected
+
+Handle 0x009B, DMI type 33, 31 bytes
+64-bit Memory Error Information
+	Type: OK
+	Granularity: Unknown
+	Operation: Unknown
+	Vendor Syndrome: Unknown
+	Memory Array Address: Unknown
+	Device Address: Unknown
+	Resolution: Unknown
+
+Handle 0x009C, DMI type 126, 4 bytes
+Inactive
+
+Handle 0x009D, DMI type 127, 4 bytes
+End Of Table
+

--- a/test/rhsmlib_test/dmidecodedata/x86_64-qemu-1.txt
+++ b/test/rhsmlib_test/dmidecodedata/x86_64-qemu-1.txt
@@ -1,0 +1,146 @@
+# dmidecode 3.3
+Getting SMBIOS data from sysfs.
+SMBIOS 2.8 present.
+10 structures occupying 436 bytes.
+Table at 0x000F5960.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+	Vendor: SeaBIOS
+	Version: 1.16.0-1.fc36
+	Release Date: 04/01/2014
+	Address: 0xE8000
+	Runtime Size: 96 kB
+	ROM Size: 64 kB
+	Characteristics:
+		BIOS characteristics not supported
+		Targeted content distribution is supported
+	BIOS Revision: 0.0
+
+Handle 0x0100, DMI type 1, 27 bytes
+System Information
+	Manufacturer: QEMU
+	Product Name: PPPPPPPPPP
+	Version: pc-q35-2.11
+	Serial Number: Not Specified
+	UUID: 11111111-2222-3333-4444-555555555555
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Not Specified
+
+Handle 0x0300, DMI type 3, 22 bytes
+Chassis Information
+	Manufacturer: QEMU
+	Type: Other
+	Lock: Not Present
+	Version: pc-q35-2.11
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: Unknown
+	OEM Information: 0x00000000
+	Height: Unspecified
+	Number Of Power Cords: Unspecified
+	Contained Elements: 0
+	SKU Number: Not Specified
+
+Handle 0x0400, DMI type 4, 42 bytes
+Processor Information
+	Socket Designation: CPU 0
+	Type: Central Processor
+	Family: Other
+	Manufacturer: QEMU
+	ID: 5A 06 05 00 FF FB 8B 0F
+	Version: pc-q35-2.11
+	Voltage: Unknown
+	External Clock: Unknown
+	Max Speed: 2000 MHz
+	Current Speed: 2000 MHz
+	Status: Populated, Enabled
+	Upgrade: Other
+	L1 Cache Handle: Not Provided
+	L2 Cache Handle: Not Provided
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 1
+	Core Enabled: 1
+	Thread Count: 1
+	Characteristics: None
+
+Handle 0x0401, DMI type 4, 42 bytes
+Processor Information
+	Socket Designation: CPU 1
+	Type: Central Processor
+	Family: Other
+	Manufacturer: QEMU
+	ID: 5A 06 05 00 FF FB 8B 0F
+	Version: pc-q35-2.11
+	Voltage: Unknown
+	External Clock: Unknown
+	Max Speed: 2000 MHz
+	Current Speed: 2000 MHz
+	Status: Populated, Enabled
+	Upgrade: Other
+	L1 Cache Handle: Not Provided
+	L2 Cache Handle: Not Provided
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 1
+	Core Enabled: 1
+	Thread Count: 1
+	Characteristics: None
+
+Handle 0x1000, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: Other
+	Use: System Memory
+	Error Correction Type: Multi-bit ECC
+	Maximum Capacity: 2 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 1
+
+Handle 0x1100, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x1000
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: 2 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 0
+	Bank Locator: Not Specified
+	Type: RAM
+	Type Detail: Other
+	Speed: Unknown
+	Manufacturer: QEMU
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown
+	Configured Memory Speed: Unknown
+	Minimum Voltage: Unknown
+	Maximum Voltage: Unknown
+	Configured Voltage: Unknown
+
+Handle 0x1300, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x0007FFFFFFF
+	Range Size: 2 GB
+	Physical Array Handle: 0x1000
+	Partition Width: 1
+
+Handle 0x2000, DMI type 32, 11 bytes
+System Boot Information
+	Status: No errors detected
+
+Handle 0x7F00, DMI type 127, 4 bytes
+End Of Table
+

--- a/test/rhsmlib_test/test_collector.py
+++ b/test/rhsmlib_test/test_collector.py
@@ -20,10 +20,9 @@ except ImportError:
 
 import platform
 import mock
-from test.fixture import open_mock, OPEN_FUNCTION
+from test.fixture import open_mock
 
 from rhsmlib.facts import collector, firmware_info
-from rhsmlib.facts.firmware_info import UuidFirmwareInfoCollector
 
 
 class GetArchTest(unittest.TestCase):
@@ -44,23 +43,3 @@ class GetArchTest(unittest.TestCase):
     def test_get_platform_specific_info_provider(self):
         info_provider = firmware_info.get_firmware_collector(arch=platform.machine())
         self.assertTrue(info_provider is not None)
-
-
-class GetNonDmiUuid(unittest.TestCase):
-    def test_get_aarch64_firmware_collector(self):
-        firmware_provider_class = firmware_info.get_firmware_collector(arch='aarch64')
-        self.assertTrue(isinstance(firmware_provider_class, UuidFirmwareInfoCollector))
-
-    @mock.patch(OPEN_FUNCTION, mock.mock_open(read_data="356B6CCC-30C4-11B2-A85C-BBB0CCD29F36"))
-    def test_get_aarch64_uuid_collection(self):
-        firmware_provider_class = firmware_info.get_firmware_collector(arch='aarch64')
-        firmware_provider_class.arch = 'aarch64'
-        result = firmware_provider_class.get_all()
-        self.assertTrue(result['dmi.system.uuid'] == '356B6CCC-30C4-11B2-A85C-BBB0CCD29F36')
-
-    @mock.patch(OPEN_FUNCTION, mock.MagicMock(side_effect=IOError()))
-    def test_get_aarch64_uuid_collection_no_file(self):
-        firmware_provider_class = firmware_info.get_firmware_collector(arch='aarch64')
-        firmware_provider_class.arch = 'aarch64'
-        result = firmware_provider_class.get_all()
-        self.assertTrue('dmi.system.uuid' not in result)

--- a/test/rhsmlib_test/test_dmifacts.py
+++ b/test/rhsmlib_test/test_dmifacts.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+
+from rhsmlib.facts.dmidecodeparser import DmidecodeParser
+from rhsmlib.facts.dmiinfo import DmidecodeFactCollector
+
+import contextlib
+import os
+import unittest
+
+
+FAKE_PART_NUMBER = "AAAAAAAAAAAAA-ZZ"
+FAKE_PRODUCT_NAME = "PPPPPPPPPP"
+FAKE_SERIAL_NUMBER = "SSSSSSSS"
+FAKE_UUID = "11111111-2222-3333-4444-555555555555"
+
+
+class DmidecodeTestDataMixin:
+    """
+    Simple mixin for testing dmidecode output files.
+    """
+
+    DATA_SUFFIX = ".txt"
+
+    def __init__(self, *args, **kwargs):
+        curdir = os.path.dirname(os.path.realpath(__file__))
+        self._datadir = os.path.join(curdir, "dmidecodedata")
+        super(DmidecodeTestDataMixin, self).__init__(*args, **kwargs)
+
+    @property
+    def datadir(self):
+        return self._datadir
+
+    def load_data(self, name):
+        name = os.path.join(self.datadir, name)
+        parser = DmidecodeParser()
+        parser.parse_file(name)
+        return parser
+
+    def get_testfiles(self):
+        testfiles = []
+        with os.scandir(self.datadir) as it:
+            for entry in it:
+                if not entry.name.endswith(self.DATA_SUFFIX) or not entry.is_file():
+                    continue
+                testfiles.append(entry.name)
+        return testfiles
+
+
+class TestDmidecodeParser(DmidecodeTestDataMixin, unittest.TestCase):
+    def test_data(self):
+        testfiles = self.get_testfiles()
+
+        for tf in testfiles:
+            with self.subTest(file=tf):
+                parser = self.load_data(tf)
+                self.assertEqual(
+                    parser.get_key(DmidecodeParser.DmiTypes.SYSTEM_INFORMATION, "UUID"), FAKE_UUID
+                )
+                with contextlib.suppress(KeyError):
+                    # not all the systems have a serial number set
+                    self.assertEqual(
+                        parser.get_key(DmidecodeParser.DmiTypes.SYSTEM_INFORMATION, "Serial Number"),
+                        FAKE_SERIAL_NUMBER,
+                    )
+
+
+class TestDmidecodeFactCollector(DmidecodeTestDataMixin, unittest.TestCase):
+    # subtags of "dmi" that we expected to be present in the facts
+    FACTS_SUBTAGS = [
+        "dmi.bios.",
+        "dmi.chassis.",
+        "dmi.system.",
+    ]
+
+    def test_data(self):
+        datadir = self.datadir
+        testfiles = self.get_testfiles()
+
+        for tf in testfiles:
+            with self.subTest(file=tf):
+                c = DmidecodeFactCollector()
+                c.set_dmidecode_output(os.path.join(datadir, tf))
+                facts = c.get_all()
+                for subtag in self.FACTS_SUBTAGS:
+                    with self.subTest(subtag=subtag):
+                        # at least one fact for the specific subtag
+                        self.assertTrue(any(f.startswith(subtag) for f in facts))
+                self.assertEqual(facts["dmi.system.uuid"], FAKE_UUID)
+                with contextlib.suppress(KeyError):
+                    # not all the systems have a serial number set
+                    self.assertEqual(facts["dmi.system.serial_number"], FAKE_SERIAL_NUMBER)


### PR DESCRIPTION
The python-dmidecode module has currently not received work upstream in the last 7 years, and it starts to fails in some situations (e.g. Kernel Lockdown, when /dev/mem cannot be read). Hence, we cannot keep using python-dmidecode anymore.

As way forward, create a parser to parse the output of `dmidecode(1)`, and a fact collector that uses this parser to provide `"dmi.*"` facts.
The parser and the facts collector are tested using collected outputs (and anonymized) of `dmidecode(1)`, so it is easy to check whether changes will break existing outputs.

Cloud-what has its own facts collector using python-dmidecode in case subscription-manager is not installed. In it, manually query `dmidecode(1)` for known DMI strings used by the cloud detection, so it should work in that case too.

The dmidecode is available on ARM64. Thus it make sense to use same approach, which is used on x86_64 platform and
parse output of `dmidecode(1)`.

Please refer to the individual commits for few more explanations.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2173583
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2109365 (fixed by dropping the old code)

Backport of:
- #3077
- #3128
- #3096