### PR TITLE
[1.24] Stop using M2Crypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ python-dateutil==1.5;python_version<="2.7"
 python-dateutil>=2.0;python_version>="3.0"
 
 configparser<5
-M2crypto

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -44,8 +44,13 @@ from nose import SkipTest
 # for some exceptions
 from rhsm import connection
 from rhsm.https import ssl
+HAS_M2CRYPTO = False
 if six.PY2:
-    from M2Crypto import SSL
+    try:
+        from M2Crypto import SSL
+        HAS_M2CRYPTO = True
+    except ImportError:
+        pass
 
 
 class InstalledProductStatusTests(SubManFixture):
@@ -2218,7 +2223,7 @@ class HandleExceptionTests(unittest.TestCase):
             self.assertEqual(e.code, os.EX_SOFTWARE)
 
     def test_he_ssl_wrong_host(self):
-        if not six.PY2:
+        if not HAS_M2CRYPTO:
             raise SkipTest("M2Crypto-specific interface. Not used with Python 3.")
         e = SSL.Checker.WrongHost("expectedHost.example.com",
                                    "actualHost.example.com",


### PR DESCRIPTION
It is not used by default (and not supported anymore at this point), so do not install it.