### PR TITLE
[1.28] New extraction for translatable strings

### DIFF
--- a/po/keys.pot
+++ b/po/keys.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-12 16:52+0100\n"
+"POT-Creation-Date: 2023-05-05 09:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -181,120 +181,120 @@ msgstr ""
 msgid "Register System"
 msgstr ""
 
-#: cockpit/src/insights.jsx:84 cockpit/src/insights.jsx:310
+#: cockpit/src/insights.jsx:97 cockpit/src/insights.jsx:323
 msgid "The $0 package is not available from any repository."
 msgstr ""
 
-#: cockpit/src/insights.jsx:87
+#: cockpit/src/insights.jsx:100
 msgid ""
 "The system could not be connected to Insights because installing the $0 "
 "package requires the unexpected removal of other packages."
 msgstr ""
 
-#: cockpit/src/insights.jsx:100
+#: cockpit/src/insights.jsx:113
 msgid "Connecting to Insights"
 msgstr ""
 
-#: cockpit/src/insights.jsx:138
+#: cockpit/src/insights.jsx:151
 msgid ""
 "Proactively identify and remediate threats to security, performance, "
 "availability, and stability with Red Hat Insights — with predictive "
 "analytics, avoid problems and unplanned downtime in your Red Hat environment."
 msgstr ""
 
-#: cockpit/src/insights.jsx:156 cockpit/src/subscriptions-register.jsx:94
+#: cockpit/src/insights.jsx:169 cockpit/src/subscriptions-register.jsx:94
 msgid "The $0 package will be installed."
 msgstr ""
 
-#: cockpit/src/insights.jsx:158
+#: cockpit/src/insights.jsx:171
 msgid "The $0 package and $1 other package will be installed."
 msgid_plural "The $0 package and $1 other packages will be installed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: cockpit/src/insights.jsx:166
+#: cockpit/src/insights.jsx:179
 msgid "$0 package needs to be removed."
 msgid_plural "$0 packages need to be removed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: cockpit/src/insights.jsx:180
+#: cockpit/src/insights.jsx:193
 msgid "Additional packages:"
 msgstr ""
 
-#: cockpit/src/insights.jsx:188
+#: cockpit/src/insights.jsx:201
 msgid "Removals:"
 msgstr ""
 
-#: cockpit/src/insights.jsx:194 cockpit/src/insights.jsx:422
-#: cockpit/src/insights.jsx:427
+#: cockpit/src/insights.jsx:207 cockpit/src/insights.jsx:435
+#: cockpit/src/insights.jsx:440
 msgid "Details"
 msgstr ""
 
-#: cockpit/src/insights.jsx:205 cockpit/src/insights.jsx:216
-#: cockpit/src/insights.jsx:300
+#: cockpit/src/insights.jsx:218 cockpit/src/insights.jsx:229
+#: cockpit/src/insights.jsx:313
 msgid "Waiting for other software management operations to finish"
 msgstr ""
 
-#: cockpit/src/insights.jsx:207 cockpit/src/insights.jsx:302
+#: cockpit/src/insights.jsx:220 cockpit/src/insights.jsx:315
 msgid "Checking installed software"
 msgstr ""
 
-#: cockpit/src/insights.jsx:220
+#: cockpit/src/insights.jsx:233
 msgid "Downloading $0"
 msgstr ""
 
-#: cockpit/src/insights.jsx:222
+#: cockpit/src/insights.jsx:235
 msgid "Removing $0"
 msgstr ""
 
-#: cockpit/src/insights.jsx:224
+#: cockpit/src/insights.jsx:237
 msgid "Installing $0"
 msgstr ""
 
-#: cockpit/src/insights.jsx:241
+#: cockpit/src/insights.jsx:254
 msgid "Connect to Red Hat Insights"
 msgstr ""
 
-#: cockpit/src/insights.jsx:244
+#: cockpit/src/insights.jsx:257
 msgid "This system is not connected to $0."
 msgstr ""
 
-#: cockpit/src/insights.jsx:254
+#: cockpit/src/insights.jsx:267
 msgid "Connect"
 msgstr ""
 
-#: cockpit/src/insights.jsx:344
+#: cockpit/src/insights.jsx:357
 msgid "unknown"
 msgstr ""
 
-#: cockpit/src/insights.jsx:397
+#: cockpit/src/insights.jsx:410
 msgid "The last Insights data upload has failed."
 msgstr ""
 
-#: cockpit/src/insights.jsx:402
+#: cockpit/src/insights.jsx:415
 msgid "Connected to Red Hat Insights"
 msgstr ""
 
-#: cockpit/src/insights.jsx:408
+#: cockpit/src/insights.jsx:421
 msgid "Next Insights data upload"
 msgstr ""
 
-#: cockpit/src/insights.jsx:413
+#: cockpit/src/insights.jsx:426
 msgid "Last Insights data upload"
 msgstr ""
 
-#: cockpit/src/insights.jsx:430 cockpit/src/insights.jsx:434
+#: cockpit/src/insights.jsx:443 cockpit/src/insights.jsx:447
 msgid "Disconnect from Insights"
 msgstr ""
 
-#: cockpit/src/insights.jsx:432
+#: cockpit/src/insights.jsx:445
 msgid ""
 "If you disconnect this system from Insights, it will no longer report it's "
 "Insights status in Red Hat Cloud or Satellite."
 msgstr ""
 
-#: cockpit/src/insights.jsx:442 cockpit/src/insights.jsx:461
+#: cockpit/src/insights.jsx:455 cockpit/src/insights.jsx:474
 #: src/subscription_manager/gui/data/glade/factsdialog.glade:262
 #: src/subscription_manager/gui/data/glade/registration_info.glade:261
 #: src/subscription_manager/gui/data/glade/repositories.glade:276
@@ -304,59 +304,59 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: cockpit/src/insights.jsx:450
+#: cockpit/src/insights.jsx:463
 #: src/subscription_manager/gui/data/glade/redeem.glade:29
 #: src/subscription_manager/gui/data/ui/redeem.ui:29
 msgid "Cancel"
 msgstr ""
 
-#: cockpit/src/insights.jsx:520
+#: cockpit/src/insights.jsx:533
 msgid "No rule hits"
 msgstr ""
 
-#: cockpit/src/insights.jsx:528
+#: cockpit/src/insights.jsx:541
 msgid "$0 critical hit"
 msgid_plural "$0 hits, including critical"
 msgstr[0] ""
 msgstr[1] ""
 
-#: cockpit/src/insights.jsx:533
+#: cockpit/src/insights.jsx:546
 msgid "$0 important hit"
 msgid_plural "$0 hits, including important"
 msgstr[0] ""
 msgstr[1] ""
 
-#: cockpit/src/insights.jsx:538
+#: cockpit/src/insights.jsx:551
 msgid "$0 moderate hit"
 msgid_plural "$0 hits, including moderate"
 msgstr[0] ""
 msgstr[1] ""
 
-#: cockpit/src/insights.jsx:543
+#: cockpit/src/insights.jsx:556
 msgid "$0 low severity hit"
 msgid_plural "$0 low severity hits"
 msgstr[0] ""
 msgstr[1] ""
 
-#: cockpit/src/insights.jsx:549
+#: cockpit/src/insights.jsx:562
 msgid "$0 hit"
 msgid_plural "$0 hits"
 msgstr[0] ""
 msgstr[1] ""
 
-#: cockpit/src/insights.jsx:556
+#: cockpit/src/insights.jsx:569
 msgid "View your Insights results"
 msgstr ""
 
-#: cockpit/src/insights.jsx:562
+#: cockpit/src/insights.jsx:575
 msgid "Connected to Insights"
 msgstr ""
 
-#: cockpit/src/insights.jsx:574
+#: cockpit/src/insights.jsx:587
 msgid "Not connected"
 msgstr ""
 
-#: cockpit/src/insights.jsx:579 cockpit/src/subscriptions-register.jsx:85
+#: cockpit/src/insights.jsx:592 cockpit/src/subscriptions-register.jsx:85
 msgid "Insights"
 msgstr ""
 
@@ -403,21 +403,21 @@ msgstr ""
 #: cockpit/src/subscriptions-view.jsx:139
 #: src/rhsmlib/services/entitlement.py:94
 #: src/rhsmlib/services/syspurpose.py:105
-#: src/subscription_manager/cert_sorter.py:284
+#: src/subscription_manager/cert_sorter.py:289
 #: src/subscription_manager/gui/factsgui.py:94
 #: src/subscription_manager/gui/factsgui.py:119
 #: src/subscription_manager/gui/installedtab.py:214
-#: src/subscription_manager/managercli.py:94
-#: src/subscription_manager/managercli.py:385
-#: src/subscription_manager/managercli.py:388
+#: src/subscription_manager/managercli.py:95
+#: src/subscription_manager/managercli.py:386
 #: src/subscription_manager/managercli.py:389
 #: src/subscription_manager/managercli.py:390
-#: src/subscription_manager/managercli.py:2777
+#: src/subscription_manager/managercli.py:391
+#: src/subscription_manager/managercli.py:2821
 #: src/subscription_manager/reasons.py:109
-#: src/subscription_manager/utils.py:278 src/subscription_manager/utils.py:292
-#: src/subscription_manager/utils.py:294 src/subscription_manager/utils.py:313
-#: src/subscription_manager/utils.py:314 src/subscription_manager/utils.py:315
-#: src/subscription_manager/utils.py:334
+#: src/subscription_manager/utils.py:277 src/subscription_manager/utils.py:293
+#: src/subscription_manager/utils.py:295 src/subscription_manager/utils.py:314
+#: src/subscription_manager/utils.py:315 src/subscription_manager/utils.py:316
+#: src/subscription_manager/utils.py:335
 msgid "Unknown"
 msgstr ""
 
@@ -515,7 +515,7 @@ msgstr ""
 
 #: cockpit/src/subscriptions-view.jsx:111
 #: src/subscription_manager/gui/installedtab.py:222
