### PR TITLE
[1.24] 2182768: Disallowed attaching pool in SCA mode

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -266,7 +266,7 @@ This command has no options.
 .SS ATTACH OPTIONS
 The
 .B attach
-command applies a specific subscription to the system.
+command applies a specific subscription to the system. This command is not possible to use, when the content access mode of the organization to which the system is registered is simple content access mode.
 
 .TP
 .B --auto

--- a/src/rhsmlib/dbus/objects/attach.py
+++ b/src/rhsmlib/dbus/objects/attach.py
@@ -23,6 +23,7 @@ from rhsmlib.dbus import constants, base_object, util, dbus_utils
 from rhsmlib.services.attach import AttachService
 
 from subscription_manager.injectioninit import init_dep_injection
+from subscription_manager.utils import is_simple_content_access
 
 init_dep_injection()
 
@@ -55,6 +56,10 @@ class AttachDBusObject(base_object.BaseObject):
         Locale.set(locale)
 
         cp = self.build_uep(proxy_options, proxy_only=True)
+
+        if is_simple_content_access(uep=cp) is True:
+            raise dbus.DBusException('Auto-attaching is not allowed in simple content access mode')
+
         attach_service = AttachService(cp)
 
         try:
@@ -85,6 +90,10 @@ class AttachDBusObject(base_object.BaseObject):
             raise dbus.DBusException("Quantity must be a positive number.")
 
         cp = self.build_uep(proxy_options, proxy_only=True)
+
+        if is_simple_content_access(uep=cp) is True:
+            raise dbus.DBusException('Attaching of pool(s) is not allowed in simple content access mode')
+
         attach_service = AttachService(cp)
 
         try:

--- a/src/rhsmlib/dbus/objects/attach.py
+++ b/src/rhsmlib/dbus/objects/attach.py
@@ -57,8 +57,13 @@ class AttachDBusObject(base_object.BaseObject):
 
         cp = self.build_uep(proxy_options, proxy_only=True)
 
+        # TODO: Change log.info() to:
+        # raise dbus.DBusException('Auto-attaching is not allowed in simple content access mode')
+        # in the next minor release of subscription-manager
         if is_simple_content_access(uep=cp) is True:
-            raise dbus.DBusException('Auto-attaching is not allowed in simple content access mode')
+            log.info('Calling D-Bus method AutoAttach() is deprecated, when Simple Content Access mode '
+                     'is used and it will be not be supported in the next minor release of '
+                     'subscription-manager')
 
         attach_service = AttachService(cp)
 
@@ -91,8 +96,13 @@ class AttachDBusObject(base_object.BaseObject):
 
         cp = self.build_uep(proxy_options, proxy_only=True)
 
+        # TODO: Change log.info() to:
+        # raise dbus.DBusException('Attaching of pool(s) is not allowed in simple content access mode')
+        # in the next minor release of subscription-manager
         if is_simple_content_access(uep=cp) is True:
-            raise dbus.DBusException('Attaching of pool(s) is not allowed in simple content access mode')
+            log.info('Calling D-Bus method PoolAttach() is deprecated, when Simple Content Access mode '
+                     'is used and it will be not be supported in the next minor release of '
+                     'subscription-manager')
 
         attach_service = AttachService(cp)
 

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -991,7 +991,23 @@ class ContentAccessModeCache(ConsumerCache):
         if uep is None:
             cp_provider = inj.require(inj.CP_PROVIDER)
             uep = cp_provider.get_consumer_auth_cp()
