### PR TITLE
Simplify D-Bus tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,6 @@ addopts =
 	# Mark some tests not to be run
 	-m "not functional"
 markers =
-	dbus: subscription-manager tests for DBus.
 	slow: subscription-manager tests that may be slower than the rest.
 	zypper: subscription-manager tests for the Zypper package manager.
 	functional: subscription-manager functional tests.
@@ -17,4 +16,3 @@ testpaths =
 required_plugins =
 	pytest-randomly
 	pytest-timeout
-	pytest-forked

--- a/src/rhsmlib/dbus/objects/attach.py
+++ b/src/rhsmlib/dbus/objects/attach.py
@@ -10,10 +10,13 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
+from typing import List
+
 import dbus
 import json
 import logging
 
+from rhsm.connection import UEPConnection
 from subscription_manager import entcertlib
 from subscription_manager.i18n import Locale
 
@@ -26,6 +29,64 @@ from subscription_manager.utils import is_simple_content_access
 init_dep_injection()
 
 log = logging.getLogger(__name__)
+
+
+class AttachDBusImplementation(base_object.BaseImplementation):
+    def auto_attach(self, service_level: str, proxy_options: dict) -> dict:
+        self.ensure_registered()
+
+        uep: UEPConnection = self.build_uep(proxy_options, proxy_only=True)
+
+        # TODO Change log.info()
+        #  to raise dbus.DBusException('Auto-attaching is not allowed in simple content access mode')
+        #  in next minor subscription-manager release
+        if is_simple_content_access(uep=uep):
+            log.info(
+                "Calling D-Bus method AutoAttach() is deprecated, when Simple Content Access mode "
+                "is used and it will be not be supported in the next minor release of "
+                "subscription-manager"
+            )
+
+        service = AttachService(uep)
+        try:
+            response: dict = service.attach_auto(service_level)
+        except Exception as exc:
+            log.exception(exc)
+            raise dbus.DBusException(str(exc))
+
+        # TODO This should probably be called only if something is actually attached
+        entcertlib.EntCertActionInvoker().update()
+        return response
+
+    def pool_attach(self, pools: List[str], quantity: int, proxy_options: dict) -> List[dict]:
+        self.ensure_registered()
+
+        if quantity < 1:
+            raise dbus.DBusException("Quantity must be a positive number.")
+
+        uep: UEPConnection = self.build_uep(proxy_options, proxy_only=True)
+
+        # TODO Change log.info()
+        #  to raise dbus.DBusException('Auto-attaching is not allowed in simple content access mode')
+        #  in next minor subscription-manager release
+        if is_simple_content_access(uep=uep):
+            log.info(
+                "Calling D-Bus method AutoAttach() is deprecated, when Simple Content Access mode "
+                "is used and it will be not be supported in the next minor release of "
+                "subscription-manager"
+            )
+
+        service = AttachService(uep)
+        try:
+            results: List[dict] = []
+            for pool in pools:
+                response = service.attach_pool(pool, quantity)
+                results.append(response)
+        except Exception as exc:
+            log.exception(exc)
+            raise dbus.DBusException(str(exc))
+
+        return results
 
 
 class AttachDBusObject(base_object.BaseObject):
@@ -41,6 +102,7 @@ class AttachDBusObject(base_object.BaseObject):
 
     def __init__(self, conn=None, object_path=None, bus_name=None):
         super(AttachDBusObject, self).__init__(conn=conn, object_path=object_path, bus_name=bus_name)