-#: src/subscription_manager/managercli.py:90
+#: src/subscription_manager/managercli.py:91
 msgid "Subscribed"
 msgstr ""
 
@@ -675,66 +675,66 @@ msgid ""
 "is installed. Reported status: $0 ($1)"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:92
+#: src/daemons/rhsmcertd.c:111
 msgid "deprecated, see --cert-check-interval"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:95
+#: src/daemons/rhsmcertd.c:114
 msgid "interval to run cert check (in minutes)"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:99
+#: src/daemons/rhsmcertd.c:118
 msgid "deprecated, see --auto-attach-interval"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:102
+#: src/daemons/rhsmcertd.c:121
 msgid "interval to run auto-attach (in minutes)"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:105
+#: src/daemons/rhsmcertd.c:124
 msgid "interval to run auto-registration (in minutes)"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:108
+#: src/daemons/rhsmcertd.c:127
 msgid "run the initial checks immediately, with no delay"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:111 src/rhsm_icon/rhsm_icon.c:81
+#: src/daemons/rhsmcertd.c:130
 msgid "show debug messages"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:113
+#: src/daemons/rhsmcertd.c:132
 msgid "do not add an offset to the initial checks."
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:116
+#: src/daemons/rhsmcertd.c:135
 msgid "try to perform auto-registration."
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:442
+#: src/daemons/rhsmcertd.c:616
 #, c-format
 msgid "For more information run: rhsmcertd --help\n"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:502
+#: src/daemons/rhsmcertd.c:733
 msgid "Wrong number of arguments specified.\n"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:578
+#: src/daemons/rhsmcertd.c:809
 msgid "Invalid argument specified.\n"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:584
+#: src/daemons/rhsmcertd.c:815
 #, c-format
 msgid "WARN: Deprecated CLI arguments are being used.\n"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:599
+#: src/daemons/rhsmcertd.c:830
 #, c-format
 msgid "Invalid option: %s\n"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:613
+#: src/daemons/rhsmcertd.c:844
 #, c-format
 msgid "Invalid argument specified: %s\n"
 msgstr ""
@@ -1253,7 +1253,7 @@ msgid "Unknown Certificate Type"
 msgstr ""
 
 #: src/rhsm_debug/debug_commands.py:42
-#: src/subscription_manager/managercli.py:84
+#: src/subscription_manager/managercli.py:85
 msgid ""
 "This system is not yet registered. Try 'subscription-manager register --"
 "help' for more information."
@@ -1301,88 +1301,13 @@ msgstr ""
 msgid "Unable to create zip file of system information: %s"
 msgstr ""
 
-#: src/rhsm_icon/rhsm_icon.c:79
-msgid "how often to check for validity (in seconds; default is one day)"
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:83
-msgid "force display of the icon (expired, partial or warning)"
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:86
-msgid "run the first status check without delay (otherwise wait 4 minutes)"
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:208
-msgid "Register System For Support And Updates"
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:211
-msgid ""
-"In order for Subscription Manager to provide your system with updates, your "
-"system must be registered with the Customer Portal. Please enter your Red "
-"Hat login to ensure your system is up-to-date."
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:216
-msgid "Invalid or Missing Subscriptions"
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:219
-msgid "This system is missing one or more subscriptions."
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:222
-msgid "Partially Entitled Subscriptions"
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:225
-msgid ""
-"This system is missing one or more subscriptions to fully cover its products."
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:229
-msgid "This System's Subscriptions Are About to Expire"
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:232
-msgid "One or more of this system's subscriptions are about to expire."
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:251
-msgid "Remind Me Later"
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:258
-msgid "Register Now"
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:265
-msgid "Manage My Subscriptions..."
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:344
-#, c-format
-msgid "Unknown argument to force-icon: %s\n"
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:384 src/rhsm_icon/rhsm_icon.c:495
-#, c-format
-msgid "Failed to open connection to bus: %s\n"
-msgstr ""
-
-#: src/rhsm_icon/rhsm_icon.c:462
-#, c-format
-msgid "option parsing failed: %s\n"
-msgstr ""
-
-#: src/rhsmlib/dbus/objects/register.py:99
+#: src/rhsmlib/dbus/objects/register.py:105
 #, python-format
 msgid ""
 "User %s is member of more organizations, but no organization was selected"
 msgstr ""
 
-#: src/rhsmlib/dbus/objects/register.py:114
+#: src/rhsmlib/dbus/objects/register.py:120
 #, python-format
 msgid "User %s is not member of any organization"
 msgstr ""
@@ -1406,16 +1331,6 @@ msgstr ""
 msgid "Error: Unable to load bus '{name}'"
 msgstr ""
 
-#: src/rhsmlib/facts/dmiinfo.py:91 src/rhsmlib/facts/dmiinfo.py:130
-#, python-format
-msgid "Error reading system DMI information: %s"
-msgstr ""
-
-#: src/rhsmlib/facts/dmiinfo.py:100
-#, python-format
-msgid "Error reading system DMI information with %s: %s"
-msgstr ""
-
 #: src/rhsmlib/services/entitlement.py:53
 msgid "Date entered is invalid. Date should be in YYYY-MM-DD format (example: "
 msgstr ""
@@ -1432,26 +1347,26 @@ msgstr ""
 #: src/rhsmlib/services/entitlement.py:265
 #: src/subscription_manager/gui/mysubstab.py:297
 #: src/subscription_manager/gui/widgets.py:862
-#: src/subscription_manager/managercli.py:3376
+#: src/subscription_manager/managercli.py:3420
 msgid "Virtual"
 msgstr ""
 
 #: src/rhsmlib/services/entitlement.py:267
 #: src/subscription_manager/gui/mysubstab.py:299
 #: src/subscription_manager/gui/widgets.py:861
-#: src/subscription_manager/managercli.py:3378
+#: src/subscription_manager/managercli.py:3422
 msgid "Physical"
 msgstr ""
 
 #: src/rhsmlib/services/entitlement.py:270
 #: src/subscription_manager/gui/mysubstab.py:302
-#: src/subscription_manager/managercli.py:3381
+#: src/subscription_manager/managercli.py:3425
 msgid "Yes"
 msgstr ""
 
 #: src/rhsmlib/services/entitlement.py:272
 #: src/subscription_manager/gui/mysubstab.py:304
-#: src/subscription_manager/managercli.py:3383
+#: src/subscription_manager/managercli.py:3427
 msgid "No"
 msgstr ""
 
@@ -1479,32 +1394,32 @@ msgid ""
 msgstr ""
 
 #: src/rhsmlib/services/entitlement.py:453
-#: src/subscription_manager/managercli.py:3248
+#: src/subscription_manager/managercli.py:3292
 msgid "Error: --all is only applicable with --available"
 msgstr ""
 
 #: src/rhsmlib/services/entitlement.py:457
-#: src/subscription_manager/managercli.py:3250
+#: src/subscription_manager/managercli.py:3294
 msgid "Error: --ondate is only applicable with --available"
 msgstr ""
 
 #: src/rhsmlib/services/entitlement.py:462
-#: src/subscription_manager/managercli.py:3252
+#: src/subscription_manager/managercli.py:3296
 msgid "Error: --servicelevel is only applicable with --available or --consumed"
 msgstr ""
 
 #: src/rhsmlib/services/entitlement.py:466
-#: src/subscription_manager/managercli.py:3256
+#: src/subscription_manager/managercli.py:3300
 msgid "Error: --match-installed is only applicable with --available"
 msgstr ""
 
 #: src/rhsmlib/services/entitlement.py:470
-#: src/subscription_manager/managercli.py:3258
+#: src/subscription_manager/managercli.py:3302
 msgid "Error: --no-overlap is only applicable with --available"
 msgstr ""
 
 #: src/rhsmlib/services/entitlement.py:475
-#: src/subscription_manager/managercli.py:3260
+#: src/subscription_manager/managercli.py:3304
 msgid ""
 "Error: --pool-only is only applicable with --available and/or --consumed"
 msgstr ""
@@ -1518,12 +1433,12 @@ msgid "This system is already registered. Add force to options to override."
 msgstr ""
 
 #: src/rhsmlib/services/register.py:165
-#: src/subscription_manager/managercli.py:1838
+#: src/subscription_manager/managercli.py:1839
 msgid "Error: system name can not be empty."
 msgstr ""
 
 #: src/rhsmlib/services/register.py:167
-#: src/subscription_manager/managercli.py:1857
+#: src/subscription_manager/managercli.py:1858
 msgid ""
 "Error: Can not force registration while attempting to recover registration "
 "with consumerid. Please use --force without --consumerid to re-register or "
@@ -1531,22 +1446,22 @@ msgid ""
 msgstr ""
 
 #: src/rhsmlib/services/register.py:175
-#: src/subscription_manager/managercli.py:1849
+#: src/subscription_manager/managercli.py:1850
 msgid "Error: Must specify an activation key"
 msgstr ""
 
 #: src/rhsmlib/services/register.py:177
-#: src/subscription_manager/managercli.py:1840
+#: src/subscription_manager/managercli.py:1841
 msgid "Error: Activation keys do not require user credentials."
 msgstr ""
 
 #: src/rhsmlib/services/register.py:179
-#: src/subscription_manager/managercli.py:1842
+#: src/subscription_manager/managercli.py:1843
 msgid "Error: Activation keys can not be used with previously registered IDs."
 msgstr ""
 
 #: src/rhsmlib/services/register.py:182
-#: src/subscription_manager/managercli.py:1844
+#: src/subscription_manager/managercli.py:1845
 msgid "Error: Activation keys do not allow environments to be specified."
 msgstr ""
 
@@ -1571,7 +1486,7 @@ msgid "Not Specified"
 msgstr ""
 
 #: src/rhsmlib/services/syspurpose.py:104
-#: src/subscription_manager/cert_sorter.py:283
+#: src/subscription_manager/cert_sorter.py:288
 msgid "Disabled"
 msgstr ""
 
