### PR TITLE
2178610: do not collect unentitled products in SCA mode

### DIFF
--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -154,6 +154,8 @@ class ComplianceManager:
         if status is None:
             return
 
+        is_sca = utils.is_simple_content_access(self.cp_provider.get_consumer_auth_cp(), self.identity)
+
         # TODO: we're now mapping product IDs to entitlement cert JSON,
         # previously we mapped to actual entitlement cert objects. However,
         # nothing seems to actually use these, so it may not matter for now.
@@ -190,17 +192,20 @@ class ComplianceManager:
         # Lookup product certs for each unentitled product returned by
         # the server:
         unentitled_pids: List[str] = status["nonCompliantProducts"]
-        # Add in any installed products not in the server response. This
-        # could happen if something changes before the certd runs. Log
-        # a warning if it does, and treat it like an unentitled product.
-        for pid in list(self.installed_products.keys()):
-            if (
-                pid not in self.valid_products
-                and pid not in self.partially_valid_products
-                and pid not in unentitled_pids
-            ):
-                log.warning("Installed product %s not present in response from " "server." % pid)
-                unentitled_pids.append(pid)
+        # When using SCA, the compliance status does not include the installed
+        # products.
+        if not is_sca:
+            # Add in any installed products not in the server response. This
+            # could happen if something changes before the certd runs. Log
+            # a warning if it does, and treat it like an unentitled product.
+            for pid in list(self.installed_products.keys()):
+                if (
+                    pid not in self.valid_products
+                    and pid not in self.partially_valid_products
+                    and pid not in unentitled_pids
+                ):
+                    log.warning("Installed product %s not present in response from " "server." % pid)
+                    unentitled_pids.append(pid)
 
         for unentitled_pid in unentitled_pids:
             prod_cert = self.product_dir.find_by_product(unentitled_pid)


### PR DESCRIPTION
In SCA mode, the compliance status from Candlepin does not include any products. Because of that, the installed products will be considered as "unentitleed", being logged as such.

Since this situation is expected, avoid collecting unentitled products from the installed products when in SCA mode.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2178610