### PR TITLE
2225403: Parse URL properly

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -356,8 +356,8 @@ class BaseConnection:
         if proxy_description:
             connection_description += proxy_description
         connection_description += "host=%s port=%s handler=%s %s" % (
-            self.host,
-            self.ssl_port,
+            normalized_host(self.host),
+            safe_int(self.ssl_port),
             self.handler,
             auth_description,
         )
@@ -874,13 +874,18 @@ class BaseRestLib:
 
             # When proxy server is used, then print some additional information about proxy connection
             if self.proxy_hostname and self.proxy_port:
-                msg += (
-                    blue_col
-                    + "Using proxy: "
-                    + magenta_col
-                    + f"https://{self.proxy_hostname}:{self.proxy_port}"
-                    + end_col
-                )
+                # Note: using only https:// is not a mistake. We use only https for proxy connection.
+                msg += blue_col + "Using proxy: " + magenta_col + "https://"
+                # Print username and eventually password
+                if self.proxy_user:
+                    if self.proxy_user and self.proxy_password:
+                        msg += f"{self.proxy_user}:{self.proxy_password}@"
+                    elif self.proxy_user and not self.proxy_password:
+                        msg += f"{self.proxy_user}@"
+                # Print hostname and port
+                msg += f"{normalized_host(self.proxy_hostname)}:{safe_int(self.proxy_port)}"
+                msg += end_col
+                # Print HTTP headers used for proxy connection
                 tunel_headers = None
                 if self.__conn is not None and hasattr(self.__conn, "_tunnel_headers"):
                     tunel_headers = getattr(self.__conn, "_tunnel_headers")
@@ -892,7 +897,12 @@ class BaseRestLib:
                 msg += blue_col + f"Making insecure ({auth}) request:" + end_col
             else:
                 msg += blue_col + f"Making ({auth}) request:" + end_col
-            msg += red_col + f" https://{self.host}:{self.ssl_port}{handler} {request_type}" + end_col
+            msg += (
+                red_col
+                + " https://"
+                + f"{normalized_host(self.host)}:{safe_int(self.ssl_port)}{handler} {request_type}"
+                + end_col
+            )
 
             if os.environ.get("SUBMAN_DEBUG_PRINT_REQUEST_HEADER", ""):
                 msg += blue_col + " %s" % final_headers + end_col
@@ -1038,7 +1048,10 @@ class BaseRestLib:
                         self.is_consumer_cert_key_valid = True
                         break  # this client cert worked, no need to try more
                     elif self.cert_dir:
-                        log.debug("Unable to get valid response: %s from CDN: %s" % (result, self.host))
+                        log.debug(
+                            "Unable to get valid response: %s from CDN: %s"
+                            % (result, normalized_host(self.host))
+                        )
                 except ssl.SSLError:
                     if self.cert_file and not self.cert_dir:
                         id_cert = certificate.create_from_file(self.cert_file)
@@ -1065,7 +1078,7 @@ class BaseRestLib:
                 if self.cert_dir:
                     raise NoValidEntitlement(
                         "Cannot access CDN content on: %s using any of entitlement cert-key pair: %s"
-                        % (self.host, cert_key_pairs)
+                        % (normalized_host(self.host), cert_key_pairs)
                     )
         return result, response
 

--- a/src/subscription_manager/cli_command/cli.py
+++ b/src/subscription_manager/cli_command/cli.py
@@ -327,6 +327,8 @@ class CliCommand(AbstractCLICommand):
             proxy_user, proxy_pass, proxy_hostname, proxy_port, proxy_prefix = rhsm.utils.parse_url(
                 self.options.proxy_url, default_port=default_proxy_port
             )
+            self.proxy_user = proxy_user
+            self.proxy_password = proxy_pass
             self.proxy_hostname = proxy_hostname
             self.proxy_port = int(proxy_port)
 

--- a/src/subscription_manager/cli_command/cli.py
+++ b/src/subscription_manager/cli_command/cli.py
@@ -28,7 +28,7 @@ from rhsm.certificate2 import CertificateLoadingError
 from rhsm.connection import ProxyException, ConnectionOSErrorException
 from rhsm.https import ssl
 import rhsm.utils
-from rhsm.utils import cmd_name, ServerUrlParseError, remove_scheme
+from rhsm.utils import cmd_name, ServerUrlParseError
 
 from rhsmlib.services import config
 
@@ -322,17 +322,13 @@ class CliCommand(AbstractCLICommand):
             )
             config_changed = True
 
-        # support foo.example.com:3128 format
         if hasattr(self.options, "proxy_url") and self.options.proxy_url:
-            parts = remove_scheme(self.options.proxy_url).split(":")
-            self.proxy_hostname = parts[0]
-            # no ':'
-            if len(parts) > 1:
-                self.proxy_port = int(parts[1])
-            else:
-                # if no port specified, use the one from the config, or fallback to the default
-                self.proxy_port = conf["server"].get_int("proxy_port") or rhsm.config.DEFAULT_PROXY_PORT
-            config_changed = True
+            default_proxy_port = conf["server"].get_int("proxy_port") or rhsm.config.DEFAULT_PROXY_PORT
+            proxy_user, proxy_pass, proxy_hostname, proxy_port, proxy_prefix = rhsm.utils.parse_url(
+                self.options.proxy_url, default_port=default_proxy_port
+            )
+            self.proxy_hostname = proxy_hostname
+            self.proxy_port = int(proxy_port)
 
         if hasattr(self.options, "proxy_user") and self.options.proxy_user:
             self.proxy_user = self.options.proxy_user

--- a/test/cli_command/test_override.py
+++ b/test/cli_command/test_override.py
@@ -50,6 +50,24 @@ class TestOverrideCommand(TestCliProxyCommand):
         self.cc._validate_options()
         self.assertTrue(self.cc.options.list)
 
+    def test_proxy_user_and_pass_from_url_overridden_by_cli_options(self):
+        """
+        Test that --proxyuser and --proxypassword have higher priority than --proxy
+        """
+        self.cc.main(
+            [
+                "--proxy",
+                "https://foo:bar@www.example.com",
+                "--proxyuser",
+                "other-user",
+                "--proxypassword",
+                "other-password",
+            ]
+        )
+        self.cc._validate_options()
+        self.assertEqual(self.cc.proxy_user, "other-user")
+        self.assertEqual(self.cc.proxy_password, "other-password")
+
     def test_add_with_multiple_colons(self):
         self.cc.main(["--repo", "x", "--add", "url:http://example.com"])
         self.cc._validate_options()

--- a/test/rhsm/unit/test_connection.py
+++ b/test/rhsm/unit/test_connection.py
@@ -253,7 +253,9 @@ class ConnectionTests(unittest.TestCase):
     def test_https_proxy_info_allcaps(self):
         with patch.dict("os.environ", {"HTTPS_PROXY": "http://u:p@host:4444"}):
             with patch.object(connection.config, "get", self.mock_config_without_proxy_settings):
-                uep = UEPConnection(username="dummy", password="dummy", handler="/Test/", insecure=True)
+                uep = UEPConnection(
+                    host="dummy", username="dummy", password="dummy", handler="/Test/", insecure=True
+                )
                 self.assertEqual("u", uep.proxy_user)
                 self.assertEqual("p", uep.proxy_password)
                 self.assertEqual("host", uep.proxy_hostname)
@@ -265,7 +267,9 @@ class ConnectionTests(unittest.TestCase):
             "os.environ", {"HTTPS_PROXY": "http://u:p@host:4444", "http_proxy": "http://notme:orme@host:2222"}
         ):
             with patch.object(connection.config, "get", self.mock_config_without_proxy_settings):
-                uep = UEPConnection(username="dummy", password="dummy", handler="/Test/", insecure=True)
+                uep = UEPConnection(
+                    host="dummy", username="dummy", password="dummy", handler="/Test/", insecure=True
+                )
                 self.assertEqual("u", uep.proxy_user)
                 self.assertEqual("p", uep.proxy_password)
                 self.assertEqual("host", uep.proxy_hostname)
@@ -274,7 +278,9 @@ class ConnectionTests(unittest.TestCase):
     def test_no_port(self):
         with patch.dict("os.environ", {"HTTPS_PROXY": "http://u:p@host"}):
             with patch.object(connection.config, "get", self.mock_config_without_proxy_settings):
-                uep = UEPConnection(username="dummy", password="dummy", handler="/Test/", insecure=True)
+                uep = UEPConnection(
+                    host="dummy", username="dummy", password="dummy", handler="/Test/", insecure=True
+                )
                 self.assertEqual("u", uep.proxy_user)
                 self.assertEqual("p", uep.proxy_password)
                 self.assertEqual("host", uep.proxy_hostname)
@@ -283,7 +289,9 @@ class ConnectionTests(unittest.TestCase):
     def test_no_user_or_password(self):
         with patch.dict("os.environ", {"HTTPS_PROXY": "http://host:1111"}):
             with patch.object(connection.config, "get", self.mock_config_without_proxy_settings):