@@ -1589,8 +1504,7 @@ msgstr ""
 
 #: src/subscription_manager/branding/__init__.py:85
 #: src/subscription_manager/branding/redhat_branding.py:12
-#: src/subscription_manager/managercli.py:3794
-#: src/subscription_manager/migrate/migrate.py:998
+#: src/subscription_manager/managercli.py:3838
 msgid "WARNING"
 msgstr ""
 
@@ -1686,15 +1600,15 @@ msgid ""
 "cache with server."
 msgstr ""
 
-#: src/subscription_manager/cert_sorter.py:280
+#: src/subscription_manager/cert_sorter.py:285
 msgid "Current"
 msgstr ""
 
-#: src/subscription_manager/cert_sorter.py:281
+#: src/subscription_manager/cert_sorter.py:286
 msgid "Insufficient"
 msgstr ""
 
-#: src/subscription_manager/cert_sorter.py:282
+#: src/subscription_manager/cert_sorter.py:287
 msgid "Invalid"
 msgstr ""
 
@@ -3254,7 +3168,7 @@ msgstr ""
 
 #: src/subscription_manager/gui/factsgui.py:153
 #: src/subscription_manager/gui/widgets.py:514
-#: src/subscription_manager/managercli.py:1345
+#: src/subscription_manager/managercli.py:1346
 #: src/subscription_manager/printing_utils.py:167
 #: src/subscription_manager/printing_utils.py:186
 msgid "None"
@@ -3307,7 +3221,7 @@ msgid "Certificate import was successful."
 msgstr ""
 
 #: src/subscription_manager/gui/installedtab.py:193
-#: src/subscription_manager/managercli.py:89
+#: src/subscription_manager/managercli.py:90
 msgid "Future Subscription"
 msgstr ""
 
@@ -3316,7 +3230,7 @@ msgid "Future Subscribed"
 msgstr ""
 
 #: src/subscription_manager/gui/installedtab.py:197
-#: src/subscription_manager/managercli.py:92
+#: src/subscription_manager/managercli.py:93
 msgid "Expired"
 msgstr ""
 
@@ -3327,7 +3241,7 @@ msgstr ""
 
 #: src/subscription_manager/gui/installedtab.py:210
 #: src/subscription_manager/gui/installedtab.py:211
-#: src/subscription_manager/managercli.py:93
+#: src/subscription_manager/managercli.py:94
 msgid "Partially Subscribed"
 msgstr ""
 
@@ -3348,7 +3262,7 @@ msgstr[1] ""
 
 #: src/subscription_manager/gui/installedtab.py:231
 #: src/subscription_manager/gui/installedtab.py:232
-#: src/subscription_manager/managercli.py:91
+#: src/subscription_manager/managercli.py:92
 msgid "Not Subscribed"
 msgstr ""
 
@@ -3536,8 +3450,8 @@ msgstr ""
 #: src/subscription_manager/gui/registergui.py:210
 #: src/subscription_manager/gui/registergui.py:454
 #: src/subscription_manager/gui/registergui.py:1579
-#: src/subscription_manager/managercli.py:2164
-#: src/subscription_manager/utils.py:293
+#: src/subscription_manager/managercli.py:2208
+#: src/subscription_manager/utils.py:294
 msgid "This system is currently not registered."
 msgstr ""
 
@@ -3547,7 +3461,6 @@ msgstr ""
 
 #: src/subscription_manager/gui/registergui.py:388
 #: src/subscription_manager/gui/registergui.py:441
-#: src/subscription_manager/migrate/migrate.py:723
 #, python-format
 msgid "System '%s' successfully registered.\n"
 msgstr ""
@@ -3669,7 +3582,7 @@ msgid "You must enter an activation key."
 msgstr ""
 
 #: src/subscription_manager/gui/registergui.py:1736
-#: src/subscription_manager/gui/registergui.py:2297
+#: src/subscription_manager/gui/registergui.py:2299
 msgid "_Next"
 msgstr ""
 
@@ -3689,7 +3602,7 @@ msgid "Error validating server: %s"
 msgstr ""
 
 #: src/subscription_manager/gui/registergui.py:1839
-#: src/subscription_manager/managercli.py:527
+#: src/subscription_manager/managercli.py:528
 #, python-format
 msgid "Unable to reach the server at %s:%s%s"
 msgstr ""
@@ -3702,7 +3615,7 @@ msgstr ""
 msgid "Server supports environments, but none are available."
 msgstr ""
 
-#: src/subscription_manager/gui/registergui.py:2074
+#: src/subscription_manager/gui/registergui.py:2076
 msgid ""
 "Not all expected subscriptions were attached, see /var/log/rhsm/rhsm.log for "
 "more details."
@@ -3717,8 +3630,8 @@ msgid "No repositories are available without an attached subscription."
 msgstr ""
 
 #: src/subscription_manager/gui/reposgui.py:56
-#: src/subscription_manager/managercli.py:2971
-#: src/subscription_manager/managercli.py:3546
+#: src/subscription_manager/managercli.py:3015
+#: src/subscription_manager/managercli.py:3590
 msgid "Repositories disabled by configuration."
 msgstr ""
 
@@ -3813,7 +3726,7 @@ msgid "Click to Adjust Quantity"
 msgstr ""
 
 #: src/subscription_manager/i18n_argparse.py:38
-#: src/subscription_manager/managercli.py:983
+#: src/subscription_manager/managercli.py:984
 #, python-format
 msgid "%(prog)s [OPTIONS]"
 msgstr ""
@@ -3823,193 +3736,193 @@ msgstr ""
 msgid "{prog}: error: {msg}"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:98
-#: src/subscription_manager/managercli.py:109
-#: src/subscription_manager/managercli.py:151
-msgid "Product Name:"
-msgstr ""
-
 #: src/subscription_manager/managercli.py:99
 #: src/subscription_manager/managercli.py:110
-msgid "Product ID:"
+#: src/subscription_manager/managercli.py:152
+msgid "Product Name:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:100
 #: src/subscription_manager/managercli.py:111
-msgid "Version:"
+msgid "Product ID:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:101
 #: src/subscription_manager/managercli.py:112
-msgid "Arch:"
+msgid "Version:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:102
-#: src/subscription_manager/managercli.py:152
-msgid "Status:"
+#: src/subscription_manager/managercli.py:113
+msgid "Arch:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:103
-#: src/subscription_manager/managercli.py:178
-#: src/subscription_manager/managercli.py:201
-msgid "Status Details:"
+#: src/subscription_manager/managercli.py:153
+msgid "Status:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:104
-#: src/subscription_manager/managercli.py:130
-#: src/subscription_manager/managercli.py:180
-#: src/subscription_manager/managercli.py:203
-msgid "Starts:"
+#: src/subscription_manager/managercli.py:179
+#: src/subscription_manager/managercli.py:202
+msgid "Status Details:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:105
 #: src/subscription_manager/managercli.py:131
 #: src/subscription_manager/managercli.py:181
 #: src/subscription_manager/managercli.py:204
-msgid "Ends:"
+msgid "Starts:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:116
-#: src/subscription_manager/managercli.py:136
-#: src/subscription_manager/managercli.py:166
-#: src/subscription_manager/managercli.py:186
-msgid "Subscription Name:"
+#: src/subscription_manager/managercli.py:106
+#: src/subscription_manager/managercli.py:132
+#: src/subscription_manager/managercli.py:182
+#: src/subscription_manager/managercli.py:205
+msgid "Ends:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:117
 #: src/subscription_manager/managercli.py:137
 #: src/subscription_manager/managercli.py:167
 #: src/subscription_manager/managercli.py:187
-msgid "Provides:"
+msgid "Subscription Name:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:118
 #: src/subscription_manager/managercli.py:138
 #: src/subscription_manager/managercli.py:168
 #: src/subscription_manager/managercli.py:188
-msgid "SKU:"
+msgid "Provides:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:119
 #: src/subscription_manager/managercli.py:139
 #: src/subscription_manager/managercli.py:169
 #: src/subscription_manager/managercli.py:189
-msgid "Contract:"
+msgid "SKU:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:120
-#: src/subscription_manager/managercli.py:172
-#: src/subscription_manager/managercli.py:192
-msgid "Pool ID:"
+#: src/subscription_manager/managercli.py:140
+#: src/subscription_manager/managercli.py:170
+#: src/subscription_manager/managercli.py:190
+msgid "Contract:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:121
 #: src/subscription_manager/managercli.py:173
 #: src/subscription_manager/managercli.py:193
-msgid "Provides Management:"
+msgid "Pool ID:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:122
-msgid "Available:"
+#: src/subscription_manager/managercli.py:174
+#: src/subscription_manager/managercli.py:194
+msgid "Provides Management:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:123
-msgid "Suggested:"
+msgid "Available:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:124
-#: src/subscription_manager/managercli.py:176
-#: src/subscription_manager/managercli.py:196
-msgid "Service Type:"
+msgid "Suggested:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:125
+#: src/subscription_manager/managercli.py:177
 #: src/subscription_manager/managercli.py:197
-msgid "Roles:"
+msgid "Service Type:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:126
-#: src/subscription_manager/managercli.py:140
-#: src/subscription_manager/managercli.py:177
 #: src/subscription_manager/managercli.py:198
-msgid "Service Level:"
+msgid "Roles:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:127
+#: src/subscription_manager/managercli.py:141
+#: src/subscription_manager/managercli.py:178
 #: src/subscription_manager/managercli.py:199
-msgid "Usage:"
+msgid "Service Level:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:128
 #: src/subscription_manager/managercli.py:200
-msgid "Add-ons:"
+msgid "Usage:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:129
-#: src/subscription_manager/managercli.py:179
-#: src/subscription_manager/managercli.py:202
+#: src/subscription_manager/managercli.py:201
+msgid "Add-ons:"
+msgstr ""
+
+#: src/subscription_manager/managercli.py:130
+#: src/subscription_manager/managercli.py:180
+#: src/subscription_manager/managercli.py:203
 msgid "Subscription Type:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:132
