### PR TITLE
2132242: [1.28] Outsource uploading DNF profile to rhsmcertd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Python setup.py doesn't cover all our bases.  Additionally, setuptools does not like
 # to install files outside of /usr (see http://stackoverflow.com/a/13476594/6124862).
 #
-# Therefore the Makefile performs the master build, but please keep the following guidelines
+# Therefore the Makefile performs the main build, but please keep the following guidelines
 # in mind when updating it:
 #
 # * If the file goes under /usr, put it in setup.py
@@ -319,6 +319,7 @@ install-via-setup: install-subpackages-via-setup
 	mv $(DESTDIR)/$(PREFIX)/bin/rhsmcertd-worker $(DESTDIR)/$(LIBEXEC_DIR)/
 	mv $(DESTDIR)/$(PREFIX)/bin/rhsm-service $(DESTDIR)/$(LIBEXEC_DIR)/
 	mv $(DESTDIR)/$(PREFIX)/bin/rhsm-facts-service $(DESTDIR)/$(LIBEXEC_DIR)/
+	mv $(DESTDIR)/$(PREFIX)/bin/rhsm-package-profile-uploader $(DESTDIR)/$(LIBEXEC_DIR)/
 	if [[ "$(WITH_SUBMAN_GUI)" == "true" ]]; then \
 		mv $(DESTDIR)/$(PREFIX)/bin/subscription-manager-gui $(DESTDIR)/$(PREFIX)/sbin/; \
 	else \

--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -108,3 +108,4 @@ default_log_level = INFO
 # rhsm = DEBUG
 # rhsm.connection = DEBUG
 # rhsm-app = DEBUG
+# rhsmcertd = DEBUG

