### PR TITLE
2174297: register: do a simple `strip()` on environment(s) input

### DIFF
--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -439,10 +439,12 @@ class RegisterCommand(UserPassCommand):
             )
 
         if self.cp.has_capability(MULTI_ENV):
-            environment = input(_("Environments: ")).replace(" ", "")
+            environment = input(_("Environments: "))
         else:
-            environment = input(_("Environment: ")).strip()
+            environment = input(_("Environment: "))
         readline.clear_history()
+        # ensure the input is not empty
+        environment = environment.strip()
         return environment or self._prompt_for_environment()
 
     def _process_environments(self, admin_cp, owner_key):

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -11,6 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+import contextlib
 import os
 
 from unittest.mock import Mock, NonCallableMock, patch, MagicMock
@@ -232,6 +233,34 @@ class CliRegistrationTests(SubManFixture):
             rc.options.activation_keys = None
             rc.options.environments = None
             rc._prompt_for_environment = Mock(return_value="somename,othername")
+            env_id = rc._process_environments(mock_uep, "owner")
+            expected = "1234,5678"
+            self.assertEqual(expected, env_id)
+
+    def test_set_multi_environment_id_multi_available_input(self):
+        def env_list(*args, **kwargs):
+            return [{"id": "1234", "name": "some name with space"}, {"id": "5678", "name": "othername"}]
+
+        with contextlib.ExitStack() as stack:
+            mock_uep = stack.enter_context(patch("rhsm.connection.UEPConnection", new_callable=StubUEP))
+            mock_uep.getEnvironmentList = env_list
+            mock_uep.supports_resource = Mock(return_value=True)
+            mock_uep.has_capability = Mock(return_value=True)
+            self.stub_cp_provider.basic_auth_cp = mock_uep
+
+            stack.enter_context(
+                patch("subscription_manager.cli_command.register.is_interactive", return_value=True)
+            )
+
+            stack.enter_context(patch("builtins.input", return_value="some name with space, othername "))
+
+            stack.enter_context(patch("subscription_manager.cli_command.register.readline"))
+
+            rc = RegisterCommand()
+            rc.cp = mock_uep
+            rc.options = Mock()
+            rc.options.activation_keys = None
+            rc.options.environments = None
             env_id = rc._process_environments(mock_uep, "owner")
             expected = "1234,5678"
             self.assertEqual(expected, env_id)


### PR DESCRIPTION
When we prompt the user for multiple environments, in the input string any space is removed before further internal processing.  Most likely this was done to minic the non-multi-environment case that strips the input to ensure it is not empty; sadly this makes more than that, making it impossible to interactively type environment names that contain a space, as it will be removed.

Since the result of `_prompt_for_environment()` is passed to `check_set_environment_names()`, which `strip()`s any environment after splitting the input string by comma, we can simply `strip()` the input string in both multi-environments and non-multi-environments cases: it will be enough to ensure that it is non-empty.

Add a simple test to check a couple of these whitespace situations, i.e. in the middle after a comma and at the end.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2174297