-        if hasattr(uep.conn, 'is_consumer_cert_key_valid') and uep.conn.is_consumer_cert_key_valid is True:
-            return False
+
+        if hasattr(uep.conn, 'is_consumer_cert_key_valid'):
+            if uep.conn.is_consumer_cert_key_valid is None:
+                log.debug(
+                    'Cache file %s cannot be considered as valid, because no connection has not '
+                    'been created yet',
+                    self.CACHE_FILE
+                )
+                return True
+            elif uep.conn.is_consumer_cert_key_valid is True:
+                return False
+            else:
+                log.debug(
+                    'Cache file %s cannot be considered as valid, because consumer certificate '
+                    'probably is not valid',
+                    self.CACHE_FILE
+                )
+                return True
         else:
             return True

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -995,7 +995,7 @@ class ContentAccessModeCache(ConsumerCache):
         if hasattr(uep.conn, 'is_consumer_cert_key_valid'):
             if uep.conn.is_consumer_cert_key_valid is None:
                 log.debug(
-                    'Cache file %s cannot be considered as valid, because no connection has not '
+                    'Cache file %s cannot be considered as valid, because no connection has '
                     'been created yet',
                     self.CACHE_FILE
                 )

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -314,7 +314,7 @@ class CliCommand(AbstractCLICommand):
 
         self.correlation_id = generate_correlation_id()
 
-    def _print_ignore_auto_attach_mesage(self):
+    def _print_ignore_auto_attach_message(self):
         """
         This message is shared by attach command and register command, because
         both commands can do auto-attach.
@@ -327,8 +327,9 @@ class CliCommand(AbstractCLICommand):
         owner_id = owner['key']
         print(
             _(
-                'Ignoring request to auto-attach. '
-                'It is disabled for org "{owner_id}" because of the content access mode setting.'
+                "Ignoring request to auto-attach. "
+                'Attaching subscriptions is disabled for organization "{owner_id}" '
+                "because of the content access mode setting."
             ).format(owner_id=owner_id)
         )
 
@@ -1337,7 +1338,7 @@ class RegisterCommand(UserPassCommand):
         # Do not try to do auto-attach, when simple content access mode is used
         # Only print info message to stdout
         if is_simple_content_access(uep=self.cp, identity=self.identity):
-            self._print_ignore_auto_attach_mesage()
+            self._print_ignore_auto_attach_message()
             return
 
         if 'serviceLevel' not in consumer and self.options.service_level:
@@ -1894,7 +1895,7 @@ class AttachCommand(CliCommand):
         #
         if is_simple_content_access(uep=self.cp, identity=self.identity):
             if self.auto_attach is True:
-                self._print_ignore_auto_attach_mesage()
+                self._print_ignore_auto_attach_message()
             else:
                 self._print_ignore_attach_message()
             return 0

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -327,9 +327,9 @@ class CliCommand(AbstractCLICommand):
         owner_id = owner['key']
         print(
             _(
-                "Ignoring request to auto-attach. "
+                "Ignoring the request to auto-attach. "
                 'Attaching subscriptions is disabled for organization "{owner_id}" '
-                "because of the content access mode setting."
+                "because Simple Content Access (SCA) is enabled."
             ).format(owner_id=owner_id)
         )
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -1874,8 +1874,9 @@ class AttachCommand(CliCommand):
         owner_id = owner['key']
         print(
             _(
-                'Ignoring request to attach. '
-                'It is disabled for org "{owner_id}" because of the content access mode setting.'
+                "Ignoring the request to attach. "
+                'Attaching subscriptions is disabled for organization "{owner_id}" '
+                "because Simple Content Access (SCA) is enabled."
             ).format(owner_id=owner_id)
         )
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -59,12 +59,12 @@ from subscription_manager.utils import parse_server_info, \
         parse_baseurl_info, format_baseurl, is_valid_server_info, \
         MissingCaCertException, get_client_versions, get_server_versions, \
         restart_virt_who, get_terminal_width, print_error, unique_list_items, \
-        is_simple_content_access
+        is_simple_content_access, \
+        generate_correlation_id
 from subscription_manager.overrides import Overrides, Override
 from subscription_manager.exceptions import ExceptionMapper
 from subscription_manager.printing_utils import columnize, format_name, \
         none_wrap_columnize_callback, echo_columnize_callback, highlight_by_filter_string_columnize_cb
-from subscription_manager.utils import generate_correlation_id
 from subscription_manager.syspurposelib import save_sla_to_syspurpose_metadata
 from subscription_manager.packageprofilelib import PackageProfileActionInvoker
 
@@ -313,6 +313,24 @@ class CliCommand(AbstractCLICommand):
         self.identity = inj.require(inj.IDENTITY)
 
         self.correlation_id = generate_correlation_id()
+
+    def _print_ignore_auto_attach_mesage(self):
+        """
+        This message is shared by attach command and register command, because
+        both commands can do auto-attach.
+        :return: None
+        """
+        owner = get_current_owner(self.cp, self.identity)
+        # We displayed Owner name: `owner_name = owner['displayName']`, but such behavior
+        # was not consistent with rest of subscription-manager
+        # Look at this comment: https://bugzilla.redhat.com/show_bug.cgi?id=1826300#c8
+        owner_id = owner['key']
+        print(
+            _(
+                'Ignoring request to auto-attach. '
+                'It is disabled for org "{owner_id}" because of the content access mode setting.'
+            ).format(owner_id=owner_id)
+        )
 
     def _get_logger(self):
         return logging.getLogger('rhsm-app.%s.%s' % (self.__module__, self.__class__.__name__))
@@ -1310,6 +1328,36 @@ class RegisterCommand(UserPassCommand):
         """
         return True
 
