### PR TITLE
Stop subclassing 'object'

### DIFF
--- a/build_ext/build_ext/lint.py
+++ b/build_ext/build_ext/lint.py
@@ -69,7 +69,7 @@ class Flake8(BaseCommand):
         spawn(["flake8"])
 
 
-class AstVisitor(object):
+class AstVisitor:
     """Visitor pattern for looking at specific nodes in an AST.  Basically a copy of
     ast.NodeVisitor, but with the additional feature of appending return values onto a result
     list that is ultimately returned.
@@ -163,7 +163,7 @@ class GettextVisitor(AstVisitor):
                 )
 
 
-class AstChecker(object):
+class AstChecker:
     name = "SubscriptionManagerAstChecker"
     version = "1.0"
 

--- a/build_ext/build_ext/utils.py
+++ b/build_ext/build_ext/utils.py
@@ -68,7 +68,7 @@ class BaseCommand(cmd.Command):
         pass
 
 
-class Utils(object):
+class Utils:
     @staticmethod
     def run_if_new(src, dest, callback):
         src_mtime = os.stat(src)[8]

--- a/scripts/gen_test_en_po.py
+++ b/scripts/gen_test_en_po.py
@@ -4,7 +4,7 @@ import polib
 import sys
 
 
-class PotFile(object):
+class PotFile:
     def __init__(self):
 
         self.msgids = []

--- a/src/cloud_what/_base_provider.py
+++ b/src/cloud_what/_base_provider.py
@@ -28,7 +28,7 @@ from typing import Union
 log = logging.getLogger(__name__)
 
 
-class BaseCloudProvider(object):
+class BaseCloudProvider:
     """
     Base class of cloud provider. This class is used for cloud detecting
     and collecting metadata/signature.

--- a/src/cloud_what/fact_collector.py
+++ b/src/cloud_what/fact_collector.py
@@ -27,7 +27,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class MiniHostCollector(object):
+class MiniHostCollector:
     """
     Minimalistic collector of host facts
     """
@@ -124,7 +124,7 @@ class MiniHostCollector(object):
 
 
 # We do not need this collector for cloud-what, so it is really dummy
-class MiniCustomFactsCollector(object):
+class MiniCustomFactsCollector:
     @staticmethod
     def get_all() -> dict:
         return {}

--- a/src/plugins/zypper/services/rhsm
+++ b/src/plugins/zypper/services/rhsm
@@ -72,7 +72,7 @@ class RepoLocker(Locker):
             self.lock.release()
 
 
-class ZypperService(object):
+class ZypperService:
 
     ZYPP_RHSM_PLUGIN_CONFIG_FILE = '/etc/rhsm/zypper.conf'
 

--- a/src/rct/printing.py
+++ b/src/rct/printing.py
@@ -32,7 +32,7 @@ def xstr(value):
         return str(value)
 
 
-class ProductPrinter(object):
+class ProductPrinter:
     def as_str(self, product):
         s = []
         s.append("%s:" % _("Product"))
@@ -56,7 +56,7 @@ class ProductPrinter(object):
         return "%s\n" % "\n".join(s)
 
 
-class OrderPrinter(object):
+class OrderPrinter:
     def as_str(self, order):
 
         if order is None:
@@ -90,7 +90,7 @@ class OrderPrinter(object):
         return "%s\n" % "\n".join(s)
 
 
-class ContentPrinter(object):
+class ContentPrinter:
     def as_str(self, content):
         s = []
         s.append("%s:" % _("Content"))
@@ -109,7 +109,7 @@ class ContentPrinter(object):
         return "\n".join(s)
 
 
-class CertificatePrinter(object):
+class CertificatePrinter:
     def cert_to_str(self, cert):
         s = []
         s.append("\n+-------------------------------------------+")
@@ -228,7 +228,7 @@ class EntitlementCertificatePrinter(ProductCertificatePrinter):
         return "%s" % "\n".join(s)
 
 
-class CertificatePrinterFactory(object):
+class CertificatePrinterFactory:
     def get_printer(self, cert, **kwargs):
         if isinstance(cert, EntitlementCertificate):
             return EntitlementCertificatePrinter(**kwargs)

--- a/src/rhsm/certificate.py
+++ b/src/rhsm/certificate.py
@@ -116,7 +116,7 @@ def deprecated(func: Callable) -> Callable:
     return new_func
 
 
-class Certificate(object):
+class Certificate:
     """
     Represents and x.509 certificate.
 
@@ -505,7 +505,7 @@ class EntitlementCertificate(ProductCertificate):
         return "\n".join(s)
 
 
-class Key(object):
+class Key:
     """
     The (private|public) key.
 
@@ -572,7 +572,7 @@ class Key(object):
         return self.content
 
 
-class DateRange(object):
+class DateRange:
     """
     Date range object.
 
@@ -906,7 +906,7 @@ class OID:
         return self._str
 
 
-class Order(object):
+class Order:
     @deprecated
     def __init__(self, ext):
         self.ext = ext
@@ -996,7 +996,7 @@ class Order(object):
         return "\n".join(s)
 
 
-class Product(object):
+class Product:
     @deprecated
     def __init__(self, p_hash: str, ext: Extensions) -> None:
         self.hash = p_hash

--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -872,7 +872,7 @@ class Order:
         return "<Order: name=%s number=%s sku=%s>" % (self.name, self.number, self.sku)
 
 
-class Content(object):
+class Content:
     def __init__(
         self,
         content_type=None,
@@ -929,7 +929,7 @@ class Content(object):
         return hash(self.label)
 
 
-class Pool(object):
+class Pool:
     """
     Represents the pool an entitlement originates from.
     """

--- a/src/rhsm/pathtree.py
+++ b/src/rhsm/pathtree.py
@@ -24,7 +24,7 @@ PATH_END = "PATH END"
 LISTING = "listing"
 
 
-class PathTree(object):
+class PathTree:
     """
     This builds and makes available a tree that represents matchable paths. A
     path must be matched starting from its root and the root of the tree,

--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -55,7 +55,7 @@ class InvalidProfileType(Exception):
     pass
 
 
-class ModulesProfile(object):
+class ModulesProfile:
     def __init__(self) -> None:
         self.content: List[dict] = self.__generate()
 
@@ -191,7 +191,7 @@ class ModulesProfile(object):
         return self.content
 
 
-class EnabledRepos(object):
+class EnabledRepos:
     def __generate(self) -> List[dict]:
         if not os.path.exists(self.repofile):
             return []
@@ -279,7 +279,7 @@ class EnabledRepos(object):
         return {"releasever": self.yb.conf.yumvar["releasever"], "basearch": self.yb.conf.yumvar["basearch"]}
 
 
-class EnabledReposProfile(object):
+class EnabledReposProfile:
     """
     Collect information about enabled repositories
     """
@@ -298,7 +298,7 @@ class EnabledReposProfile(object):
         return self._enabled_repos.content
 
 
-class Package(object):
+class Package:
     """
     Represents a package installed on the system.
     """
@@ -354,7 +354,7 @@ class Package(object):
         return value
 
 
