### PR TITLE
dbus: don't catch exceptions in DomainSocketServer.run()

### DIFF
--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -327,16 +327,13 @@ class DomainSocketServer:
         self.cmd_line = None
 
     def run(self):
-        try:
-            self._server = dbus.server.Server(self._server_socket)
+        self._server = dbus.server.Server(self._server_socket)
 
-            for clazz in self.object_classes:
-                self._server.on_connection_added.append(
-                    partial(DomainSocketServer.connection_added, self, clazz, self.objects)
-                )
+        for clazz in self.object_classes:
+            self._server.on_connection_added.append(
+                partial(DomainSocketServer.connection_added, self, clazz, self.objects)
+            )
 
-            self._server.on_connection_removed.append(partial(DomainSocketServer.connection_removed, self))
+        self._server.on_connection_removed.append(partial(DomainSocketServer.connection_removed, self))
 
-            return self.address
-        except Exception as e:
-            log.exception(e)
+        return self.address

--- a/test/rhsmlib/dbus/test_server.py
+++ b/test/rhsmlib/dbus/test_server.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2023 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+import dbus
+import logging
+
+from rhsmlib.dbus.server import DomainSocketServer
+
+from test import subman_marker_dbus
+from test.fixture import SubManFixture
+
+# Set DBus mainloop early in test run (test import time!)
+dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+log = logging.getLogger(__name__)
+
+
+@subman_marker_dbus
+class TestDomainSocketServer(SubManFixture):
+    def test_unix_socket_invalid_path(self):
+        server = DomainSocketServer()
+        # force an unix socket in all the cases
+        server._server_socket_iface = "unix:dir="
+        # force an invalid path
+        server._server_socket_path = "/i-dont-exists/really"
+        with self.assertRaises(dbus.exceptions.DBusException):
+            path = server.run()
+            self.assertIsNotNone(path)


### PR DESCRIPTION
Catching all the exceptions in `DomainSocketServer.run()` has two big drawbacks in case anything in it fails:
- the error is logged, and then nothing is done with it
- callers of it cannot even know that an issue happened
- even worse: `run()` returns a string in case of no errors, whereas the exception case did not return anything (thus None), causing type issues in callers

The only user of `DomainSocketServer` is `RegisterDBusObject`, and all the D-Bus methods already catch all the exceptions that happen during their execution (turning them into D-Bus exceptions). Hence, it is possible to safely drop all the exception handling in `DomainSocketServer.run()`, letting errors that happen in it properly propagate back as error reply to D-Bus.