### PR TITLE
spec: Obsolete subscription-manager-migration

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -201,6 +201,8 @@ BuildRequires: %{py_package_prefix}-dateutil
 
 BuildRequires: systemd
 
+Obsoletes: subscription-manager-migration <= %{version}-%{release}
+
 Obsoletes: subscription-manager-initial-setup-addon <= %{version}-%{release}
 
 Obsoletes: rhsm-gtk <= %{version}-%{release}


### PR DESCRIPTION
When subscription-manager-migration was dropped, the Obsoletes for it in subscription-manager was not added; since sub-man-migration had a strict dependency on sub-man, adding the Obsoletes helps during upgrades.

Followup of commit 5c792d4e97c0fe5e09b7c6b17f54afafdaa203d7.