### PR TITLE
ci: stop testing on Fedora Rawhide

### DIFF
--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -18,8 +18,6 @@ jobs:
             image: "quay.io/centos/centos:stream8"
           - name: "Fedora latest"
             image: "fedora:latest"
-          - name: "Fedora Rawhide"
-            image: "fedora:rawhide"
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,9 +25,6 @@ jobs:
           - name: "Fedora latest"
             image: "fedora:latest"
             pytest_args: ''
-          - name: "Fedora Rawhide"
-            image: "fedora:rawhide"
-            pytest_args: ''
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -18,8 +18,6 @@ jobs:
             image: "quay.io/centos/centos:stream9"
           - name: "Fedora latest"
             image: "fedora:latest"
-          - name: "Fedora Rawhide"
-            image: "fedora:rawhide"
 
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
While testing on Rawhide it can be a good idea for the 'main' branch, it can be potentially unstable, and this kind of instabilities are not something we'd like in a stable branch (targeted at RHEL 8, even).

Hence, disable testing on Fedora Rawhide.