### PR TITLE
[1.28] ENT-5624: Properly translate error strings

### DIFF
--- a/src/rhsmlib/dbus/objects/syspurpose.py
+++ b/src/rhsmlib/dbus/objects/syspurpose.py
@@ -69,17 +69,13 @@ class ThreeWayMergeConflict(dbus.DBusException):
         if len(conflicts) == 1:
             return _(
                 'Warning: A {conflict_msg} was recently set '
-                'for this system by the entitlement server administrator.'.format(
-                    conflict_msg=conflict_msg
-                )
-            )
+                'for this system by the entitlement server administrator.'
+            ).format(conflict_msg=conflict_msg)
         else:
             return _(
                 'Warning: A {conflict_msg} were recently set '
-                'for this system by the entitlement server administrator.'.format(
-                    conflict_msg=conflict_msg
-                )
-            )
+                'for this system by the entitlement server administrator.'
+            ).format(conflict_msg=conflict_msg)
 
 
 class SyspurposeDBusObject(base_object.BaseObject):

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -987,7 +987,7 @@ class AbstractSyspurposeCommand(CliCommand):
 
     def check_syspurpose_support(self, attr):
         if self.is_registered() and not self.cp.has_capability('syspurpose'):
-            print(_("Note: The currently configured entitlement server does not support System Purpose {attr}.".format(attr=attr)))
+            print(_("Note: The currently configured entitlement server does not support System Purpose {attr}.").format(attr=attr))
 
     def _check_result(self, expectation, success_msg, command, attr):
         if self.store:
@@ -998,7 +998,7 @@ class AbstractSyspurposeCommand(CliCommand):
         if result and not expectation(result):
             advice = SP_ADVICE.format(command=command)
             value = result[attr]
-            msg = _(SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice))
+            msg = SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice)
             system_exit(os.EX_SOFTWARE, msg)
         else:
             print(success_msg)


### PR DESCRIPTION
* Card ID: ENT-5624

These errors were found using flake8-gettext. Since the string is filled in inside of the gettext() call, the strings are not replaced for their correct translations and they are printed in English every time.