### PR TITLE
Collect GCP Project information as cloud facts

### DIFF
--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -165,6 +165,16 @@ class CloudFactsCollector(collector.FactsCollector):
                         facts["gcp_license_codes"] = " ".join(gcp_license_codes)
                     else:
                         log.debug("GCP license codes not found in JWT token")
+                    # ID of project
+                    if "project_id" in values["google"]["compute_engine"]:
+                        facts["gcp_project_id"] = values["google"]["compute_engine"]["project_id"]
+                    else:
+                        log.debug("GCP project_id not found in JWT token")
+                    # number of project
+                    if "project_number" in values["google"]["compute_engine"]:
+                        facts["gcp_project_number"] = values["google"]["compute_engine"]["project_number"]
+                    else:
+                        log.debug("GCP project_number not found in JWT token")
                 else:
                     log.debug("GCP google.compute_engine on found in JWT token")
         return facts

--- a/test/rhsmlib/facts/test_cloud_facts.py
+++ b/test/rhsmlib/facts/test_cloud_facts.py
@@ -341,7 +341,7 @@ class TestCloudCollector(unittest.TestCase):
         self.assertIn("gcp_project_id", facts)
         self.assertEqual(facts["gcp_project_id"], "fair-kingdom-308514")
         self.assertIn("gcp_project_number", facts)
-        self.assertEqual(facts["gcp_project_number"], "161958465613")
+        self.assertEqual(facts["gcp_project_number"], 161958465613)
 
     @patch("cloud_what.providers.aws.requests.Session", name="mock_session_class")
     def test_get_not_aws_instance(self, mock_session_class):

--- a/test/rhsmlib/facts/test_cloud_facts.py
+++ b/test/rhsmlib/facts/test_cloud_facts.py
@@ -338,6 +338,10 @@ class TestCloudCollector(unittest.TestCase):
         self.assertEqual(facts["gcp_instance_id"], "2589221140676718026")
         self.assertIn("gcp_license_codes", facts)
         self.assertEqual(facts["gcp_license_codes"], "5731035067256925298")
+        self.assertIn("gcp_project_id", facts)
+        self.assertEqual(facts["gcp_project_id"], "fair-kingdom-308514")
+        self.assertIn("gcp_project_number", facts)
+        self.assertEqual(facts["gcp_project_number"], "161958465613")
 
     @patch("cloud_what.providers.aws.requests.Session", name="mock_session_class")
     def test_get_not_aws_instance(self, mock_session_class):


### PR DESCRIPTION
* Collect the project_id from the processed JWT
* Collect the project_number from the processed JWT
* This project identifiers can be used to connect the system to an associated marketplace offer