### PR TITLE
[1.29.33] ci: run jobs only on CentOS Stream 9

### DIFF
--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -14,10 +14,6 @@ jobs:
         include:
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
-          - name: "Fedora latest"
-            image: "fedora:latest"
-          - name: "Fedora Rawhide"
-            image: "fedora:rawhide"
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,13 +18,7 @@ jobs:
         include:
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
-            pytest_args: '--deselect test/rhsmlib/facts/test_hwprobe.py::HardwareProbeTest::test_networkinfo --deselect test/rhsmlib/test_facts.py::TestFactsDBusObject::test_GetFacts'
-            # The 'test_networkinfo' breaks in CentOS container because it has IPv6 disabled.
-            # Because of a bug in Python, collecting 'socket.AF_INET6' via 'socket.getaddrinfo()' causes
-            # segfaults instead of exceptions when the IPv6 network is not available.
-            # This deselect is a workaround until it is fixed or until we switch to a different way of
-            # collecting network facts.
-            # 'test_GetFacts' triggers full fact collection and causes the same error.
+            pytest_args: ''
           - name: "Fedora latest"
             image: "fedora:latest"
             pytest_args: ''

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,12 +19,6 @@ jobs:
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
             pytest_args: ''
-          - name: "Fedora latest"
-            image: "fedora:latest"
-            pytest_args: ''
-          - name: "Fedora Rawhide"
-            image: "fedora:rawhide"
-            pytest_args: ''
 
     runs-on: ubuntu-latest
     container:
@@ -55,7 +49,7 @@ jobs:
         uses: MishaKav/pytest-coverage-comment@main
         if: |
           github.event.pull_request.head.repo.full_name == github.repository
-          && matrix.name == 'Fedora latest'
+          && matrix.name == 'CentOS Stream 9'
         with:
           title: "Coverage (computed on ${{ matrix.name }})"
           report-only-changed-files: true

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -14,10 +14,6 @@ jobs:
         include:
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
-          - name: "Fedora latest"
-            image: "fedora:latest"
-          - name: "Fedora Rawhide"
-            image: "fedora:rawhide"
 
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
This branch is aimed at RHEL 9.2.x, so the only testing needed is on
CentOS Stream 9.

Modify the coverage reporting to use CentOS Stream 9, rather than
Fedora latest.

Also, enable all the tests on CentOS Stream 9, as the systemd bug that affected IPv6 sockets in IPv6-less environments was never in this version.