### PR TITLE
ENT-5582: Remove container detection envvar overwrite

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -109,10 +109,6 @@ def in_container() -> bool:
     """
     Are we running in a container or not?
     """
-    # For development in containers we must be able to turn container detection off
-    if os.environ.get("SMDEV_CONTAINER_OFF", ""):
-        return False
-
     # If the path exists, we are in a container.
     # In UBI containers (RHEL, CentOS), path HOST_CONFIG_DIR='/etc/rhsm-host/'
     # is a symlink to /run/secrets/rhsm. That path is a symlink/Podman secret


### PR DESCRIPTION
* Card ID: ENT-5582

SMDEV_CONTAINER_OFF used to be a environment variable an user could set to overwrite subscription-manager's detection of container runtime.

Initially a developer feature, it ended up being used by customers who wanted to run RHEL UBI images on top of registered RHEL hosts independently. It was evaluated that the extended container detection is not worth and causes more issues than it solves.

After reverting back to /etc/* (config and certificate) based detection we can remove the environment variable.

The only supported way of overwriting this settings now will be removing the secrets from within the container:

```
# rm -f /etc/rhsm-host
# rm -f /etc/pki/entitlement-host
```