### PR TITLE
ENT-5603: Explicitly check for provided entitlement certificates

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -114,19 +114,30 @@ def in_container() -> bool:
         return False
 
     # If the path exists, we are in a container.
-    # In UBI containers (RHEL, CentOS), path HOST_CONFIG_DIR='/etc/rhsm-host/'
-    # is a symlink to /run/secrets/rhsm. That path is a symlink/Podman secret
-    # specified in /usr/share/containers/mounts.conf, pointing to host's directory
-    # /usr/share/rhel/secrets. The directories inside are themselves symlinks
-    # to other host directories populated by subscription-manager.
-    # If this secret (= the container directory /etc/rhsm-host/) exists,
-    #   the system is considered to be a container.
-    # If this secret does not exist,
-    #   the system is considered to be a non-container.
-    if os.path.isdir(HOST_CONFIG_DIR):
-        log.debug(f"Container detected: found certificate directory {HOST_CONFIG_DIR}.")
+    #
+    # In UBI containers (RHEL, CentOS), paths HOST_CONFIG_DIR and HOST_ENT_CERT_DIR
+    # are symlinks to container's directories:
+    #   /etc/rhsm-host            -> /run/secrets/rhsm/
+    #   /etc/pki/entitlement-host -> /run/secrets/etc-pki-entitlement/
+    #
+    # The container secrets are bind-mounted to a directory on the host:
+    #   /run/secrets (container)  -> /usr/share/rhel/secrets (host)
+    # which is specified in '/usr/share/containers/mounts.conf' (= Podman secret).
+    #
+    # The directories inside this host's directory are themselves
+    # symlinks to other host directories populated by subscription-manager:
+    #   /usr/share/rhel/secrets/etc-pki-entitlement -> /etc/pki/entitlement
+    #   /usr/share/rhel/secrets/redhat.repo         -> /etc/yum.repos.d/redhat.repo
+    #   /usr/share/rhel/secrets/rhsm                -> /etc/rhsm
+    #
+    # If the container secrets exists, the system is considered to be a container:
+    #   /etc/rhsm-host/            exists
+    #   /etc/pki/entitlement/host/ exists and is not empty
+    if os.path.isdir(HOST_CONFIG_DIR) and (
+        os.path.isdir(HOST_ENT_CERT_DIR) and any(os.walk(HOST_ENT_CERT_DIR))
+    ):
+        log.debug(f"Container detected: found directories {HOST_CONFIG_DIR} and {HOST_ENT_CERT_DIR}.")
         return True
-
     return False
 
 

--- a/test/rhsm/unit/test_config.py
+++ b/test/rhsm/unit/test_config.py
@@ -402,7 +402,9 @@ class NoCaCertDirTests(BaseConfigTests):
 
 
 class InContainerTests(unittest.TestCase):
-    """Test that config.is_container() detects container system via /etc/rhsm-host/.
+    """Test that config.is_container() detects container system:
+    - /etc/rhsm-host/ exists,
+    - /etc/pki/entitlement-host/ exists and is not empty.
 
     In previous versions of subscription-manager (starting with 1.29), the
     container detection was extended to also cover files like
@@ -417,16 +419,103 @@ class InContainerTests(unittest.TestCase):
     was reverted back to 'simple' detection.
     """
 
+    @patch("os.walk")
     @patch("os.path.isdir")
-    def test_etc_rhsm_host_exists(self, os_path_isdir_mock):
-        os_path_isdir_mock.side_effect = lambda path: path == "/etc/rhsm-host/"
+    def test_etc_directories_exist(self, is_dir_mock, walk_mock):
+        """If both directories exist and contain entitlements, container is on RHEL host"""
 
-        exists: bool = in_container()
-        self.assertTrue(exists)
+        def custom_is_dir(path: str) -> bool:
+            path = path.rstrip("/")
+            if path == "/etc/rhsm-host":
+                return True
+            if path == "/etc/pki/entitlement-host":
+                return True
+            return False
 
+        is_dir_mock.side_effect = custom_is_dir
+
+        def custom_walk(path: str):
+            path = path.rstrip("/")
+            if path == "/etc/pki/entitlement-host":
+                return ("foo", "bar")
+            return tuple()
+
+        walk_mock.side_effect = custom_walk
+
+        result: bool = in_container()
+        self.assertTrue(result)
+
+    @patch("os.walk")
     @patch("os.path.isdir")
-    def test_etc_rhsm_host_does_not_exist(self, os_path_isdir_mock):
-        os_path_isdir_mock.side_effect = lambda path: path != "/etc/rhsm-host/"
+    def test_etc_rhsm_host_does_not_exist(self, is_dir_mock, walk_mock):
+        """If /etc/rhsm-host/ does not exist, container is not on RHEL host"""
 
-        exists: bool = in_container()
-        self.assertFalse(exists)
+        def custom_is_dir(path: str) -> bool:
+            path = path.rstrip("/")
+            if path == "/etc/rhsm-host":
+                return False
+            if path == "/etc/pki/entitlement-host":
+                return True
+            return False
+
+        is_dir_mock.side_effect = custom_is_dir
+
+        def custom_walk(path: str):
+            path = path.rstrip("/")
+            if path == "/etc/pki/entitlement-host":
+                return ("foo", "bar")
+            return tuple()
+
+        walk_mock.side_effect = custom_walk
+
+        result: bool = in_container()
+        self.assertFalse(result)
+
+    @patch("os.walk")
+    @patch("os.path.isdir")
+    def test_etc_pki_entitlement_host_does_not_exist(self, is_dir_mock, walk_mock):
+        """If /etc/pki/entitlement-host/ does not exist, container is not on RHEL host"""
+
+        def custom_is_dir(path: str) -> bool:
+            path = path.rstrip("/")
+            if path == "/etc/rhsm-host":
+                return True
+            if path == "/etc/pki/entitlement-host":
+                return False
+            return False
+
+        is_dir_mock.side_effect = custom_is_dir
+
+        def custom_walk(path: str):
+            path = path.rstrip("/")
+            if path == "/etc/pki/entitlement-host":
+                return ("foo", "bar")
+            return tuple()
+
+        walk_mock.side_effect = custom_walk
+
+        result: bool = in_container()
+        self.assertFalse(result)
+
+    @patch("os.walk")
+    @patch("os.path.isdir")
+    def test_etc_pki_entitlement_host_is_empty(self, is_dir_mock, walk_mock):
+        """If /etc/pki/entitlement-host/ is empty, container is not on RHEL host"""
+
+        def custom_is_dir(path: str) -> bool:
+            path = path.rstrip("/")
+            if path == "/etc/rhsm-host":
+                return True
+            if path == "/etc/pki/entitlement-host":
+                return True
+            return False
+
+        is_dir_mock.side_effect = custom_is_dir
+
+        def custom_walk(_: str):
+            return tuple()
+
+        walk_mock.side_effect = custom_walk
+
+        result: bool = in_container()
+        self.assertFalse(result)


### PR DESCRIPTION
* Card ID: ENT-5603

UBI images (by accident or oversight) come with /etc/rhsm-host/ directory already existing. This makes our detection fire every time, even if the host mapping is disabled and this directory is empty.

This patch also uses /etc/pki/entitlement-host/ to perform container detection, not just /etc/rhsm-host/.