### PR TITLE
[1.29.30] ENT-5624: Properly translate error strings

### DIFF
--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -493,8 +493,8 @@ class AbstractSyspurposeCommand(CliCommand):
             print(
                 _(
                     "Note: The currently configured entitlement server does "
-                    "not support System Purpose {attr}.".format(attr=attr)
-                )
+                    "not support System Purpose {attr}."
+                ).format(attr=attr)
             )
 
     def _check_result(self, expectation, success_msg, command, attr):
@@ -506,7 +506,7 @@ class AbstractSyspurposeCommand(CliCommand):
         if result and not expectation(result):
             advice = SP_ADVICE.format(command=command)
             value = result[attr]
-            msg = _(SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice))
+            msg = SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice)
             system_exit(os.EX_SOFTWARE, msgs=msg)
         else:
             print(success_msg)


### PR DESCRIPTION
* Card ID: ENT-5624

These errors were found using flake8-gettext. Since the string is filled in inside of the gettext() call, the strings are not replaced for their correct translations and they are printed in English every time.

(Cherry-picked from 201dc52)