### PR TITLE
[1.28] Update cockpit test lib for Chromium 113 fix

### DIFF
--- a/integration-tests/run
+++ b/integration-tests/run
@@ -69,9 +69,9 @@ bots:
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time
-# 273 + https://github.com/cockpit-project/cockpit/commit/49a7122df2
+# 274 + fix for chromium 113
 integration-test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 49a7122df205ab434bab884eb3a7be94d1a8e255
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 5aaa9a11975330c52f6d72b831d8e33de32eb660
 	git archive FETCH_HEAD -- test/common | tar -x -C integration-tests --strip-components=1 -f -
 
 node_modules:


### PR DESCRIPTION
The most recent Chromium 113 does not work any more with sizzle, tests
were hanging as soon as they switched to a frame. The latest cockpit
testlib applied a workaround [1]. As the latest Cockpit library also
moved to PatternFly 5, but that would be prohibitively expensive for
sub-man's stable branch, switch to the (temporary) "274+chromium-sizzle"
branch, which has that workaround backported.

[1] https://github.com/cockpit-project/cockpit/pull/18812

---

This will fix the [current test failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-4847-20230606-073138-c9c1f2f3-rhel-8-4-candlepin-subscription-manager-subscription-manager-1.28/log.html), which started to happen with the update to Chromium 113. This blocks https://github.com/cockpit-project/bots/pull/4847