+    def _do_auto_attach(self, consumer):
+        """
+        Try to do auto-attach, when it was requested using --auto-attach CLI option
+        :return: None
+        """
+
+        # Do not try to do auto-attach, when simple content access mode is used
+        # Only print info message to stdout
+        if is_simple_content_access(uep=self.cp, identity=self.identity):
+            self._print_ignore_auto_attach_mesage()
+            return
+
+        if 'serviceLevel' not in consumer and self.options.service_level:
+            system_exit(
+                os.EX_UNAVAILABLE,
+                _(
+                    "Error: The --servicelevel option is not supported "
+                    "by the server. Did not complete your request."
+                )
+            )
+        try:
+            # We don't call auto_attach with self.option.service_level, because it has been already
+            # set during service.register() call
+            attach.AttachService(self.cp).attach_auto(service_level=None)
+        except connection.RestlibException as rest_lib_err:
+            print_error(rest_lib_err.msg)
+        except Exception:
+            log.exception("Auto-attach failed")
+            raise
+
     def _do_command(self):
         """
         Executes the command.
@@ -1431,20 +1479,7 @@ class RegisterCommand(UserPassCommand):
             self.cp.updateConsumer(consumer['uuid'], release=self.options.release)
 
         if self.autoattach:
-            if 'serviceLevel' not in consumer and self.options.service_level:
-                system_exit(os.EX_UNAVAILABLE, _("Error: The --servicelevel option is not supported "
-                                 "by the server. Did not complete your request."))
-            try:
-                attach.AttachService(self.cp).attach_auto(self.options.service_level)
-            except connection.RestlibException as re:
-                print_error(re.msg)
-            except Exception:
-                log.exception("Auto-attach failed")
-                raise
-            else:
-                if self.options.service_level is not None:
-                    save_sla_to_syspurpose_metadata(self.options.service_level)
-                    print(_("Service level set to: %s") % self.options.service_level)
+            self._do_auto_attach(consumer)
 
         if self.options.consumerid or self.options.activation_keys or self.autoattach or self.cp.has_capability(CONTENT_ACCESS_CERT_CAPABILITY):
             log.debug("System registered, updating entitlements if needed")
@@ -1838,16 +1873,7 @@ class AttachCommand(CliCommand):
         # BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1826300
         if self.auto_attach is True:
             if is_simple_content_access(uep=self.cp, identity=self.identity):
-                owner = get_current_owner(self.cp, self.identity)
-                # We displayed Owner name: `owner_name = owner['displayName']`, but such behavior
-                # was not consistent with rest of subscription-manager
-                # Look at this comment: https://bugzilla.redhat.com/show_bug.cgi?id=1826300#c8
-                owner_id = owner['key']
-                print(_(
-                        'Ignoring request to auto-attach. '
-                        'It is disabled for org "{owner_id}" because of the content access mode setting.'
-                        ).format(owner_id=owner_id)
-                     )
+                self._print_ignore_auto_attach_mesage()
                 return 0
 
         installed_products_num = 0

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -170,7 +170,6 @@ def is_simple_content_access(uep=None, identity=None):
     This function has three optional arguments that can be reused for getting required information.
     :param uep: connection to candlepin server
     :param identity: reference on current identity
-    :param owner: reference on current owner
     :return: True, when current owner uses contentAccesMode equal to org_environment. False otherwise.
     """
     if identity is None:

--- a/test/rhsmlib_test/test_attach.py
+++ b/test/rhsmlib_test/test_attach.py
@@ -311,8 +311,11 @@ class TestAttachDBusObject(DBusObjectTest, InjectionMockingTest):
         self.mock_attach.attach_auto.return_value = CONTENT_JSON
 
         dbus_method_args = ['service_level', {}, '']
-        with self.assertRaises(dbus.exceptions.DBusException):
-            self.dbus_request(None, self.interface.AutoAttach, dbus_method_args)
+
+        # TODO: change following code to assert, when calling AutoAttach will not be supported in SCA mode
+        # with self.assertRaises(dbus.exceptions.DBusException):
+        #     self.dbus_request(None, self.interface.AutoAttach, dbus_method_args)
+        self.dbus_request(None, self.interface.AutoAttach, dbus_method_args)
 
     def test_attach_pool_sca(self):
         """
@@ -323,5 +326,7 @@ class TestAttachDBusObject(DBusObjectTest, InjectionMockingTest):
         self.mock_attach.attach_pool.return_value = CONTENT_JSON
         dbus_method_args = [['x', 'y'], 1, {}, '']
 
-        with self.assertRaises(dbus.exceptions.DBusException):
-            self.dbus_request(None, self.interface.PoolAttach, dbus_method_args)
+        # TODO: change following code to assert, when calling PoolAttach will not be supported in SCA mode
+        # with self.assertRaises(dbus.exceptions.DBusException):
+        #     self.dbus_request(None, self.interface.PoolAttach, dbus_method_args)
+        self.dbus_request(None, self.interface.PoolAttach, dbus_method_args)

--- a/test/rhsmlib_test/test_attach.py
+++ b/test/rhsmlib_test/test_attach.py
@@ -180,6 +180,11 @@ class TestAttachDBusObject(DBusObjectTest, InjectionMockingTest):
         self.mock_identity.is_valid.return_value = True
         self.mock_identity.uuid = "id"
 
+        is_simple_content_access_patcher = mock.patch('rhsmlib.dbus.objects.attach.is_simple_content_access')
+        self.mock_is_simple_content_access = is_simple_content_access_patcher.start()
+        self.mock_is_simple_content_access.return_value = False
+        self.addCleanup(is_simple_content_access_patcher.stop)
+
     def injection_definitions(self, *args, **kwargs):
         if args[0] == inj.IDENTITY:
             return self.mock_identity
@@ -281,7 +286,13 @@ class TestAttachDBusObject(DBusObjectTest, InjectionMockingTest):
         with six.assertRaisesRegex(self, dbus.DBusException, r'requires the consumer to be registered.*'):
             self.dbus_request(None, self.interface.AutoAttach, auto_method_args)
 
-    def test_auto_attach(self):
+    @mock.patch('rhsmlib.dbus.objects.attach.is_simple_content_access')
+    def test_auto_attach(self, mock_is_simple_content_access):
+        """
+        Test calling AutoAttach method in non-SCA mode
+        """
+        mock_is_simple_content_access.return_value = False
+
         def assertions(*args):
             result = args[0]
             self.assertEqual(result, json.dumps(CONTENT_JSON))
@@ -290,3 +301,27 @@ class TestAttachDBusObject(DBusObjectTest, InjectionMockingTest):
 
         dbus_method_args = ['service_level', {}, '']
         self.dbus_request(assertions, self.interface.AutoAttach, dbus_method_args)
+
+    def test_auto_attach_sca(self):
+        """
+        Test that calling AutoAttach method raises exception, when system is in SCA mode
+        """
+        self.mock_is_simple_content_access.return_value = True
+
+        self.mock_attach.attach_auto.return_value = CONTENT_JSON
+
+        dbus_method_args = ['service_level', {}, '']
+        with self.assertRaises(dbus.exceptions.DBusException):
+            self.dbus_request(None, self.interface.AutoAttach, dbus_method_args)
+
+    def test_attach_pool_sca(self):
+        """
+        Test that calling PoolAttach method raises exception in SCA mode
+        """
+        self.mock_is_simple_content_access.return_value = True
+
+        self.mock_attach.attach_pool.return_value = CONTENT_JSON
+        dbus_method_args = [['x', 'y'], 1, {}, '']
+
+        with self.assertRaises(dbus.exceptions.DBusException):
+            self.dbus_request(None, self.interface.PoolAttach, dbus_method_args)

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1582,13 +1582,8 @@ class TestAttachCommand(TestCliProxyCommand):
         Test the case, when SCA mode is used. Auto-attach is not possible in this case
         """
         mock_is_simple_content_access.return_value = True