-class RPMProfile(object):
+class RPMProfile:
     def __init__(self, from_file: _io.TextIOWrapper = None) -> None:
         """
         Load the RPM package profile from a given file, or from rpm itself.

--- a/src/rhsm_debug/debug_commands.py
+++ b/src/rhsm_debug/debug_commands.py
@@ -263,7 +263,7 @@ class SystemCommand(CliCommand):
         os.makedirs(dest_dir_name, ROOT_READ_ONLY_DIR)
 
 
-class SaferFileMove(object):
+class SaferFileMove:
     """Try to copy a file avoiding race conditions.
 
     Opens the dest file os.O_RDWR | os.O_CREAT | os.O_EXCL, which

--- a/src/rhsmlib/candlepin/api.py
+++ b/src/rhsmlib/candlepin/api.py
@@ -45,7 +45,7 @@ class CandlepinApiNetworkError(CandlepinApiError):
     pass
 
 
-class Candlepin(object):
+class Candlepin:
     def __init__(self, uep):
         self.uep = uep
         self._default_args = ()

--- a/src/rhsmlib/dbus/facts/client.py
+++ b/src/rhsmlib/dbus/facts/client.py
@@ -28,7 +28,7 @@ class FactsClientAuthenticationError(Exception):
         self.action_id = action_id
 
 
-class FactsClient(object):
+class FactsClient:
     bus_name = facts_constants.FACTS_DBUS_NAME
     object_path = facts_constants.FACTS_DBUS_PATH
     interface_name = facts_constants.FACTS_DBUS_INTERFACE

--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -43,7 +43,7 @@ parser = get_config_parser()
 conf = config.Config(parser)
 
 
-class Server(object):
+class Server:
     """
     Class used for rhsm.service providing D-Bus API
     """
@@ -246,7 +246,7 @@ class Server(object):
             dir_watcher.enable()
 
 
