### PR TITLE
[1.24] Update RestlibException error reporting

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -272,6 +272,9 @@ def get_current_owner(uep=None, identity=None):
 
     try:
         owner = uep.getOwner(identity.uuid)
+    except connection.RestlibException as re_err:
+        log.error(re_err)
+        system_exit(os.EX_SOFTWARE, re_err.msg)
     except Exception as err:
         handle_exception(_("Error: Unable to retrieve org list from server"), err)
     return owner

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -895,8 +895,7 @@ class RefreshCommand(CliCommand):
             _refresh_service.refresh(force=self.options.force)
         except connection.RestlibException as re_err:
             log.error(re_err)
-            mapped_message = ExceptionMapper().get_message(re_err)
-            system_exit(os.EX_SOFTWARE, mapped_message)
+            system_exit(os.EX_SOFTWARE, re_err.msg)
         except Exception as e:
             handle_exception(
                 _("Unable to perform refresh due to the following exception: {e}").format(e=e), e


### PR DESCRIPTION
Recent PRs in the 1.24 branch (#3261 & #3271) changed how a `RestlibException` is formatted when exiting with an error; since 1.24 is a long-lived maintenance branch, the expectation is that the error reporting stays unchanged when possible.

Hence, update the error reporting for `RestlibException` in a couple of places to be back how it used to be before commit 3b3eda26eb058ab20fde1edf25e8a5b5cb9d3200 & commit c4c120a007f8b97bc41335f095ccee3e19dec94f.