### PR TITLE
[1.28] Prevent Mock failures for ModulesProfile tests

### DIFF
--- a/test/cloud_what/test_cloud_what.py
+++ b/test/cloud_what/test_cloud_what.py
@@ -128,10 +128,7 @@ class TestAWSCloudProvider(unittest.TestCase):
     Class used for testing of AWS cloud provider
     """
 
-    def setUp(self) -> None:
-        """
-        Destroy instance of singleton and set instance not initialized
-        """
+    def tearDown(self) -> None:
         aws.AWSCloudProvider._instance = None
         aws.AWSCloudProvider._initialized = False
 
@@ -600,11 +597,13 @@ class TestAzureCloudProvider(unittest.TestCase):
         """
         Patch communication with metadata provider
         """
-        azure.AzureCloudProvider._instance = None
-        azure.AzureCloudProvider._initialized = False
         requests_patcher = patch('cloud_what._base_provider.requests')
         self.requests_mock = requests_patcher.start()
         self.addCleanup(requests_patcher.stop)
+
+    def tearDown(self) -> None:
+        azure.AzureCloudProvider._instance = None
+        azure.AzureCloudProvider._initialized = False
 
     def test_azure_cloud_provider_id(self):
         """
@@ -837,11 +836,13 @@ class TestGCPCloudProvider(unittest.TestCase):
         """
         Patch communication with metadata provider
         """
-        gcp.GCPCloudProvider._instance = None
-        gcp.GCPCloudProvider._initialized = False
         requests_patcher = patch('cloud_what._base_provider.requests')
         self.requests_mock = requests_patcher.start()
         self.addCleanup(requests_patcher.stop)
+
+    def tearDown(self) -> None:
+        gcp.GCPCloudProvider._instance = None
+        gcp.GCPCloudProvider._initialized = False
 
     def test_gcp_cloud_provider_id(self):
         """
@@ -1011,13 +1012,6 @@ class TestCloudProvider(unittest.TestCase):
         """
         Set up two mocks that are used in all tests
         """
-        aws.AWSCloudProvider._instance = None
-        aws.AWSCloudProvider._initialized = False
-        azure.AzureCloudProvider._instance = None
-        azure.AzureCloudProvider._initialized = False
-        gcp.GCPCloudProvider._instance = None
-        gcp.GCPCloudProvider._initialized = False
-
         host_collector_patcher = patch('cloud_what.provider.HostCollector')
         self.host_collector_mock = host_collector_patcher.start()
         self.host_fact_collector_instance = Mock()
@@ -1037,6 +1031,14 @@ class TestCloudProvider(unittest.TestCase):
         self.requests_patcher = patch('cloud_what._base_provider.requests')
         self.azure_requests_mock = self.requests_patcher.start()
         self.addCleanup(self.requests_patcher.stop)
+
+    def tearDown(self) -> None:
+        aws.AWSCloudProvider._instance = None
+        aws.AWSCloudProvider._initialized = False
+        azure.AzureCloudProvider._instance = None
+        azure.AzureCloudProvider._initialized = False
+        gcp.GCPCloudProvider._instance = None
+        gcp.GCPCloudProvider._initialized = False
 
     def test_detect_cloud_provider_aws(self):
         """

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -8,6 +8,8 @@ import six
 import sys
 import tempfile
 
+from cloud_what.providers import aws, azure, gcp
+
 try:
     import unittest2 as unittest
 except ImportError:
@@ -296,6 +298,13 @@ class SubManFixture(unittest.TestCase):
             # Assuming these are tempfile.NamedTemporaryFile, created with
             # the write_tempfile() method in this class.
             f.close()
