### PR TITLE
Remove deprecated `locale.*()` functions

### DIFF
--- a/src/rhsmlib/facts/host_collector.py
+++ b/src/rhsmlib/facts/host_collector.py
@@ -62,14 +62,11 @@ class HostCollector(collector.FactsCollector):
 
         locale_info = {}
         effective_locale = "Unknown"
-        # When there is no locale set (system variable LANG is unset),
-        # then this is value returned by locale.getdefaultlocale()
-        # Tuple contains: (language[_territory], encoding identifier)
-        default_locale = (None, None)
         try:
-            default_locale = locale.getdefaultlocale()
+            default_locale = locale.getlocale(category=locale.LC_MESSAGES)
         except ValueError as err:
             log.warning("Unable to get default locale (bad environment variable?): %s" % err)
+            default_locale = (None, None)
         if default_locale[0] is not None:
             effective_locale = ".".join([_f for _f in default_locale if _f])
         locale_info["system.default_locale"] = effective_locale

--- a/test/rhsm/unit/test_connection.py
+++ b/test/rhsm/unit/test_connection.py
@@ -1067,7 +1067,7 @@ class DatetimeFormattingTests(unittest.TestCase):
         self.cp = UEPConnection(username="dummy", password="dummy", handler="/Test/", insecure=True)
 
     def tearDown(self):
-        locale.resetlocale()
+        locale.setlocale(category=locale.LC_ALL, locale="")
 
     @patch("subscription_manager.cache.open", MOCK_OPEN_CACHE)
     def test_date_formatted_properly_with_japanese_locale(self):

--- a/test/rhsmlib/facts/test_host_collector.py
+++ b/test/rhsmlib/facts/test_host_collector.py
@@ -19,7 +19,7 @@ from rhsmlib.facts import host_collector
 
 
 class HostCollectorTest(unittest.TestCase):
-    @mock.patch("locale.getdefaultlocale")
+    @mock.patch("locale.getlocale")
     def test_unknown_locale(self, mock_locale):
         collector = host_collector.HostCollector()
         mock_locale.return_value = (None, None)
@@ -28,7 +28,7 @@ class HostCollectorTest(unittest.TestCase):
         self.assertTrue(isinstance(facts, dict))
         self.assertEqual(facts["system.default_locale"], "Unknown")
 
-    @mock.patch("locale.getdefaultlocale")
+    @mock.patch("locale.getlocale")
     def test_en_us_utf8_locale(self, mock_locale):
         collector = host_collector.HostCollector()
         mock_locale.return_value = ("en_US", "UTF-8")
@@ -37,7 +37,7 @@ class HostCollectorTest(unittest.TestCase):
         self.assertTrue(isinstance(facts, dict))
         self.assertEqual(facts["system.default_locale"], "en_US.UTF-8")
 
-    @mock.patch("locale.getdefaultlocale")
+    @mock.patch("locale.getlocale")
     def test_en_us_no_encoding_locale(self, mock_locale):
         collector = host_collector.HostCollector()
         mock_locale.return_value = ("en_US", None)


### PR DESCRIPTION
These functions are deprecated since Python 3.11.
- `getdefaultlocale()` can be replaced with `getlocale(category=)`
- `resetlocale()` can be replaced with `setlocale(category=, locale=)`