### PR TITLE
[1.28] spec: Obsolete subscription-manager-migration

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -374,6 +374,8 @@ BuildRequires: systemd-rpm-macros
 BuildRequires: systemd
 %endif
 
+Obsoletes: subscription-manager-migration <= %{version}-%{release}
+
 %if !%{use_container_plugin}
 Obsoletes: subscription-manager-plugin-container
 %endif


### PR DESCRIPTION
When subscription-manager-migration was dropped, the Obsoletes for it in subscription-manager was not added; since sub-man-migration had a strict dependency on sub-man, adding the Obsoletes helps during upgrades.

Followup of commit 1b4a84147734a6d777309866e3e353d023798ff2.

(cherry picked from commit 77a650d995e5871906ed9b8b82746b0c3d933583)

Backport of #3265 to 1.28.