### PR TITLE
[1.28] Use Cockpit lib with chromium sizzle fix

### DIFF
--- a/cockpit/Makefile
+++ b/cockpit/Makefile
@@ -45,6 +45,6 @@ rpm: dist-gzip
 
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
-	git clone -b 253 --depth=1 https://github.com/cockpit-project/cockpit.git tmp/cockpit
+	git clone -b 253+chromium-sizzle --depth=1 https://github.com/cockpit-project/cockpit.git tmp/cockpit
 	mv tmp/cockpit/pkg/lib src/
 	rm -rf tmp/cockpit


### PR DESCRIPTION
The most recent Chromium 113 does not work any more with sizzle, tests were hanging as soon as they switched to a frame. Use a 259 release branch with the sizzle fix backported.

This failed on the stable branch here https://github.com/cockpit-project/bots/pull/4847