### PR TITLE
2229754: [1.26] Hotfix of D-Bus policy

### DIFF
--- a/etc-conf/dbus/system.d/com.redhat.RHSM1.conf
+++ b/etc-conf/dbus/system.d/com.redhat.RHSM1.conf
@@ -7,23 +7,9 @@
     <policy user="root">
         <allow own="com.redhat.RHSM1"/>
 
-        <!-- Basic D-Bus API stuff -->
-        <allow send_destination="com.redhat.RHSM1"
-            send_interface="org.freedesktop.DBus.Introspectable"/>
-        <allow send_destination="com.redhat.RHSM1"
-            send_interface="org.freedesktop.DBus.Properties"/>
-        <allow send_destination="com.redhat.RHSM1"
-            send_interface="org.freedesktop.DBus.ObjectManager"/>
-
-        <!-- allow Config.Set from root -->
-        <allow send_destination="com.redhat.RHSM1"
-            send_interface="com.redhat.RHSM1.Config"
-            send_member="Set"/>
-    </policy>
-
-
-    <policy context="default">
-        <!-- TODO: make these read-only by default -->
+        <!--
+        Lock down the objects to root access only
+        -->
 
         <allow send_destination="com.redhat.RHSM1"
             send_interface="com.redhat.RHSM1"/>
@@ -36,11 +22,6 @@
 
         <allow send_destination="com.redhat.RHSM1"
             send_interface="com.redhat.RHSM1.Config"/>
-
-        <!-- deny Config.Set by default -->
-        <deny send_destination="com.redhat.RHSM1"
-            send_interface="com.redhat.RHSM1.Config"
-            send_member="Set"/>
 
         <allow send_destination="com.redhat.RHSM1"
             send_interface="com.redhat.RHSM1.RegisterServer"/>
@@ -65,5 +46,54 @@
         <allow send_destination="com.redhat.RHSM1"
             send_interface="org.freedesktop.DBus.ObjectManager"/>
     </policy>
-</busconfig>
 
+
+    <policy context="default">
+
+        <!--
+        Non-root users can execute only methods providing
+        information from files readable by non-root users.
+        -->
+
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.Entitlement"
+            send_member="GetStatus"/>
+
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.Products"
+            send_member="ListInstalledProducts"/>
+
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.Syspurpose"
+            send_member="GetSyspurpose"/>
+
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.Syspurpose"
+            send_member="GetSyspurposeStatus"/>
+
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.Config"
+            send_member="GetAll"/>
+
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.Config"
+            send_member="Get"/>
+
+        <!--
+        The UUID returned by following method is read
+        from consumer cert. Only this file is not
+        readable by non-root users.
+        -->
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.Consumer"
+            send_member="GetUuid"/>
+
+        <!-- Basic D-Bus API stuff -->
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="org.freedesktop.DBus.Introspectable"/>
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="org.freedesktop.DBus.Properties"/>
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="org.freedesktop.DBus.ObjectManager"/>
+    </policy>
+</busconfig>


### PR DESCRIPTION
* Backport to RHEL 8.2 branch:
  * Original PR: https://github.com/candlepin/subscription-manager/pull/3318
  * Original commit: d9f9be830f5f571400b6b9cc6ff48ed74e56662e
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2229754
* Non-root users should be able to call only methods providing data that are gathered from files readable by non-root users.
* Non-root users are not allowed to call methods changing the system (like, Register(), Unregister(), etc.) or obtaining sensitive data.
* Non-root users are allowed to call only following methods: Entitlement.GetStatus, Products.ListInstalledProducts, Syspurpose.GetSyspurpose, Syspurpose.GetSyspurposeStatus, Config.GetAll, Config.Get, Consumer.GetUuid
* Added patch file, modified spec file: changed release number, added changelog, added autopatch macro