-#: src/subscription_manager/managercli.py:205
+#: src/subscription_manager/managercli.py:133
+#: src/subscription_manager/managercli.py:206
 msgid "Entitlement Type:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:144
+#: src/subscription_manager/managercli.py:145
 msgid "Repo ID:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:145
+#: src/subscription_manager/managercli.py:146
 msgid "Repo Name:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:146
+#: src/subscription_manager/managercli.py:147
 msgid "Repo URL:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:147
+#: src/subscription_manager/managercli.py:148
 msgid "Enabled:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:156
-#: src/subscription_manager/managercli.py:161
+#: src/subscription_manager/managercli.py:157
+#: src/subscription_manager/managercli.py:162
 msgid "Name:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:157
+#: src/subscription_manager/managercli.py:158
 msgid "Description:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:162
+#: src/subscription_manager/managercli.py:163
 msgid "Key:"
-msgstr ""
-
-#: src/subscription_manager/managercli.py:170
-#: src/subscription_manager/managercli.py:190
-msgid "Account:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:171
 #: src/subscription_manager/managercli.py:191
-msgid "Serial:"
+msgid "Account:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:174
-#: src/subscription_manager/managercli.py:194
-msgid "Active:"
+#: src/subscription_manager/managercli.py:172
+#: src/subscription_manager/managercli.py:192
+msgid "Serial:"
 msgstr ""
 
 #: src/subscription_manager/managercli.py:175
 #: src/subscription_manager/managercli.py:195
+msgid "Active:"
+msgstr ""
+
+#: src/subscription_manager/managercli.py:176
+#: src/subscription_manager/managercli.py:196
 msgid "Quantity Used:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:182
+#: src/subscription_manager/managercli.py:183
 msgid "System Type:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:208
+#: src/subscription_manager/managercli.py:209
 #, python-brace-format
 msgid ""
 "Warning: A {attr} of \"{download_value}\" was recently set for this system "
@@ -4017,162 +3930,162 @@ msgid ""
 "{advice}"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:210
+#: src/subscription_manager/managercli.py:211
 #, python-brace-format
 msgid "If you'd like to overwrite the server side change please run: {command}"
 msgstr ""
 
 #. TRANSLATORS: this refers to a deprecated command
-#: src/subscription_manager/managercli.py:213
+#: src/subscription_manager/managercli.py:214
 msgid "Deprecated, see 'syspurpose'"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:252
+#: src/subscription_manager/managercli.py:253
 msgid "No products installed."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:256
+#: src/subscription_manager/managercli.py:257
 msgid "Installed Product Current Status:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:267
+#: src/subscription_manager/managercli.py:268
 msgid "Unable to find available subscriptions for all your installed products."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:321
+#: src/subscription_manager/managercli.py:322
 #, python-brace-format
 msgid ""
 "Ignoring the request to auto-attach. Attaching subscriptions is disabled for "
 "organization \"{owner_id}\" because Simple Content Access (SCA) is enabled."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:337
+#: src/subscription_manager/managercli.py:338
 msgid "server URL in the form of https://hostname:port/prefix"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:339
+#: src/subscription_manager/managercli.py:340
 msgid ""
 "do not check the entitlement server SSL certificate against available "
 "certificate authorities"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:345
+#: src/subscription_manager/managercli.py:346
 msgid "proxy URL in the form of hostname:port"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:347
+#: src/subscription_manager/managercli.py:348
 msgid "user for HTTP proxy with basic authentication"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:349
+#: src/subscription_manager/managercli.py:350
 msgid "password for HTTP proxy with basic authentication"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:351
+#: src/subscription_manager/managercli.py:352
 msgid "host suffixes that should bypass HTTP proxy"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:361
+#: src/subscription_manager/managercli.py:362
 msgid ""
 "Consumer identity either does not exist or is corrupted. Try register --help"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:411
+#: src/subscription_manager/managercli.py:412
 msgid ""
 "subscription-manager is disabled when running inside a container. Please "
 "refer to your host system for subscription management.\n"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:423
+#: src/subscription_manager/managercli.py:424
 #, python-brace-format
 msgid "{prog}: error: no such option: {args}"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:439
+#: src/subscription_manager/managercli.py:440
 msgid "Error parsing serverurl:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:455
+#: src/subscription_manager/managercli.py:456
 msgid "Error parsing baseurl:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:535
+#: src/subscription_manager/managercli.py:536
 msgid "Error: CA certificate for subscription service has not been installed."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:557
+#: src/subscription_manager/managercli.py:558
 msgid "System certificates corrupted. Please reregister."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:561
+#: src/subscription_manager/managercli.py:562
 #, python-format
 msgid ""
 "Consumer profile \"%s\" has been deleted from the server. You can use "
 "command clean or unregister to remove local profile."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:594
+#: src/subscription_manager/managercli.py:595
 #, python-brace-format
 msgid "set {attr} of system purpose"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:601
+#: src/subscription_manager/managercli.py:602
 #, python-brace-format
 msgid "unset {attr} of system purpose"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:609
+#: src/subscription_manager/managercli.py:610
 #, python-brace-format
 msgid "add an item to the list ({attr})."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:617
+#: src/subscription_manager/managercli.py:618
 #, python-brace-format
 msgid "remove an item from the list ({attr})."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:624
+#: src/subscription_manager/managercli.py:625
 #, python-brace-format
 msgid "show this system's current {attr}"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:631
+#: src/subscription_manager/managercli.py:632
 #, python-brace-format
 msgid "list all {attr} available"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:669
+#: src/subscription_manager/managercli.py:670
 msgid "--unset cannot be used with --set, --add, or --remove"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:671
+#: src/subscription_manager/managercli.py:672
 msgid "--add cannot be used with --remove"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:680
+#: src/subscription_manager/managercli.py:681
 msgid "Error: you can specify --username or --token not both"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:685
+#: src/subscription_manager/managercli.py:686
 #, python-brace-format
 msgid ""
 "Error: you must register or specify --username and --password to list {attr}"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:701
-#: src/subscription_manager/managercli.py:1667
+#: src/subscription_manager/managercli.py:702
+#: src/subscription_manager/managercli.py:1668
 msgid ""
 "Error: --username, --password, --token and --org can be used only on "
 "unregistered systems"
 msgstr ""
 
 #. TRANSLATORS: this is used to quote a string
-#: src/subscription_manager/managercli.py:774
+#: src/subscription_manager/managercli.py:775
 #, python-brace-format
 msgid "\"{value}\""
 msgstr ""
 
-#: src/subscription_manager/managercli.py:777
+#: src/subscription_manager/managercli.py:778
 #, python-brace-format
 msgid ""
 "Warning: Provided value {vals} is not included in the list of valid values"
@@ -4181,7 +4094,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/subscription_manager/managercli.py:784
+#: src/subscription_manager/managercli.py:785
 #, python-brace-format
 msgid ""
 "Warning: This organization does not have any subscriptions that provide a "
@@ -4189,1630 +4102,1293 @@ msgid ""
 "subscriptions."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:798
+#: src/subscription_manager/managercli.py:799
 #, python-brace-format
 msgid "{attr} set to \"{val}\"."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:815
+#: src/subscription_manager/managercli.py:816
 #, python-brace-format
 msgid "{attr} unset."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:832
-#: src/subscription_manager/managercli.py:855
+#: src/subscription_manager/managercli.py:833
+#: src/subscription_manager/managercli.py:856
 #, python-brace-format
 msgid "{attr} updated."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:884
+#: src/subscription_manager/managercli.py:885
 #, python-brace-format
 msgid "Current {name}: {val}"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:887
+#: src/subscription_manager/managercli.py:888
 #, python-brace-format
 msgid "{name} not set."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:905
+#: src/subscription_manager/managercli.py:906
 #, python-brace-format
 msgid "Available {syspurpose_attr}"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:915
-#: src/subscription_manager/managercli.py:1767
+#: src/subscription_manager/managercli.py:916
+#: src/subscription_manager/managercli.py:1768
 #, python-brace-format
 msgid ""
 "There are no available values for the system purpose \"{syspurpose_attr}\" "
 "from the available subscriptions in this organization."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:919
+#: src/subscription_manager/managercli.py:920
 #, python-brace-format
 msgid ""
 "Unable to get the list of valid values for the system purpose "
 "\"{syspurpose_attr}\"."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:939
+#: src/subscription_manager/managercli.py:940
 msgid "Unable to connect to server using token"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:989
+#: src/subscription_manager/managercli.py:990
 #, python-brace-format
 msgid ""
 "Note: The currently configured entitlement server does not support System "
 "Purpose {attr}."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1017
+#: src/subscription_manager/managercli.py:1018
 msgid "username to use when authorizing against the server"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1019
+#: src/subscription_manager/managercli.py:1020
 msgid "password to use when authorizing against the server"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1021
+#: src/subscription_manager/managercli.py:1022
 msgid "token to use when authorizing against the server"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1032
+#: src/subscription_manager/managercli.py:1033
 msgid "Error: --username is a required parameter in non-interactive mode."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1034
+#: src/subscription_manager/managercli.py:1035
 msgid "Error: --password is a required parameter in non-interactive mode."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1036
+#: src/subscription_manager/managercli.py:1037
 msgid "Username: "
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1039
+#: src/subscription_manager/managercli.py:1040
 msgid "Password: "
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1071
+#: src/subscription_manager/managercli.py:1072
 msgid "specify an organization"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1082
-#: src/subscription_manager/managercli.py:2143
+#: src/subscription_manager/managercli.py:1083
+#: src/subscription_manager/managercli.py:2187
 msgid "Error: --org is a required parameter in non-interactive mode."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1084
-#: src/subscription_manager/managercli.py:2147
+#: src/subscription_manager/managercli.py:1085
+#: src/subscription_manager/managercli.py:2191
 msgid "Organization: "
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1098
+#: src/subscription_manager/managercli.py:1099
 #, python-brace-format
 msgid "Error: User {username} is not member of any organization."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1110
