### PR TITLE
Fix an error in debug logging of cloud-what

### DIFF
--- a/src/cloud_what/_base_provider.py
+++ b/src/cloud_what/_base_provider.py
@@ -366,7 +366,7 @@ class BaseCloudProvider:
             print(colorize("Request headers:", COLOR.GREEN))
             print(colorize(f"{request.headers}", COLOR.BLUE))
 
-        if os.environ.get("SUBMAN_DEBUG_PRINT_REQUEST_BODY", "") and request.body is not None:
+        if os.environ.get("SUBMAN_DEBUG_PRINT_REQUEST_BODY", "") and hasattr(request, "body"):
             print(colorize("Request body:", COLOR.GREEN))
             print(colorize(f"{request.body}", COLOR.YELLOW))
 


### PR DESCRIPTION
The `requests.PreparedRequest` may not have any `.body` attribute set. This happens when unit tests are run, for example. In that case the test would crash.

This is a follow-up to #3361 