### PR TITLE
2232316: fix D-Bus regressions

### DIFF
--- a/src/rhsmlib/dbus/objects/attach.py
+++ b/src/rhsmlib/dbus/objects/attach.py
@@ -86,6 +86,8 @@ class AttachDBusImplementation(base_object.BaseImplementation):
             log.exception(exc)
             raise dbus.DBusException(str(exc))
 
+        # TODO This should probably be called only if something is actually attached
+        entcertlib.EntCertActionInvoker().update()
         return results
 
 

--- a/test/rhsmlib/dbus/test_register.py
+++ b/test/rhsmlib/dbus/test_register.py
@@ -444,7 +444,7 @@ class DomainSocketRegisterDBusObjectTest(SubManDBusFixture):
         self.patches["is_registered"].return_value = True
 
         result = self.impl.register_with_credentials(
-            "org", {"username": "username", "password": "password"}, {"force": True}
+            "org", {"username": "username", "password": "password", "force": True}, {}
         )
         self.assertEqual(expected, result)
 
@@ -537,7 +537,7 @@ class DomainSocketRegisterDBusObjectTest(SubManDBusFixture):
 
         result = self.impl.register_with_activation_keys(
             "username",
-            {"keys": ["key1", "key2"]},
-            {"force": True, "host": "localhost", "port": "8443", "handler": "/candlepin"},
+            {"keys": ["key1", "key2"], "force": True},
+            {"host": "localhost", "port": "8443", "handler": "/candlepin"},
         )
         self.assertEqual(expected, result)


### PR DESCRIPTION
There are a couple of regressions introduced by a recent D-Bus refactoring (#3283):
- on `PoolAttach`, `EntCertActionInvoker` was not used anymore
- the `force` option for `Register` and `RegisterWithActivationKeys` was looked into the connection options rather than the registration options, making it no more effective

See the individual commit messages for longer explanations.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2232316