### PR TITLE
Drop further ethtool dependency mentions

### DIFF
--- a/scripts/build_updates_img.sh
+++ b/scripts/build_updates_img.sh
@@ -67,7 +67,7 @@ make -e install
 PYTHON_SITE_PACKAGE_DIRS=`${PYTHON_BIN} -c "import site; print(' '.join(site.getsitepackages()))"`
 
 # List of required Python packages
-PY_PACKAGES="dateutil ethtool"
+PY_PACKAGES="dateutil"
 
 # Copy required Python modules to updates.img too
 for pkg in `echo ${PY_PACKAGES}`
@@ -94,7 +94,7 @@ do
 done
 
 # List of Python eggs (yes, names can be different from package names)
-PY_PACKAGES="python_dateutil ethtool"
+PY_PACKAGES="python_dateutil"
 
 # Copy required Python eggs to updates.img too
 for pkg in `echo ${PY_PACKAGES}`

--- a/scripts/container-pre-test.sh
+++ b/scripts/container-pre-test.sh
@@ -18,7 +18,7 @@ dnf --setopt install_weak_deps=False install -y \
   python3-setuptools \
   openssl-devel glib2-devel libdnf-devel \
   python3-rpm python3-librepo python3-gobject python3-gobject python3-dbus \
-  python3-dateutil python3-requests python3-iniparse python3-ethtool \
+  python3-dateutil python3-requests python3-iniparse \
   glibc-langpack-en glibc-langpack-de glibc-langpack-ja
 
 # Install test packages

--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,6 @@ setup_requires = []
 install_requires = [
     "iniparse",
     "python-dateutil",
-    "ethtool",
     "dbus-python",
 ]
 


### PR DESCRIPTION
* Card ID: ENT-5099

This is a follow-up to 4c81d7c and #3284.

While the ethtool dependency was dropped from the .spec file, it was not completely removed from the rest of the build files. This commit fixes that.