### PR TITLE
[1.29.33] ENT-5624: Properly translate error strings

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -262,7 +262,7 @@ class RhsmConfigParser(SafeConfigParser):
         if value not in valid + ["NOTSET"]:
             if print_warning is True:
                 print(
-                    _("Invalid Log Level: {lvl}, setting to INFO for this run.".format(lvl=value)),
+                    _("Invalid Log Level: {lvl}, setting to INFO for this run.").format(lvl=value),
                     file=sys.stderr,
                 )
                 print(
@@ -273,7 +273,7 @@ class RhsmConfigParser(SafeConfigParser):
                     file=sys.stderr,
                 )
                 valid_str = ", ".join(valid)
-                print(_("Valid Values: {valid_str}".format(valid_str=valid_str)), file=sys.stderr)
+                print(_("Valid Values: {valid_str}").format(valid_str=valid_str), file=sys.stderr)
             return False
         return True
 

--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -490,8 +490,8 @@ class AbstractSyspurposeCommand(CliCommand):
             print(
                 _(
                     "Note: The currently configured entitlement server does "
-                    "not support System Purpose {attr}.".format(attr=attr)
-                )
+                    "not support System Purpose {attr}."
+                ).format(attr=attr)
             )
 
     def _check_result(self, expectation, success_msg, command, attr):
@@ -503,7 +503,7 @@ class AbstractSyspurposeCommand(CliCommand):
         if result and not expectation(result):
             advice = SP_ADVICE.format(command=command)
             value = result[attr]
-            msg = _(SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice))
+            msg = SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice)
             system_exit(os.EX_SOFTWARE, msg)
         else:
             print(success_msg)


### PR DESCRIPTION
* Card ID: ENT-5624

These errors were found using flake8-gettext. Since the string is filled in inside of the gettext() call, the strings are not replaced for their correct translations and they are printed in English every time.

(Cherry-picked from 201dc52)