### PR TITLE
RPM: Avoid needless runtime requirement on python3-setuptools

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -156,10 +156,9 @@ Requires: python3-gobject-base
 %endif
 
 # rhel 8 has different naming for setuptools going forward
+# on newer rhels and Fedora setuptools is not needed on runtime at all
 %if (0%{?rhel} && 0%{?rhel} == 8)
 Requires:  platform-python-setuptools
-%else
-Requires:  %{py_package_prefix}-setuptools
 %endif
 
 %if %{use_dnf}


### PR DESCRIPTION
setuptools is not used on runtime at all.

pkg_resources (part of the python3-setuptools package) is used in 2 places:

 - console_scripts entry points (/usr/bin/*) on Python < 3.8
 - subscription_manager.utils:get_client_versions
   - conditional on subscription_manager.version.pkg_version presence
   - hence never imported from the RPM package

Hence, this is really only needed on RHEL 8 or lower, but the specfile conditionals do not seem to support RHEL 7 at all.

No idea about SUSE but if they have at least Python 3.8 they should be good as well.

This is from https://src.fedoraproject.org/rpms/subscription-manager/pull-request/36