### PR TITLE
[1.28] Revert "Try to use --forked for all unit tests."

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,8 +6,6 @@ addopts =
 	-rfEsw
 	# Mark some tests not to be run
 	-m "not functional"
-        # Use own process for each unit test
-        --forked
 markers =
 	dbus: subscription-manager tests for DBus.
 	slow: subscription-manager tests that may be slower than the rest.


### PR DESCRIPTION
The D-Bus tests were changed to not actually do D-Bus communication anymore; as they were most (if not all) of the instabilities of the unit tests, let's try to disable the forking behaviour for all the tests, and speed things up a bit.

This reverts commit 21f2172c32ec5aaa56d104cf38fe74a1d5a703ce.