### PR TITLE
spec: Add missing GLib dependency when building without DNF

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -186,6 +186,7 @@ BuildRequires: openssl-devel
 BuildRequires: gcc
 BuildRequires: %{py_package_prefix}-setuptools
 BuildRequires: gettext
+BuildRequires: glib2-devel
 
 %if 0%{?suse_version}
 BuildRequires: distribution-release


### PR DESCRIPTION
GLib is required to build `rhsmcertd(8)`.  When building with DNF support, `glib2-devel` is pulled in by `libdnf-devel`.  However, turning off DNF support doesn't disable building `rhsmcertd(8)`.  Therefore, the depedency needs to be listed explicitly.