### PR TITLE
[1.28] 2091269: Make locking more reliable

### DIFF
--- a/src/subscription_manager/lock.py
+++ b/src/subscription_manager/lock.py
@@ -18,8 +18,13 @@ from __future__ import print_function, division, absolute_import
 #
 import fcntl
 import os
+import tempfile
 from threading import RLock as Mutex
 import time
+from typing import Union, Optional, TextIO
+
+import logging
+log = logging.getLogger(__name__)
 
 # how long to sleep before rechecking if we can
 # acquire the lock.
@@ -36,56 +41,92 @@ class LockFile(object):
         self.pid = None
         self.fp = None
 
-    def open(self):
+    def open(self, blocking: bool = False) -> None:
+        """
+        Try to open lock file, write PID to the lock file and finally lock the file
+        :param blocking: When it is set to True, then file locking blocks
+        """
         if self.notcreated():
             self.fp = open(self.path, 'w')
             self.setpid()
             self.close()
         self.fp = open(self.path, 'r+')
         fd = self.fp.fileno()
-        fcntl.flock(fd, fcntl.LOCK_EX)
+        if blocking is True:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        else:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
 
     def getpid(self):
-        if self.pid is None:
+        """
+        Try to get PID from the locked file
+        """
+        if self.pid is None and self.fp is not None:
             content = self.fp.read().strip()
             if content:
                 self.pid = int(content)
         return self.pid
 
     def setpid(self):
+        """
+        Try to set PID. When the self.fp is not set, then exception is raised.
+        """
         self.fp.seek(0)
         content = str(os.getpid())
         self.fp.write(content)
         self.fp.flush()
 
     def mypid(self):
+        """
+        If the PID in the locked file is PID of current process, then return True.
+        Otherwise, return False.
+        """
         return (os.getpid() == self.getpid())
 
     def valid(self):
+        """
+        Check if the process with PID is still running
+        """
         status = False
         try:
             os.kill(self.getpid(), 0)
+        except Exception as err:
+            log.debug(f"Unable to send 0 signal to process: {err}")
+        else:
             status = True
-        except Exception:
-            pass
         return status
 
     def delete(self):
+        """
+        Try to delete lock file
+        """
         if self.mypid() or not self.valid():
             self.close()
             os.unlink(self.path)
 
     def close(self):
+        """
+        Try to close lock file
+        """
+        if self.fp is None:
+            self.pid = None
+            return
         try:
             fd = self.fp.fileno()
             fcntl.flock(fd, fcntl.LOCK_UN)
+        except Exception as err:
+            log.debug(f"Unable to unlock file {self.path}: {err}")
+        try:
             self.fp.close()
-        except Exception:
-            pass
+        except Exception as err:
+            log.debug(f"Unable to close file {self.path}: {err}")
         self.pid = None
         self.fp = None
 
     def notcreated(self):
+        """
+        Check if lock file already exists
+        """
         return (not os.path.exists(self.path))
 
     def __del__(self):
@@ -106,30 +147,53 @@ class Lock(object):
         try:
             if not os.path.exists(lock_dir):
                 os.makedirs(lock_dir)
-            self.lockdir = lock_dir
-        except Exception:
+            else:
+                # When lock directory exists, then check if the owner is
+                # the same as current user. Otherwise, try to create some temporary
+                # file to check if user can write to given directory. When the
+                # file system is mounted as read-only, then root cannot write to
+                # the directory despite it is super-user. In that case exception
+                # PermissionError will be raised.
+                if os.getuid() != os.stat(lock_dir).st_uid:
+                    temp_file = tempfile.NamedTemporaryFile(dir=lock_dir)
+                    temp_file.close()
+        except PermissionError as err:
+            log.info(f"Unable to create lock/write to directory {lock_dir}: {err}")
+            raise err
+        except Exception as err:
+            log.debug(f"Unable to create lock directory {lock_dir}: {err}")
             self.lockdir = None
+        else:
+            self.lockdir = lock_dir
 
