### PR TITLE
[1.28] ci: stop testing on Fedora

### DIFF
--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -16,8 +16,6 @@ jobs:
             image: "quay.io/centos/centos:stream9"
           - name: "CentOS Stream 8"
             image: "quay.io/centos/centos:stream8"
-          - name: "Fedora latest"
-            image: "fedora:latest"
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,9 +22,6 @@ jobs:
           - name: "CentOS Stream 8"
             image: "quay.io/centos/centos:stream8"
             pytest_args: ''
-          - name: "Fedora latest"
-            image: "fedora:latest"
-            pytest_args: ''
 
     runs-on: ubuntu-latest
     container:
@@ -55,7 +52,7 @@ jobs:
         uses: MishaKav/pytest-coverage-comment@main
         if: |
           github.event.pull_request.head.repo.full_name == github.repository
-          && matrix.name == 'Fedora latest'
+          && matrix.name == 'CentOS Stream 9'
         with:
           title: "Coverage (computed on ${{ matrix.name }})"
           report-only-changed-files: true

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -16,8 +16,6 @@ jobs:
             image: "quay.io/centos/centos:stream8"
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
-          - name: "Fedora latest"
-            image: "fedora:latest"
 
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Even if it can be useful for testing on developers' system, in practice the 1.28 branch lags a lot behind in terms of changes for newer versions of Python.

Since the branch is stable, and targets only old versions of RHEL 8, then drop the testing on Fedora.