### PR TITLE
RHEL-21049: [1.28] Fix issue with registration using gsd-subman 

### DIFF
--- a/etc-conf/dbus/system.d/com.redhat.RHSM1.conf
+++ b/etc-conf/dbus/system.d/com.redhat.RHSM1.conf
@@ -80,6 +80,21 @@
             send_member="Get"/>
 
         <!--
+        Non-root user can create abstract socket with Start()
+        method and only root user or user with same UID can
+        use this socket. Only root user can use such socket
+        for calling Register() on interface
+        com.redhat.RHSM1.Register
+        -->
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.RegisterServer"
+            send_member="Start"/>
+
+        <allow send_destination="com.redhat.RHSM1"
+            send_interface="com.redhat.RHSM1.RegisterServer"
+            send_member="Stop"/>
+
+        <!--
         The UUID returned by following method is read
         from consumer cert. Only this file is not
         readable by non-root users.

--- a/src/rhsmlib/dbus/dbus_utils.py
+++ b/src/rhsmlib/dbus/dbus_utils.py
@@ -55,6 +55,13 @@ def pid_of_sender(bus, sender):
         pid = int(dbus_iface.GetConnectionUnixProcessID(sender))
     except ValueError:
         return None
+    # It seems that Python D-Bus implementation contains error. This should not happen,
+    # when we try to call GetConnectionUnixProcessID() with sender that does not exist
+    # anymore
+    except dbus.exceptions.DBusException as err:
+        log.debug(f"D-Bus raised exception: {err}")
+        return None
+
     return pid
 
 

--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -56,7 +56,13 @@ class RegisterDBusObject(base_object.BaseObject):
         Locale.set(locale)
 
         with self.lock:
-            if self.server:
+            # When some other application already started domain socket listener, then
+            # write log message and return existing address
+            if self.server is not None:
+                log.debug(f"Domain socket listener already running, started by: {self.server.sender}")
+                # Add sender to the list of senders using server
+                log.debug(f"Adding another sender {sender} to the set of senders")
+                self.server.add_sender(sender)
                 return self.server.address
 
             log.debug('Attempting to create new domain socket server')
@@ -80,13 +86,21 @@ class RegisterDBusObject(base_object.BaseObject):
         locale = dbus_utils.dbus_to_python(locale, expected_type=str)
         Locale.set(locale)
         with self.lock:
-            if self.server:
-                self.server.shutdown()
-                self.server = None
-                log.debug("Stopped DomainSocketServer")
-                return True
-            else:
+            if self.server is None:
                 raise exceptions.Failed("No domain socket server is running")
+
+            # Remove current sender and check if other senders are still running.
+            # If there is at least one sender using this server still running, then
+            # only return False
+            self.server.remove_sender(sender)
+            if self.server.are_other_senders_still_running() is True:
+                log.debug("Not stopping domain socket server, because some senders still uses it.")
+                return False
+
+            self.server.shutdown()
+            self.server = None
+            log.debug("Domain socket server stopped.")
+            return True
 
 
 class OrgNotSpecifiedException(dbus.DBusException):

--- a/src/rhsmlib/dbus/server.py
+++ b/src/rhsmlib/dbus/server.py
@@ -26,6 +26,7 @@ ga_loader.init_ga()
 from subscription_manager.ga import GLib
 from functools import partial
 from rhsmlib.services import config
+from rhsmlib.dbus.dbus_utils import pid_of_sender
 from rhsm.config import get_config_parser
 from rhsmlib.file_monitor import create_filesystem_watcher, DirectoryWatch
 from rhsmlib.file_monitor import CONSUMER_WATCHER, ENTITLEMENT_WATCHER, CONFIG_WATCHER, PRODUCT_WATCHER, \
@@ -310,12 +311,52 @@ class DomainSocketServer(object):
         self.object_classes = object_classes or []
         self.objects = []
         self._server = None
-        self.sender = sender
+        self.sender = sender  # sender created the server
+        self._senders = set()  # other senders using server
+        log.debug(f"Adding sender {sender} to the set of senders")
+        self._senders.add(sender)
         self.cmd_line = cmd_line
 
         self.lock = threading.Lock()
         with self.lock:
             self.connection_count = 0
+
+    def add_sender(self, sender: str) -> None:
+        """
+        Add sender to the list of senders
+        """
+        self._senders.add(sender)
+
+    def remove_sender(self, sender: str) -> bool:
+        """
+        Try to remove sender from the set of sender
+        """
+        try:
+            self._senders.remove(sender)
+        except KeyError:
+            log.debug(f"Sender {sender} wasn't removed from the set of senders (not member of the set)")
+            return False
+        else:
+            log.debug(f"Sender {sender} removed from the set of senders")
+            return True
+
+    def are_other_senders_still_running(self) -> bool:
+        """
+        Check if other users are still running. It sender in the set is not
+        running, then remove sender from the set, because sender could
+        crash, or it was terminated since it called Start() method.
+        """
+        is_one_sender_running = False
+        not_running = set()
+        bus = dbus.SystemBus()
+        for sender in self._senders:
+            pid = pid_of_sender(bus, sender)
+            if pid is None:
+                not_running.add(sender)
+            else:
+                is_one_sender_running = True
+        self._senders = self._senders.difference(not_running)
+        return is_one_sender_running
 
     def shutdown(self):
         for o in self.objects:


### PR DESCRIPTION
* Backport to 1.28 branch. Original PR: https://github.com/candlepin/subscription-manager/pull/3350
* Original commits:
  * https://github.com/candlepin/subscription-manager/commit/ba1e0e419b5fe5bf6742d3341481279180110a23
  * https://github.com/candlepin/subscription-manager/commit/bc3377669a1ac3766842fe81f2b341c014df0429
* We were too agresive, when we fixed CVE in this PR:
  https://github.com/candlepin/subscription-manager/pull/3318
* It is still safe to allow non-root user to create abstract
  socket using `Start()` on interface `com.redhat.RHSM1.RegisterServer`
  and destroy it later using `Stop()`. This abstract socket
  could be later used by root user for calling e.g. `Register()`
  on interface `com.redhat.RHSM1.Register`. This is way how
  it works for `gsd-subman` (run by non-root user) and
  `gsd-subman-helper` (run by root user).
* When some application starts `RegisterServer` using `Start()`,
  then it returns address. When this method is called multiple
  times and `RegisterServer` is still running, then the same
  address is returned. It means, when user starts multiple
  applications, then all of these applications should be able
  to use the same address to keep backward compatibility.
  The `RegisterServer` should be terminated only in the case,
  when the last application call Stop() and there is no running
  process using this `RegisterServer`.
* This change does not allow to stop `RegisterServer` by some other
  user or application using Stop() method, when `RegisterServer`
  is still needed.
* Non-root user can stop the `RegisterServer` only in the situation,
  when it is not needed by any application.
* Implementation of `Stop()` method did not return anything explicitly,
  but the D-Bus method was designed to return boolean value. Thus,
  None object was interpreted as "False" value. It was fixed and it
  returns "True", when it was really stopped and it return "False",
  when it was not possible to stop it, because some application
  still uses `RegisterServer`.
* It looks like that there was probably intention to use similar
  approach, but it has never been finished.
* Modified some unit tests