+    # FIXME: Following code is absolutely stochastic and there has to be some black magic, because
+    # it is miracle that it works and it does not block any application using this code.
+    # It seems that nothing uses blocking keyed argument. Thus only default equal None is used.
     def acquire(self, blocking=None):
         """Behaviour here is modeled after threading.RLock.acquire.
 
-        If 'blocking' is False, we return True if we didn't need to block and we acquired the lock.
-        We return False if couldn't acquire the lock and would have
+        If 'blocking' is False, we return True if we didn't need to block, and we acquired the lock.
+        We return False, if we couldn't acquire the lock and would have
         had to wait and block.
 
-        if 'blocking' is None, we return None when we acquire the lock, otherwise block until we do.
+        If 'blocking' is None, we return None when we acquire the lock, otherwise block until we do.
 
-        if 'blocking' is True, we behave the same as with blocking=None, except we return True.
+        If 'blocking' is True, we behave the same as with blocking=None, except we return True.
 
         """
 
         if self.lockdir is None:
             return
         f = LockFile(self.path)
+        log.debug(f"Locking file: {self.path}")
         try:
             try:
                 while True:
-                    f.open()
+                    # FIXME: if you set blocking to True, then this code would work anyway.
+                    # It is absolutely unclear, how it is possible, because fcntl.flock()
+                    # should block in this case. The blocking is set to False here to be sure
+                    # that the code will be still functional, when the magic would be over.
+                    f.open(blocking=False)
                     f.getpid()
                     if f.mypid():
                         self.P()
@@ -149,8 +213,7 @@ class Lock(object):
                 self.P()
                 f.setpid()
             except OSError as e:
-                log.exception(e)
-                print("could not create lock")
+                log.exception(f"Could not lock file: {self.path}", exc_info=e)
         finally:
             f.close()
 
@@ -167,8 +230,10 @@ class Lock(object):
         self.V()
         if self.acquired():
             return
+        log.debug(f"Unlocking file {self.path}")
         f = LockFile(self.path)
         try:
+            # FIXME: it does not make any sense to try to lock file again here
             f.open()
             f.delete()
         finally:
@@ -215,7 +280,34 @@ class Lock(object):
 
 class ActionLock(Lock):
 
+    # Standard path of lock file
     PATH = '/run/rhsm/cert.pid'
 
+    # This path is used, when standard directory is read-only and environment
+    # variable XDG_RUNTIME_DIR is defined
+    USER_PATH = "{XDG_RUNTIME_DIR}/rhsm/cert.pid"
+
     def __init__(self):
-        super(ActionLock, self).__init__(self.PATH)
+        try:
+            super(ActionLock, self).__init__(self.PATH)
+        except PermissionError:
+            # When it is not possible to create lock in standard directory, then
+            # try to use one in user directory
+            user_path = self._get_user_lock_dir()
+            if user_path is not None:
+                super(ActionLock, self).__init__(user_path)
+            else:
+                log.error("Unable to create lock directory in user runtime directory")
+
+    def _get_user_lock_dir(self) -> Union[None, str]:
+        """
+        Try to get lock directory in user runtime directory (typically /run/user/${UID}/)
+        """
+        if "XDG_RUNTIME_DIR" in os.environ:
+            xdg_runtime_dir = os.environ["XDG_RUNTIME_DIR"]
+            user_path = self.USER_PATH.format(XDG_RUNTIME_DIR=xdg_runtime_dir)
+        else:
+            log.debug("Environment variable XDG_RUNTIME_DIR not defined")
+            return None
+        log.info(f"Trying to use user lock directory: {user_path} (influenced by $XDG_RUNTIME_DIR)")
+        return user_path

--- a/test/test_lock.py
+++ b/test/test_lock.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+import stat
 try:
     import unittest2 as unittest
 except ImportError:
@@ -12,6 +13,7 @@ import shutil
 import tempfile
 import threading
 import time
+from typing import Union
 
 from subscription_manager import lock
 
