### PR TITLE
Remove deprecated `datetime.datetime.utcnow()`

### DIFF
--- a/src/rhsm/certificate.py
+++ b/src/rhsm/certificate.py
@@ -194,7 +194,7 @@ class Certificate:
         :return: True if valid.
         """
         valid_range = self.validRange()
-        gmt = datetime.datetime.utcnow()
+        gmt = datetime.datetime.now(datetime.timezone.utc)
         if on_date:
             gmt = on_date
         gmt = gmt.replace(tzinfo=GMT())
@@ -207,7 +207,7 @@ class Certificate:
         :return: True if valid.
         """
         valid_range = self.validRange()
-        gmt = datetime.datetime.utcnow()
+        gmt = datetime.datetime.now(datetime.timezone.utc)
         if on_date:
             gmt = on_date
         gmt = gmt.replace(tzinfo=GMT())
@@ -612,7 +612,7 @@ class DateRange:
 
         :return: True if valid.
         """
-        gmt: datetime.datetime = datetime.datetime.utcnow()
+        gmt: datetime.datetime = datetime.datetime.now(datetime.timezone.utc)
         gmt = gmt.replace(tzinfo=GMT())
         return self.has_date(gmt)
 

--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -534,14 +534,14 @@ class Certificate:
         self.issuer: Optional[dict] = issuer
 
     def is_valid(self, on_date: Optional[datetime.datetime] = None):
-        gmt = datetime.datetime.utcnow()
+        gmt = datetime.datetime.now(datetime.timezone.utc)
         if on_date:
             gmt = on_date
         gmt = gmt.replace(tzinfo=GMT())
         return self.valid_range.has_date(gmt)
 
     def is_expired(self, on_date: Optional[datetime.datetime] = None):
-        gmt = datetime.datetime.utcnow()
+        gmt = datetime.datetime.now(datetime.timezone.utc)
         if on_date:
             gmt = on_date
         gmt = gmt.replace(tzinfo=GMT())
@@ -658,7 +658,7 @@ class EntitlementCertificate(ProductCertificate):
         return paths
 
     def is_expiring(self, on_date=None):
-        gmt = datetime.datetime.utcnow()
+        gmt = datetime.datetime.now(datetime.timezone.utc)
         if on_date:
             gmt = on_date
         gmt = gmt.replace(tzinfo=GMT())

--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -23,7 +23,7 @@ import re
 import subprocess
 import sys
 
-from datetime import datetime, timedelta
+import datetime
 from rhsmlib.facts import cpuinfo
 from rhsmlib.facts import collector
 
@@ -230,9 +230,9 @@ class HardwareCollector(collector.FactsCollector):
         # spacewalk/blob/master/client/rhel/rhn-client-tools/src/bin/rhn_check.py
         try:
             uptime = float(open("/proc/uptime", "r").read().split()[0])
-            uptime_delta = timedelta(seconds=uptime)
-            now = datetime.utcnow()
-            last_boot_date: datetime = now - uptime_delta
+            uptime_delta = datetime.timedelta(seconds=uptime)
+            now = datetime.datetime.now(datetime.timezone.utc)
+            last_boot_date: datetime.datetime = now - uptime_delta
             last_boot: str = last_boot_date.strftime("%Y-%m-%d %H:%M:%S") + " UTC"
         except Exception as e:
             log.warning("Error reading uptime information %s", e)

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -13,7 +13,7 @@
 #
 
 from collections import defaultdict
-from datetime import datetime, timedelta
+import datetime
 import io
 from unittest import mock
 import random
@@ -228,9 +228,9 @@ class StubProductCertificate(ProductCertificate):
             self.provided_tags = set(provided_tags)
 
         if not start_date:
-            start_date = datetime.now() - timedelta(days=100)
+            start_date = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=100)
         if not end_date:
-            end_date = datetime.now() + timedelta(days=365)
+            end_date = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365)
 
         path = "/path/to/fake_product.pem"
 
@@ -285,9 +285,9 @@ class StubEntitlementCertificate(EntitlementCertificate):
             products = products + provided_products
 
         if not start_date:
-            start_date = datetime.utcnow()
+            start_date = datetime.datetime.now(datetime.timezone.utc)
         if not end_date:
-            end_date = start_date + timedelta(days=365)
+            end_date = start_date + datetime.timedelta(days=365)
 
         # to simulate a cert with no product
         sku = None
@@ -344,11 +344,11 @@ class StubEntitlementCertificate(EntitlementCertificate):
         self.is_deleted = True
 
     def is_expiring(self, on_date=None):
-        gmt = datetime.utcnow()
+        gmt = datetime.datetime.now(datetime.timezone.utc)
         if on_date:
             gmt = on_date
         gmt = gmt.replace(tzinfo=GMT())
-        warning_time = timedelta(days=int(self.order.warning_period))
+        warning_time = datetime.timedelta(days=int(self.order.warning_period))
         return self.valid_range.end() - warning_time < gmt
 
 


### PR DESCRIPTION
This function is deprecated since Python 3.12.
`datetime.datetime.now(datetime.UTC)` is a timezone-aware equivalent.