+#: src/subscription_manager/managercli.py:1111
 #, python-brace-format
 msgid "Hint: User \"{name}\" is member of following organizations: {orgs}"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1132
+#: src/subscription_manager/managercli.py:1133
 msgid "Convenient module for managing all system purpose settings"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1142
+#: src/subscription_manager/managercli.py:1143
 msgid "show current system purpose"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1164
+#: src/subscription_manager/managercli.py:1165
 #, python-brace-format
 msgid "{prog} {name}"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1166
+#: src/subscription_manager/managercli.py:1167
 msgid "Syspurpose submodules"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1180
+#: src/subscription_manager/managercli.py:1181
 #, python-format, python-brace-format
 msgid "%(prog)s {name} [SUBMODULE] [OPTIONS]"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1243
+#: src/subscription_manager/managercli.py:1244
 msgid ""
 "Remove all local system and subscription data without affecting the server"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1249
-#: src/subscription_manager/managercli.py:1948
+#: src/subscription_manager/managercli.py:1250
+#: src/subscription_manager/managercli.py:1997
 msgid "All local data removed"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1262
+#: src/subscription_manager/managercli.py:1263
 msgid "Pull the latest subscription data from the server"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1266
+#: src/subscription_manager/managercli.py:1267
 msgid "force certificate regeneration"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1278
+#: src/subscription_manager/managercli.py:1279
 #, python-brace-format
 msgid "Unable to perform refresh due to the following exception: {e}"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1281
+#: src/subscription_manager/managercli.py:1282
 msgid "All local data refreshed"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1287
+#: src/subscription_manager/managercli.py:1288
 msgid "Display the identity certificate for this system or request a new one"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1293
+#: src/subscription_manager/managercli.py:1294
 msgid "request a new certificate be generated"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1295
+#: src/subscription_manager/managercli.py:1296
 msgid ""
 "force certificate regeneration (requires username and password); Only used "
 "with --regenerate"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1301
+#: src/subscription_manager/managercli.py:1302
 msgid "--force can only be used with --regenerate"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1303
+#: src/subscription_manager/managercli.py:1304
 msgid "--username and --password can only be used with --force"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1305
+#: src/subscription_manager/managercli.py:1306
 msgid "--token can only be used with --force"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1314
-#: src/subscription_manager/managercli.py:1317
-#: src/subscription_manager/managercli.py:3631
+#: src/subscription_manager/managercli.py:1315
+#: src/subscription_manager/managercli.py:1318
+#: src/subscription_manager/managercli.py:3675
 #, python-format
 msgid "server type: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1329
+#: src/subscription_manager/managercli.py:1330
 #, python-format
 msgid "system identity: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1330
+#: src/subscription_manager/managercli.py:1331
 #, python-format
 msgid "name: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1331
+#: src/subscription_manager/managercli.py:1332
 #, python-format
 msgid "org name: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1332
+#: src/subscription_manager/managercli.py:1333
 #, python-format
 msgid "org ID: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1346
+#: src/subscription_manager/managercli.py:1347
 #, python-brace-format
 msgid "environment name: {environment_name}"
 msgid_plural "environment names: {environment_name}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/subscription_manager/managercli.py:1364
+#: src/subscription_manager/managercli.py:1365
 msgid "Identity certificate has been regenerated."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1376
+#: src/subscription_manager/managercli.py:1377
 msgid "Error: Unable to generate a new identity for the system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1382
+#: src/subscription_manager/managercli.py:1383
 msgid "Display the organizations against which a user can register a system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1401
+#: src/subscription_manager/managercli.py:1402
 msgid "Organizations"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1408
-#: src/subscription_manager/managercli.py:2127
-#: src/subscription_manager/migrate/migrate.py:302
+#: src/subscription_manager/managercli.py:1409
+#: src/subscription_manager/managercli.py:2171
 #, python-format
 msgid "%s cannot register with any organizations."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1415
+#: src/subscription_manager/managercli.py:1416
 msgid "Error: Unable to retrieve org list from server"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1421
+#: src/subscription_manager/managercli.py:1422
 msgid "Display the environments available for a user"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1422
+#: src/subscription_manager/managercli.py:1423
 msgid "specify organization for environment list, using organization key"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1428
+#: src/subscription_manager/managercli.py:1429
 msgid "set an ordered comma-separated list of environments for this consumer"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1430
+#: src/subscription_manager/managercli.py:1431
 msgid "list all environments for the organization"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1432
+#: src/subscription_manager/managercli.py:1433
 msgid "list the environments enabled for this consumer in order"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1434
+#: src/subscription_manager/managercli.py:1435
 msgid "list the environments not enabled for this consumer"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1442
+#: src/subscription_manager/managercli.py:1443
 msgid "You may not specify an --org for environments when registered."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1451
-#: src/subscription_manager/managercli.py:2091
+#: src/subscription_manager/managercli.py:1452
+#: src/subscription_manager/managercli.py:2135
 msgid "Error: Server does not support environments."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1458
+#: src/subscription_manager/managercli.py:1459
 msgid "This operation requires user credentials"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1472
+#: src/subscription_manager/managercli.py:1473
 msgid "Error: Unable to retrieve environment list from server"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1489
+#: src/subscription_manager/managercli.py:1490
 msgid "Environments updated."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1491
+#: src/subscription_manager/managercli.py:1492
 msgid "Error: Server does not support environment updates."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1499
+#: src/subscription_manager/managercli.py:1500
 msgid "Error: Server does not support multi-environment operations."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1517
+#: src/subscription_manager/managercli.py:1518
 msgid "Environments"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1523
+#: src/subscription_manager/managercli.py:1524
 msgid "This list operation does not have any environments to report."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1560
+#: src/subscription_manager/managercli.py:1561
 msgid "Error: The same environment may not be listed more than once. "
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1565
+#: src/subscription_manager/managercli.py:1566
 #, python-brace-format
 msgid "No such environment: {names}"
 msgid_plural "No such environments: {names}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/subscription_manager/managercli.py:1578
+#: src/subscription_manager/managercli.py:1579
 msgid "Set if subscriptions are attached on a schedule (default of daily)"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1579
+#: src/subscription_manager/managercli.py:1580
 msgid "specify whether to enable or disable auto-attaching of subscriptions"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1584
+#: src/subscription_manager/managercli.py:1585
 msgid "try to attach subscriptions for uncovered products each check-in"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1586
+#: src/subscription_manager/managercli.py:1587
 msgid "do not try to automatically attach subscriptions each check-in"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1588
+#: src/subscription_manager/managercli.py:1589
 msgid "show the current auto-attach preference"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1600
+#: src/subscription_manager/managercli.py:1601
 msgid "Auto-attach preference: enabled"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1602
+#: src/subscription_manager/managercli.py:1603
 msgid "Auto-attach preference: disabled"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1617
+#: src/subscription_manager/managercli.py:1618
 msgid "Show or modify the system purpose service-level setting"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1644
+#: src/subscription_manager/managercli.py:1645
 msgid "Error: --org is only supported with the --list or --set option"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1651
+#: src/subscription_manager/managercli.py:1652
 msgid ""
 "Error: you must register or specify --username and --password to list "
 "service levels"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1692
+#: src/subscription_manager/managercli.py:1693
 msgid "Error: Unable to retrieve service levels."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1722
+#: src/subscription_manager/managercli.py:1723
 #, python-brace-format
 msgid "Service level set to: \"{val}\"."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1730
+#: src/subscription_manager/managercli.py:1731
 msgid "Service level preference has been unset"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1736
-#: src/subscription_manager/managercli.py:1743
-#: src/subscription_manager/managercli.py:1773
-#: src/subscription_manager/managercli.py:1778
-#: src/subscription_manager/migrate/migrate.py:727
+#: src/subscription_manager/managercli.py:1737
+#: src/subscription_manager/managercli.py:1744
+#: src/subscription_manager/managercli.py:1774
+#: src/subscription_manager/managercli.py:1779
 msgid "Error: The service-level command is not supported by the server."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1746
+#: src/subscription_manager/managercli.py:1747
 #, python-format
 msgid "Current service level: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1748
+#: src/subscription_manager/managercli.py:1749
 msgid "Service level preference not set"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1762
+#: src/subscription_manager/managercli.py:1763
 msgid "Available Service Levels"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1788
+#: src/subscription_manager/managercli.py:1789
 msgid "Show or modify the system purpose usage setting"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1807
+#: src/subscription_manager/managercli.py:1808
 msgid "base URL for content in form of https://hostname:port/prefix"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1811
+#: src/subscription_manager/managercli.py:1812
 msgid "name of the system to register, defaults to the hostname"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1813
+#: src/subscription_manager/managercli.py:1814
 msgid "the existing system data is pulled from the server"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1815
+#: src/subscription_manager/managercli.py:1816
 msgid ""
 "register with one of multiple organizations for the user, using organization "
 "key"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1817
+#: src/subscription_manager/managercli.py:1818
 msgid ""
 "register with a specific environment (single value) or multiple environments "
 "(a comma-separated list) in the destination org. The ability to use multiple "
 "environments is controlled by the entitlement server"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1821
+#: src/subscription_manager/managercli.py:1822
 msgid "set a release version"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1823
+#: src/subscription_manager/managercli.py:1824
 msgid "Deprecated, see --auto-attach"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1825
+#: src/subscription_manager/managercli.py:1826
 msgid "automatically attach compatible subscriptions to this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1827
+#: src/subscription_manager/managercli.py:1828
 msgid "register the system even if it is already registered"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1829
-#: src/subscription_manager/migrate/migrate.py:923
+#: src/subscription_manager/managercli.py:1830
 msgid ""
 "activation key to use for registration (can be specified more than once)"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1831
+#: src/subscription_manager/managercli.py:1832
 msgid ""
 "system preference used when subscribing automatically, requires --auto-attach"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1836
