### PR TITLE
TESTING: Update testing requirements

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,8 +47,7 @@ jobs:
             --cov 'src/' --cov-report 'term:skip-covered'
             --cov-report 'xml:/tmp/coverage.xml' --junitxml '/tmp/pytest.xml'"
         run: |
-          dbus-run-session \
-            python3 -m pytest ${{ matrix.pytest_args }}
+          python3 -m pytest ${{ matrix.pytest_args }}
 
       - name: "Publish coverage"
         uses: MishaKav/pytest-coverage-comment@main

--- a/TESTING.md
+++ b/TESTING.md
@@ -42,12 +42,6 @@ pytest -k cache
 pytest -k cache --no-summary
 ```
 
-To run tests in virtual machine or container without GUI, where DBus is not running, you can start it on-demand:
-
-```bash
-dbus-run-session pytest
-```
-
 To disable pytest-randomly plugin, run
 
 ```bash

--- a/scripts/container-pre-test.sh
+++ b/scripts/container-pre-test.sh
@@ -14,10 +14,9 @@ fi
 
 # Install system, build and runtime packages
 dnf --setopt install_weak_deps=False install -y \
-  intltool dbus-daemon dbus-devel \
-  python3-setuptools \
-  openssl-devel glib2-devel libdnf-devel \
-  python3-rpm python3-librepo python3-gobject python3-gobject python3-dbus \
+  intltool python3-setuptools \
+  openssl-devel libdnf-devel \
+  python3-rpm python3-librepo python3-gobject \
   python3-dateutil python3-requests python3-iniparse \
   glibc-langpack-en glibc-langpack-de glibc-langpack-ja
 


### PR DESCRIPTION
We are not using D-Bus during tests anymore. The D-Bus packages and `run-dbus-session` workaround inside of a container are no longer necessary.

This PR is blocked by https://github.com/candlepin/subscription-manager/pull/3313 (we need all branches passing).