### PR TITLE
2218282: [1.28] report extra facts from VMs running on public clouds

### DIFF
--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -110,7 +110,8 @@ class CloudFactsCollector(collector.FactsCollector):
             {
                 "azure_instance_id": some_instance_ID,
                 "azure_offer": some_offer,
-                "azure_sku": some_sku
+                "azure_sku": some_sku,
+                "azure_subscription_id": some_subscription_ID
             }
         :return: dictionary containing Azure facts, when the machine is able to gather metadata
             from Azure cloud provider; otherwise returns empty dictionary {}
@@ -128,6 +129,8 @@ class CloudFactsCollector(collector.FactsCollector):
                     facts['azure_sku'] = values['compute']['sku']
                 if 'offer' in values['compute']:
                     facts['azure_offer'] = values['compute']['offer']
+                if "subscriptionId" in values["compute"]:
+                    facts["azure_subscription_id"] = values["compute"]["subscriptionId"]
         return facts
 
     def get_gcp_facts(self):

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -159,6 +159,16 @@ class CloudFactsCollector(collector.FactsCollector):
                         facts["gcp_license_codes"] = " ".join(gcp_license_codes)
                     else:
                         log.debug("GCP license codes not found in JWT token")
+                    # ID of project
+                    if "project_id" in values["google"]["compute_engine"]:
+                        facts["gcp_project_id"] = values["google"]["compute_engine"]["project_id"]
+                    else:
+                        log.debug("GCP project_id not found in JWT token")
+                    # number of project
+                    if "project_number" in values["google"]["compute_engine"]:
+                        facts["gcp_project_number"] = values["google"]["compute_engine"]["project_number"]
+                    else:
+                        log.debug("GCP project_number not found in JWT token")
                 else:
                     log.debug("GCP google.compute_engine on found in JWT token")
         return facts

--- a/test/rhsmlib_test/test_cloud_facts.py
+++ b/test/rhsmlib_test/test_cloud_facts.py
@@ -335,6 +335,10 @@ class TestCloudCollector(unittest.TestCase):
         self.assertEqual(facts["gcp_instance_id"], "2589221140676718026")
         self.assertIn("gcp_license_codes", facts)
         self.assertEqual(facts["gcp_license_codes"], "5731035067256925298")
+        self.assertIn("gcp_project_id", facts)
+        self.assertEqual(facts["gcp_project_id"], "fair-kingdom-308514")
+        self.assertIn("gcp_project_number", facts)
+        self.assertEqual(facts["gcp_project_number"], 161958465613)
 
     @patch('cloud_what.providers.aws.requests.Session', name='mock_session_class')
     def test_get_not_aws_instance(self, mock_session_class):

--- a/test/rhsmlib_test/test_cloud_facts.py
+++ b/test/rhsmlib_test/test_cloud_facts.py
@@ -153,6 +153,7 @@ AWS_BILLING_PRODUCTS = "bp-0124abcd bp-63a5400a"
 AZURE_INSTANCE_ID = "12345678-1234-1234-1234-123456789abc"
 AZURE_SKU = "8.1-ci"
 AZURE_OFFER = "RHEL"
+AZURE_SUBSCRIPTION_ID = "01234567-0123-0123-0123-012345679abc"
 
 
 def mock_prepare_request(request):
@@ -300,6 +301,8 @@ class TestCloudCollector(unittest.TestCase):
         self.assertEqual(facts["azure_sku"], AZURE_SKU)
         self.assertIn("azure_offer", facts)
         self.assertEqual(facts["azure_offer"], AZURE_OFFER)
+        self.assertIn("azure_subscription_id", facts)
+        self.assertEqual(facts["azure_subscription_id"], AZURE_SUBSCRIPTION_ID)
 
     @patch('cloud_what.providers.gcp.GCPCloudProvider._write_token_to_cache_file')
     @patch('cloud_what.providers.gcp.GCPCloudProvider._get_metadata_from_cache')


### PR DESCRIPTION
* Card ID: ENT-5606
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2218282
* Backport two PRs to 1.28 branch:
  * (Azure) https://github.com/candlepin/subscription-manager/pull/3285
  * (GCP) https://github.com/candlepin/subscription-manager/pull/3287
* Squashed commits a little bit (fixing typo, etc.)