+
+        aws.AWSCloudProvider._instance = None
+        aws.AWSCloudProvider._initialized = False
+        azure.AzureCloudProvider._instance = None
+        azure.AzureCloudProvider._initialized = False
+        gcp.GCPCloudProvider._instance = None
+        gcp.GCPCloudProvider._initialized = False
 
     def write_tempfile(self, contents):
         """

--- a/test/rhsm/unit/test_profile.py
+++ b/test/rhsm/unit/test_profile.py
@@ -15,6 +15,7 @@ import unittest
 import mock
 from mock import patch
 
+from cloud_what.providers import aws, azure, gcp
 from rhsm.profile import ModulesProfile, EnabledReposProfile
 
 
@@ -32,6 +33,14 @@ class TestModulesProfile(unittest.TestCase):
         libdnf_patcher = patch("rhsm.profile.libdnf")
         self.libdnf_mock = libdnf_patcher.start()
         self.addCleanup(libdnf_patcher.stop)
+
+    def tearDown(self) -> None:
+        aws.AWSCloudProvider._instance = None
+        aws.AWSCloudProvider._initialized = False
+        azure.AzureCloudProvider._instance = None
+        azure.AzureCloudProvider._initialized = False
+        gcp.GCPCloudProvider._instance = None
+        gcp.GCPCloudProvider._initialized = False
 
     def test_default_status(self) -> None:
         """

--- a/test/rhsmlib_test/test_cloud_facts.py
+++ b/test/rhsmlib_test/test_cloud_facts.py
@@ -161,12 +161,6 @@ def mock_prepare_request(request):
 
 class TestCloudCollector(unittest.TestCase):
     def setUp(self):
-        aws.AWSCloudProvider._instance = None
-        aws.AWSCloudProvider._initialized = False
-        azure.AzureCloudProvider._instance = None
-        azure.AzureCloudProvider._initialized = False
-        gcp.GCPCloudProvider._instance = None
-        gcp.GCPCloudProvider._initialized = False
         super(TestCloudCollector, self).setUp()
         self.mock_facts = mock.Mock()
         inj.provide(inj.FACTS, self.mock_facts)
@@ -174,6 +168,14 @@ class TestCloudCollector(unittest.TestCase):
         self.requests_patcher = patch('cloud_what._base_provider.requests')
         self.requests_mock = self.requests_patcher.start()
         self.addCleanup(self.requests_patcher.stop)
+
+    def tearDown(self) -> None:
+        aws.AWSCloudProvider._instance = None
+        aws.AWSCloudProvider._initialized = False
+        azure.AzureCloudProvider._instance = None
+        azure.AzureCloudProvider._initialized = False
+        gcp.GCPCloudProvider._instance = None
+        gcp.GCPCloudProvider._initialized = False
 
     @patch('cloud_what.providers.aws.requests.Session', name='test_get_aws_facts.mock_session_class')
     def test_get_aws_facts(self, mock_session_class):

--- a/test/test_auto_registration.py
+++ b/test/test_auto_registration.py
@@ -101,7 +101,7 @@ def mock_prepare_request(request):
 
 class TestAutomaticRegistration(unittest.TestCase):
 
-    def setUp(self):
+    def tearDown(self):
         aws.AWSCloudProvider._instance = None
         aws.AWSCloudProvider._initialized = False
         azure.AzureCloudProvider._instance = None


### PR DESCRIPTION
Tests for Cloud collector were not properly cleaned up. When they were
run before ModulesProfile tests, they caused them to fail, because they
are altering the global state by manipulating the singleton instances.

---
_Previous description:_

From time to time (`--randomly-seed=571057011`), the four tests in `TestModulesProfile` would fail.

Some AWS test is not properly un-mocked, which causes the tests in
test_profile to fail. It is because the unknown test leaves the global
state dirty, which makes the rest of the code think we are running on
AWS. This makes `AWSCloudProvider.rhui_repos()` iterate over a mock which
does not support it, making it fail.

The traceback is:
```
  ModulesProfile.__init__()
  ModulesProfile.__generate()
  ModulesProfile.fix_aws_rhui_repos(base=$MOCK)
  AWSCloudProvider.rhui_repos(base=$MOCK)

  TypeError: 'Mock' object is not iterable
```