+#: src/subscription_manager/managercli.py:1837
 msgid "This system is already registered. Use --force to override"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1846
+#: src/subscription_manager/managercli.py:1847
 msgid "Error: Activation keys cannot be used with --auto-attach."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1851
+#: src/subscription_manager/managercli.py:1852
 msgid "Error: Must use --auto-attach with --servicelevel."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1853
+#: src/subscription_manager/managercli.py:1854
 msgid "Error: Must provide --org with activation keys."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1863
+#: src/subscription_manager/managercli.py:1864
 msgid "Error: The --type option has been deprecated and may not be used."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1866
-#: src/subscription_manager/managercli.py:2117
+#: src/subscription_manager/managercli.py:1867
+#: src/subscription_manager/managercli.py:2161
 msgid "The entitlement server does not allow multiple environments"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1891
-#: src/subscription_manager/managercli.py:2527
+#: src/subscription_manager/managercli.py:1892
+#: src/subscription_manager/managercli.py:2571
 msgid ""
 "Error: The --servicelevel option is not supported by the server. Did not "
 "complete your request."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1930
-#: src/subscription_manager/managercli.py:2166
+#: src/subscription_manager/managercli.py:1979
+#: src/subscription_manager/managercli.py:2210
 #, python-format
 msgid "Unregistering from: %s:%s%s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1937
+#: src/subscription_manager/managercli.py:1986
 #, python-format
 msgid "The system with UUID %s has been unregistered"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1960
+#: src/subscription_manager/managercli.py:2009
 #, python-format
 msgid "Registering to: %s:%s%s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:1997
+#: src/subscription_manager/managercli.py:2046
 #, python-format
 msgid "Error during registration: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2000
+#: src/subscription_manager/managercli.py:2049
 #, python-format
 msgid "The system has been registered with ID: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2001
+#: src/subscription_manager/managercli.py:2050
 #, python-format
 msgid "The registered system name is: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2003
-#: src/subscription_manager/managercli.py:2541
+#: src/subscription_manager/managercli.py:2052
+#: src/subscription_manager/managercli.py:2585
 #, python-format
 msgid "Service level set to: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2073
+#: src/subscription_manager/managercli.py:2115
 msgid "Error: --environments is a required parameter in non-interactive mode."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2075
+#: src/subscription_manager/managercli.py:2117
 msgid "Environments: "
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2077
-#: src/subscription_manager/migrate/migrate.py:339
+#: src/subscription_manager/managercli.py:2119
 msgid "Environment: "
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2113
+#: src/subscription_manager/managercli.py:2157
 #, python-format
 msgid "Hint: Organization \"%s\" contains following environments: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2138
+#: src/subscription_manager/managercli.py:2182
 #, python-format
 msgid "Hint: User \"%s\" is member of following organizations: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2192
+#: src/subscription_manager/managercli.py:2236
 msgid "System has been unregistered."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2198
+#: src/subscription_manager/managercli.py:2242
 msgid "Show or modify the system purpose addons setting"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2212
+#: src/subscription_manager/managercli.py:2256
 msgid "Attempt to redeem a subscription for a preconfigured system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2216
+#: src/subscription_manager/managercli.py:2260
 msgid "email address to notify when subscription redemption is complete"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2219
+#: src/subscription_manager/managercli.py:2263
 msgid ""
 "optional language to use for email notification when subscription redemption "
 "is complete (Examples: en-us, de-de)"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2225
+#: src/subscription_manager/managercli.py:2269
 msgid ""
 "Error: This command requires that you specify an email address with --email."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2266
+#: src/subscription_manager/managercli.py:2310
 msgid "Configure which operating system release to use"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2270
+#: src/subscription_manager/managercli.py:2314
 msgid "shows current release setting; default command"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2272
+#: src/subscription_manager/managercli.py:2316
 msgid "list available releases"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2275
+#: src/subscription_manager/managercli.py:2319
 msgid "set the release for this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2278
+#: src/subscription_manager/managercli.py:2322
 msgid "unset the release for this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2281
+#: src/subscription_manager/managercli.py:2325
 msgid "Error: The 'release' command is not supported by the server."
-msgstr ""
-
-#: src/subscription_manager/managercli.py:2290
-#, python-format
-msgid "Release: %s"
-msgstr ""
-
-#: src/subscription_manager/managercli.py:2292
-msgid "Release not set"
-msgstr ""
-
-#: src/subscription_manager/managercli.py:2313
-msgid "Release preference has been unset"
-msgstr ""
-
-#: src/subscription_manager/managercli.py:2329
-#, python-format
-msgid "No releases match '%s'.  Consult 'release --list' for a full listing."
 msgstr ""
 
 #: src/subscription_manager/managercli.py:2334
 #, python-format
+msgid "Release: %s"
+msgstr ""
+
+#: src/subscription_manager/managercli.py:2336
+msgid "Release not set"
+msgstr ""
+
+#: src/subscription_manager/managercli.py:2357
+msgid "Release preference has been unset"
+msgstr ""
+
+#: src/subscription_manager/managercli.py:2373
+#, python-format
+msgid "No releases match '%s'.  Consult 'release --list' for a full listing."
+msgstr ""
+
+#: src/subscription_manager/managercli.py:2378
+#, python-format
 msgid "Release set to: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2344
+#: src/subscription_manager/managercli.py:2388
 msgid "No release versions available, please check subscriptions."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2347
+#: src/subscription_manager/managercli.py:2391
 msgid "Available Releases"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2368
+#: src/subscription_manager/managercli.py:2412
 msgid "The ID of the pool to attach (can be specified more than once)"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2370
+#: src/subscription_manager/managercli.py:2414
 msgid "Number of subscriptions to attach. May not be used with an auto-attach."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2372
+#: src/subscription_manager/managercli.py:2416
 msgid ""
 "Automatically attach compatible subscriptions to this system. This is the "
 "default action."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2375
+#: src/subscription_manager/managercli.py:2419
 msgid ""
 "Automatically attach only subscriptions matching the specified service "
 "level; only used with --auto"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2378
+#: src/subscription_manager/managercli.py:2422
 msgid ""
 "A file from which to read pool IDs. If a hyphen is provided, pool IDs will "
 "be read from stdin."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2382
+#: src/subscription_manager/managercli.py:2426
 msgid "All installed products are covered by valid entitlements."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2383
+#: src/subscription_manager/managercli.py:2427
 msgid "No need to update subscriptions at this time."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2395
+#: src/subscription_manager/managercli.py:2439
 msgid ""
 "Attach a specified subscription to the registered system, when system does "
 "not use Simple Content Access mode"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2408
+#: src/subscription_manager/managercli.py:2452
 msgid "Error: --auto may not be used when specifying pools."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2410
+#: src/subscription_manager/managercli.py:2454
 msgid "Error: The --servicelevel option cannot be used when specifying pools."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2415
+#: src/subscription_manager/managercli.py:2459
 msgid "Error: Quantity must be a positive integer."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2417
+#: src/subscription_manager/managercli.py:2461
 msgid "Error: --quantity may not be used with an auto-attach"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2427
+#: src/subscription_manager/managercli.py:2471
 msgid "Error: Received data does not contain any pool IDs."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2429
+#: src/subscription_manager/managercli.py:2473
 #, python-format
 msgid "Error: The file \"%s\" does not contain any pool IDs."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2431
+#: src/subscription_manager/managercli.py:2475
 #, python-format
 msgid "Error: The file \"%s\" does not exist or cannot be read."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2442
+#: src/subscription_manager/managercli.py:2486
 #, python-brace-format
 msgid ""
 "Ignoring the request to attach. Attaching subscriptions is disabled for "
 "organization \"{owner_id}\" because Simple Content Access (SCA) is enabled."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2486
+#: src/subscription_manager/managercli.py:2530
 msgid "Please enter a valid numeric pool ID."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2493
+#: src/subscription_manager/managercli.py:2537
 #, python-format
 msgid "Successfully attached a subscription for: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2515
+#: src/subscription_manager/managercli.py:2559
 msgid "No Installed products on system. No need to attach subscriptions."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2518
+#: src/subscription_manager/managercli.py:2562
 msgid ""
 "All installed products are covered by valid entitlements. No need to update "
 "subscriptions at this time."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2550
+#: src/subscription_manager/managercli.py:2594
 msgid "Entitlement Certificate(s) update failed due to the following reasons:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2584
+#: src/subscription_manager/managercli.py:2628
 msgid "Deprecated, see attach"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2602
+#: src/subscription_manager/managercli.py:2646
 msgid "certificate serial number to remove (can be specified more than once)"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2604
+#: src/subscription_manager/managercli.py:2648
 msgid "the ID of the pool to remove (can be specified more than once)"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2606
+#: src/subscription_manager/managercli.py:2650
 msgid "remove all subscriptions from this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2609
+#: src/subscription_manager/managercli.py:2653
 msgid "Remove all or specific subscriptions from this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2622
+#: src/subscription_manager/managercli.py:2666
 #, python-format
 msgid "Error: '%s' is not a valid serial number"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2628
+#: src/subscription_manager/managercli.py:2672
 msgid ""
 "Error: The registered entitlement server does not support remove --pool.\n"
 "Instead, use the remove --serial option."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2631
+#: src/subscription_manager/managercli.py:2675
 msgid ""
 "Error: This command requires that you specify one of --serial, --pool or --"
 "all."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2636
+#: src/subscription_manager/managercli.py:2680
 msgid "The entitlement server successfully removed these pools:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2638
+#: src/subscription_manager/managercli.py:2682
 msgid "The entitlement server successfully removed these serial numbers:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2640
+#: src/subscription_manager/managercli.py:2684
 msgid "The entitlement server successfully removed these IDs:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2645
+#: src/subscription_manager/managercli.py:2689
 msgid "The entitlement server failed to remove these pools:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2647
+#: src/subscription_manager/managercli.py:2691
 msgid "The entitlement server failed to remove these serial numbers:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2649
