### PR TITLE
RHEL-15110: Fix issue with registration using gsd-subman

### DIFF
--- a/etc-conf/dbus/system.d/com.redhat.RHSM1.conf
+++ b/etc-conf/dbus/system.d/com.redhat.RHSM1.conf
@@ -80,6 +80,21 @@
             send_member="Get"/>
 
         <!--
+        Non-root user can create abstract socket with Start()
+        method and only root user or user with same UID can
+        use this socket. Only root user can use such socket
+        for calling Register() on interface
+        com.redhat.RHSM1.Register
+        -->
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.RegisterServer"
+            send_member="Start"/>
+
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.RegisterServer"
+            send_member="Stop"/>
+
+        <!--
         The UUID returned by following method is read
         from consumer cert. Only this file is not
         readable by non-root users.

--- a/src/rhsmlib/dbus/dbus_utils.py
+++ b/src/rhsmlib/dbus/dbus_utils.py
@@ -48,6 +48,13 @@ def pid_of_sender(bus, sender):
         pid = int(dbus_iface.GetConnectionUnixProcessID(sender))
     except ValueError:
         return None
+    # It seems that Python D-Bus implementation contains error. This should not happen,
+    # when we try to call GetConnectionUnixProcessID() with sender that does not exist
+    # anymore
+    except dbus.exceptions.DBusException as err:
+        log.debug(f"D-Bus raised exception: {err}")
+        return None
+
     return pid
 
 

--- a/test/rhsmlib/dbus/test_register.py
+++ b/test/rhsmlib/dbus/test_register.py
@@ -340,12 +340,26 @@ class RegisterDBusObjectTest(SubManDBusFixture):
         get_cmd_line_mock = get_cmd_line_patch.start()
         get_cmd_line_mock.return_value = "unit-test sender"
 
+        pid_of_sender_patch = mock.patch(
+            "rhsmlib.dbus.server.pid_of_sender",
+            autospec=True,
+        )
+        pid_of_sender_mock = pid_of_sender_patch.start()
+        pid_of_sender_mock.return_value = 123456
+
+        are_others_running_path = mock.patch(
+            "rhsmlib.dbus.server.DomainSocketServer.are_other_senders_still_running",
+            autospec=True,
+        )
+        are_others_running_mock = are_others_running_path.start()
+        are_others_running_mock.return_value = False
+
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
     def tearDown(self) -> None:
         """Make sure the domain server is stopped once the test ends."""
         with contextlib.suppress(rhsmlib.dbus.exceptions.Failed):
-            self.impl.stop()
+            self.impl.stop("sender")
 
         super().tearDown()
 
@@ -373,11 +387,11 @@ class RegisterDBusObjectTest(SubManDBusFixture):
 
     def test_Stop(self):
         self.impl.start("sender")
-        self.impl.stop()
+        self.impl.stop("sender")
 
     def test_Stop__not_running(self):
         with self.assertRaises(rhsmlib.dbus.exceptions.Failed):
-            self.impl.stop()
+            self.impl.stop("sender")
 
 
 class DomainSocketRegisterDBusObjectTest(SubManDBusFixture):


### PR DESCRIPTION
* We were too agresive, when we fixed CVE in this PR: https://github.com/candlepin/subscription-manager/pull/3317
* It is still safe to allow non-root user to create abstract socket using Start() on interface com.redhat.RHSM1.RegisterServer and destroy it later using Stop(). This abstract socket could be later used by root user for calling e.g. Register() on interface com.redhat.RHSM1.Register. This is way how it works for gsd-subman (run by non-root user) and gsd-subman-helper (run by root user).