--- a/setup.py
+++ b/setup.py
@@ -423,6 +423,7 @@ setup(
             'rhsm-facts-service = subscription_manager.scripts.rhsm_facts_service:main',
             'rhsm-service = subscription_manager.scripts.rhsm_service:main',
             'rhsmcertd-worker = subscription_manager.scripts.rhsmcertd_worker:main',
+            'rhsm-package-profile-uploader = subscription_manager.scripts.package_profile_upload:main',
         ],
         'gui_scripts': [
             'subscription-manager-gui = subscription_manager.scripts.subscription_manager_gui:main',

--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -19,6 +19,8 @@
 #include <linux/version.h>
 #include <sys/file.h>
 #include <sys/syscall.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <stdlib.h>
 #include <signal.h>
 #include <stdio.h>
@@ -34,7 +36,8 @@
 #include <libintl.h>
 #include <locale.h>
 
-#define LOGFILE "/var/log/rhsm/rhsmcertd.log"
+#define LOGDIR "/var/log/rhsm"
+#define LOGFILE LOGDIR"/rhsmcertd.log"
 #define LOCKFILE "/var/lock/subsys/rhsmcertd"
 #define NEXT_CERT_UPDATE_FILE "/run/rhsm/next_cert_check_update"
 #define NEXT_AUTO_ATTACH_UPDATE_FILE "/run/rhsm/next_auto_attach_update"
@@ -162,7 +165,14 @@ r_log (const char *level, const char *message, ...)
 {
     bool use_stdout = false;
     va_list argp;
-    FILE *log_file = fopen (LOGFILE, "a");
+    FILE *log_file = NULL;
+    struct stat log_dir_stat;
+
+    /* When log directory does not exist, then try to create this directory */
+    if (stat(LOGDIR, &log_dir_stat) != 0) {
+        mkdir(LOGDIR, 0755);
+    }
+    log_file = fopen (LOGFILE, "a");
     if (!log_file) {
         // redirect message to stdout
         log_file = stdout;

--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -58,6 +58,10 @@
 
 #define MAX_AUTO_REGISTER_ATTEMPTS 3
 
+#if !GLIB_CHECK_VERSION(2, 58, 0)
+#define G_SOURCE_FUNC(f) ((GSourceFunc) (void (*)(void)) (f))
+#endif
+
 #if defined(__linux)
 # if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 #  ifdef HAVE_LINUX_GETRANDOM

--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -52,7 +52,6 @@ typedef enum {
 #define WORKER LIBEXECDIR"/rhsmcertd-worker"
 #define WORKER_NAME WORKER
 #define PACKAGE_PROFILE_UPLOADER LIBEXECDIR"/rhsm-package-profile-uploader"
-#define PACKAGE_PROFILE_UPLOADER_NAME PACKAGE_PROFILE_UPLOADER
 #define INITIAL_DELAY_SECONDS 120
 #define DEFAULT_AUTO_REG_INTERVAL_SECONDS 3600 /* 1 hour */
 #define DEFAULT_CERT_INTERVAL_SECONDS 14400    /* 4 hours */
@@ -254,13 +253,15 @@ long long gen_random(long long max) {
 /**
  * Try to run Python script package-profile-uploader. This script tries to upload DNF profile
  * to server, when server supports profile. New process is spawned in blocking way.
+ * Note: this script is spawned with --force-upload. Thus report_package_config configuration
+ * option is ignored and this configuration option should be checked before using this approach.
  * @return Return true, when uploading was successful. Otherwise, return false.
  */
 static gboolean
 upload_package_profile ()
 {
     gboolean ret;
-    const char * argv[] = {PACKAGE_PROFILE_UPLOADER, NULL};
+    const char * argv[] = {PACKAGE_PROFILE_UPLOADER, "--force-upload", NULL};
     gchar *standard_output = NULL;
     gchar *standard_error = NULL;
     gint wait_status = 0;

--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -36,6 +36,13 @@
 #include <libintl.h>
 #include <locale.h>
 
+typedef enum {
+    LOG_LEVEL_ERROR = 0,
+    LOG_LEVEL_WARNING = 1,
+    LOG_LEVEL_INFO = 2,
+    LOG_LEVEL_DEBUG = 3
+} LOG_LEVEL;
+
 #define LOGDIR "/var/log/rhsm"
 #define LOGFILE LOGDIR"/rhsmcertd.log"
 #define LOCKFILE "/var/lock/subsys/rhsmcertd"
@@ -52,6 +59,8 @@
 #define DEFAULT_HEAL_INTERVAL_SECONDS 86400    /* 24 hours */
 #define DEFAULT_SPLAY_ENABLED true
 #define DEFAULT_AUTO_REGISTRATION false
+#define DEFAULT_LOG_LEVEL LOG_LEVEL_INFO
+#define DEFAULT_LOG_LEVEL_NAME "INFO"
 #define BUF_MAX 256
 #define RHSM_CONFIG_FILE "/etc/rhsm/rhsm.conf"
 
@@ -80,6 +89,7 @@
 # endif
 #endif
 
+static LOG_LEVEL log_level = DEFAULT_LOG_LEVEL;
 static gboolean show_debug = FALSE;
 static gboolean run_now = FALSE;
 static gint arg_cert_interval_minutes = -1;
@@ -191,10 +201,10 @@ r_log (const char *level, const char *message, ...)
     va_end(argp);
 }
 
-#define info(msg, ...) r_log ("INFO", msg, ##__VA_ARGS__)
-#define warn(msg, ...) r_log ("WARN", msg, ##__VA_ARGS__)
-#define error(msg, ...) r_log ("ERROR", msg, ##__VA_ARGS__)
-#define debug(msg, ...) if (show_debug) r_log ("DEBUG", msg, ##__VA_ARGS__)
+#define error(msg, ...) if (log_level >= LOG_LEVEL_ERROR) r_log ("ERROR", msg, ##__VA_ARGS__)
+#define warn(msg, ...) if (log_level >= LOG_LEVEL_WARNING) r_log ("WARN", msg, ##__VA_ARGS__)
+#define info(msg, ...) if (log_level >= LOG_LEVEL_INFO) r_log ("INFO", msg, ##__VA_ARGS__)
+#define debug(msg, ...) if (log_level >= LOG_LEVEL_DEBUG) r_log ("DEBUG", msg, ##__VA_ARGS__)
 
 static gboolean
 log_update (int delay, char *path_to_file)
@@ -455,8 +465,10 @@ cert_check (gboolean heal)
     }
     if (pid == 0) {
         if (heal) {
+            debug ("(Auto-attach) executing: %s --autoheal", WORKER);
             execl (WORKER, WORKER_NAME, "--autoheal", NULL);
         } else {
+            debug ("(Cert check) executing: %s", WORKER);
             execl (WORKER, WORKER_NAME, NULL);
         }
         _exit (errno);
@@ -532,6 +544,7 @@ get_int_from_config_file (GKeyFile * key_file, const char *group, const char *ke
     int value = g_key_file_get_integer (key_file, group, key, &error);
     // If key does not exist in config file, return CONFIG_KEY_NOT_FOUND, aka 0
     if (error != NULL && error->code == G_KEY_FILE_ERROR_KEY_NOT_FOUND) {
+        debug ("Key %s does not exists in the group %s", key, group);
         value = CONFIG_KEY_NOT_FOUND;
     }
     // Get the integer value from the config file. If value is 0 (due
@@ -553,13 +566,29 @@ get_int_from_config_file (GKeyFile * key_file, const char *group, const char *ke
 
 // Similar to the above,
 bool
-get_bool_from_config_file (GKeyFile * key_file, const char *group, const char *key, bool default_value)
+get_bool_from_config_file (GKeyFile *key_file, const char *group, const char *key, bool default_value)
 {
     GError *error = NULL;
     bool value = g_key_file_get_boolean (key_file, group, key, &error);
-        // If key does not exist in config file, return the default_value given
+    // If key does not exist in config file, return the default_value given
     if (error != NULL && (error->code == G_KEY_FILE_ERROR_KEY_NOT_FOUND || error->code == G_KEY_FILE_ERROR_INVALID_VALUE)) {
+        debug ("Key %s does not exists in the group %s. Using default value: %d", key, group, default_value);
         value = default_value;
+    }
+    return value;
+}
+
+gchar *
+get_string_from_config_file (GKeyFile *key_file, const char *group, const char *key)
+{
+    GError *error = NULL;
+    gchar *value = g_key_file_get_string (key_file, group, key, &error);
+    if (error != NULL) {
+        if (error->code == G_KEY_FILE_ERROR_GROUP_NOT_FOUND) {
+            debug ("Group %s does not exist", group);
+        } else if (error->code == G_KEY_FILE_ERROR_KEY_NOT_FOUND) {
+            debug ("Key %s does not exists in the group %s", key, group);
+        }
     }
     return value;
 }
@@ -585,6 +614,32 @@ print_argument_error (const char *message, ...)
     vprintf(message, argp);
     printf(N_("For more information run: rhsmcertd --help\n"));
     va_end(argp);
+}
+
+void
+set_log_level (const gchar *conf_log_level, const char *conf_option_name)
+{
+    bool using_default_log_level = false;
+    if (g_strcmp0(conf_log_level, "DEBUG") == 0) {
+        log_level = LOG_LEVEL_DEBUG;
+    } else if (g_strcmp0(conf_log_level, "INFO") == 0) {
+        log_level = LOG_LEVEL_INFO;
+    } else if (g_strcmp0(conf_log_level, "WARN") == 0) {
+        log_level = LOG_LEVEL_WARNING;
+    } else if (g_strcmp0(conf_log_level, "ERROR") == 0) {
+        log_level = LOG_LEVEL_ERROR;
+    } else {
+        warn ("Unsupported log level: %s of configuration option: %s in file: %s",
+              conf_log_level, conf_option_name, RHSM_CONFIG_FILE);
+        log_level = DEFAULT_LOG_LEVEL;
+        using_default_log_level = true;
+    }
+    if (using_default_log_level == false) {
+        debug ("Using log level: %s of configuration option: %s in file: %s",
+               conf_log_level, conf_option_name, RHSM_CONFIG_FILE);
+    } else {
+        info ("Using default log level: %s", DEFAULT_LOG_LEVEL_NAME);
+    }
 }
 
 void
@@ -636,6 +691,37 @@ key_file_init_config (Config * config, GKeyFile * key_file)
             DEFAULT_AUTO_REGISTRATION
             );
     config->auto_registration = auto_registration_enabled;
+
+    gchar *default_log_level = get_string_from_config_file(
+            key_file,
+            "logging",
+            "default_log_level"
+    );
+
+    gchar *rhsmcertd_log_level = get_string_from_config_file(
+            key_file,
+            "logging",
+            "rhsmcertd"
+    );
+
+    if (show_debug) {
+        // When --debug CLI option is used, then ignore configuration options related to logging, and
+        // print debug log about it
+        if (rhsmcertd_log_level != NULL) {
+            debug("Ignoring logging.rhsmcertd configuration option, because --debug CLI option was used");
+        } else if (default_log_level != NULL) {
+            debug("Ignoring logging.default_log_level configuration option, because --debug CLI option was used");
+        }
+    } else {
+        if (rhsmcertd_log_level != NULL) {
+            set_log_level(rhsmcertd_log_level, "logging.rhsmcertd");
+        } else if (default_log_level != NULL) {
+            set_log_level(default_log_level, "logging.default_log_level");
+        }
+    }
+
+    g_free(default_log_level);
+    g_free(rhsmcertd_log_level);
 }
 
 void
@@ -709,7 +795,7 @@ get_config (int argc, char *argv[])
     }
     g_key_file_free (key_file);
 
-    // Set any values provided from the options parser.
+    // Set any values provided from the option parser.
     bool options_provided = opt_parse_init_config (config);
 
     // If there are any args that were ignored by opt_parse, we assume
@@ -758,6 +844,13 @@ parse_cli_args (int *argc, char *argv[])
                 argv[i]);
             exit (EXIT_FAILURE);
         }
+    }
+
+    // When --debug CLI option is set, then set log_level to DEBUG now, because
+    // 1. we want to override configuration options from rhsm.conf
+    // 2. we want to see debug messages during parsing of configuration file
+    if (show_debug) {
+        log_level = LOG_LEVEL_DEBUG;
     }
 }
 

