### PR TITLE
Prevent Mock failures for ModulesProfile tests 

### DIFF
--- a/test/cloud_what/test_cloud_what.py
+++ b/test/cloud_what/test_cloud_what.py
@@ -32,13 +32,6 @@ class TestCloudProvider(unittest.TestCase):
         """
         Set up two mocks that are used in all tests
         """
-        aws.AWSCloudProvider._instance = None
-        aws.AWSCloudProvider._initialized = False
-        azure.AzureCloudProvider._instance = None
-        azure.AzureCloudProvider._initialized = False
-        gcp.GCPCloudProvider._instance = None
-        gcp.GCPCloudProvider._initialized = False
-
         custom_facts_collector_patcher = patch("cloud_what.provider.CustomFactsCollector")
         self.custom_facts_collector_mock = custom_facts_collector_patcher.start()
         self.custom_facts_collector_instance = Mock()

--- a/test/fixture.py
+++ b/test/fixture.py
@@ -9,6 +9,8 @@ import unittest
 # just log py.warnings (and pygtk warnings in particular)
 import logging
 
+from cloud_what.providers import aws, azure, gcp
+
 try:
     # 2.7+
     logging.captureWarnings(True)
@@ -272,6 +274,13 @@ class SubManFixture(unittest.TestCase):
             # Assuming these are tempfile.NamedTemporaryFile, created with
             # the write_tempfile() method in this class.
             f.close()
+
+        aws.AWSCloudProvider._instance = None
+        aws.AWSCloudProvider._initialized = False
+        azure.AzureCloudProvider._instance = None
+        azure.AzureCloudProvider._initialized = False
+        gcp.GCPCloudProvider._instance = None
+        gcp.GCPCloudProvider._initialized = False
 
     def write_tempfile(self, contents):
         """

--- a/test/rhsm/unit/test_profile.py
+++ b/test/rhsm/unit/test_profile.py
@@ -15,6 +15,8 @@ import unittest
 from unittest import mock
 from unittest.mock import patch
 
+from cloud_what.providers import aws, azure, gcp
+
 from rhsm.profile import ModulesProfile, EnabledReposProfile
 
 
@@ -37,6 +39,14 @@ class TestModulesProfile(unittest.TestCase):
         self.cloud_provider_mock = cloud_provider_patcher.start()
         self.cloud_provider_mock.get_cloud_provider = mock.Mock(return_value=None)
         self.addCleanup(cloud_provider_patcher.stop)
+
+    def tearDown(self) -> None:
+        aws.AWSCloudProvider._instance = None
+        aws.AWSCloudProvider._initialized = False
+        azure.AzureCloudProvider._instance = None
+        azure.AzureCloudProvider._initialized = False
+        gcp.GCPCloudProvider._instance = None
+        gcp.GCPCloudProvider._initialized = False
 
     def test_default_status(self) -> None:
         """

--- a/test/rhsmlib/facts/test_cloud_facts.py
+++ b/test/rhsmlib/facts/test_cloud_facts.py
@@ -187,6 +187,14 @@ class TestCloudCollector(unittest.TestCase):
         self.requests_mock = self.requests_patcher.start()
         self.addCleanup(self.requests_patcher.stop)
 
+    def tearDown(self) -> None:
+        aws.AWSCloudProvider._instance = None
+        aws.AWSCloudProvider._initialized = False
+        azure.AzureCloudProvider._instance = None
+        azure.AzureCloudProvider._initialized = False
+        gcp.GCPCloudProvider._instance = None
+        gcp.GCPCloudProvider._initialized = False
+
     @patch("cloud_what.providers.aws.requests.Session", name="test_get_aws_facts.mock_session_class")
     def test_get_aws_facts(self, mock_session_class):
         """

--- a/test/test_auto_registration.py
+++ b/test/test_auto_registration.py
@@ -98,7 +98,7 @@ def mock_prepare_request(request):
 
 
 class TestAutomaticRegistration(unittest.TestCase):
-    def setUp(self):
+    def tearDown(self):
         aws.AWSCloudProvider._instance = None
         aws.AWSCloudProvider._initialized = False
         azure.AzureCloudProvider._instance = None


### PR DESCRIPTION
Tests directly and indirectly using Cloud What were not being properly cleaned up. When they were run before ModulesProfile (and other) tests, they caused them to fail, because they are altering the global state by manipulating the singleton instances.

(Adapted from 2b35656)

Note: The issues were not showing up in this branch, because test_cloud_what.py was already resetting the singletons in tearDown(). However, to keep this from happening in another situation, this patch is ensuring that those classes are reset every time, even if they do not cause errors.