### PR TITLE
spec: update deps for dnf or in libdnf packages

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -164,7 +164,7 @@ Requires:  %{py_package_prefix}-setuptools
 
 %if %{use_dnf}
 %if %{create_libdnf_rpm}
-Requires: dnf >= 1.0.0
+Requires: python3-dnf
 Requires: python3-dnf-plugins-core
 Requires: python3-librepo
 %else

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -250,9 +250,6 @@ BuildRequires: cmake
 BuildRequires: gcc
 BuildRequires: json-c-devel
 BuildRequires: libdnf-devel >= 0.22.5
-Requires: json-c
-Requires: libdnf >= 0.22.5
-Requires: dnf >= 1.0.0
 
 Obsoletes: dnf-plugin-subscription-manager < 1.29.0
 


### PR DESCRIPTION
Update the dependencies of libdnf-plugin-subscription-manager (which
contains the C plugin using libdnf), removing old or unneeded ones:
- drop 'dnf', as the plugin needs the library and not dnf itself
- drop 'libdnf' & 'json-c', as the right shared libs dependencies will
  be added automatically, and the 'libdnf' version pinned here is super
  old; the versioned 'libdnf-devel' 'will ensure the build against a
  needed version

Switch the manual 'dnf' dependency in subscription-manager with 
'python3-dnf', which is what is actually needed (since there are Python
plugins).

There should be no behaviour changes.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2209387
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2209411