-        try:
-            self.cc.main("--auto")
-            self.cc._validate_options()
-        except SystemExit as e:
-            self.assertEqual(e.code, os.EX_USAGE)
-        else:
-            self.fail("No Exception Raised")
+        self.cc.main(["--auto"])
+        self.cc._validate_options()
 
     @patch('subscription_manager.managercli.is_simple_content_access')
     def test_attach_sca_mode(self, mock_is_simple_content_access):
@@ -1596,13 +1591,8 @@ class TestAttachCommand(TestCliProxyCommand):
         Test the case, when SCA mode is used. Attaching of pool is not possible in this case
         """
         mock_is_simple_content_access.return_value = True
-        try:
-            self.cc.main("--pool 123456789")
-            self.cc._validate_options()
-        except SystemExit as e:
-            self.assertEqual(e.code, os.EX_USAGE)
-        else:
-            self.fail("No Exception Raised")
+        self.cc.main(["--pool", "123456789"])
+        self.cc._validate_options()
 
 
 # Test Attach and Subscribe are the same

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1576,6 +1576,34 @@ class TestAttachCommand(TestCliProxyCommand):
         else:
             self.fail("No Exception Raised")
 
+    @patch('subscription_manager.managercli.is_simple_content_access')
+    def test_auto_attach_sca_mode(self, mock_is_simple_content_access):
+        """
+        Test the case, when SCA mode is used. Auto-attach is not possible in this case
+        """
+        mock_is_simple_content_access.return_value = True
+        try:
+            self.cc.main("--auto")
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)
+        else:
+            self.fail("No Exception Raised")
+
+    @patch('subscription_manager.managercli.is_simple_content_access')
+    def test_attach_sca_mode(self, mock_is_simple_content_access):
+        """
+        Test the case, when SCA mode is used. Attaching of pool is not possible in this case
+        """
+        mock_is_simple_content_access.return_value = True
+        try:
+            self.cc.main("--pool 123456789")
+            self.cc._validate_options()
+        except SystemExit as e:
+            self.assertEqual(e.code, os.EX_USAGE)
+        else:
+            self.fail("No Exception Raised")
+
 
 # Test Attach and Subscribe are the same
 class TestSubscribeCommand(TestAttachCommand):


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2182768
* Manual attaching of pool using --pool CLI option is not
  allowed now. When user tries to attach any pool in SCA
  mode, then info message is printedn and subscription-manager
  is terminated
* Added two unit tests for auto-attach ins SCA mode and
  manual attach
* Added more debug prints for cache used by function
  is_simple_content_access(), because I considered using
  this method, when --help is used, but calling
  subscription-manager attach --help would cause calling
  one REST API endpoint
* Updated manual page about subscription-manager
* Make sure to not disallow auto-attach in the D-Bus interface, to avoid breaking users

Backport to 1.24 of the following PRs (backported from 1.28 to ease the backport changed needed):
- an own commit to add an helper function, keeping backports easier
- part of PR #2568
  - commit a5dc6f6
- PR #2912
  - commit 4d258b1
  - commit a0b5d65
  - commit 8a08c55
- PR #2965
  - commit 9a3f219
- PR #3118
  - commit 7ee691a
- PR #3140
  - commit f32cd11
- PR #3145
  - commit b52b2ea
- PR #3273
  - commit d6f2b79