### PR TITLE
[1.28.36] ENT-5624: Properly translate error strings

### DIFF
--- a/src/rhsmlib/dbus/objects/syspurpose.py
+++ b/src/rhsmlib/dbus/objects/syspurpose.py
@@ -69,17 +69,13 @@ class ThreeWayMergeConflict(dbus.DBusException):
         if len(conflicts) == 1:
             return _(
                 'Warning: A {conflict_msg} was recently set '
-                'for this system by the entitlement server administrator.'.format(
-                    conflict_msg=conflict_msg
-                )
-            )
+                'for this system by the entitlement server administrator.'
+            ).format(conflict_msg=conflict_msg)
         else:
             return _(
                 'Warning: A {conflict_msg} were recently set '
-                'for this system by the entitlement server administrator.'.format(
-                    conflict_msg=conflict_msg
-                )
-            )
+                'for this system by the entitlement server administrator.'
+            ).format(conflict_msg=conflict_msg)
 
 
 class SyspurposeDBusObject(base_object.BaseObject):

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -986,7 +986,7 @@ class AbstractSyspurposeCommand(CliCommand):
 
     def check_syspurpose_support(self, attr):
         if self.is_registered() and not self.cp.has_capability('syspurpose'):
-            print(_("Note: The currently configured entitlement server does not support System Purpose {attr}.".format(attr=attr)))
+            print(_("Note: The currently configured entitlement server does not support System Purpose {attr}.").format(attr=attr))
 
     def _check_result(self, expectation, success_msg, command, attr):
         if self.store:
@@ -997,7 +997,7 @@ class AbstractSyspurposeCommand(CliCommand):
         if result and not expectation(result):
             advice = SP_ADVICE.format(command=command)
             value = result[attr]
-            msg = _(SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice))
+            msg = SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice)
             system_exit(os.EX_SOFTWARE, msg)
         else:
             print(success_msg)

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -464,7 +464,7 @@ class MigrationEngine(object):
         for prod_id, mappings in list(collisions.items()):
             single_key = sorted(mappings.keys())[0]
             applicable_certs[prod_id] = {single_key: mappings[single_key]}
-            print(_("Mapping product '%s' to certificate '%s'." % (prod_id, single_key)))
+            print(_("Mapping product '%s' to certificate '%s'.") % (prod_id, single_key))
 
     def deploy_prod_certificates(self, subscribed_channels):
         release = self.get_release()


### PR DESCRIPTION
* Card ID: ENT-5624

These errors were found using flake8-gettext. Since the string is filled in inside of the gettext() call, the strings are not replaced for their correct translations and they are printed in English every time.

(Adapted from 201dc52)