### PR TITLE
Small improvement of debugging of http traffic

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -911,8 +911,10 @@ class BaseRestLib:
         """
 
         if os.environ.get("SUBMAN_DEBUG_PRINT_RESPONSE", ""):
-            print("%s %s" % (result["status"], result["headers"]))
-            print(result["content"])
+            gray_col = "\033[90m"
+            end_col = "\033[0m"
+            print(gray_col + "%s %s" % (result["status"], result["headers"]))
+            print(result["content"] + end_col)
             print()
 
     def _set_accept_language_in_header(self) -> None:


### PR DESCRIPTION
* When debugging of http traffic is enabled and responses are printed to console, then color of response is set to gray. Thus it is easier to distinguish standard output to console and debug print of response. It should work on dark and light backgrounds of terminal.