### PR TITLE
Collect Azure Subscription ID as a cloud fact

### DIFF
--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -116,7 +116,8 @@ class CloudFactsCollector(collector.FactsCollector):
             {
                 "azure_instance_id": some_instance_ID,
                 "azure_offer": some_offer,
-                "azure_sku": some_sku
+                "azure_sku": some_sku,
+                "azure_subscription_id": some_subscription_ID
             }
         :return: dictionary containing Azure facts, when the machine is able to gather metadata
             from Azure cloud provider; otherwise returns empty dictionary {}
@@ -134,6 +135,8 @@ class CloudFactsCollector(collector.FactsCollector):
                     facts["azure_sku"] = values["compute"]["sku"]
                 if "offer" in values["compute"]:
                     facts["azure_offer"] = values["compute"]["offer"]
+                if "offer" in values["compute"]:
+                    facts["azure_subscription_id"] = values["compute"]["subscriptionId"]
         return facts
 
     def get_gcp_facts(self) -> Dict[str, str]:

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -135,7 +135,7 @@ class CloudFactsCollector(collector.FactsCollector):
                     facts["azure_sku"] = values["compute"]["sku"]
                 if "offer" in values["compute"]:
                     facts["azure_offer"] = values["compute"]["offer"]
-                if "offer" in values["compute"]:
+                if "subscriptionId" in values["compute"]:
                     facts["azure_subscription_id"] = values["compute"]["subscriptionId"]
         return facts
 

--- a/test/rhsmlib/facts/test_cloud_facts.py
+++ b/test/rhsmlib/facts/test_cloud_facts.py
@@ -165,6 +165,7 @@ AWS_BILLING_PRODUCTS = "bp-0124abcd bp-63a5400a"
 AZURE_INSTANCE_ID = "12345678-1234-1234-1234-123456789abc"
 AZURE_SKU = "8.1-ci"
 AZURE_OFFER = "RHEL"
+AZURE_SUBSCRRIPTION_ID = "01234567-0123-0123-0123-012345679abc"
 
 
 def mock_prepare_request(request):
@@ -306,6 +307,8 @@ class TestCloudCollector(unittest.TestCase):
         self.assertEqual(facts["azure_sku"], AZURE_SKU)
         self.assertIn("azure_offer", facts)
         self.assertEqual(facts["azure_offer"], AZURE_OFFER)
+        self.assertIn("azure_subscription_id", facts)
+        self.assertEqual(facts["azure_subscription_id"], AZURE_SUBSCRRIPTION_ID)
 
     @patch("cloud_what.providers.gcp.GCPCloudProvider._write_token_to_cache_file")
     @patch("cloud_what.providers.gcp.GCPCloudProvider._get_metadata_from_cache")

--- a/test/rhsmlib/facts/test_cloud_facts.py
+++ b/test/rhsmlib/facts/test_cloud_facts.py
@@ -165,7 +165,7 @@ AWS_BILLING_PRODUCTS = "bp-0124abcd bp-63a5400a"
 AZURE_INSTANCE_ID = "12345678-1234-1234-1234-123456789abc"
 AZURE_SKU = "8.1-ci"
 AZURE_OFFER = "RHEL"
-AZURE_SUBSCRRIPTION_ID = "01234567-0123-0123-0123-012345679abc"
+AZURE_SUBSCRIPTION_ID = "01234567-0123-0123-0123-012345679abc"
 
 
 def mock_prepare_request(request):
@@ -308,7 +308,7 @@ class TestCloudCollector(unittest.TestCase):
         self.assertIn("azure_offer", facts)
         self.assertEqual(facts["azure_offer"], AZURE_OFFER)
         self.assertIn("azure_subscription_id", facts)
-        self.assertEqual(facts["azure_subscription_id"], AZURE_SUBSCRRIPTION_ID)
+        self.assertEqual(facts["azure_subscription_id"], AZURE_SUBSCRIPTION_ID)
 
     @patch("cloud_what.providers.gcp.GCPCloudProvider._write_token_to_cache_file")
     @patch("cloud_what.providers.gcp.GCPCloudProvider._get_metadata_from_cache")


### PR DESCRIPTION
* Azure internal metadata API provides the Subscription ID for the running Virtual Machine just need to capture the fact
* This subscription ID can be used to connect the system to an associated marketplace offer