### PR TITLE
Use Fedora registry to pull container images

### DIFF
--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -15,9 +15,9 @@ jobs:
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
           - name: "Fedora latest"
-            image: "fedora:latest"
+            image: "registry.fedoraproject.org/fedora:latest"
           - name: "Fedora Rawhide"
-            image: "fedora:rawhide"
+            image: "registry.fedoraproject.org/fedora:rawhide"
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,10 +20,10 @@ jobs:
             image: "quay.io/centos/centos:stream9"
             pytest_args: ''
           - name: "Fedora latest"
-            image: "fedora:latest"
+            image: "registry.fedoraproject.org/fedora:latest"
             pytest_args: ''
           - name: "Fedora Rawhide"
-            image: "fedora:rawhide"
+            image: "registry.fedoraproject.org/fedora:rawhide"
             pytest_args: ''
 
     runs-on: ubuntu-latest

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -15,9 +15,9 @@ jobs:
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
           - name: "Fedora latest"
-            image: "fedora:latest"
+            image: "registry.fedoraproject.org/fedora:latest"
           - name: "Fedora Rawhide"
-            image: "fedora:rawhide"
+            image: "registry.fedoraproject.org/fedora:rawhide"
 
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
The Actions are implicitly using 'docker.io/library/fedora:rawhide', which is not the latest possible build. This makes the CI fail even when there is a fix in upstream image already.