### PR TITLE
[1.26] ENT-5624: Properly translate error strings

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -568,14 +568,14 @@ class SyspurposeCommand(CliCommand):
             self.parser.add_option(
                 "--set",
                 dest="set",
-                help=(_("Set {attr} of system purpose".format(attr=attr)))
+                help=_("Set {attr} of system purpose").format(attr=attr)
             )
         if 'unset' in commands:
             self.parser.add_option(
                 "--unset",
                 dest="unset",
                 action="store_true",
-                help=(_("Unset {attr} of system purpose".format(attr=attr)))
+                help=_("Unset {attr} of system purpose").format(attr=attr)
             )
         if 'add' in commands:
             self.parser.add_option(
@@ -583,7 +583,7 @@ class SyspurposeCommand(CliCommand):
                 dest="to_add",
                 action="append",
                 default=[],
-                help=_("Add an item to the list ({attr}).".format(attr=attr))
+                help=_("Add an item to the list ({attr}).").format(attr=attr)
             )
         if 'remove' in commands:
             self.parser.add_option(
@@ -591,7 +591,7 @@ class SyspurposeCommand(CliCommand):
                 dest="to_remove",
                 action="append",
                 default=[],
-                help=_("Remove an item from the list ({attr}).".format(attr=attr))
+                help=_("Remove an item from the list ({attr}).").format(attr=attr)
             )
 
     def _get_synced_store(self):
@@ -704,10 +704,10 @@ class SyspurposeCommand(CliCommand):
         if syspurpose is not None and self.attr in syspurpose and syspurpose[self.attr]:
             val = syspurpose[self.attr]
             values = val if not isinstance(val, list) else ", ".join(val)
-            print(_("Current {name}: {val}".format(name=self.name.capitalize(),
-                                                   val=values)))
+            print(_("Current {name}: {val}").format(name=self.name.capitalize(),
+                                                   val=values))
         else:
-            print(_("{name} not set.".format(name=self.name.capitalize())))
+            print(_("{name} not set.").format(name=self.name.capitalize()))
 
     def sync(self):
         return syspurposelib.SyspurposeSyncActionCommand().perform(include_result=True)[1]
@@ -728,7 +728,7 @@ class SyspurposeCommand(CliCommand):
 
     def check_syspurpose_support(self, attr):
         if self.is_registered() and not self.cp.has_capability('syspurpose'):
-            print(_("Note: The currently configured entitlement server does not support System Purpose {attr}.".format(attr=attr)))
+            print(_("Note: The currently configured entitlement server does not support System Purpose {attr}.").format(attr=attr))
 
     def _check_result(self, expectation, success_msg, command, attr):
         if self.store:
@@ -739,7 +739,7 @@ class SyspurposeCommand(CliCommand):
         if result and not expectation(result):
             advice = SP_ADVICE.format(command=command)
             value = result[attr]
-            msg = _(SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice))
+            msg = SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice)
             system_exit(os.EX_SOFTWARE, msgs=msg)
         else:
             print(_(success_msg))
@@ -1164,7 +1164,7 @@ class ServiceLevelCommand(SyspurposeCommand, OrgCommand):
             super(ServiceLevelCommand, self).set()
         else:
             self.update_service_level(self.options.set)
-            print(_("Service level set to: \"{val}\".".format(val=self.options.set)))
+            print(_("Service level set to: \"{val}\".").format(val=self.options.set))
 
     def unset(self):
         if self.cp.has_capability("syspurpose"):


### PR DESCRIPTION
* Card ID: ENT-5624

These errors were found using flake8-gettext. Since the string is filled in inside of the gettext() call, the strings are not replaced for their correct translations and they are printed in English every time.