### PR TITLE
ENT-5580: Disable the proper container detection

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,7 +42,6 @@ jobs:
 
       - name: "Run pytest"
         env:
-          SUBMAN_TEST_IN_CONTAINER: "1"
           PYTEST_ADDOPTS:
             "--color=yes --code-highlight=yes --showlocals
             --cov 'src/' --cov-report 'term:skip-covered'

--- a/TESTING.md
+++ b/TESTING.md
@@ -87,8 +87,7 @@ Enter the container (assuming you are in the project root) and run a pre-test sc
 NAME="subscription-manager"  # Or something more descriptive, like "rhsm-cs9"
 podman run -it --rm \
   --name $NAME \
-  -v .:/subscription-manager --workdir /subscription-manager \
-  --env 'SUBMAN_TEST_IN_CONTAINER=1' --privileged \
+  -v .:/subscription-manager --workdir /subscription-manager --privileged \
   $IMAGE bash
 bash scripts/container-pre-test.sh
 ```
@@ -96,7 +95,7 @@ bash scripts/container-pre-test.sh
 Then you can run the test suite. You have to use `dbus-run-session` wrapper, because D-Bus is not running in containers:
 
 ```bash
-SUBMAN_TEST_IN_CONTAINER=1 dbus-run-session python3 -m pytest
+dbus-run-session python3 -m pytest
 ```
 
 ### Local subscription-manager images


### PR DESCRIPTION
* Card ID: ENT-5580

In RHEL 9, the container detection was made smarter to be able to detect Docker and Podman. However, this broke many workflows that were registering containers during build or runtime.

To make those use cases supported, the strong container detection is removed. Container mode will still be detected using secrets provided by the host OS.