-class DomainSocketServer(object):
+class DomainSocketServer:
     """This class sets up a DBus server on a domain socket. That server can then be used to perform
     registration. The issue is that we can't send registration credentials over the regular system or
     session bus since those aren't really locked down. The work-around is the client asks our service

--- a/src/rhsmlib/facts/collection.py
+++ b/src/rhsmlib/facts/collection.py
@@ -69,7 +69,7 @@ def compare_with_graylist(dict_a: dict, dict_b: dict, graylist: Set[str]) -> boo
     return ka == kb and all(dict_a[k] == dict_b[k] for k in ka)
 
 
-class FactsCollection(object):
+class FactsCollection:
     def __init__(self, facts_dict: FactsDict = None):
         self.data: FactsDict = facts_dict or FactsDict()
         self.collection_datetime = datetime.now()

--- a/src/rhsmlib/facts/collector.py
+++ b/src/rhsmlib/facts/collector.py
@@ -58,7 +58,7 @@ def get_arch(prefix: str = None) -> str:
 # An empty FactsCollector should just return an empty dict on get_all()
 
 
-class FactsCollector(object):
+class FactsCollector:
     def __init__(
         self,
         arch: str = None,

--- a/src/rhsmlib/facts/cpuinfo.py
+++ b/src/rhsmlib/facts/cpuinfo.py
@@ -107,7 +107,7 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, U
 log = logging.getLogger("rhsm-app." + __name__)
 
 
-class DefaultCpuFields(object):
+class DefaultCpuFields:
     """Maps generic cpuinfo fields to the corresponding field from ProcessorModel.
 
     For, a cpu MODEL (a number or string that the cpu vendor assigns to that model of
@@ -121,23 +121,23 @@ class DefaultCpuFields(object):
     MODEL: str = "model"
 
 
-class X86_64Fields(object):
+class X86_64Fields:
     MODEL_NAME: str = "model_name"
     MODEL: str = "model"
 
 
-class Aarch64Fields(object):
+class Aarch64Fields:
     MODEL: str = "cpu_part"
     MODEL_NAME: str = "model_name"
 
 
-class Ppc64Fields(object):
+class Ppc64Fields:
     MODEL: str = "model"
     MODEL_NAME: str = "machine"
 
 
 # represent the data in /proc/cpuinfo, which may include multiple processors
-class CpuinfoModel(object):
+class CpuinfoModel:
     fields_class: type = DefaultCpuFields
 
     def __init__(self, cpuinfo_data: str = None):
@@ -347,7 +347,7 @@ Hardware    : APM X-Gene Mustang board
 """
 
 
-class BaseCpuInfo(object):
+class BaseCpuInfo:
     cpu_info: CpuinfoModel
 
     @classmethod
@@ -473,7 +473,7 @@ class Ppc64CpuInfo(BaseCpuInfo):
         return item[0] != "timebase"
 
 
-class SystemCpuInfoFactory(object):
+class SystemCpuInfoFactory:
     uname_to_cpuinfo: Dict[str, type(BaseCpuInfo)] = {
         "x86_64": X86_64CpuInfo,
         "aarch64": Aarch64CpuInfo,

--- a/src/rhsmlib/facts/custom.py
+++ b/src/rhsmlib/facts/custom.py
@@ -24,7 +24,7 @@ from rhsmlib.facts.collector import FactsCollector
 log = logging.getLogger(__name__)
 
 
-class CustomFacts(object):
+class CustomFacts:
     def __init__(self, data: Dict[str, Any] = None):
         self.data: Dict[str, Any] = data
 
@@ -52,7 +52,7 @@ class CustomFactsFileError(Exception):
     pass
 
 
-class CustomFactsFile(object):
+class CustomFactsFile:
     def __init__(self, path: str = None):
         self.path: str = path
         self.buf = None
@@ -73,7 +73,7 @@ class CustomFactsFile(object):
         pass
 
 
-class CustomFactsDirectory(object):
+class CustomFactsDirectory:
     def __init__(self, path: str = None, glob_pattern: str = None):
         self.path: str = path
         self.glob_pattern: str = glob_pattern
@@ -94,7 +94,7 @@ class CustomFactsDirectory(object):
             yield CustomFacts.from_json(fact_file.read())
 
 
-class CustomFactsDirectories(object):
+class CustomFactsDirectories:
     def __init__(self, path_and_globs: Dict[str, str]):
         self.path_and_globs: Dict[str, str] = path_and_globs
 

--- a/src/rhsmlib/facts/firmware_info.py
+++ b/src/rhsmlib/facts/firmware_info.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 # This doesn't really do anything other than provide a null/noop provider for
 # non-DMI platforms.
-class NullFirmwareInfoCollector(object):
+class NullFirmwareInfoCollector:
     """Default provider for platform without a specific platform info provider.
 
     ie, all platforms except those with DMI (ie, intel platforms)"""

--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -41,7 +41,7 @@ except ImportError:
     ethtool = None
 
 
-class ClassicCheck(object):
+class ClassicCheck:
     def is_registered_with_classic(self) -> bool:
         try:
             sys.path.append("/usr/share/rhn")
@@ -82,7 +82,7 @@ def gather_entries(entries_string: str) -> List[int]:
 
 
 # FIXME This class does not seem to be used anywhere
-class GenericPlatformSpecificInfoProvider(object):
+class GenericPlatformSpecificInfoProvider:
     """Default provider for platform without a specific platform info provider.
     ie, all platforms except those with DMI (ie, intel platforms)"""
 

--- a/src/rhsmlib/file_monitor.py
+++ b/src/rhsmlib/file_monitor.py
@@ -43,7 +43,7 @@ PRODUCT_WATCHER = "PRODUCT_WATCHER"
 SYSPURPOSE_WATCHER = "SYSPURPOSE_WATCHER"
 
 
-class FilesystemWatcher(object):
+class FilesystemWatcher:
     """
     Watches a set of directories and notifies when there are changes
 
@@ -233,7 +233,7 @@ class InotifyFilesystemWatcher(FilesystemWatcher):
             self.watch_manager.rm_watch(dir_watch.path, rec=True)
 
 
-class DirectoryWatch(object):
+class DirectoryWatch:
     """
     Directory to be watched
 

--- a/src/rhsmlib/services/attach.py
+++ b/src/rhsmlib/services/attach.py
@@ -18,7 +18,7 @@ from rhsm.connection import UEPConnection
 log = logging.getLogger(__name__)
 
 
-class AttachService(object):
+class AttachService:
     """
     Service using for attach pools by ID or auto-attaching
     """

--- a/src/rhsmlib/services/consumer.py
+++ b/src/rhsmlib/services/consumer.py
@@ -19,7 +19,7 @@ This module provides service for consumer identity.
 from subscription_manager import injection as inj
 
 
-class Consumer(object):
+class Consumer:
     def __init__(self) -> None:
         """
         Initialization of Consumer instance.

--- a/src/rhsmlib/services/entitlement.py
+++ b/src/rhsmlib/services/entitlement.py
@@ -29,7 +29,7 @@ import rhsm.connection as connection
 log = logging.getLogger(__name__)
 
 
-class EntitlementService(object):
+class EntitlementService:
     def __init__(self, cp: connection.UEPConnection = None) -> None:
         self.cp = cp
         self.identity = inj.require(inj.IDENTITY)

--- a/src/rhsmlib/services/products.py
+++ b/src/rhsmlib/services/products.py
@@ -19,7 +19,7 @@ from subscription_manager import utils
 from subscription_manager import managerlib
 
 
-class InstalledProducts(object):
+class InstalledProducts:
     """
     Class for listing installed products
     """

--- a/src/rhsmlib/services/refresh.py
+++ b/src/rhsmlib/services/refresh.py
@@ -26,7 +26,7 @@ from subscription_manager.entcertlib import EntCertActionInvoker
 log = logging.getLogger(__name__)
 
 
-class Refresh(object):
+class Refresh:
     """
     Class used for refreshing entitlement certificates
     """

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -27,7 +27,7 @@ from subscription_manager.i18n import ugettext as _
 log = logging.getLogger(__name__)
 
 
-class RegisterService(object):
+class RegisterService:
     def __init__(self, cp: UEPConnection) -> None:
         self.plugin_manager = inj.require(inj.PLUGIN_MANAGER)
         self.installed_mgr = inj.require(inj.INSTALLED_PRODUCTS_MANAGER)

--- a/src/rhsmlib/services/syspurpose.py
+++ b/src/rhsmlib/services/syspurpose.py
@@ -34,7 +34,7 @@ from rhsmlib.dbus.server import Server
 log = logging.getLogger(__name__)
 
 
-class Syspurpose(object):
+class Syspurpose:
     def __init__(self, cp: UEPConnection) -> None:
         self.cp = cp
         self.identity = inj.require(inj.IDENTITY)

--- a/src/rhsmlib/services/unregister.py
+++ b/src/rhsmlib/services/unregister.py
@@ -29,7 +29,7 @@ from rhsm import connection
 log = logging.getLogger(__name__)
 
 
-class UnregisterService(object):
+class UnregisterService:
     """
     Class providing functionality of unregistering the system from
     Candlepin server.

--- a/src/subscription_manager/base_action_client.py
+++ b/src/subscription_manager/base_action_client.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-class BaseActionClient(object):
+class BaseActionClient:
     """
     An object used to update the certificates, DNF repos, and facts for the system.
     """

--- a/src/subscription_manager/base_plugin.py
+++ b/src/subscription_manager/base_plugin.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from subscription_manager.plugins import PluginConfig
 
 
-class SubManPlugin(object):
+class SubManPlugin:
     """Base class for all subscription-manager "rhsm-plugins"
 
     Plugins need to subclass SubManPlugin() to be found

--- a/src/subscription_manager/branding/__init__.py
+++ b/src/subscription_manager/branding/__init__.py
@@ -52,7 +52,7 @@ def get_branding():
     return _branding
 
 
-class Branding(object):
+class Branding:
     def __init__(self, custom_branding=None):
         self._default = DefaultBranding()
         if custom_branding is None:
@@ -66,7 +66,7 @@ class Branding(object):
             return getattr(self._default, x)
 
 
-class DefaultBranding(object):
+class DefaultBranding:
 
     """
     Default branding. values are defined in init to help with i18n/l10n
@@ -88,7 +88,7 @@ class DefaultBranding(object):
         self.REGISTERED_TO_SUBSCRIPTION_MANAGEMENT_SUMMARY = _("Red Hat Subscription Management")
 
 
-class EmptyBranding(object):
+class EmptyBranding:
     """
     Empty branding object to use in place of a custom branding
     (so we always fall back to the defaults.

--- a/src/subscription_manager/branding/redhat_branding.py
+++ b/src/subscription_manager/branding/redhat_branding.py
@@ -1,7 +1,7 @@
 from subscription_manager.i18n import ugettext as _
 
 
-class Branding(object):
+class Branding:
     def __init__(self):
         self.CLI_REGISTER = _(
             "Register this system to the Customer Portal or another subscription management service"

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -54,7 +54,7 @@ PACKAGES_RESOURCE = "packages"
 conf = config.Config(get_config_parser())
 
 
-class CacheManager(object):
+class CacheManager:
     """
     Parent class used for common logic in a number of collections
     where we need to push some consumer JSON up to the server,
@@ -668,7 +668,7 @@ class PoolStatusCache(StatusCache):
         self.server_status = uep.getEntitlementList(uuid)
 
 
-class PoolTypeCache(object):
+class PoolTypeCache:
     """
     Cache type of pool
     """
@@ -718,7 +718,7 @@ class PoolTypeCache(object):
         self.pooltype_map = {}
 
 
-class ContentAccessCache(object):
+class ContentAccessCache:
     CACHE_FILE = "/var/lib/rhsm/cache/content_access.json"
 
     def __init__(self):

--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -64,7 +64,7 @@ RHSM_PARTIALLY_VALID = 4
 RHSM_REGISTRATION_REQUIRED = 5
 
 
-class ComplianceManager(object):
+class ComplianceManager:
     def __init__(self, on_date: Optional[datetime] = None):
         self.cp_provider: CPProvider = inj.require(inj.CP_PROVIDER)
         self.product_dir: ProductDirectory = inj.require(inj.PROD_DIR)
@@ -454,7 +454,7 @@ class CertSorter(ComplianceManager):
         return len(self.entitlement_dir.list()) > 0
 
 
-class StackingGroupSorter(object):
+class StackingGroupSorter:
     def __init__(self, entitlements: List["EntitlementCertificate"]):
         self.groups: List[EntitlementGroup] = []
         stacking_groups: Dict[str, EntitlementGroup] = {}
@@ -480,7 +480,7 @@ class StackingGroupSorter(object):
         raise NotImplementedError("Subclasses must implement: _get_identity_name")
 
 
-class EntitlementGroup(object):
+class EntitlementGroup:
     def __init__(self, entitlement: "EntitlementCertificate", name: str = ""):
         self.name = name
         self.entitlements: List[EntitlementCertificate] = []

--- a/src/subscription_manager/certdirectory.py
+++ b/src/subscription_manager/certdirectory.py
@@ -35,7 +35,7 @@ conf = config.Config(get_config_parser())
 DEFAULT_PRODUCT_CERT_DIR = "/etc/pki/product-default"
 
 
-class Directory(object):
+class Directory:
     def __init__(self, path):
         self.path = Path.abs(path)
 
@@ -352,7 +352,7 @@ class EntitlementDirectory(CertificateDirectory):
         return pool_id_to_serials
 
 
-class Path(object):
+class Path:
 
     # Used during Anaconda install by the yum pidplugin to ensure we operate
     # beneath /mnt/sysimage/ instead of /.
@@ -376,7 +376,7 @@ class Path(object):
         return os.path.isdir(path)
 
 
-class Writer(object):
+class Writer:
     def __init__(self):
         self.ent_dir: EntitlementDirectory = require(ENT_DIR)
 

--- a/src/subscription_manager/certlib.py
+++ b/src/subscription_manager/certlib.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-class Locker(object):
+class Locker:
     def __init__(self):
         self.lock: ActionLock = self._get_lock()
 
@@ -24,7 +24,7 @@ class Locker(object):
         return inj.require(inj.ACTION_LOCK)
 
 
-class BaseActionInvoker(object):
+class BaseActionInvoker:
     def __init__(self, locker: Optional[Locker] = None):
         self.locker = locker or Locker()
         self.report: Any = None
@@ -39,7 +39,7 @@ class BaseActionInvoker(object):
         return
 
 
-class ActionReport(object):
+class ActionReport:
     """Base class for cert lib and action reports"""
 
     name: str = "Report"

--- a/src/subscription_manager/cli.py
+++ b/src/subscription_manager/cli.py
@@ -45,7 +45,7 @@ def flush_stdout_stderr() -> None:
         log.error("Error: Unable to print data to stdout/stderr output during exit process: %s" % io_err)
 
 
-class AbstractCLICommand(object):
+class AbstractCLICommand:
     """
     Base class for rt commands. This class provides a templated run
     strategy.
@@ -102,7 +102,7 @@ class AbstractCLICommand(object):
 
 
 # taken wholseale from rho...
-class CLI(object):
+class CLI:
     def __init__(self, command_classes: List[Type[AbstractCLICommand]] = None):
         command_classes = command_classes or []
         self.cli_commands: Dict[str, AbstractCLICommand] = {}

--- a/src/subscription_manager/content_action_client.py
+++ b/src/subscription_manager/content_action_client.py
@@ -47,7 +47,7 @@ class ContentPluginActionReport(certlib.ActionReport):
         self.reports.add(report)
 
 
-class ContentPluginActionCommand(object):
+class ContentPluginActionCommand:
     """An ActionCommand used to wrap 'content_update' plugin invocations.
 
     args:

--- a/src/subscription_manager/cpuinfo.py
+++ b/src/subscription_manager/cpuinfo.py
@@ -107,7 +107,7 @@ from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Set,
 log = logging.getLogger(__name__)
 
 
-class DefaultCpuFields(object):
+class DefaultCpuFields:
     """Maps generic cpuinfo fields to the corresponding field from ProcessorModel.
 
     For, a cpu MODEL (a number or string that the cpu vendor assigns to that model of
@@ -121,23 +121,23 @@ class DefaultCpuFields(object):
     MODEL = "model"
 
 
-class X86_64Fields(object):
+class X86_64Fields:
     MODEL_NAME = "model_name"
     MODEL = "model"
 
 
-class Aarch64Fields(object):
+class Aarch64Fields:
     MODEL = "cpu_part"
     MODEL_NAME = "model_name"
 
 
-class Ppc64Fields(object):
+class Ppc64Fields:
     MODEL = "model"
     MODEL_NAME = "machine"
 
 
 # represent the data in /proc/cpuinfo, which may include multiple processors
-class CpuinfoModel(object):
+class CpuinfoModel:
     fields_class = DefaultCpuFields
 
     def __init__(self, cpuinfo_data: Optional[Dict] = None):
@@ -348,7 +348,7 @@ Hardware    : APM X-Gene Mustang board
 """
 
 
-class BaseCpuInfo(object):
+class BaseCpuInfo:
     @classmethod
     def from_proc_cpuinfo_string(cls: type, proc_cpuinfo_string: str):
         """Return a BaseCpuInfo subclass based on proc_cpuinfo_string.
@@ -470,7 +470,7 @@ class Ppc64CpuInfo(BaseCpuInfo):
         return item[0] != "timebase"
 
 
-class SystemCpuInfoFactory(object):
+class SystemCpuInfoFactory:
     uname_to_cpuinfo = {
         "x86_64": X86_64CpuInfo,
         "aarch64": Aarch64CpuInfo,

--- a/src/subscription_manager/entbranding.py
+++ b/src/subscription_manager/entbranding.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-class BrandsInstaller(object):
+class BrandsInstaller:
     def __init__(self, ent_certs: Optional[List["EntitlementCertificate"]] = None):
         self.ent_certs: Optional[List[EntitlementCertificate]] = ent_certs
 
@@ -41,7 +41,7 @@ class BrandsInstaller(object):
             brand_installer.install()
 
 
-class BrandInstaller(object):
+class BrandInstaller:
     """Install branding info for a set of entitlement certs."""
 
     def __init__(self, ent_certs: Optional[List["EntitlementCertificate"]] = None):
@@ -79,7 +79,7 @@ class BrandInstaller(object):
         raise NotImplementedError
 
 
-class BrandPicker(object):
+class BrandPicker:
     """Returns the branded name to install.
 
     Check installed product certs, and the list of entitlement certs
@@ -92,7 +92,7 @@ class BrandPicker(object):
         raise NotImplementedError
 
 
-class Brand(object):
+class Brand:
     """Base class for Brand objects."""
 
     name: Optional[str] = None
@@ -166,7 +166,7 @@ class CurrentBrand(Brand):
         return None
 
 
-class BrandFile(object):
+class BrandFile:
     """The file used for storing product branding info.
 
     Default is "/var/lib/rhsm/branded_name

--- a/src/subscription_manager/entcertlib.py
+++ b/src/subscription_manager/entcertlib.py
@@ -57,7 +57,7 @@ class EntCertActionInvoker(certlib.BaseActionInvoker):
 # NOTE: this lib and EntCertDeleteAction are currently
 # unused. Intention is to replace managerlib.clean_all_data
 # with a CertActionClient.delete invocation
-class EntCertDeleteLib(object):
+class EntCertDeleteLib:
     """Invoker for entitlement certificate delete actions."""
 
     def __init__(self, serial_numbers=None, ent_dir=None):
@@ -73,7 +73,7 @@ class EntCertDeleteLib(object):
 
 
 # FIXME: currently unused
-class EntCertDeleteAction(object):
+class EntCertDeleteAction:
     """Action for deleting all entitlement certs."""
 
     def __init__(self, ent_dir=None):
@@ -88,7 +88,7 @@ class EntCertDeleteAction(object):
         return self
 
 
-class EntCertUpdateAction(object):
+class EntCertUpdateAction:
     """Action for syncing entitlement certificates.
 
     EntCertUpdateAction is used to sync entitlement certs based on
@@ -338,7 +338,7 @@ class EntCertUpdateAction(object):
             self.ent_dir.refresh()
 
 
-class EntitlementCertBundlesInstaller(object):
+class EntitlementCertBundlesInstaller:
     """Install a list of entitlement cert bundles.
 
     pre_install() is triggered before any of the ent cert
@@ -381,7 +381,7 @@ class EntitlementCertBundlesInstaller(object):
         return self.report.added
 
 
-class EntitlementCertBundleInstaller(object):
+class EntitlementCertBundleInstaller:
     """Install an entitlement cert bundle (cert/key).
 
     Split a bundle into an certificate.EntitlementCertificate and a

--- a/src/subscription_manager/exceptions.py
+++ b/src/subscription_manager/exceptions.py
@@ -70,7 +70,7 @@ CONNECTION_UNREACHABLE_MESSAGE = _("Unable to reach the server at {host}: {messa
 RESTLIB_MESSAGE = _("{message} (HTTP error code {code}: {title})")
 
 
-class ExceptionMapper(object):
+class ExceptionMapper:
     def __init__(self):
 
         self.message_map: Dict[str, Callable] = {

--- a/src/subscription_manager/factlib.py
+++ b/src/subscription_manager/factlib.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 
 # FactsActionInvoker has a Facts
 #   Facts is a CacheManager
-class FactsActionInvoker(object):
+class FactsActionInvoker:
     """Used by CertActionClient to update a system's facts with the server, used
     primarily by the cron job but in a couple other places as well.
 
@@ -67,7 +67,7 @@ class FactsActionReport(ActionReport):
         return len(self.fact_updates)
 
 
-class FactsActionCommand(object):
+class FactsActionCommand:
     """UpdateAction for facts.
 
     Update facts if calculated local facts are different than

--- a/src/subscription_manager/healinglib.py
+++ b/src/subscription_manager/healinglib.py
@@ -48,7 +48,7 @@ class HealingActionInvoker(certlib.BaseActionInvoker):
         return action.perform()
 
 
-class HealingUpdateAction(object):
+class HealingUpdateAction:
     """UpdateAction for ent cert healing.
 
     Core if entitlement certificate healing.

--- a/src/subscription_manager/i18n.py
+++ b/src/subscription_manager/i18n.py
@@ -95,7 +95,7 @@ def ungettext(*args, **kwargs) -> str:
         return TRANSLATION.ngettext(*args, **kwargs)
 
 
-class Locale(object):
+class Locale:
     """
     Class used for changing languages on the fly
     """

--- a/src/subscription_manager/identity.py
+++ b/src/subscription_manager/identity.py
@@ -33,7 +33,7 @@ conf = config.Config(get_config_parser())
 log = logging.getLogger(__name__)
 
 
-class ConsumerIdentity(object):
+class ConsumerIdentity:
     """Consumer info and certificate information.
 
     Includes helpers for reading/writing consumer identity certificates
@@ -126,7 +126,7 @@ class ConsumerIdentity(object):
         return 'consumer: name="%s", uuid=%s' % (self.getConsumerName(), self.getConsumerId())
 
 
-class Identity(object):
+class Identity:
     """Wrapper for sharing consumer identity without constant reloading."""
 
     def __init__(self):

--- a/src/subscription_manager/identitycertlib.py
+++ b/src/subscription_manager/identitycertlib.py
@@ -39,7 +39,7 @@ class IdentityCertActionInvoker(certlib.BaseActionInvoker):
         return action.perform()
 
 
-class IdentityUpdateAction(object):
+class IdentityUpdateAction:
     """UpdateAction for consumer identity certificates.
 
     Returns a certlib.ActionReport. report.status of

--- a/src/subscription_manager/injection.py
+++ b/src/subscription_manager/injection.py
@@ -40,7 +40,7 @@ CONTENT_ACCESS_CACHE = "CONTENT_ACCESS_CACHE"
 SYSTEMPURPOSE_COMPLIANCE_STATUS_CACHE = "SYSTEMPURPOSE_COMPLIANCE_STATUS_CACHE"
 
 
-class FeatureBroker(object):
+class FeatureBroker:
     """
     Tracks all configured features.
 

--- a/src/subscription_manager/installedproductslib.py
+++ b/src/subscription_manager/installedproductslib.py
@@ -31,7 +31,7 @@ class InstalledProductsActionInvoker(certlib.BaseActionInvoker):
         return action.perform()
 
 
-class InstalledProductsActionCommand(object):
+class InstalledProductsActionCommand:
     """Update the consumers installed product list to RHSM API.
 
     Returns a InstalledProductsActionReport.

--- a/src/subscription_manager/jsonwrapper.py
+++ b/src/subscription_manager/jsonwrapper.py
@@ -18,7 +18,7 @@ from typing import Dict, List, Optional, Union
 from subscription_manager.utils import is_true_value
 
 
-class PoolWrapper(object):
+class PoolWrapper:
     def __init__(self, pool_json: dict):
         self.data: dict = pool_json
 

--- a/src/subscription_manager/listing.py
+++ b/src/subscription_manager/listing.py
@@ -14,7 +14,7 @@
 from typing import List, Optional
 
 
-class ListingFile(object):
+class ListingFile:
     def __init__(self, data: Optional[str] = None):
         self.data: Optional[str] = data
         self.releases: List[str] = []

--- a/src/subscription_manager/lock.py
+++ b/src/subscription_manager/lock.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 LOCK_WAIT_DURATION: float = 0.5
 
 
-class LockFile(object):
+class LockFile:
     def __init__(self, path: str):
         self.path: str = path
         self.pid: Optional[int] = None
@@ -90,7 +90,7 @@ class LockFile(object):
         self.close()
 
 
-class Lock(object):
+class Lock:
 
     mutex = Mutex()
 

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -128,7 +128,7 @@ def fetch_certificates(certlib) -> Literal[True]:
     return True
 
 
-class PoolFilter(object):
+class PoolFilter:
     """
     Helper to filter a list of pools.
     """
@@ -451,7 +451,7 @@ def get_available_entitlements(
     return data
 
 
-class MergedPools(object):
+class MergedPools:
     """
     Class to track the view of merged pools for the same product.
     Used to view total entitlement information across all pools for a
@@ -545,7 +545,7 @@ class MergedPoolsStackingGroupSorter(StackingGroupSorter):
         return merged_pool.pools[0]["productName"]
 
 
-class PoolStash(object):
+class PoolStash:
     """
     Object used to fetch pools from the server, sort them into compatible,
     incompatible, and installed lists. Also does filtering based on name.
@@ -759,7 +759,7 @@ class PoolStash(object):
         return provided_products
 
 
-class ImportFileExtractor(object):
+class ImportFileExtractor:
     """
     Responsible for checking an import file and pulling cert and key from it.
     An import file may include only the certificate, but may also include its

--- a/src/subscription_manager/model/__init__.py
+++ b/src/subscription_manager/model/__init__.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 # be based on containers.abc.Iterable
 
 
-class Content(object):
+class Content:
     """
     A generic representation of entitled content.
     """
@@ -54,7 +54,7 @@ class Content(object):
         self.arches = arches
 
 
-class Entitlement(object):
+class Entitlement:
     """Represent an entitlement.
 
     Has a 'contents' attribute that is an
@@ -69,7 +69,7 @@ class Entitlement(object):
         self.entitlement_type = entitlement_type
 
 
-class EntitlementSource(object):
+class EntitlementSource:
     """Populate with info needed for plugins to find content.
 
     Acts as a iterable over entitlements.

--- a/src/subscription_manager/overrides.py
+++ b/src/subscription_manager/overrides.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 # Module for manipulating content overrides
 
 
-class Overrides(object):
+class Overrides:
     def __init__(self):
         self.cp_provider: CPProvider = inj.require(inj.CP_PROVIDER)
 
@@ -75,7 +75,7 @@ class Overrides(object):
         return self.cp_provider.get_consumer_auth_cp()
 
 
-class Override(object):
+class Override:
     def __init__(self, repo_id: str, name: str, value: Optional[object] = None):
         self.repo_id: str = repo_id
         self.name: str = name

--- a/src/subscription_manager/packageprofilelib.py
+++ b/src/subscription_manager/packageprofilelib.py
@@ -31,7 +31,7 @@ class PackageProfileActionInvoker(certlib.BaseActionInvoker):
         return action.perform()
 
 
-class PackageProfileActionCommand(object):
+class PackageProfileActionCommand:
     """Action for updating the list of installed packages to RHSM API,
 
     Returns a PackageProfileActionReport.

--- a/src/subscription_manager/plugin/container/__init__.py
+++ b/src/subscription_manager/plugin/container/__init__.py
@@ -31,7 +31,7 @@ RH_CDN_REGEX = re.compile(r"^cdn\.(?:.*\.)?redhat\.com$")
 RH_CDN_CA = "/etc/rhsm/ca/redhat-entitlement-authority.pem"
 
 
-class ContainerContentUpdateActionCommand(object):
+class ContainerContentUpdateActionCommand:
     """
     UpdateActionCommand for Docker configuration.
 
@@ -74,7 +74,7 @@ class ContainerContentUpdateActionCommand(object):
         return unique_cert_paths
 
 
-class KeyPair(object):
+class KeyPair:
     """Simple object to hold paths to an entitlement cert and key."""
 
     def __init__(self, cert_path, key_path):
@@ -108,7 +108,7 @@ class KeyPair(object):
         return hash(self.__repr__())
 
 
-class ContainerCertDir(object):
+class ContainerCertDir:
     """
     An object to manage the docker certificate directory at
     /etc/docker/certs.d/.

--- a/src/subscription_manager/plugin/ostree/action_invoker.py
+++ b/src/subscription_manager/plugin/ostree/action_invoker.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 OSTREE_CONTENT_TYPE = "ostree"
 
 
-class OstreeContentUpdateActionCommand(object):
+class OstreeContentUpdateActionCommand:
     """UpdateActionCommand for ostree repos.
 
     Update the repo configuration for rpm-ostree when triggered.

--- a/src/subscription_manager/plugin/ostree/config.py
+++ b/src/subscription_manager/plugin/ostree/config.py
@@ -118,7 +118,7 @@ class KeyFileConfigParser(RhsmConfigParser):
         super(KeyFileConfigParser, self).save()
 
 
-class BaseOstreeConfigFile(object):
+class BaseOstreeConfigFile:
     config_parser_class = KeyFileConfigParser
 
     def __init__(self, filename=None):

--- a/src/subscription_manager/plugin/ostree/model.py
+++ b/src/subscription_manager/plugin/ostree/model.py
@@ -42,7 +42,7 @@ class RemoteSectionNameParseError(OstreeContentError):
         self.section = section
 
 
-class OstreeRemote(object):
+class OstreeRemote:
     """Represent a ostree repo remote.
 
     A repo remote is one of the the '[remote "ostree-awesomeos-8"]' section in
@@ -238,7 +238,7 @@ class OstreeRemote(object):
         return self.report_template.format(self=self)
 
 
-class OstreeRemotes(object):
+class OstreeRemotes:
     """A container/set of OstreeRemote objects.
 
     Representing OstreeRemote's as found in the repo configs, or
@@ -281,7 +281,7 @@ class OstreeRemotes(object):
         return s
 
 
-class OstreeConfigFileStore(object):
+class OstreeConfigFileStore:
     """For loading/saving a ostree remotes repo config file."""
 
     default_repo_file_path = OSTREE_REPO_CONFIG_PATH
@@ -303,7 +303,7 @@ class OstreeConfigFileStore(object):
 
 
 # persist OstreeConfig object to a config file
-class OstreeConfigFileWriter(object):
+class OstreeConfigFileWriter:
     """Populate config file parser with infrom from OstreeConfig and save."""
 
     def __init__(self, repo_file):
@@ -336,7 +336,7 @@ class OstreeConfigFileWriter(object):
         self.repo_file.set_core(ostree_config.core)
 
 
-class OstreeConfigUpdatesBuilder(object):
+class OstreeConfigUpdatesBuilder:
     def __init__(self, ostree_config, contents):
         self.orig_ostree_config = ostree_config
         self.contents = contents
@@ -382,7 +382,7 @@ class OstreeCore(dict):
     pass
 
 
-class OstreeConfig(object):
+class OstreeConfig:
     """Represents the config state of the systems ostree tool.
 
     Config file loading and parsing will create one of these and populate it
@@ -448,7 +448,7 @@ class OstreeRepoConfig(OstreeConfig):
     default_repo_file_path = OSTREE_REPO_CONFIG_PATH
 
 
-class OstreeConfigUpdates(object):
+class OstreeConfigUpdates:
     """The info a ostree update action needs to update OstreeConfig.
 
     remote sets, branches, etc.

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -133,7 +133,7 @@ class SlotNameException(Exception):
         return "slot name %s does not have a conduit to handle it" % self.slot_name
 
 
-class BaseConduit(object):
+class BaseConduit:
     """An API entry point for rhsm plugins.
 
     Conduit()'s are used to provide access to the data a SubManPlugin may need.
@@ -429,7 +429,7 @@ class PostAutoAttachConduit(PostSubscriptionConduit):
         super(PostAutoAttachConduit, self).__init__(clazz, consumer_uuid, entitlement_data)
 
 
-class PluginConfig(object):
+class PluginConfig:
     """Represents configuation for each rhsm plugin.
 
     Attributes:
@@ -493,7 +493,7 @@ class PluginConfig(object):
         return buf
 
 
-class PluginHookRunner(object):
+class PluginHookRunner:
     """Encapsulates a Conduit() instance and a bound plugin method.
 
     PluginManager.runiter() returns an iterable that will yield
@@ -514,7 +514,7 @@ class PluginHookRunner(object):
 
 # NOTE: need to be super paranoid here about existing of cfg variables
 # BasePluginManager with our default config info
-class BasePluginManager(object):
+class BasePluginManager:
     """Finds, load, and provides access to subscription-manager plugins."""
 
     def __init__(self, search_path: Optional[str] = None, plugin_conf_path: Optional[str] = None):

--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -51,7 +51,7 @@ class ProductIdRepoMap(utils.DefaultDict):
         # FIXME Missing super() call
 
 
-class ProductDatabase(object):
+class ProductDatabase:
     def __init__(self):
         self.dir = DatabaseDirectory()
         self.content = ProductIdRepoMap()
@@ -108,7 +108,7 @@ class ProductDatabase(object):
         return self.dir.abspath("productid.js")
 
 
-class ComparableMixin(object):
+class ComparableMixin:
     """Needs compare_keys to be implemented."""
 
     # FIXME self.compare_keys should be defined here, raising NotImplementedError
@@ -135,7 +135,7 @@ class ComparableMixin(object):
         return self._compare(self.compare_keys(other), lambda s, o: s >= o)
 
 
-class RpmVersion(object):
+class RpmVersion:
     """Represent the epoch, version, release of a rpm style version.
 
     This includes the rich comparison methods to support >,<,==,!-
@@ -273,7 +273,7 @@ class ComparableProductCert(ComparableMixin):
         return self.comp_product.compare_keys(other.comp_product)
 
 
-class ProductId(object):
+class ProductId:
     def __init__(self, product_cert):
         self.product_cert = product_cert
 
@@ -293,7 +293,7 @@ class ProductId(object):
     # def compare(self, other):   # version check?
 
 
-class ProductManager(object):
+class ProductManager:
     """Manager product certs, detecting when they need to be installed, or deleted.
 
     Note that this class has no knowledge of when it runs, and no nothing of the

--- a/src/subscription_manager/reasons.py
+++ b/src/subscription_manager/reasons.py
@@ -16,7 +16,7 @@ from typing import Dict, List
 from subscription_manager.i18n import ugettext as _
 
 
-class Reasons(object):
+class Reasons:
     """
     Holds reasons and parses them for
     the client.

--- a/src/subscription_manager/release.py
+++ b/src/subscription_manager/release.py
@@ -61,12 +61,12 @@ class MultipleReleaseProductsError(ValueError):
         ) % ", ".join([certificate.path for certificate in self.certificates])
 
 
-class ContentConnectionProvider(object):
+class ContentConnectionProvider:
     def __init__(self):
         pass
 
 
-class ReleaseBackend(object):
+class ReleaseBackend:
     def get_releases(self):
         provider: CdnReleaseVersionProvider = self._get_release_version_provider()
         return provider.get_releases()
@@ -78,7 +78,7 @@ class ReleaseBackend(object):
         return CdnReleaseVersionProvider()
 
 
-class ApiReleaseVersionProvider(object):
+class ApiReleaseVersionProvider:
     def __init__(self):
         self.cp_provider = inj.require(inj.CP_PROVIDER)
         self.identity = inj.require(inj.IDENTITY)
@@ -93,7 +93,7 @@ class ApiReleaseVersionProvider(object):
         return self.cp_provider.get_consumer_auth_cp()
 
 
-class CdnReleaseVersionProvider(object):
+class CdnReleaseVersionProvider:
     def __init__(self):
         self.entitlement_dir: EntitlementDirectory = inj.require(inj.ENT_DIR)
         self.product_dir: ProductDirectory = inj.require(inj.PROD_DIR)

--- a/src/subscription_manager/repofile.py
+++ b/src/subscription_manager/repofile.py
@@ -285,7 +285,7 @@ def manage_repos_enabled() -> bool:
     return bool(manage_repos)
 
 
-class TidyWriter(object):
+class TidyWriter:
 
     """
     ini file reader that removes successive newlines,
@@ -329,7 +329,7 @@ class TidyWriter(object):
             self.backing_file.write("\n")
 
 
-class RepoFileBase(object):
+class RepoFileBase:
     """
     Base class for managing repository.
     """

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -53,7 +53,7 @@ conf = config.Config(rhsm.config.get_config_parser())
 ALLOWED_CONTENT_TYPES = ["yum", "deb"]
 
 
-class YumPluginManager(object):
+class YumPluginManager:
     """
     Instance of this class is used for automatic enabling of dnf plugins
     (formerly for yum plugins, hence the name).
@@ -258,7 +258,7 @@ class RepoActionInvoker(BaseActionInvoker):
 # just the marker, and get_expansion would change
 #
 # For example, for full craziness, we could expand facts in urls...
-class YumReleaseverSource(object):
+class YumReleaseverSource:
     """
     Contains a ReleaseStatusCache and releasever helpers.
 
@@ -332,7 +332,7 @@ class YumReleaseverSource(object):
         return self._expansion
 
 
-class RepoUpdateActionCommand(object):
+class RepoUpdateActionCommand:
     """UpdateAction for yum repos.
 
     Update yum repos when triggered. Generates yum repo config

--- a/src/subscription_manager/rhelproduct.py
+++ b/src/subscription_manager/rhelproduct.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from rhsm.certificate2 import Product
 
 
-class RHELProductMatcher(object):
+class RHELProductMatcher:
     """Check a Product object to see if it is a RHEL product.
 
     Compares the provided tags to see if any provide 'rhel-VERSION'.

--- a/src/subscription_manager/syspurposelib.py
+++ b/src/subscription_manager/syspurposelib.py
@@ -242,7 +242,7 @@ class SyspurposeSyncActionReport(certlib.ActionReport):
         return buf
 
 
-class SyspurposeSyncActionCommand(object):
+class SyspurposeSyncActionCommand:
     """
     Sync the system purpose values, by performing a three-way merge between:
       - The last known shared state (SyspurposeCache)

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -403,7 +403,7 @@ def chroot(dirname: str) -> None:
     Path.ROOT = dirname
 
 
-class CertificateFilter(object):
+class CertificateFilter:
     def match(self, cert: "EntitlementCertificate"):
         """
         Checks if the specified certificate matches this filter's restrictions.

--- a/src/subscription_manager/validity.py
+++ b/src/subscription_manager/validity.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-class ValidProductDateRangeCalculator(object):
+class ValidProductDateRangeCalculator:
     def __init__(self, uep: Optional["UEPConnection"] = None):
         uep = uep or inj.require(inj.CP_PROVIDER).get_consumer_auth_cp()
         self.identity: Identity = inj.require(inj.IDENTITY)

--- a/src/syspurpose/files.py
+++ b/src/syspurpose/files.py
@@ -73,7 +73,7 @@ def post_process_received_data(data: dict) -> dict:
     return data
 
 
-class SyspurposeStore(object):
+class SyspurposeStore:
     """
     Represents and maintains a json syspurpose file
     """
@@ -222,7 +222,7 @@ class SyspurposeStore(object):
         return new_store
 
 
-class SyncResult(object):
+class SyncResult:
     """
     A container class for the results of a sync operation performed by a SyncedStore class.
     """
@@ -234,7 +234,7 @@ class SyncResult(object):
         self.cached_changed = cached_changed
 
 
-class SyncedStore(object):
+class SyncedStore:
     """
     Stores values in a local file backed by a cache which is then synced with another source
     of the same values.

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -91,7 +91,7 @@ def locale_context(new_locale, category=None):
         locale.setlocale(category, old_locale)
 
 
-class FakeLogger(object):
+class FakeLogger:
     def __init__(self):
         self.expected_msg = ""
         self.msg = None
@@ -124,7 +124,7 @@ class FakeException(Exception):
         return repr(self.msg)
 
 
-class Matcher(object):
+class Matcher:
     @staticmethod
     def set_eq(first, second):
         """Useful for dealing with sets that have been cast to or instantiated as lists."""
@@ -330,8 +330,8 @@ class SubManFixture(unittest.TestCase):
         return True
 
 
-class Capture(object):
-    class Tee(object):
+class Capture:
+    class Tee:
         def __init__(self, stream, silent):
             self.buf = io.StringIO()
             self.stream = stream

--- a/test/plugins/dummy_plugin.py
+++ b/test/plugins/dummy_plugin.py
@@ -12,5 +12,5 @@ class DummyPlugin(SubManPlugin):
         conduit.log.error("Hello World")
 
 
-class DontImportMe(object):
+class DontImportMe:
     pass

--- a/test/rhsmlib/base.py
+++ b/test/rhsmlib/base.py
@@ -37,7 +37,7 @@ dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 log = logging.getLogger(__name__)
 
 
-class TestUtilsMixin(object):
+class TestUtilsMixin:
     def assert_items_equals(self, a, b):
         """Assert that two lists contain the same items regardless of order."""
         if sorted(a) != sorted(b):

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -428,7 +428,7 @@ class StubProductDirectory(StubCertificateDirectory, ProductDirectory):
         pass
 
 
-class StubConsumerIdentity(object):
+class StubConsumerIdentity:
     CONSUMER_NAME = "John Q Consumer"
     CONSUMER_ID = "211211381984"
     SERIAL = "23234523452345234523453453434534534"
@@ -467,7 +467,7 @@ class StubConsumerIdentity(object):
         return ""
 
 
-class StubUEP(object):
+class StubUEP:
     def __init__(
         self,
         host=None,
@@ -601,7 +601,7 @@ class StubUEP(object):
         }
 
 
-class StubBackend(object):
+class StubBackend:
     def __init__(self, uep=None):
         self.cp_provider = StubCPProvider()
         self.entitlement_dir = None
@@ -618,7 +618,7 @@ class StubBackend(object):
         pass
 
 
-class StubContentConnection(object):
+class StubContentConnection:
     proxy_hostname = None
     proxy_port = None
 
@@ -652,7 +652,7 @@ class StubFacts(Facts):
         self.server_status = None
 
 
-class StubConsumer(object):
+class StubConsumer:
     def __init__(self):
         self.uuid = None
 
@@ -666,7 +666,7 @@ class StubConsumer(object):
         return "12341234234"
 
 
-class StubEntActionInvoker(object):
+class StubEntActionInvoker:
     def __init__(self, uep=None):
         self.uep = uep or StubUEP()
 
@@ -687,7 +687,7 @@ class StubCertSorter(CertSorter):
         pass
 
 
-class StubCPProvider(object):
+class StubCPProvider:
     def __init__(self):
         self.cert_file = StubConsumerIdentity.certpath()
         self.key_file = StubConsumerIdentity.keypath()
@@ -818,7 +818,7 @@ class StubCurrentOwnerCache(CurrentOwnerCache):
         self.server_status = None
 
 
-class StubPool(object):
+class StubPool:
     def __init__(self, poolid):
         self.id = poolid
 

--- a/test/test_branding.py
+++ b/test/test_branding.py
@@ -16,7 +16,7 @@ import unittest
 from subscription_manager.branding import Branding
 
 
-class TestBranding(object):
+class TestBranding:
     def __init__(self):
         self.CLI_REGISTER = "register with awesomeness"
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -60,7 +60,7 @@ from test import subman_marker_slow, subman_marker_slow_timeout
 log = logging.getLogger(__name__)
 
 
-class _FACT_MATCHER(object):
+class _FACT_MATCHER:
     def __eq__(self, other):
         return True
 

--- a/test/test_managerlib.py
+++ b/test/test_managerlib.py
@@ -695,7 +695,7 @@ class PoolFilterTests(SubManFixture):
         return pool
 
 
-class MockLog(object):
+class MockLog:
     def info(self):
         pass
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -59,7 +59,7 @@ class TestEntitlement(fixture.SubManFixture):
         self.assertTrue(isinstance(e.contents[0], mock.Mock))
 
 
-class EntitlementSourceBuilder(object):
+class EntitlementSourceBuilder:
     def contents_list(self, name):
         return [self.mock_content(name), self.mock_content(name)]
 

--- a/test/test_ostree_content_plugin.py
+++ b/test/test_ostree_content_plugin.py
@@ -23,7 +23,7 @@ from subscription_manager.plugin.ostree import action_invoker
 from rhsm import certificate2
 
 
-class StubPluginManager(object):
+class StubPluginManager:
     pass
 
 

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -247,7 +247,7 @@ class TestBasePluginManagerAddPluginsFromModule(unittest.TestCase):
         mock_module = mock.Mock()
         mock_module.__name__ = "mock_module"
 
-        class NotAPluginClass(object):
+        class NotAPluginClass:
             pass
 
         mock_module.NotAPluginClass = NotAPluginClass
@@ -830,7 +830,7 @@ class TestPluginManagerRunIter(TestPluginManagerRun):
             runner.run()
 
     def test_iter_wrapper(self):
-        class Wrapper(object):
+        class Wrapper:
             def __init__(self, runner):
                 self.runner = runner
                 self.runner_func = self.runner.func


### PR DESCRIPTION
New-style classes are the only type of classes available in Python 3, and they already inherit from `object`. Hence, drop all the manual `object` subclassing, which is redundant now.

This only removes the `object` subclassing, without changing any leftover of support for old-style classes; hence, there should be no behaviour changes.

Card ID: ENT-5406