--- a/src/daemons/rhsmcertd.c
+++ b/src/daemons/rhsmcertd.c
@@ -27,6 +27,7 @@
 #include <time.h>
 #include <wait.h>
 #include <glib.h>
+#include <glib-unix.h>
 #include <stdbool.h>
 #include <string.h>
 #include <errno.h>
@@ -40,6 +41,8 @@
 #define NEXT_AUTO_REGISTER_UPDATE_FILE "/run/rhsm/next_auto_register_update"
 #define WORKER LIBEXECDIR"/rhsmcertd-worker"
 #define WORKER_NAME WORKER
+#define PACKAGE_PROFILE_UPLOADER LIBEXECDIR"/rhsm-package-profile-uploader"
+#define PACKAGE_PROFILE_UPLOADER_NAME PACKAGE_PROFILE_UPLOADER
 #define INITIAL_DELAY_SECONDS 120
 #define DEFAULT_AUTO_REG_INTERVAL_SECONDS 3600 /* 1 hour */
 #define DEFAULT_CERT_INTERVAL_SECONDS 14400    /* 4 hours */
@@ -224,21 +227,134 @@ long long gen_random(long long max) {
     return random_num % true_max;
 }
 
-/* Handle program signals */
-void
-signal_handler(int signo) {
-    if (signo == SIGTERM) {
-        /* Close lock file and release lock on this file */
-        if (fd_lock != -1) {
-            close(fd_lock);
-            fd_lock = -1;
-        }
-        info ("rhsmcertd is shutting down...");
-        signal (signo, SIG_DFL);
-        raise (signo);
+/**
+ * Try to run Python script package-profile-uploader. This script tries to upload DNF profile
+ * to server, when server supports profile. New process is spawned in blocking way.
+ * @return Return true, when uploading was successful. Otherwise, return false.
+ */
+static gboolean
+upload_package_profile ()
+{
+    gboolean ret;
+    const char * argv[] = {PACKAGE_PROFILE_UPLOADER, NULL};
+    gchar *standard_output = NULL;
+    gchar *standard_error = NULL;
+    gint wait_status = 0;
+    GError *error = NULL;
+
+    debug ("Spawning new process of uploading package profile...");
+
+    // Following function will block until process is finished. Other signals
+    // are queued and will be processed, when following process is finished.
+    // It means other signals (SIGTERM) are blocked too. systemd can resolve
+    // this issue. When sending SIGTERM does not terminate daemon, then it
+    // sends SIGKILL signal after some timeout.
+    ret = g_spawn_sync(
+            "/",                // Working directory
+            (gchar**)argv,      // Executable with arguments
+            NULL,               // List of environments is read from parent process
+            G_SPAWN_DEFAULT,    // Default flags
+            NULL,               // No function running before spawning process
+            NULL,               // No argument for such function is needed as well
+            &standard_output,   // stdout if any
+            &standard_error,    // stderr if any
+            &wait_status,       // status if any
+            &error);            // Error if any
+
+    debug ("Spawning of uploading package profile finished: %d", ret);
+
+    // Print stdout/stderr to log file only in the case, when stdout/stderr are not empty strings
+    if (standard_output != NULL && standard_output[0] != 0) {
+        debug ("stdout of uploading package profile: %s", standard_output);
+        g_free(standard_output);
+        standard_output = NULL;
     }
+    if (standard_error != NULL && standard_error[0] != 0) {
+        debug ("stderr of uploading package profile: %s", standard_error);
+        g_free(standard_error);
+        standard_error = NULL;
+    }
+
+    // Error is usually not NULL, when it wasn't possible to span child process
+    // for some reason (e.g. file does not exist)
+    if (error != NULL) {
+        error ("Spawning of child process (uploading profile) failed: %s", error->message);
+        g_error_free(error);
+        error = NULL;
+        return false;
+    }
+
+#if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION >= 70
+    // Following function is available since Fedora 35 (not RHEL7, RHEL8, RHEL9)
+    ret = g_spawn_check_wait_status(wait_status, &error);
+#else
+    // Following function is available on RHEL7, RHEL8, RHEL9 (not RHEL6),
+    // and it was deprecated on Fedora 35
+    ret = g_spawn_check_exit_status(wait_status, &error);
+#endif
+
+    if (error != NULL) {
+        error ("Child process exited abnormally: %s", error->message);
+        g_error_free(error);
+        error = NULL;
+        return false;
+    }
+
+    info ("Uploading of package profile performed successfully");
+
+    return ret;
 }
 
+/**
+ * Callback function for SIGUSR1 signal
+ * @return Always returns G_SOURCE_CONTINUE
+ */
+gboolean
+sigusr1_callback(void) {
+    debug ("Received SIGUSR1 signal");
+    upload_package_profile();
+    // Return this value to signal that this callback function
+    // should remain in main loop
+    return G_SOURCE_CONTINUE;
+}
+
+/**
+ * Callback function for SIGTERM signal
+ * @return Always returns G_SOURCE_REMOVE
+ */
+gboolean
+sigterm_callback(void) {
+    int ret;
+    info ("rhsmcertd is shutting down...");
+    /* Close lock file and release lock on this file */
+    if (fd_lock != -1) {
+        /* Truncate lock file to zero value (delete PID before unlinking),
+         * because unlinking could fail for several reasons. Thus, it should not
+         * contain at least non-valid value of PID. */
+        ret = ftruncate(fd_lock, 0);
+        if (ret == -1) {
+            warn ("Unable to truncate lock file: %s, %s", LOCKFILE, strerror (errno));
+        }
+        close(fd_lock);
+        fd_lock = -1;
+    }
+    /* Try to delete lock file */
+    ret = unlink(LOCKFILE);
+    if (ret == -1) {
+        error ("Unable to unlink lock file: %s, %s", LOCKFILE, strerror(errno));
+    }
+    // Set handler to SIGTERM to default
+    signal (SIGTERM, SIG_DFL);
+    // Raise the signal once again to terminate this process
+    raise (SIGTERM);
+    return G_SOURCE_REMOVE;
+}
+
+/**
+ * Try to lock file /var/lock/subsys/rhsmcertd and write current PID to this file
+ * @return Return 0, when it was possible lock file and write PID to lock file.
+ *         Otherwise, return non-zero value.
+ */
 int
 get_lock ()
 {
@@ -246,12 +362,24 @@ get_lock ()
     int ret = 0;
 
     if (fd_lock == -1) {
+        error ("Unable to open file: %s, %s", LOCKFILE, strerror(errno));
         ret = 1;
     } else {
         if (flock (fd_lock, LOCK_EX | LOCK_NB) == -1) {
+            debug ("Unable to lock file: %s, %s", LOCKFILE, strerror(errno));
             close (fd_lock);
             fd_lock = -1;
-            ret = 1;
+            ret = 2;
+        } else {
+            pid_t pid = getpid ();
+            debug ("Writing PID: %d to lock file: %s", pid, LOCKFILE);
+            /* Lock file in /var/lock should use HDB UUCP lock file format. More details could be found here:
+             * https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s09.html */
+            int num = dprintf (fd_lock, "%10d\n", pid);
+            if (num < 0) {
+                error ("Unable to write PID to lock file: %s, %s", LOCKFILE, strerror (errno));
+                ret = 3;
+            }
         }
     }
 
@@ -622,9 +750,6 @@ parse_cli_args (int *argc, char *argv[])
 int
 main (int argc, char *argv[])
 {
-    if (signal(SIGTERM, signal_handler) == SIG_ERR) {
-        warn ("Unable to catch SIGTERM\n");
-    }
     setlocale (LC_ALL, "");
     bindtextdomain ("rhsm", "/usr/share/locale");
     textdomain ("rhsm");
@@ -645,9 +770,27 @@ main (int argc, char *argv[])
         return EXIT_FAILURE;
 
     if (get_lock () != 0) {
-        error ("unable to get lock, exiting");
+        error ("Unable to get lock, exiting");
         return EXIT_FAILURE;
     }
+
+    // NOTE: it is important to create callback function for signals after calling daemon()
+    // Create main context for main loop
+    GMainContext *main_context;
+    main_context = g_main_context_default ();
+
+    // Create sources for handling SIGUSR1 and SIGTERM signal
+    GSource *sigusr1_source, *sigterm_source;
+    sigusr1_source = g_unix_signal_source_new (SIGUSR1);
+    sigterm_source = g_unix_signal_source_new (SIGTERM);
+
+    // Attach callback function to the source. We don't pass any data to callback functions
+    g_source_set_callback (sigusr1_source, G_SOURCE_FUNC(sigusr1_callback), NULL, NULL);
+    g_source_set_callback (sigterm_source, G_SOURCE_FUNC(sigterm_callback), NULL, NULL);
+
+    // Attach signal sources to the main_context
+    g_source_attach (sigusr1_source, main_context);
+    g_source_attach (sigterm_source, main_context);
 
     info ("Starting rhsmcertd...");
     if (auto_reg_enabled) {
@@ -764,7 +907,7 @@ main (int argc, char *argv[])
     log_update (cert_check_initial_delay, NEXT_CERT_UPDATE_FILE);
     log_update (auto_attach_initial_delay, NEXT_AUTO_ATTACH_UPDATE_FILE);
 
-    GMainLoop *main_loop = g_main_loop_new (NULL, FALSE);
+    GMainLoop *main_loop = g_main_loop_new (main_context, FALSE);
     g_main_loop_run (main_loop);
     // we will never get past here
 

--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -140,6 +140,7 @@ class ModulesProfile(object):
             self.fix_aws_rhui_repos(base)
 
             try:
+                log.debug("Trying to fill dnf sack object...")
                 base.fill_sack()
             except dnf.exceptions.RepoError as err:
                 log.error("Unable to create sack object: %s" % str(err))

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1911,7 +1911,7 @@ class RegisterCommand(UserPassCommand):
         try:
             profile_mgr = inj.require(inj.PROFILE_MANAGER)
             # 767265: always force an upload of the packages when registering
-            profile_mgr.update_check(self.cp, consumer["uuid"], True)
+            profile_mgr.update_check(self.cp, consumer["uuid"], force=True)
         except RemoteServerException as err:
             # When it is not possible to upload profile ATM, then print only error about this
             # to rhsm.log. The rhsmcertd will try to upload it next time.
@@ -1933,7 +1933,10 @@ class RegisterCommand(UserPassCommand):
             if is_process_running("rhsmcertd", rhsmcertd_pid) is True:
                 # This will only send SIGUSR1 signal, which triggers gathering and uploading
                 # of DNF profile by rhsmcertd. We try to "outsource" this activity to rhsmcertd
-                # server to not block registration process
+                # server to not block registration process.
+                # Note: rhsmcertd tries to upload profile using Python script and this script
+                # is always triggered with --force-upload CLI option. We ignore report_package_config
+                # configure option here due to BZ: 767265
                 log.debug("Sending SIGUSR1 signal to rhsmcertd process")
                 try:
                     os.kill(rhsmcertd_pid, signal.SIGUSR1)

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -632,19 +632,25 @@ def get_process_names():
             match = re.search(proc_name_expr, lines)
             if match:
                 proc_name = match.groupdict().get('proc_name')
+                proc_id = int(subdir)
                 if proc_name:
-                    yield proc_name
+                    yield proc_name, proc_id
 
 
-def is_process_running(process_to_find):
+def is_process_running(process_to_find: str, process_id_to_find: int = None) -> bool:
     """
     Check if process with given name is running
     :param process_to_find: string with process name
+    :param process_id_to_find: int with process ID
     :return: True, when at least one process is running; Otherwise returns False
     """
-    for process_name in get_process_names():
+    for process_name, process_id in get_process_names():
         if process_to_find == process_name:
-            return True
+            if process_id_to_find is None:
+                return True
+            else:
+                if process_id_to_find == process_id:
+                    return True
     return False
 
 

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -607,14 +607,33 @@ def get_process_names():
     for subdir in os.listdir('/proc'):
         if re.match('[0-9]+', subdir):
             process_status_file_path = os.path.join(os.path.sep, 'proc', subdir, 'status')
-            with open(process_status_file_path) as status:
-                lines = "".join(status.readlines())
-                # Find first value of something that looks like "Name: THING"
-                match = re.search(proc_name_expr, lines)
-                if match:
-                    proc_name = match.groupdict().get('proc_name')
-                    if proc_name:
-                        yield proc_name
+            status_file = None
+            lines = ""
+            try:
+                status_file = open(process_status_file_path)
+                lines = "".join(status_file.readlines())
+            except IOError as e:
+                # See https://bugzilla.redhat.com/show_bug.cgi?id=1890080
+                # Sometimes when processes are killed after we have listed the
+                # /proc dir content we can end up trying to open a file which no
+                # longer exists.
+                log.debug("A process has likely ended before it's status could be read for"
+                          " {subdir} : {ex}".format(subdir=subdir, ex=e))
+                continue
+            except Exception as e:
+                log.debug("Unexpected exception while trying to read process names from /proc for"
+                          " {subdir} : {ex}".format(subdir=subdir, ex=e))
+                continue
+            finally:
+                if status_file is not None:
+                    status_file.close()
+
+            # Find first value of something that looks like "Name: THING"
+            match = re.search(proc_name_expr, lines)
+            if match:
+                proc_name = match.groupdict().get('proc_name')
+                if proc_name:
+                    yield proc_name
 
 
 def is_process_running(process_to_find):

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -27,7 +27,6 @@ import signal
 import socket
 import syslog
 import uuid
-import pkg_resources
 
 from six.moves import urllib
 from rhsm.https import ssl
@@ -280,6 +279,8 @@ def get_client_versions():
     try:
         sm_version = subscription_manager.version.rpm_version
         if sm_version is None or sm_version == "None":
+            import pkg_resources
+
             sm_version = pkg_resources.require("subscription-manager")[0].version
     except Exception as e:
         log.debug("Client Versions: Unable to check client versions")

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -930,6 +930,7 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %attr(755,root,root) %{_bindir}/rhsmcertd
 
 %attr(755,root,root) %{_libexecdir}/rhsmcertd-worker
+%attr(755,root,root) %{_libexecdir}/rhsm-package-profile-uploader
 
 
 # our config dirs and files

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -902,18 +902,25 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
             status.write(process_status_contents.format(name=name))
 
     @staticmethod
-    def redirect_open(new_root):
+    def redirect_open(new_root, path_to_error=None):
         """
         Construct a suitable side_effect for a mock of the open builtin
         function, such that any path that is opened is transformed to
         {new_root}/{original_path}
         """
+        if path_to_error is None:
+            path_to_error = {}
+
         def new_open(*args, **kwargs):
             original_path = args[0]
             if original_path.startswith(os.path.sep):
                 original_path = original_path[1:]
+            # Allow our mock open function to be made to raise errors selectively
+            for path in path_to_error.keys():
+                if path in original_path:
+                    print("raise the roof")
+                    raise path_to_error.get(original_path)
             corrected_path = os.path.join(new_root, original_path)
-            print(corrected_path)
             return original_open(corrected_path, *args[1:], **kwargs)
         return new_open
 
@@ -986,6 +993,30 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
         self.create_fake_process_status(name=fake_process_name)
         ld = os.listdir(self.proc_root)
         new_open = self.redirect_open(self.root_dir)
+        os_patch = patch('subscription_manager.utils.os.listdir')
+        m = os_patch.start()
+        m.return_value = ld
+        open_patch = patch(fixture.OPEN_FUNCTION)
+        mopen = open_patch.start()
+        mopen.side_effect = new_open
+        res = get_process_names()
+        res = list(res)
+        self.assertEquals(res, [fake_process_name],
+                          "Expected a list containing '%s', Actual: %s" % (fake_process_name, res))
+
+    def test_get_process_names_ioerror(self):
+        """
+        Test getting list of processes when unable to read one or more of the files
+        """
+        fake_process_name = "magic_process"
+        self.create_fake_process_status(name=fake_process_name)
+        ld = os.listdir(self.proc_root)
+        errors = {
+            "1337": IOError("Cannot access bad_path"),
+            "8675309": Exception("AHHHH")
+        }
+        ld.extend(errors.keys())
+        new_open = self.redirect_open(self.root_dir, path_to_error=errors)
         os_patch = patch('subscription_manager.utils.os.listdir')
         m = os_patch.start()
         m.return_value = ld

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -901,6 +901,8 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
             process_status_contents = "\n".join(process_status_contents)
             status.write(process_status_contents.format(name=name))
 
+        return fake_pid
+
     @staticmethod
     def redirect_open(new_root, path_to_error=None):
         """
@@ -990,7 +992,7 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
         Test getting list of processes
         """
         fake_process_name = "magic_process"
-        self.create_fake_process_status(name=fake_process_name)
+        fake_pid = self.create_fake_process_status(name=fake_process_name)
         ld = os.listdir(self.proc_root)
         new_open = self.redirect_open(self.root_dir)
         os_patch = patch('subscription_manager.utils.os.listdir')
@@ -1001,7 +1003,8 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
         mopen.side_effect = new_open
         res = get_process_names()
         res = list(res)
-        self.assertEquals(res, [fake_process_name],
+        expected_result = [(fake_process_name, fake_pid)]
+        self.assertEquals(res, expected_result,
                           "Expected a list containing '%s', Actual: %s" % (fake_process_name, res))
 
     def test_get_process_names_ioerror(self):
@@ -1009,7 +1012,7 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
         Test getting list of processes when unable to read one or more of the files
         """
         fake_process_name = "magic_process"
-        self.create_fake_process_status(name=fake_process_name)
+        fake_pid = self.create_fake_process_status(name=fake_process_name)
         ld = os.listdir(self.proc_root)
         errors = {
             "1337": IOError("Cannot access bad_path"),
@@ -1025,7 +1028,8 @@ class TestGetProcessNamesAndIsProcessRunning(fixture.SubManFixture):
         mopen.side_effect = new_open
         res = get_process_names()
         res = list(res)
-        self.assertEquals(res, [fake_process_name], "Expected an empty list, Actual: %s" % res)
+        expected_result = [(fake_process_name, fake_pid)]
+        self.assertEquals(res, expected_result, "Expected an empty list, Actual: %s" % res)
 
 
 class TestTerminalPrintableContent(fixture.SubManFixture):


### PR DESCRIPTION
* Backport to 1.28 branch.
  * Original PRs:
    * #3139
    * #3179 
    * #3142
  * Original commits:
    * b70c0d524675a0cb3b7971df56ffcb588ad52df6
    * cc3f24c2107ccf0ed43026d7daceb5e533b8df8d
    * 43e7905cc935226a394832ecb872e94694bbde03
    * 3a8e42afb855f4f7378a862a0445348d14728b49
    * d3075accf0bb3b0c5f49eb185312480f3d6ee620
    * 1bb1850325f9b157b8111e871e1193a33cd7b484
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2132242
* Card ID: ENT-5530
* The subscription-manager tries to upload combined DNF profile at the end of registration process. Gathering of this profile can take very long time. It can be several minutes in some edge cases. This blocked registration process and the activity of gathering DNF profile was not communicated using live status message like other activities.
* This commit uses novel approach. The process of gathering and uploading of DNF process is outsourced to rhsmcertd service. The subscription-manager sends SIGUSR1 signal to rhsmcertd service to trigger gathering and uploading DNF profile. When rhsmcertd is not running, then old blocking approach is used, but this activity is communicated to user using live status message.
* The rhsmcertd can receive SIGUSR1 signal and it starts Python script package-profile-uploader, which is already part of installation.
* The information about rhsmcertd PID is written to lock file of rhsmcertd /var/lock/subsys/rhsmcertd
* When rhsmcertd is shutting down, then it tries to delete lock file
* glib functions are used for handling signals and spawning new process (only uploading of profile ATM).
* Fixes one issue with not supported macro in old glib
* Updated some unit tests
* rhsm-package-profile-uploader is always spawned with --force-upload CLI option
* rhsmcertd reads log levels from rhsm.conf