+        self.impl = AttachDBusImplementation()
 
     @util.dbus_service_method(
         constants.ATTACH_INTERFACE,
@@ -50,35 +112,13 @@ class AttachDBusObject(base_object.BaseObject):
     @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def AutoAttach(self, service_level, proxy_options, locale, sender=None):
-        self.ensure_registered()
         service_level = dbus_utils.dbus_to_python(service_level, expected_type=str) or None
         proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
         locale = dbus_utils.dbus_to_python(locale, expected_type=str)
         Locale.set(locale)
 
-        cp = self.build_uep(proxy_options, proxy_only=True)
-
-        # TODO: Change log.info() to:
-        # raise dbus.DBusException('Auto-attaching is not allowed in simple content access mode')
-        # in the next minor release of subscription-manager
-        if is_simple_content_access(uep=cp) is True:
-            log.info(
-                "Calling D-Bus method AutoAttach() is deprecated, when Simple Content Access mode "
-                "is used and it will be not be supported in the next minor release of "
-                "subscription-manager"
-            )
-
-        attach_service = AttachService(cp)
-
-        try:
-            resp = attach_service.attach_auto(service_level)
-        except Exception as e:
-            log.exception(e)
-            raise dbus.DBusException(str(e))
-
-        # TODO Likely should only call this if something is actually attached
-        entcertlib.EntCertActionInvoker().update()
-        return json.dumps(resp)
+        result: dict = self.impl.auto_attach(service_level, proxy_options)
+        return json.dumps(result)
 
     @util.dbus_service_method(
         constants.ATTACH_INTERFACE,
@@ -88,7 +128,6 @@ class AttachDBusObject(base_object.BaseObject):
     @util.dbus_handle_sender
     @util.dbus_handle_exceptions
     def PoolAttach(self, pools, quantity, proxy_options, locale, sender=None):
-        self.ensure_registered()
         pools = dbus_utils.dbus_to_python(pools, expected_type=list)
         quantity = dbus_utils.dbus_to_python(quantity, expected_type=int)
         proxy_options = dbus_utils.dbus_to_python(proxy_options, expected_type=dict)
@@ -96,32 +135,5 @@ class AttachDBusObject(base_object.BaseObject):
         locale = dbus_utils.dbus_to_python(locale, expected_type=str)
         Locale.set(locale)
 
-        if quantity < 1:
-            raise dbus.DBusException("Quantity must be a positive number.")
-
-        cp = self.build_uep(proxy_options, proxy_only=True)
-
-        # TODO: Change log.info() to:
-        # raise dbus.DBusException('Attaching of pool(s) is not allowed in simple content access mode')
-        # in the next minor release of subscription-manager
-        if is_simple_content_access(uep=cp) is True:
-            log.info(
-                "Calling D-Bus method PoolAttach() is deprecated, when Simple Content Access mode "
-                "is used and it will be not be supported in the next minor release of "
-                "subscription-manager"
-            )
-
-        attach_service = AttachService(cp)
-
-        try:
-            results = []
-            for pool in pools:
-                resp = attach_service.attach_pool(pool, quantity)
-                results.append(json.dumps(resp))
-        except Exception as e:
-            log.exception(e)
-            raise dbus.DBusException(str(e))
-
-        # TODO Likely should only call this if something is actually attached
-        entcertlib.EntCertActionInvoker().update()
-        return results
+        result: List[dict] = self.impl.pool_attach(pools, quantity, proxy_options)
+        return [json.dumps(item) for item in result]

--- a/src/rhsmlib/dbus/service_wrapper.py
+++ b/src/rhsmlib/dbus/service_wrapper.py
@@ -10,17 +10,24 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
+import argparse
 import os
 import sys
-import argparse
+from typing import List, Optional, TYPE_CHECKING, Type
+
 import dbus
 import dbus.mainloop.glib
 import rhsmlib
 import logging
 
+import rhsmlib.dbus.constants
 from rhsmlib.dbus import server
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.cli import system_exit
+
+if TYPE_CHECKING:
+    import dbus.service
+    from rhsmlib.dbus.base_object import BaseObject
 
 log = logging.getLogger(__name__)
 
@@ -49,7 +56,11 @@ def parse_argv(argv, default_dbus_name):
     return opts, args
 
 
-def main(argv=sys.argv, object_classes=None, default_bus_name=None):
+def main(
+    argv=sys.argv,
+    object_classes: List[Type["BaseObject"]] = None,
+    default_bus_name: Optional[str] = None,
+) -> int:
     # Set default mainloop
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 

--- a/src/rhsmlib/services/products.py
+++ b/src/rhsmlib/services/products.py
@@ -11,6 +11,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 import collections
+from typing import List
 
 from rhsm.connection import UEPConnection
 
@@ -32,14 +33,14 @@ class InstalledProducts:
         self.plugin_manager = inj.require(inj.PLUGIN_MANAGER)
         self.cp = cp
 
-    def list(self, filter_string: str = None, iso_dates: bool = False) -> list:
+    def list(self, filter_string: str = None, iso_dates: bool = False) -> List[tuple]:
         """
         Method for listening installed products in the system
         :param filter_string: String for filtering out products
         :param iso_dates: Whether output dates in ISO 8601 format
         :return: List of installed products.
         """
-        product_status = []
+        product_status: List[tuple] = []
 
         # It is important to gather data from certificates of installed
         # products at the first time: sorter = inj.require(inj.CERT_SORTER)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,7 +12,6 @@ flake8
 pytest<7
 pytest-randomly
 pytest-timeout
-pytest-forked
 pytest-cov
 polib
 pyinotify

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -17,16 +17,6 @@ subman_marker_slow = pytest.mark.slow
 subman_marker_slow_timeout = pytest.mark.timeout(40)
 
 
-def subman_marker_dbus(func: Callable) -> Callable:
-    """
-    Fork each D-Bus unit test into it's own process, because we use threads
-    and mocking in these tests and such tests are not reliable without forking.
-    :param func: function of D-Bus unit test
-    :return: function of unit test marked as forked
-    """
-    return pytest.mark.dbus(pytest.mark.forked(func))
-
-
 def subman_marker_needs_envvars(*envvars: List[str]) -> Callable:
     """Skip test if one or more environment variables are missing."""
     missing_vars: List[str] = [v for v in envvars if v not in os.environ]

--- a/test/rhsmlib/dbus/test_attach.py
+++ b/test/rhsmlib/dbus/test_attach.py
@@ -10,50 +10,44 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-from typing import Any, Dict
 
 import dbus
-import json
 from unittest import mock
 
-from rhsmlib.dbus.objects import AttachDBusObject
+from rhsmlib.dbus.objects.attach import AttachDBusImplementation
+from subscription_manager.i18n import Locale
 
-from test.rhsmlib.base import DBusServerStubProvider
+from test.rhsmlib.base import SubManDBusFixture
 from test.rhsmlib.services.test_attach import CONTENT_JSON
 
 
-class TestAttachDBusObject(DBusServerStubProvider):
-    dbus_class = AttachDBusObject
-    dbus_class_kwargs: Dict[str, Any] = {}
+class TestAttachDBusObject(SubManDBusFixture):
+    def setUp(self) -> None:
+        super().setUp()
+        self.impl = AttachDBusImplementation()
 
-    @classmethod
-    def setUpClass(cls) -> None:
         is_simple_content_access_patch = mock.patch(
             "rhsmlib.dbus.objects.attach.is_simple_content_access",
             name="is_simple_content_access",
         )
-        cls.patches["is_simple_content_access"] = is_simple_content_access_patch.start()
-        cls.addClassCleanup(is_simple_content_access_patch.stop)
+        self.patches["is_simple_content_access"] = is_simple_content_access_patch.start()
+        self.addCleanup(is_simple_content_access_patch.stop)
+        self.patches["is_simple_content_access"].return_value = False
 
         is_registered_patch = mock.patch(
-            "rhsmlib.dbus.base_object.BaseObject.is_registered",
+            "rhsmlib.dbus.objects.attach.AttachDBusImplementation.is_registered",
             name="is_registered",
         )
-        cls.patches["is_registered"] = is_registered_patch.start()
-        cls.addClassCleanup(is_registered_patch.stop)
+        self.patches["is_registered"] = is_registered_patch.start()
+        self.addCleanup(is_registered_patch.stop)
+        self.patches["is_registered"].return_value = True
 
         update_patch = mock.patch(
             "subscription_manager.certlib.BaseActionInvoker.update",
             name="update",
         )
-        cls.patches["update"] = update_patch.start()
-        cls.addClassCleanup(update_patch.stop)
-
-        super().setUpClass()
-
-    def setUp(self) -> None:
-        self.patches["is_simple_content_access"].return_value = False
-        self.patches["is_registered"].return_value = True
+        self.patches["update"] = update_patch.start()
+        self.addCleanup(update_patch.stop)
         self.patches["update"].return_value = None
 
         AttachService_patch = mock.patch(
@@ -64,21 +58,21 @@ class TestAttachDBusObject(DBusServerStubProvider):
         self.mock_attach = AttachService_patch.start().return_value
         self.addCleanup(AttachService_patch.stop)
 
-        super().setUp()
+    def tearDown(self):
+        Locale.set(self.LOCALE)
 
     def test_PoolAttach(self):
         self.mock_attach.attach_pool.return_value = CONTENT_JSON
 
-        expected = [json.dumps(CONTENT_JSON), json.dumps(CONTENT_JSON)]
-        result = self.obj.PoolAttach.__wrapped__(self.obj, ["x", "y"], 1, {}, self.LOCALE)
+        expected = [CONTENT_JSON, CONTENT_JSON]
+        result = self.impl.pool_attach(["x", "y"], 1, {})
         self.assertEqual(result, expected)
 
     def test_PoolAttach__proxy(self):
         self.mock_attach.attach_pool.return_value = CONTENT_JSON
 
-        expected = [json.dumps(CONTENT_JSON), json.dumps(CONTENT_JSON)]
-        result = self.obj.PoolAttach.__wrapped__(
-            self.obj,
+        expected = [CONTENT_JSON, CONTENT_JSON]
+        result = self.impl.pool_attach(
             ["x", "y"],
             1,
             {
@@ -87,62 +81,65 @@ class TestAttachDBusObject(DBusServerStubProvider):
                 "proxy_user": "user",
                 "proxy_password": "password",
             },
-            self.LOCALE,
         )
         self.assertEqual(result, expected)
 
     def test_PoolAttach__de(self):
         self.mock_attach.attach_pool.return_value = CONTENT_JSON
+        Locale.set("de")
 
-        expected = [json.dumps(CONTENT_JSON), json.dumps(CONTENT_JSON)]
-        result = self.obj.PoolAttach.__wrapped__(self.obj, ["x", "y"], 1, {}, "de")
+        expected = [CONTENT_JSON, CONTENT_JSON]
+        result = self.impl.pool_attach(["x", "y"], 1, {})
         self.assertEqual(expected, result)
 
     def test_PoolAttach__de_DE(self):
         self.mock_attach.attach_pool.return_value = CONTENT_JSON
+        Locale.set("de_DE")
 
-        expected = [json.dumps(CONTENT_JSON), json.dumps(CONTENT_JSON)]
-        result = self.obj.PoolAttach.__wrapped__(self.obj, ["x", "y"], 1, {}, "de_DE")
+        expected = [CONTENT_JSON, CONTENT_JSON]
+        result = self.impl.pool_attach(["x", "y"], 1, {})
         self.assertEqual(expected, result)
 
     def test_PoolAttach__de_DE_utf8(self):
         self.mock_attach.attach_pool.return_value = CONTENT_JSON
+        Locale.set("de_DE.utf-8")
 
-        expected = [json.dumps(CONTENT_JSON), json.dumps(CONTENT_JSON)]
-        result = self.obj.PoolAttach.__wrapped__(self.obj, ["x", "y"], 1, {}, "de_DE.utf-8")
+        expected = [CONTENT_JSON, CONTENT_JSON]
+        result = self.impl.pool_attach(["x", "y"], 1, {})
         self.assertEqual(expected, result)
 
     def test_PoolAttach__de_DE_UTF8(self):
         self.mock_attach.attach_pool.return_value = CONTENT_JSON
+        Locale.set("de_DE.UTF-8")
 
-        expected = [json.dumps(CONTENT_JSON), json.dumps(CONTENT_JSON)]
-        result = self.obj.PoolAttach.__wrapped__(self.obj, ["x", "y"], 1, {}, "de_DE.UTF-8")
+        expected = [CONTENT_JSON, CONTENT_JSON]
+        result = self.impl.pool_attach(["x", "y"], 1, {})
         self.assertEqual(expected, result)
 
     def test_PoolAttach__sca(self):
         self.patches["is_simple_content_access"].return_value = True
         self.mock_attach.attach_pool.return_value = CONTENT_JSON
+        Locale.set("de_DE.UTF-8")
 
         # TODO: Change to assertRaises when auto-attach is not supported in SCA mode
         # BZ 2049101, BZ 2049620
 
-        expected = [json.dumps(CONTENT_JSON), json.dumps(CONTENT_JSON)]
-        result = self.obj.PoolAttach.__wrapped__(self.obj, ["x", "y"], 1, {}, "de_DE.UTF-8")
+        expected = [CONTENT_JSON, CONTENT_JSON]
+        result = self.impl.pool_attach(["x", "y"], 1, {})
         self.assertEqual(expected, result)
 
     def test_PoolAttach__not_registered(self):
-        self.patches["is_registered"].return_value = False
         self.mock_attach.attach_pool.return_value = CONTENT_JSON
+        self.patches["is_registered"].return_value = False
 
         with self.assertRaisesRegex(dbus.DBusException, "requires the consumer to be registered"):
-            self.obj.PoolAttach.__wrapped__(self.obj, ["x", "y"], 1, {}, self.LOCALE)
+            self.impl.pool_attach(["x", "y"], 1, {})
 
     def test_AutoAttach(self):
         self.mock_attach.attach_auto.return_value = CONTENT_JSON
 
-        expected = json.dumps(CONTENT_JSON)
-        result = self.obj.AutoAttach.__wrapped__(self.obj, "service_level", {}, self.LOCALE)
-        self.assertEqual(expected, result)
+        result = self.impl.auto_attach("service_level", {})
+        self.assertEqual(CONTENT_JSON, result)
 
     def test_AutoAttach__sca(self):
         self.patches["is_simple_content_access"].return_value = True
@@ -151,13 +148,12 @@ class TestAttachDBusObject(DBusServerStubProvider):
         # TODO: Change to assertRaises when auto-attach is not supported in SCA mode
         # BZ 2049101, BZ 2049620
 
-        expected = json.dumps(CONTENT_JSON)
-        result = self.obj.AutoAttach.__wrapped__(self.obj, "service_level", {}, self.LOCALE)
-        self.assertEqual(expected, result)
+        result = self.impl.auto_attach("service_level", {})
+        self.assertEqual(CONTENT_JSON, result)
 
     def test_AutoAttach__not_registered(self):
         self.mock_attach.attach_pool.return_value = CONTENT_JSON
         self.patches["is_registered"].return_value = False
 
         with self.assertRaisesRegex(dbus.DBusException, "requires the consumer to be registered"):
-            self.obj.AutoAttach.__wrapped__(self.obj, ["x", "y"], 1, {}, self.LOCALE)
+            self.impl.auto_attach("service level", {})

--- a/test/rhsmlib/dbus/test_consumer.py
+++ b/test/rhsmlib/dbus/test_consumer.py
@@ -11,16 +11,13 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
-from rhsmlib.dbus.objects.consumer import ConsumerDBusObject
+from rhsmlib.dbus.objects.consumer import ConsumerDBusImplementation
 
 from unittest import mock
-from test.rhsmlib.base import DBusServerStubProvider
+from test.rhsmlib.base import SubManDBusFixture
 
 
-class TestConsumerDBusObject(DBusServerStubProvider):
-    dbus_class = ConsumerDBusObject
-    dbus_class_kwargs = {}
-
+class TestConsumerDBusObject(SubManDBusFixture):
     @classmethod
     def setUpClass(cls) -> None:
         get_consumer_uuid_patch = mock.patch(
@@ -30,11 +27,13 @@ class TestConsumerDBusObject(DBusServerStubProvider):
         cls.patches["get_consumer_uuid"] = get_consumer_uuid_patch.start()
         cls.addClassCleanup(get_consumer_uuid_patch)
 
+        cls.impl = ConsumerDBusImplementation()
+
         super().setUpClass()
 
     def test_GetUuid(self):
         self.patches["get_consumer_uuid"].return_value = "fake-uuid"
 
         expected = "fake-uuid"
-        result = self.obj.GetUuid.__wrapped__(self.obj, self.LOCALE)
+        result = self.impl.get_uuid()
         self.assertEqual(expected, result)

--- a/test/rhsmlib/dbus/test_entitlement.py
+++ b/test/rhsmlib/dbus/test_entitlement.py
@@ -10,19 +10,18 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
+from rhsmlib.dbus.objects.entitlement import EntitlementDBusImplementation
+
 from unittest import mock
-import json
-
-from rhsmlib.dbus.objects import EntitlementDBusObject
-
-from test.rhsmlib.base import DBusServerStubProvider
+from test.rhsmlib.base import SubManDBusFixture
 
 
-class TestEntitlementDBusObject(DBusServerStubProvider):
-    dbus_class = EntitlementDBusObject
-    dbus_class_kwargs = {}
+class TestEntitlementDBusObject(SubManDBusFixture):
+    def setUp(self):
+        super().setUp()
+        self.impl = EntitlementDBusImplementation()
 
-    def test_GetStatus(self):
+    def test_get_status(self):
         get_status_patch = mock.patch(
             "rhsmlib.services.entitlement.EntitlementService.get_status",
             name="get_status",
@@ -30,14 +29,13 @@ class TestEntitlementDBusObject(DBusServerStubProvider):
         self.patches["get_status_patch"] = get_status_patch.start()
         self.addCleanup(get_status_patch.stop)
 
-        status = {"status": "Unknown", "reasons": {}, "valid": False}
-        self.patches["get_status_patch"].return_value = status
+        expected = {"status": "Unknown", "reasons": {}, "valid": False}
+        self.patches["get_status_patch"].return_value = expected
 
-        expected = json.dumps(status)
-        result = self.obj.GetStatus.__wrapped__(self.obj, "", self.LOCALE)
+        result = self.impl.get_status("")
         self.assertEqual(expected, result)
 
-    def test_RemoveEntitlementsBySerials(self):
+    def test_remove_entitlements_by_serials(self):
         remove_entitlements_by_serials_patch = mock.patch(
             "rhsmlib.services.entitlement.EntitlementService.remove_entitlements_by_serials",
             name="remove_entitlements_by_serials",
@@ -48,11 +46,11 @@ class TestEntitlementDBusObject(DBusServerStubProvider):
         removed_nonremoved = (["123"], [])
         self.patches["remove_entitlements_by_serials"].return_value = removed_nonremoved
 
-        expected = json.dumps(removed_nonremoved[0])
-        result = self.obj.RemoveEntitlementsBySerials.__wrapped__(self.obj, ["123"], {}, self.LOCALE)
+        expected = removed_nonremoved[0]
+        result = self.impl.remove_entitlements_by_serials(["123"], {})
         self.assertEqual(expected, result)
 
-    def test_RemoveEntitlementsBySerials__multiple(self):
+    def test_remove_entitlements_by_serials__multiple(self):
         remove_entitlements_by_serials_patch = mock.patch(
             "rhsmlib.services.entitlement.EntitlementService.remove_entitlements_by_serials",
             name="remove_entitlements_by_serials",
@@ -63,11 +61,11 @@ class TestEntitlementDBusObject(DBusServerStubProvider):
         removed_nonremoved = (["123", "456"], [])
         self.patches["remove_entitlements_by_serials"].return_value = removed_nonremoved
 
-        expected = json.dumps(removed_nonremoved[0])
-        result = self.obj.RemoveEntitlementsBySerials.__wrapped__(self.obj, ["123", "456"], {}, self.LOCALE)
+        expected = removed_nonremoved[0]
+        result = self.impl.remove_entitlements_by_serials(["123", "456"], {})
         self.assertEqual(expected, result)
 
-    def test_RemoveEntitlementsBySerials__good_and_bad(self):
+    def test_remove_entitlements_by_serials__good_and_bad(self):
         remove_entitlements_by_serials_patch = mock.patch(
             "rhsmlib.services.entitlement.EntitlementService.remove_entitlements_by_serials",
             name="remove_entitlements_by_serials",
@@ -78,11 +76,11 @@ class TestEntitlementDBusObject(DBusServerStubProvider):
         removed_nonremoved = (["123"], ["456"])
         self.patches["remove_entitlements_by_serials"].return_value = removed_nonremoved
 
-        expected = json.dumps(removed_nonremoved[0])
-        result = self.obj.RemoveEntitlementsBySerials.__wrapped__(self.obj, ["123", "789"], {}, self.LOCALE)
+        expected = removed_nonremoved[0]
+        result = self.impl.remove_entitlements_by_serials(["123", "789"], {})
         self.assertEqual(expected, result)
 
-    def test_RemoveEntitlementsByPoolIds(self):
+    def test_remove_entitlements_by_pool_ids(self):
         remove_entitlements_by_pool_ids_patch = mock.patch(
             "rhsmlib.services.entitlement.EntitlementService.remove_entitlements_by_pool_ids",
             name="remove_entitlements_by_pool_ids",
@@ -93,11 +91,11 @@ class TestEntitlementDBusObject(DBusServerStubProvider):
         removed_nonremoved_serials = (["123"], [], ["456"])
         self.patches["remove_entitlements_by_pool_ids"].return_value = removed_nonremoved_serials
 
-        expected = json.dumps(removed_nonremoved_serials[2])
-        result = self.obj.RemoveEntitlementsByPoolIds.__wrapped__(self.obj, ["123"], {}, self.LOCALE)
+        expected = removed_nonremoved_serials[2]
+        result = self.impl.remove_entitlements_by_pool_ids(["123"], {})
         self.assertEqual(expected, result)
 
-    def test_RemoveAllEntitlements(self):
+    def test_remove_all_entitlements(self):
         remove_all_entitlements_patch = mock.patch(
             "rhsmlib.services.entitlement.EntitlementService.remove_all_entitlements",
             name="remove_all_entitlements",
@@ -108,6 +106,5 @@ class TestEntitlementDBusObject(DBusServerStubProvider):
         records = {"deletedRecords": 1}
         self.patches["remove_all_entitlements"].return_value = records
 
-        expected = json.dumps(records)
-        result = self.obj.RemoveAllEntitlements.__wrapped__(self.obj, {}, self.LOCALE)
-        self.assertEqual(expected, result)
+        result = self.impl.remove_all_entitlements({})
+        self.assertEqual(records, result)

--- a/test/rhsmlib/dbus/test_server.py
+++ b/test/rhsmlib/dbus/test_server.py
@@ -16,7 +16,6 @@ import logging
 
 from rhsmlib.dbus.server import DomainSocketServer
 
-from test import subman_marker_dbus
 from test.fixture import SubManFixture
 
 # Set DBus mainloop early in test run (test import time!)
@@ -24,11 +23,10 @@ dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 log = logging.getLogger(__name__)
 
 
-@subman_marker_dbus
 class TestDomainSocketServer(SubManFixture):
     def test_unix_socket_invalid_path(self):
         server = DomainSocketServer()
-        # force an unix socket in all the cases
+        # force a unix socket in all the cases
         server._server_socket_iface = "unix:dir="
         # force an invalid path
         server._server_socket_path = "/i-dont-exists/really"

--- a/test/rhsmlib/dbus/test_unregister.py
+++ b/test/rhsmlib/dbus/test_unregister.py
@@ -13,28 +13,27 @@
 import dbus
 from unittest import mock
 
-from rhsmlib.dbus.objects import UnregisterDBusObject
+from rhsmlib.dbus.objects.unregister import UnregisterDBusImplementation
 
-from test.rhsmlib.base import DBusServerStubProvider
+from test.rhsmlib.base import SubManDBusFixture
+from test import subman_marker_dbus
 
 
-class TestUnregisterDBusObject_(DBusServerStubProvider):
-    dbus_class = UnregisterDBusObject
-    dbus_class_kwargs = {}
+@subman_marker_dbus
+class TestUnregisterDBusObject(SubManDBusFixture):
+    def setUp(self) -> None:
+        super().setUp()
+        self.impl = UnregisterDBusImplementation()
 
-    @classmethod
-    def setUpClass(cls) -> None:
         is_registered_patch = mock.patch(
-            "rhsmlib.dbus.base_object.BaseObject.is_registered",
+            "rhsmlib.dbus.base_object.BaseImplementation.is_registered",
             name="is_registered",
         )
-        cls.patches["is_registered"] = is_registered_patch.start()
-        cls.addClassCleanup(is_registered_patch.stop)
-
-        super().setUpClass()
+        self.patches["is_registered"] = is_registered_patch.start()
+        self.addCleanup(is_registered_patch.stop)
 
     def test_Unregister__must_be_registered(self):
         self.patches["is_registered"].return_value = False
 
         with self.assertRaisesRegex(dbus.DBusException, r"requires the consumer to be registered.*"):
-            self.obj.Unregister.__wrapped__(self.obj, {}, self.LOCALE)
+            self.impl.unregister({})

--- a/test/rhsmlib/dbus/test_unregister.py
+++ b/test/rhsmlib/dbus/test_unregister.py
@@ -16,10 +16,8 @@ from unittest import mock
 from rhsmlib.dbus.objects.unregister import UnregisterDBusImplementation
 
 from test.rhsmlib.base import SubManDBusFixture
-from test import subman_marker_dbus
 
 
-@subman_marker_dbus
 class TestUnregisterDBusObject(SubManDBusFixture):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
For a long time, D-Bus tests had to be run in a separate threads, otherwise they were bringing down whole pytest process. Even that wasn't ideal and over time we started seeing various problems with it.

This new code makes a difference between the logic (which makes sub-man do stuff) and the API (which is published to D-Bus) to make it easily testable.

- The logic layer (`*DBusImplementation`) performs the Candlepin API calls and local changes to the system.
- The API layer (`*DBusObject`) manages l10n, sender and serialization into/from D-Bus and Python objects.

This makes it possible to test logic without having to use threads and workarounds.