### PR TITLE
ENT-5627: Add 'ruff' as a static linter

### DIFF
--- a/.github/workflows/stylish.yml
+++ b/.github/workflows/stylish.yml
@@ -6,19 +6,21 @@ on:
 
 jobs:
   stylish:
-    name: "black & flake8 & rpmlint"
+    name: "black & flake8 & ruff & rpmlint"
     runs-on: ubuntu-latest
     container:
       image: fedora:latest
 
     steps:
-    - name: Base setup
+    - name: Install testing packages
       run: |
         dnf --setopt install_weak_deps=False install -y \
             git-core \
             python3-flake8 \
             python3-pip \
             rpmlint
+        python3 -m pip install --upgrade pip wheel
+        python3 -m pip install ruff
 
     - uses: actions/checkout@v3
 
@@ -32,6 +34,10 @@ jobs:
     - name: Run flake8
       run: |
         flake8
+
+    - name: Run ruff
+      run: |
+        ruff src/ test/
 
     - name: Run rpmlint
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,88 @@
 [tool.black]
 line-length = 110
+
+[tool.ruff]
+src = ["src"]
+target-version = "py39"
+line-length = 110
+
+extend-exclude = [
+    # default build directory
+    "build/",
+    # cockpit bits downloaded during the Cockpit CI run
+    "integration-tests/submancockpit/",
+]
+
+select = [
+    # "E",    # pycodestyle (errors)
+    # "W",    # pycodestyle (warnings)
+    # "F",    # pyflakes (formatting)
+    # "I",    # imports (missing required import)
+    # "UP",   # pyupgrade
+    # "SYS",  # flake8-2020 (sys.version operations)
+    # "ANN",  # flake8-annotations
+    # "ASYNC",# flake8-async
+    # "S",    # flake8-bandit
+    # "BLE",  # flake8-blind-except
+    # "FBT",  # flake8-boolean-trap
+    # "B",    # flake8-bugbear
+    # "A",    # flake8-builtins
+    # "COM",  # flake8-commas
+    # "C4",   # flake8-comprehentions
+    # "DTZ",  # flake8-datetimez
+    # "T10",  # flake8-debugger
+    # "EM",   # flake8-errmsg
+    # "EXE",  # flake8-executable
+    # "FA",   # flake8-future-annotations
+    # "ISC",  # flake8-implicit-str-concat
+    # "ICN",  # flake8-import-conventions
+    # "G",    # flake8-logging-format
+    # "INP",  # flake8-no-pep420
+    # "PIE",  # flake8-pie
+    # "T20",  # flake8-print
+    # "PYI",  # flake8-pyi
+    # "PT",   # flake8-pytest-style
+    # "Q",    # flake8-quotes
+    # "RSE",  # flake8-raise
+    # "RET",  # flake8-return
+    # "SLF",  # flake8-self
+    # "SLOT", # flake8-slots
+    # "SIM",  # flake8-simplify
+    # "TID",  # flake8-tidy-imports
+    # "TCH",  # flake8-type-checking
+    # "INT",  # flake8-gettext
+    # "ARG",  # flake8-unused-arguments
+    # "PTH",  # flake8-use-pathlib
+    # "ERA",  # eradicate (commented out code)
+    # "PL",   # pylint
+    # "TRY",  # tryceratops (exception handling antipatterns)
+    # "FLY",  # flynt (conversion to new-type format strings)
+    # "PERF", # perflint
+    # "RUF",  # ruff
+]
+ignore = [
+    # Do not assign a `lambda` expression, use a `def`
+    "E731",
+    # Do not compare types, use `isinstance()`
+    "E721",
+]
+
+[tool.ruff.per-file-ignores]
+"test/test_repolib.py" = [
+    # we need to mock some modules before importing additional files
+    "E402"
+]
+"test/certdata.py" = [
+    # trailing whitespace in test data
+    "W291"
+]
+"test/*" = [
+    # Possible hardcoded password assigned to argument
+    "S105", "S106",
+    # `subprocess` call with `shell=True` identified, security issue
+    "S602",
+    # Use a regular `assert` instead of unittest-style
+    "PT009",
+    # String contains ambiguous unicode character
+    "RUF001",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ extend-exclude = [
 ]
 
 select = [
-    # "E",    # pycodestyle (errors)
-    # "W",    # pycodestyle (warnings)
+    "E",      # pycodestyle (errors)
+    "W",      # pycodestyle (warnings)
     # "F",    # pyflakes (formatting)
     # "I",    # imports (missing required import)
     # "UP",   # pyupgrade

--- a/src/cloud_what/providers/aws.py
+++ b/src/cloud_what/providers/aws.py
@@ -120,7 +120,7 @@ class AWSCloudProvider(BaseCloudProvider):
         found_amazon_ec2 = False
         found_aws = False
         for hw_item in self.hw_info.values():
-            if type(hw_item) != str:
+            if type(hw_item) is not str:
                 continue
             if "amazon ec2" in hw_item.lower():
                 found_amazon_ec2 = True

--- a/src/cloud_what/providers/azure.py
+++ b/src/cloud_what/providers/azure.py
@@ -126,7 +126,7 @@ class AzureCloudProvider(BaseCloudProvider):
         found_microsoft = False
         found_azure = False
         for hw_item in self.hw_info.values():
-            if type(hw_item) != str:
+            if type(hw_item) is not str:
                 continue
             if "microsoft" in hw_item.lower():
                 found_microsoft = True

--- a/src/cloud_what/providers/gcp.py
+++ b/src/cloud_what/providers/gcp.py
@@ -138,7 +138,7 @@ class GCPCloudProvider(BaseCloudProvider):
         found_google = False
         found_gcp = False
         for hw_item in self.hw_info.values():
-            if type(hw_item) != str:
+            if type(hw_item) is not str:
                 continue
             if "google" in hw_item.lower():
                 found_google = True

--- a/src/rhsmlib/client_info.py
+++ b/src/rhsmlib/client_info.py
@@ -58,7 +58,7 @@ class DBusSender:
         if bus is None:
             bus = dbus.SystemBus()
         cmd_line = dbus_utils.command_of_sender(bus, sender)
-        if cmd_line is not None and type(cmd_line) == str:
+        if cmd_line is not None and type(cmd_line) is str:
             # Store only first argument of command line (no argument including username or password)
             cmd_line = cmd_line.split()[0]
         return cmd_line

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -509,7 +509,7 @@ def merge_pools(pools: List[dict]) -> Dict:
     merged_pools: dict = {}
 
     for pool in pools:
-        if not pool["productId"] in merged_pools:
+        if pool["productId"] not in merged_pools:
             merged_pools[pool["productId"]] = MergedPools(pool["productId"], pool["productName"])
         merged_pools[pool["productId"]].add_pool(pool)
 
@@ -585,7 +585,7 @@ class PoolStash:
             list_all=True,
             active_on=active_on,
         ):
-            if not pool["id"] in self.compatible_pools:
+            if pool["id"] not in self.compatible_pools:
                 self.incompatible_pools[pool["id"]] = pool
                 self.all_pools[pool["id"]] = pool
 

--- a/src/subscription_manager/productid.py
+++ b/src/subscription_manager/productid.py
@@ -751,7 +751,7 @@ class ProductManager:
             f = open(filename)
         try:
             pem = f.read()
-            if type(pem) == bytes:
+            if type(pem) is bytes:
                 pem = pem.decode("utf-8")
             cert = create_from_pem(pem)
             cert.pem = pem

--- a/src/syspurpose/files.py
+++ b/src/syspurpose/files.py
@@ -784,7 +784,7 @@ def detect_changed(base: dict, other: dict, key: str, source: str = "server") ->
         return bool(base_val)
 
     # Handle "addons" (the lists might be out of order from the server)
-    if type(base_val) == list and type(other_val) == list:
+    if type(base_val) is list and type(other_val) is list:
         return sorted(base_val) != sorted(other_val)
 
     # When value is removed from server, then it is set to empty string, but

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,3 +16,4 @@ pytest-cov
 polib
 pyinotify
 simplejson
+ruff==0.0.285


### PR DESCRIPTION
* Card ID: ENT-5627

ruff is a Rust re-implementation for flake8 and its companion plugins that is much faster and contains all the plugins out of the box.

Fixed errors:
- E713 Test for membership should be `not in`