### PR TITLE
Remove version constraint of pytest

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,7 +9,7 @@
 # please update the version there in case it is bumped here
 black==23.3.0
 flake8
-pytest<7
+pytest
 pytest-randomly
 pytest-timeout
 pytest-cov


### PR DESCRIPTION
Previously, in f801b69, we had to limit pytest to version <7 because our tests were using pytest-forked to run D-Bus unit tests and pytest was crashing on that.

We have since changed the way we test D-Bus by not starting a server for each test case, and aren't constrained by the pytest regression anymore.