### PR TITLE
Possible Log Injection 

### DIFF
--- a/src/subscription_manager/cli_command/attach.py
+++ b/src/subscription_manager/cli_command/attach.py
@@ -210,6 +210,22 @@ class AttachCommand(CliCommand):
                                     name=pool_json["productName"]
                                 )
                             )
+                            '''
+                            ***************** OpenRefactory Warning *****************
+                            Possible Log injection!
+                            Path:
+                            	File: attach.py, Line: 204
+                            		ents = attach_service.attach_pool(pool, self.options.quantity)
+                            		Variable ents is assigned a tainted value.
+                            	File: attach.py, Line: 207
+                            		pool_json = ent["pool"]
+                            		Variable pool_json is assigned a tainted value.
+                            	File: attach.py, Line: 213
+                            		log.debug(
+                            		                                "Attached a subscription for {name}".format(name=pool_json["productName"])
+                            		                            )
+                            		Tainted information is passed through a method invocation and is used in a sink.
+                            '''
                             log.debug(
                                 "Attached a subscription for {name}".format(name=pool_json["productName"])
                             )

--- a/src/subscription_manager/cli_command/attach.py
+++ b/src/subscription_manager/cli_command/attach.py
@@ -211,20 +211,7 @@ class AttachCommand(CliCommand):
                                 )
                             )
                             '''
-                            ***************** OpenRefactory Warning *****************
                             Possible Log injection!
-                            Path:
-                            	File: attach.py, Line: 204
-                            		ents = attach_service.attach_pool(pool, self.options.quantity)
-                            		Variable ents is assigned a tainted value.
-                            	File: attach.py, Line: 207
-                            		pool_json = ent["pool"]
-                            		Variable pool_json is assigned a tainted value.
-                            	File: attach.py, Line: 213
-                            		log.debug(
-                            		                                "Attached a subscription for {name}".format(name=pool_json["productName"])
-                            		                            )
-                            		Tainted information is passed through a method invocation and is used in a sink.
                             '''
                             log.debug(
                                 "Attached a subscription for {name}".format(name=pool_json["productName"])


### PR DESCRIPTION
In file: `attach.py`, there is a method  that stores a json field value into logs without validating the data. This allows an attacker to corrupt the log file structure.

```python
#attach.py, Line: 213
log.debug(\"Attached a subscription for {name}\".format(name=pool_json[\"productName\"])                         		                            )
```

The `pool_json` json object comes from `pool` field of `ent` json object.

```python
#attach.py, Line: 206
for ent in ents:
    pool_json = ent[\"pool\"]
```

Here `ents` comes from invoking `attach_pool` method of `attach_service`.

```python
#attach.py, Line: 206
ents = attach_service.attach_pool(pool, self.options.quantity)
```

The `attach_pool` method down the line makes a POST request to a server. In the case certificate verification is not required, its possible for an attacker to send a forged response in which `productName` field contains special characters i.e. `\n`. This can disrupt the log structure.



### Sponsorship and Support

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.