### PR TITLE
[1.28] tests: repair attach cases in SCA mode

### DIFF
--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -1731,13 +1731,8 @@ class TestAttachCommand(TestCliProxyCommand):
         Test the case, when SCA mode is used. Auto-attach is not possible in this case
         """
         mock_is_simple_content_access.return_value = True
-        try:
-            self.cc.main("--auto")
-            self.cc._validate_options()
-        except SystemExit as e:
-            self.assertEqual(e.code, os.EX_USAGE)
-        else:
-            self.fail("No Exception Raised")
+        self.cc.main(["--auto"])
+        self.cc._validate_options()
 
     @patch('subscription_manager.managercli.is_simple_content_access')
     def test_attach_sca_mode(self, mock_is_simple_content_access):
@@ -1745,13 +1740,8 @@ class TestAttachCommand(TestCliProxyCommand):
         Test the case, when SCA mode is used. Attaching of pool is not possible in this case
         """
         mock_is_simple_content_access.return_value = True
-        try:
-            self.cc.main("--pool 123456789")
-            self.cc._validate_options()
-        except SystemExit as e:
-            self.assertEqual(e.code, os.EX_USAGE)
-        else:
-            self.fail("No Exception Raised")
+        self.cc.main(["--pool", "123456789"])
+        self.cc._validate_options()
 
 
 # Test Attach and Subscribe are the same


### PR DESCRIPTION
There are a couple of test cases for the "attach" command that check the behaviour for `--auto` and `--pool POOL_ID` in case of SCA; the problem is that they were broken until now for a couple of reasons:
- the `main()` method of a command class (derived from `AbstractCLICommand`) takes a list of strings, and not a single string; since `ArgumentParser.parse_known_args()` iterates on its `args` argument, and iterating over a `str` is possible in Python 3, this "runs fine", however it matches nothing, exiting with an usage message
- as consequence/related to the above, the two tests assumed the runs would fail, whereas because of the behaviour change they now cause a clean exit (with exit code 0)

Hence, repair these two tests so they work:
- pass the arguments to `main()` properly as list of strings, so `ArgumentParser` can parse them
- drop the exception expectation, since they cause a clean exit

Followup of commit 61cb998725cafbb90d2562ef39ecb1c7e5f2307c.

(cherry picked from commit 792d6852185319dcd54628fb91c395d40b2359c3)

Backport of PR #3272 to 1.28.