### PR TITLE
[1.28] ci: install nodejs-npm on Fedora

### DIFF
--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -50,10 +50,20 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
 
-      - name: Install packages
+      - name: Install npm (Fedora)
+        if: ${{ startsWith(matrix.name, 'Fedora') }}
+        run: |
+          dnf --setopt install_weak_deps=False install -y \
+            nodejs-npm
+
+      - name: Install npm (CentOS)
+        if: ${{ startsWith(matrix.name, 'CentOS') }}
         run: |
           dnf --setopt install_weak_deps=False install -y \
             npm
+
+      - name: Install packages
+        run: |
           dnf --setopt install_weak_deps=False builddep -y \
             -D '%global python3_pkgversion 3' \
             subscription-manager.spec


### PR DESCRIPTION
"npm" recently became broken in Fedora and doesn't provide the "npm"
binary any more. As a workaround, switch the "npm" build dependency to
"nodejs-npm" on Fedora to fix the build with tito.

Split the npm installation to a separate step, so "npm" is still 
installed on CentOS.