### PR TITLE
[1.28.13] ENT-5624: Properly translate error strings

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -830,8 +830,8 @@ class SyspurposeCommand(CliCommand):
         if syspurpose is not None and self.attr in syspurpose and syspurpose[self.attr]:
             val = syspurpose[self.attr]
             values = val if not isinstance(val, list) else ", ".join(val)
-            print(_("Current {name}: {val}".format(name=self.name.capitalize(),
-                                                   val=values)))
+            print(_("Current {name}: {val}").format(name=self.name.capitalize(),
+                                                   val=values))
         else:
             print(_("{name} not set.").format(name=self.name.capitalize()))
 
@@ -919,7 +919,7 @@ class SyspurposeCommand(CliCommand):
 
     def check_syspurpose_support(self, attr):
         if self.is_registered() and not self.cp.has_capability('syspurpose'):
-            print(_("Note: The currently configured entitlement server does not support System Purpose {attr}.".format(attr=attr)))
+            print(_("Note: The currently configured entitlement server does not support System Purpose {attr}.").format(attr=attr))
 
     def _check_result(self, expectation, success_msg, command, attr):
         if self.store:
@@ -930,7 +930,7 @@ class SyspurposeCommand(CliCommand):
         if result and not expectation(result):
             advice = SP_ADVICE.format(command=command)
             value = result[attr]
-            msg = _(SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice))
+            msg = SP_CONFLICT_MESSAGE.format(attr=attr, download_value=value, advice=advice)
             system_exit(os.EX_SOFTWARE, msgs=msg)
         else:
             print(success_msg)

--- a/src/subscription_manager/migrate/migrate.py
+++ b/src/subscription_manager/migrate/migrate.py
@@ -465,7 +465,7 @@ class MigrationEngine(object):
         for prod_id, mappings in list(collisions.items()):
             single_key = sorted(mappings.keys())[0]
             applicable_certs[prod_id] = {single_key: mappings[single_key]}
-            print(_("Mapping product '%s' to certificate '%s'." % (prod_id, single_key)))
+            print(_("Mapping product '%s' to certificate '%s'.") % (prod_id, single_key))
 
     def deploy_prod_certificates(self, subscribed_channels):
         release = self.get_release()


### PR DESCRIPTION
* Card ID: ENT-5624

These errors were found using flake8-gettext. Since the string is filled in inside of the gettext() call, the strings are not replaced for their correct translations and they are printed in English every time.