### PR TITLE
[1.29.33] 2221711: do not collect unentitled products in SCA mode

### DIFF
--- a/src/subscription_manager/cert_sorter.py
+++ b/src/subscription_manager/cert_sorter.py
@@ -146,6 +146,8 @@ class ComplianceManager(object):
         if status is None:
             return
 
+        is_sca = utils.is_simple_content_access(self.cp_provider.get_consumer_auth_cp(), self.identity)
+
         # TODO: we're now mapping product IDs to entitlement cert JSON,
         # previously we mapped to actual entitlement cert objects. However,
         # nothing seems to actually use these, so it may not matter for now.
@@ -182,17 +184,20 @@ class ComplianceManager(object):
         # Lookup product certs for each unentitled product returned by
         # the server:
         unentitled_pids = status["nonCompliantProducts"]
-        # Add in any installed products not in the server response. This
-        # could happen if something changes before the certd runs. Log
-        # a warning if it does, and treat it like an unentitled product.
-        for pid in list(self.installed_products.keys()):
-            if (
-                pid not in self.valid_products
-                and pid not in self.partially_valid_products
-                and pid not in unentitled_pids
-            ):
-                log.warning("Installed product %s not present in response from " "server." % pid)
-                unentitled_pids.append(pid)
+        # When using SCA, the compliance status does not include the installed
+        # products.
+        if not is_sca:
+            # Add in any installed products not in the server response. This
+            # could happen if something changes before the certd runs. Log
+            # a warning if it does, and treat it like an unentitled product.
+            for pid in list(self.installed_products.keys()):
+                if (
+                    pid not in self.valid_products
+                    and pid not in self.partially_valid_products
+                    and pid not in unentitled_pids
+                ):
+                    log.warning("Installed product %s not present in response from " "server." % pid)
+                    unentitled_pids.append(pid)
 
         for unentitled_pid in unentitled_pids:
             prod_cert = self.product_dir.find_by_product(unentitled_pid)

--- a/test/test_cert_sorter.py
+++ b/test/test_cert_sorter.py
@@ -246,6 +246,35 @@ class CertSorterTests(SubManFixture):
         self.assertEqual("Insufficient", self.sorter.get_system_status())
 
 
+class CertSorterSCATests(SubManFixture):
+    @patch("subscription_manager.cert_sorter.utils.is_simple_content_access")
+    @patch("subscription_manager.cache.InstalledProductsManager.update_check")
+    def setUp(self, mock_update, mock_is_simple_content_access):
+        SubManFixture.setUp(self)
+        # Setup mock product and entitlement cert (only one, to simulate SCA)
+        self.prod_dir = StubProductDirectory(pids=[INST_PID_1])
+        self.ent_dir = StubEntitlementDirectory(
+            [
+                StubEntitlementCertificate(PROD_1, ent_id=ENT_ID_1),
+            ]
+        )
+
+        self.mock_uep = StubUEP()
+
+        self.status_mgr = EntitlementStatusCache()
+        self.status_mgr.load_status = Mock(return_value=SAMPLE_COMPLIANCE_SCA_JSON)
+        self.status_mgr.write_cache = Mock()
+        inj.provide(inj.ENTITLEMENT_STATUS_CACHE, self.status_mgr)
+        mock_is_simple_content_access.return_value = True
+        inj.provide(inj.PROD_DIR, self.prod_dir)
+        inj.provide(inj.ENT_DIR, self.ent_dir)
+        self.sorter = CertSorter()
+        self.sorter.is_registered = Mock(return_value=True)
+
+    def test_unentitled_products(self):
+        self.assertEqual({}, self.sorter.unentitled_products)
+
+
 SAMPLE_COMPLIANCE_JSON = json.loads(
     """
 {
@@ -748,6 +777,23 @@ SAMPLE_COMPLIANCE_JSON = json.loads(
   } ],
   "status" : "invalid",
   "compliant" : false
+}
+"""
+)
+
+SAMPLE_COMPLIANCE_SCA_JSON = json.loads(
+    """
+{
+  "status": "disabled",
+  "compliant": true,
+  "date": "2023-03-20T11:11:13+0000",
+  "compliantUntil": null,
+  "compliantProducts": {},
+  "partiallyCompliantProducts": {},
+  "partialStacks": {},
+  "nonCompliantProducts": [],
+  "reasons": [],
+  "productComplianceDateRanges": {}
 }
 """
 )


### PR DESCRIPTION
In SCA mode, the compliance status from Candlepin does not include any
products. Because of that, the installed products will be considered as
"unentitleed", being logged as such.

Since this situation is expected, avoid collecting unentitled products
from the installed products when in SCA mode.

(cherry picked from commit ff10c63cbe3822e927a943b24af4e22a35f43dc5)

Backport of PRs #3226 and #3229 to 1.29.33.