-                uep = UEPConnection(username="dummy", password="dummy", handler="/Test/", insecure=True)
+                uep = UEPConnection(
+                    host="dummy", username="dummy", password="dummy", handler="/Test/", insecure=True
+                )
                 self.assertEqual(None, uep.proxy_user)
                 self.assertEqual(None, uep.proxy_password)
                 self.assertEqual("host", uep.proxy_hostname)

--- a/test/rhsm/unit/test_utils.py
+++ b/test/rhsm/unit/test_utils.py
@@ -140,12 +140,24 @@ class TestParseServerInfo(unittest.TestCase):
         self.assertRaises(ServerUrlParseErrorScheme, parse_url, local_url)
 
     def test_colon_but_no_port(self):
+        # This is correct URL
         local_url = "https://myhost.example.com:/myapp"
-        self.assertRaises(ServerUrlParseErrorPort, parse_url, local_url)
+        username, password, hostname, port, prefix = parse_url(local_url)
+        self.assertIsNone(username)
+        self.assertIsNone(password)
+        self.assertEqual(hostname, "myhost.example.com")
+        self.assertIsNone(port)
+        self.assertEqual(prefix, "/myapp")
 
     def test_colon_but_no_port_no_scheme(self):
+        # This is also correct
         local_url = "myhost.example.com:/myapp"
-        self.assertRaises(ServerUrlParseErrorPort, parse_url, local_url)
+        username, password, hostname, port, prefix = parse_url(local_url)
+        self.assertIsNone(username)
+        self.assertIsNone(password)
+        self.assertEqual(hostname, "myhost.example.com")
+        self.assertIsNone(port)
+        self.assertEqual(prefix, "/myapp")
 
     def test_colon_slash_slash_but_nothing_else(self):
         local_url = "http://"
@@ -251,6 +263,24 @@ class TestHasGoodScheme(unittest.TestCase):
 
 
 class TestParseUrl(unittest.TestCase):
+    def test_ipv4_url(self):
+        local_url = "http://user:pass@192.168.0.10:3128/prefix"
+        (username, password, hostname, port, prefix) = parse_url(local_url)
+        self.assertEqual("user", username)
+        self.assertEqual("pass", password)
+        self.assertEqual("192.168.0.10", hostname)
+        self.assertEqual("3128", port)
+        self.assertEqual("/prefix", prefix)
+
+    def test_ipv6_url(self):
+        local_url = "http://user:pass@[2001:db8::dead:beef:1]:3128/prefix"
+        (username, password, hostname, port, prefix) = parse_url(local_url)
+        self.assertEqual("user", username)
+        self.assertEqual("pass", password)
+        self.assertEqual("2001:db8::dead:beef:1", hostname)
+        self.assertEqual("3128", port)
+        self.assertEqual("/prefix", prefix)
+
     def test_username_password(self):
         local_url = "http://user:pass@hostname:1111/prefix"
         (username, password, hostname, port, prefix) = parse_url(local_url)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -185,12 +185,20 @@ class TestParseServerInfo(SubManFixture):
         self.assertRaises(ServerUrlParseErrorScheme, parse_server_info, local_url)
 
     def test_colon_but_no_port(self):
+        # This is correct!
         local_url = "https://myhost.example.com:/myapp"
-        self.assertRaises(ServerUrlParseErrorPort, parse_server_info, local_url)
+        hostname, port, prefix = parse_server_info(local_url)
+        self.assertEqual(hostname, "myhost.example.com")
+        self.assertEqual(port, DEFAULT_PORT)
+        self.assertEqual(prefix, "/myapp")
 
     def test_colon_but_no_port_no_scheme(self):
+        # This is also correct!
         local_url = "myhost.example.com:/myapp"
-        self.assertRaises(ServerUrlParseErrorPort, parse_server_info, local_url)
+        hostname, port, prefix = parse_server_info(local_url)
+        self.assertEqual(hostname, "myhost.example.com")
+        self.assertEqual(port, DEFAULT_PORT)
+        self.assertEqual(prefix, "/myapp")
 
     def test_colon_slash_slash_but_nothing_else(self):
         local_url = "http://"


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2225403
* Allow parsing of URLs containing IPv6 address like http://user:pass@[2001:db8::dead:beef:1]:3128/prefix
* Use properties of urllib.parse to get username, password, hostname, port and prefix
* Fixed `--proxy` CLI option to use parse_url() function
* Print IPv6 addresses correctly
* Fixed unit tests for the case "https://www.redhat.com:/en", because it is correct URL