+#: src/subscription_manager/managercli.py:2693
 msgid "The entitlement server failed to remove these IDs:"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2667
+#: src/subscription_manager/managercli.py:2711
 msgid "All subscriptions have been removed at the server."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2670
+#: src/subscription_manager/managercli.py:2714
 #, python-format
 msgid "%s subscription removed at the server."
 msgid_plural "%s subscriptions removed at the server."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/subscription_manager/managercli.py:2700
-#: src/subscription_manager/managercli.py:2724
+#: src/subscription_manager/managercli.py:2744
+#: src/subscription_manager/managercli.py:2768
 #, python-format
 msgid "Unable to perform remove due to the following exception: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2709
+#: src/subscription_manager/managercli.py:2753
 #, python-format
 msgid "%s subscriptions removed from this system."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2719
+#: src/subscription_manager/managercli.py:2763
 #, python-format
 msgid "Subscription with serial number %s removed from this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2737
+#: src/subscription_manager/managercli.py:2781
 msgid "Deprecated, see remove"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2749
+#: src/subscription_manager/managercli.py:2793
 msgid "View or update the detected system information"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2753
+#: src/subscription_manager/managercli.py:2797
 msgid "list known facts for this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2755
+#: src/subscription_manager/managercli.py:2799
 msgid "update the system facts"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2790
+#: src/subscription_manager/managercli.py:2834
 msgid "Successfully updated the system facts."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2795
+#: src/subscription_manager/managercli.py:2839
 msgid "Import certificates which were provided outside of the tool"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2799
+#: src/subscription_manager/managercli.py:2843
 msgid "certificate file to import (can be specified more than once)"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2803
+#: src/subscription_manager/managercli.py:2847
 msgid ""
 "Error: You may not import certificates into a system that is registered to a "
 "subscription management service."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2805
+#: src/subscription_manager/managercli.py:2849
 msgid ""
 "Error: This command requires that you specify a certificate with --"
 "certificate."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2820
+#: src/subscription_manager/managercli.py:2864
 #, python-format
 msgid "Successfully imported certificate %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2826
+#: src/subscription_manager/managercli.py:2870
 #, python-format
 msgid "%s is not a valid certificate file. Please use a valid certificate."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2832
+#: src/subscription_manager/managercli.py:2876
 msgid ""
 "An error occurred while importing the certificate. Please check log file for "
 "more information."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2836
+#: src/subscription_manager/managercli.py:2880
 #, python-format
 msgid "%s: file not found."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2859
+#: src/subscription_manager/managercli.py:2903
 msgid "View and configure with 'subscription-manager plugins'"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2863
+#: src/subscription_manager/managercli.py:2907
 #, python-format
 msgid "list %s plugins"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2865
+#: src/subscription_manager/managercli.py:2909
 #, python-format
 msgid "list %s plugin slots"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2867
+#: src/subscription_manager/managercli.py:2911
 #, python-format
 msgid "list %s plugin hooks"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2870
+#: src/subscription_manager/managercli.py:2914
 msgid "show verbose plugin info"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2884
+#: src/subscription_manager/managercli.py:2928
 msgid "disabled"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2886
+#: src/subscription_manager/managercli.py:2930
 msgid "enabled"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2937
+#: src/subscription_manager/managercli.py:2981
 msgid "List the repositories which this system is entitled to use"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2941
+#: src/subscription_manager/managercli.py:2985
 msgid "list all known repositories for this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2943
+#: src/subscription_manager/managercli.py:2987
 msgid "list known, enabled repositories for this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2945
+#: src/subscription_manager/managercli.py:2989
 msgid "list known, disabled repositories for this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2948
+#: src/subscription_manager/managercli.py:2992
 msgid ""
 "repository to enable (can be specified more than once). Wildcards (* and ?) "
 "are supported."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:2951
+#: src/subscription_manager/managercli.py:2995
 msgid ""
 "repository to disable (can be specified more than once). Wildcards (* and ?) "
 "are supported."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3012
+#: src/subscription_manager/managercli.py:3056
 #, python-format
 msgid "    Available Repositories in %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3022
+#: src/subscription_manager/managercli.py:3066
 msgid "There were no available repositories matching the specified criteria."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3024
-#: src/subscription_manager/managercli.py:3043
+#: src/subscription_manager/managercli.py:3068
+#: src/subscription_manager/managercli.py:3087
 msgid "This system has no repositories available through subscriptions."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3050
+#: src/subscription_manager/managercli.py:3094
 #, python-format
 msgid ""
 "Error: '%s' does not match a valid repository ID. Use \"subscription-manager "
 "repos --list\" to see valid repositories."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3097
+#: src/subscription_manager/managercli.py:3141
 #, python-format
 msgid "Repository '%s' is enabled for this system."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3099
+#: src/subscription_manager/managercli.py:3143
 #, python-format
 msgid "Repository '%s' is disabled for this system."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3106
+#: src/subscription_manager/managercli.py:3150
 msgid "List, set, or remove the configuration parameters in use by this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3110
+#: src/subscription_manager/managercli.py:3154
 msgid "list the configuration for this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3112
+#: src/subscription_manager/managercli.py:3156
 msgid "remove configuration entry by section.name"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3119
+#: src/subscription_manager/managercli.py:3163
 #, python-format
 msgid "Section: %s, Name: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3138
+#: src/subscription_manager/managercli.py:3182
 msgid ""
 "Error: --list should not be used with any other options for setting or "
 "removing configurations."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3157
+#: src/subscription_manager/managercli.py:3201
 msgid ""
 "Error: configuration entry designation for removal must be of format "
 "[section.name]"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3167
+#: src/subscription_manager/managercli.py:3211
 #, python-format
 msgid "Error: Section %s and name %s does not exist."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3185
+#: src/subscription_manager/managercli.py:3229
 msgid "[] - Default value in use"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3194
-#: src/subscription_manager/managercli.py:3197
+#: src/subscription_manager/managercli.py:3238
+#: src/subscription_manager/managercli.py:3241
 #, python-format
 msgid "You have removed the value for section %s and name %s."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3198
+#: src/subscription_manager/managercli.py:3242
 #, python-format
 msgid "The default value for %s will now be used."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3200
+#: src/subscription_manager/managercli.py:3244
 #, python-format
 msgid "Section %s and name %s cannot be removed."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3219
+#: src/subscription_manager/managercli.py:3263
 msgid "List subscription and product information for this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3223
+#: src/subscription_manager/managercli.py:3267
 msgid "list shows those products which are installed (default)"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3225
+#: src/subscription_manager/managercli.py:3269
 msgid "show those subscriptions which are available"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3227
+#: src/subscription_manager/managercli.py:3271
 msgid "used with --available to ensure all subscriptions are returned"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3229
+#: src/subscription_manager/managercli.py:3273
 #, python-format
 msgid ""
 "date to search on, defaults to today's date, only used with --available "
 "(example: %s)"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3232
+#: src/subscription_manager/managercli.py:3276
 msgid "show the subscriptions being consumed by this system"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3234
+#: src/subscription_manager/managercli.py:3278
 msgid ""
 "shows only subscriptions matching the specified service level; only used "
 "with --available and --consumed"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3236
+#: src/subscription_manager/managercli.py:3280
 msgid ""
 "shows pools which provide products that are not already covered; only used "
 "with --available"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3238
+#: src/subscription_manager/managercli.py:3282
 msgid ""
 "shows only subscriptions matching products that are currently installed; "
 "only used with --available"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3240
+#: src/subscription_manager/managercli.py:3284
 msgid ""
 "lists only subscriptions or products containing the specified expression in "
 "the subscription or product information, varying with the list requested and "
 "the server version (case-insensitive)."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3242
+#: src/subscription_manager/managercli.py:3286
 msgid ""
 "lists only the pool IDs for applicable available or consumed subscriptions; "
 "only used with --available and --consumed"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3244
+#: src/subscription_manager/managercli.py:3288
 #, python-format
 msgid ""
 "show pools that are active on or after the given date; only used with --"
 "available (example: %s)"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3262
+#: src/subscription_manager/managercli.py:3306
 msgid "Error: --afterdate is only applicable with --available"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3264
+#: src/subscription_manager/managercli.py:3308
 msgid "Error: --afterdate cannot be used with --ondate"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3279
+#: src/subscription_manager/managercli.py:3323
 #, python-brace-format
 msgid ""
 "Date entered is invalid. Date should be in YYYY-MM-DD format (example: "
 "{dateexample})"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3308
+#: src/subscription_manager/managercli.py:3352
 msgid "    Installed Product Status"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3342
+#: src/subscription_manager/managercli.py:3386
 #, python-format
 msgid "No installed products were found matching the expression \"%s\"."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3344
+#: src/subscription_manager/managercli.py:3388
 msgid "No installed products to list"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3371
+#: src/subscription_manager/managercli.py:3415
 msgid "Available Subscriptions"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3409
+#: src/subscription_manager/managercli.py:3453
 #, python-format
 msgid ""
 "No available subscription pools were found matching the expression \"%s\" "
 "and the service level \"%s\"."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3414
+#: src/subscription_manager/managercli.py:3458
 #, python-format
 msgid ""
 "No available subscription pools were found matching the expression \"%s\"."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3419
+#: src/subscription_manager/managercli.py:3463
 #, python-format
 msgid ""
 "No available subscription pools were found matching the service level \"%s\"."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3423
+#: src/subscription_manager/managercli.py:3467
 msgid "No available subscription pools to list"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3443
+#: src/subscription_manager/managercli.py:3487
 msgid "Consumed Subscriptions"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3459
+#: src/subscription_manager/managercli.py:3503
 #, python-format
 msgid ""
 "No consumed subscription pools were found matching the expression \"%s\" and "
 "the service level \"%s\"."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3464
+#: src/subscription_manager/managercli.py:3508
 #, python-format
 msgid ""
 "No consumed subscription pools were found matching the expression \"%s\"."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3469