@@ -23,11 +25,23 @@ class TestLock(unittest.TestCase):
 
     def setUp(self):
         self.other_process = None
+        self.lock_directory: Union[None, tempfile.TemporaryDirectory] = None
+
+    def tearDown(self) -> None:
+        # If temporary directory was created, then remove it
+        if self.lock_directory is not None:
+            self.lock_directory.cleanup()
 
     def _lock_path(self):
         tmp_dir = tempfile.mkdtemp(suffix="-lock", prefix="subman-unit-tests-")
         self.addCleanup(shutil.rmtree, tmp_dir, ignore_errors=True)
         return os.path.join(tmp_dir, self.lf_name)
+
+    def _lock_read_only_path(self):
+        self.lock_directory = tempfile.TemporaryDirectory()
+        # Make directory read only for owner
+        os.chmod(self.lock_directory.name, stat.S_IRUSR)
+        return os.path.join(self.lock_directory.name, self.lf_name)
 
     # For thread.Timer()
     def _kill_other_process(self, other_process):
@@ -132,6 +146,12 @@ class TestLock(unittest.TestCase):
         self.assertEqual(lf.path, lock_path)
         self.assertEqual(lf.depth, 0)
 
+    @unittest.skipIf(os.getuid() == 0, "Test cannot be run under root.")
+    def test_file_lock_readonly(self):
+        lock_path = self._lock_read_only_path()
+        lock_file = lock.LockFile(lock_path)
+        self.assertRaises(PermissionError, lock_file.open)
+
     def test_lock_acquire(self):
         lock_path = self._lock_path()
         lf = lock.Lock(lock_path)
@@ -160,6 +180,39 @@ class TestLock(unittest.TestCase):
         lf = lock.Lock(lock_path)
         lf.acquire()
         lf.release()
+
+    def test_lock_action(self):
+        original_path = lock.ActionLock.PATH
+        lock.ActionLock.PATH = self._lock_path()
+        lock_action = lock.ActionLock()
+        self.assertEqual(lock_action.path, lock.ActionLock.PATH)
+        # Restore original path in ActionLock
+        lock.ActionLock.PATH = original_path
+
+    @unittest.skipIf(os.getuid() == 0, "Test cannot be run under root.")
+    def test_lock_action_read_only(self):
+        """
+        Test the case, when it is not possible to create lock file in /run/rhsm/cert.pid.
+        In that case lock directory should be created in user runtime directory.
+        """
+        old_xdg_runtime_dir = None
+        if "XDG_RUNTIME_DIR" in os.environ:
+            old_xdg_runtime_dir = os.environ["XDG_RUNTIME_DIR"]
+        temp_dir = tempfile.TemporaryDirectory()
+        os.environ["XDG_RUNTIME_DIR"] = temp_dir.name
+        expected_user_dir = f"{temp_dir.name}/rhsm"
+        expected_path = expected_user_dir + "/cert.pid"
+
+        lock_action = lock.ActionLock()
+
+        self.assertTrue(
+            os.path.exists(expected_user_dir), msg=f"The rhsm directory {expected_user_dir} was not created"
+        )
+        self.assertEqual(lock_action.path, expected_path)
+
+        # Restore original environment variable
+        if old_xdg_runtime_dir is not None:
+            os.environ["XDG_RUNTIME_DIR"] = old_xdg_runtime_dir
 
     def _stale_lock(self):
         lock_path = self._lock_path()


### PR DESCRIPTION
* Card ID: ENT-5584
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2091269
* When the /run is mounted read-only, then try to create lock file in /run/user, which should never be mounted as read-only. The path to user's runtime directory should be defined in $XDG_RUNTIME_DIR.
* Added some doc strings and type hints for LockFile class and added more debug prints
* Added some comments, because the code of locking should not work, but it works for some unknown reasons
* Added some unit tests
* It is necessary to skip some tests for root user

(cherry picked from commit 7f0db752b0269dc362012713480201de6fa3444c)

Backport of PR #3134 to 1.28.