### PR TITLE
RHEL-9435: Get AWS metadata via IMDSv2

### DIFF
--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -86,7 +86,7 @@ class ModulesProfile:
         return list(ret.values())
 
     @staticmethod
-    def fix_aws_rhui_repos(base: dnf.Base) -> None:
+    def fix_aws_rhui_repos(base: "dnf.Base") -> None:
         """
         Try to fix RHUI repos on AWS systems. When the system is running on AWS, then we have
         to fix repository URL. See: https://bugzilla.redhat.com/show_bug.cgi?id=1924126


### PR DESCRIPTION
* Card ID: RHEL-9435

Even though both versions are officially supported, the AWS teams are tracking connections making v1 requests as WARNINGs [0].

This patch switches the order to try to use IMDSv2 first.

[0]: https://github.com/aws/aws-imds-packet-analyzer