+#: src/subscription_manager/managercli.py:3513
 #, python-format
 msgid ""
 "No consumed subscription pools were found matching the service level \"%s\"."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3473
+#: src/subscription_manager/managercli.py:3517
 msgid "No consumed subscription pools were found."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3478
+#: src/subscription_manager/managercli.py:3522
 msgid "Manage custom content repository settings"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3481
+#: src/subscription_manager/managercli.py:3525
 msgid "repository to modify (can be specified more than once)"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3483
+#: src/subscription_manager/managercli.py:3527
 msgid ""
 "name of the override to remove (can be specified more than once); used with "
 "--repo option."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3485
+#: src/subscription_manager/managercli.py:3529
 msgid ""
 "name and value of the option to override separated by a colon (can be "
 "specified more than once); used with --repo option."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3487
+#: src/subscription_manager/managercli.py:3531
 msgid ""
 "remove all overrides; can be specific to a repository by providing --repo"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3489
+#: src/subscription_manager/managercli.py:3533
 msgid "list all overrides; can be specific to a repository by providing --repo"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3496
+#: src/subscription_manager/managercli.py:3540
 msgid "You must specify an override in the form of \"name:value\" with --add."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3501
+#: src/subscription_manager/managercli.py:3545
 msgid "--add arguments should be in the form of \"name:value\""
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3511
+#: src/subscription_manager/managercli.py:3555
 msgid "Error: You must specify a repository to modify"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3513
+#: src/subscription_manager/managercli.py:3557
 msgid "Error: You may not use --add or --remove with --remove-all and --list"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3515
+#: src/subscription_manager/managercli.py:3559
 msgid "Error: You may not use --list with --remove-all"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3518
+#: src/subscription_manager/managercli.py:3562
 msgid "Error: The --repo option must be used with --list or --add or --remove."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3522
+#: src/subscription_manager/managercli.py:3566
 msgid "Error: You must specify an override name with --remove."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3535
+#: src/subscription_manager/managercli.py:3579
 msgid "Error: The 'repo-override' command is not supported by the server."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3553
+#: src/subscription_manager/managercli.py:3597
 msgid "This system does not have any content overrides applied to it."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3572
+#: src/subscription_manager/managercli.py:3616
 #, python-format
 msgid ""
 "Repository '%s' does not currently exist, but the override has been added."
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3596
+#: src/subscription_manager/managercli.py:3640
 #, python-format
 msgid "Nothing is known about '%s'"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3601
+#: src/subscription_manager/managercli.py:3645
 #, python-format
 msgid "Repository: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3611
+#: src/subscription_manager/managercli.py:3655
 msgid "Show or modify the system purpose role setting"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3625
+#: src/subscription_manager/managercli.py:3669
 msgid "Print version information"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3632
+#: src/subscription_manager/managercli.py:3676
 #, python-format
 msgid "subscription management server: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3633
+#: src/subscription_manager/managercli.py:3677
 #, python-format
 msgid "subscription management rules: %s"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3640
+#: src/subscription_manager/managercli.py:3684
 msgid "Show status information for this system's subscriptions and products"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3644
+#: src/subscription_manager/managercli.py:3688
 #, python-format
 msgid "future date to check status on, defaults to today's date (example: %s)"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3668
+#: src/subscription_manager/managercli.py:3712
 msgid "System Status Details"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3673
+#: src/subscription_manager/managercli.py:3717
 msgid ""
 "Content Access Mode is set to Simple Content Access. This host has access to "
 "content, regardless of subscription status.\n"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3707
+#: src/subscription_manager/managercli.py:3751
 #, python-brace-format
 msgid ""
 "Overall Status: {status}\n"
 "{message}"
 msgstr ""
 
-#: src/subscription_manager/managercli.py:3741
+#: src/subscription_manager/managercli.py:3785
 #, python-brace-format
 msgid "System Purpose Status: {status}"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:53
-#: src/subscription_manager/migrate/migrate.py:55
-msgid ""
-"Could not find up2date_client.config module! Perhaps this script was already "
-"executed with --remove-rhn-packages?"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:73
-msgid "See /var/log/rhsm/rhsm.log for more details."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:75
-#, python-format
-msgid "Unable to connect to certificate server: %s.  "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:132
-msgid ""
-"You have entered an invalid choice.  Enter a choice from the menu above."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:168
-#, python-format
-msgid "Could not read legacy system id at %s"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:200
-msgid "Legacy password: "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:200
-msgid "Legacy username: "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:206
-msgid "Destination password: "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:206
-msgid "Destination username: "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:219
-msgid "Could not read legacy proxy settings.  "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:251
-#, python-format
-msgid "Error parsing server URL: %s"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:279
-msgid "This system appears to already be registered to Satellite 6."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:281
-msgid ""
-"This system appears to already be registered to Red Hat Subscription "
-"Management."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:282
-#, python-format
-msgid ""
-"Please visit https://access.redhat.com/management/consumers/%s to view the "
-"profile details."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:288
-msgid "The CA certificate for the destination server has not been installed."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:309
-msgid "Org: "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:318
-#, python-format
-msgid "Couldn't find organization '%s'."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:327
-msgid "Environments are not supported by this server."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:350
-#, python-format
-msgid "Couldn't find environment '%s'."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:380
-msgid "Unable to authenticate to legacy server.  "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:393
-#, python-format
-msgid "You do not have access to system %s.  "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:400
-#: src/subscription_manager/migrate/migrate.py:410
-msgid "Problem encountered getting the list of subscribed channels.  "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:425
-msgid ""
-"You are subscribed to more than one jbappplatform channel.  This script does "
-"not support that configuration."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:463
-msgid ""
-"You are subscribed to channels that have conflicting product certificates."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:467
-#, python-format
-msgid "Mapping product '%s' to certificate '%s'."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:478
-#, python-format
-msgid ""
-"Unable to read mapping file: %(mappingfile)s.\n"
-"Please check that you have the %(package)s package installed."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:504
-#, python-format
-msgid "Channels not available on %s:"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:509
-msgid "No product certificates are mapped to these legacy channels:"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:515
-msgid ""
-"\n"
-"Use --force to ignore these channels and continue the migration.\n"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:528
-msgid "Installing product certificates for these legacy channels:"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:556
-#, python-format
-msgid ""
-"\n"
-"Product certificates installed successfully to %s."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:628
-msgid "Could not remove system entitlement on legacy server.  "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:644
-#, python-format
-msgid ""
-"Did not receive a completed unregistration message from legacy server for "
-"system %s."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:647
-msgid "Please investigate on the Customer Portal at https://access.redhat.com."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:657
-msgid "System successfully unregistered from legacy server."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:660
-msgid "Unable to unregister system from legacy server.  "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:668
-msgid "Could not retrieve system migration data from legacy server.  "
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:676
-#, python-format
-msgid "Consumer %s doesn't exist.  Creating new consumer."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:683
-msgid "Attempting to register system to destination server..."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:721
-msgid ""
-"\n"
-"Unable to register.\n"
-"For further assistance, please contact Red Hat Global Support Services."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:745
-msgid "No service level preference"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:752
-#, python-format
-msgid ""
-"\n"
-"Service level \"%s\" is not available."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:753
-msgid "Please select a service level agreement for this system."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:790
-msgid ""
-"\n"
-"Couldn't enable extra repositories."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:792
-#, python-format
-msgid ""
-"Please ensure system has subscriptions attached, and see '%s' to enable "
-"additional repositories"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:811
-msgid "Stopping and disabling legacy services..."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:832
-msgid "Removing legacy packages..."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:859
-msgid "Retrieving existing legacy subscription information..."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:861
-msgid "System is currently subscribed to these legacy channels:"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:873
-msgid "Preparing to unregister system from legacy server..."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:894
-msgid ""
-"don't execute the auto-attach option while registering with subscription "
-"manager"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:896
-msgid ""
-"service level to follow when attaching subscriptions, for no service level "
-"use --servicelevel=\"\""
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:899
-msgid "remove legacy packages"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:902
-msgid "don't use legacy proxy settings with destination server"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:910
-#, python-format
-msgid "state to leave system in on legacy server (default is '%s')"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:915
-msgid "organization to register to"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:917
-msgid "environment to register to"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:919
-msgid "ignore channels not available on destination server"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:929
-msgid "leave system registered in legacy environment"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:932
-msgid "specify the user name on the legacy server"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:934
-msgid "specify the password on the legacy server"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:936
-msgid "specify the subscription management server to migrate to"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:938
-msgid "specify the user name on the destination server"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:940
-msgid "specify the password on the destination server"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:946
-msgid "The --activation-key and --environment options cannot be used together."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:948
-msgid ""
-"The --activation-key option precludes the use of --destination-user and --"
-"destination-password"
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:950
-msgid "The --activation-key option requires that a --org be given."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:954
-msgid "The --servicelevel and --no-auto options cannot be used together."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:957
-msgid "The --remove-rhn-packages and --keep options cannot be used together."
-msgstr ""
-
-#: src/subscription_manager/migrate/migrate.py:960
-msgid ""
-"The --remove-rhn-packages option must be used with --registration-"
-"state=purge."
 msgstr ""
 
 #: src/subscription_manager/plugin/container/__init__.py:234
@@ -5908,12 +5484,8 @@ msgstr ""
 msgid "launches the registration dialog on startup"
 msgstr ""
 
-#: src/subscription_manager/utils.py:394
+#: src/subscription_manager/utils.py:395
 msgid "and"
-msgstr ""
-
-#: tmp/rhsm-icon.desktop.in.h:1
-msgid "Red Hat Subscription Validity Applet"
 msgstr ""
 
 #: tmp/subscription-manager-cockpit.desktop.in.h:1


### PR DESCRIPTION
No new or changed strings; this mostly includes the removal of rshm_icon and rhn-migrate-classic-to-rhsm, and the drop of a couple of DMI-related log messages that were wrongly translated.