### PR TITLE
[1.28.36] ci: run jobs only on CentOS Stream 8

### DIFF
--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -12,14 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "CentOS Stream 9"
-            image: "quay.io/centos/centos:stream9"
           - name: "CentOS Stream 8"
             image: "quay.io/centos/centos:stream8"
-          - name: "Fedora latest"
-            image: "fedora:latest"
-          - name: "Fedora Rawhide"
-            image: "fedora:rawhide"
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,22 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "CentOS Stream 9"
-            image: "quay.io/centos/centos:stream9"
-            pytest_args: '--deselect test/rhsmlib_test/test_hwprobe.py::HardwareProbeTest::test_networkinfo --deselect test/rhsmlib_test/test_facts.py::TestFactsDBusObject::test_GetFacts'
-            # The 'test_networkinfo' breaks in CentOS container because it has IPv6 disabled.
-            # Because of a bug in Python, collecting 'socket.AF_INET6' via 'socket.getaddrinfo()' causes
-            # segfaults instead of exceptions. This deselect is a workaround until it is fixed or until
-            # we switch to a different way of collecting network facts.
-            # 'test_GetFacts' triggers full fact collection and causes the same error.
           - name: "CentOS Stream 8"
             image: "quay.io/centos/centos:stream8"
-            pytest_args: ''
-          - name: "Fedora latest"
-            image: "fedora:latest"
-            pytest_args: ''
-          - name: "Fedora Rawhide"
-            image: "fedora:rawhide"
             pytest_args: ''
 
     runs-on: ubuntu-latest
@@ -63,7 +49,7 @@ jobs:
         uses: MishaKav/pytest-coverage-comment@main
         if: |
           github.event.pull_request.head.repo.full_name == github.repository
-          && matrix.name == 'Fedora latest'
+          && matrix.name == 'CentOS Stream 8'
         with:
           title: "Coverage (computed on ${{ matrix.name }})"
           report-only-changed-files: true

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -14,12 +14,6 @@ jobs:
         include:
           - name: "CentOS Stream 8"
             image: "quay.io/centos/centos:stream8"
-          - name: "CentOS Stream 9"
-            image: "quay.io/centos/centos:stream9"
-          - name: "Fedora latest"
-            image: "fedora:latest"
-          - name: "Fedora Rawhide"
-            image: "fedora:rawhide"
 
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
This branch is aimed at RHEL 8.8.x, so the only testing needed is on CentOS Stream 8.

Modify the coverage reporting to use CentOS Stream 8, rather than Fedora latest.