### PR TITLE
Skip creating the yum.repos.d structure on debian based systems

### DIFF
--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -23,12 +23,18 @@ from subscription_manager.cache import OverrideStatusCache, WrittenOverrideCache
 from subscription_manager import model
 from subscription_manager.model import ent_cert
 from subscription_manager.repofile import Repo, manage_repos_enabled, get_repo_file_classes
-from subscription_manager.repofile import YumRepoFile
+from subscription_manager.repofile import YumRepoFile, RepoFileBase
+from subscription_manager.repofile import HAS_DEB822, HAS_ZYPP
 from subscription_manager.utils import get_supported_resources
 
 import rhsm.config
 import configparser
 from rhsmlib.facts.hwprobe import HardwareCollector
+
+if HAS_DEB822:
+    from subscription_manager.repofile import AptRepoFile
+if HAS_ZYPP:
+    from subscription_manager.repofile import ZypperRepoFile
 
 # FIXME: local imports
 
@@ -217,12 +223,12 @@ class RepoActionInvoker(BaseActionInvoker):
 
         current = set()
         # Add the current repo data
-        yum_repo_file = YumRepoFile()
-        yum_repo_file.read()
+        repo_file = self.get_system_repo_file()
+        repo_file.read()
         server_value_repo_file = YumRepoFile("var/lib/rhsm/repo_server_val/")
         server_value_repo_file.read()
         for repo in repos:
-            existing = yum_repo_file.section(repo.id)
+            existing = repo_file.section(repo.id)
             server_value_repo = server_value_repo_file.section(repo.id)
             # we need a repo in the server val file to match any in
             # the main repo definition file
@@ -237,9 +243,18 @@ class RepoActionInvoker(BaseActionInvoker):
 
         return current
 
+    def get_system_repo_file(self) -> "RepoFileBase":
+        if HAS_DEB822:
+            repo = AptRepoFile()
+        elif HAS_ZYPP:
+            repo = ZypperRepoFile()
+        else:
+            repo = YumRepoFile()
+        return repo
+
     def get_repo_file(self) -> str:
-        yum_repo_file = YumRepoFile()
-        return yum_repo_file.path
+        repo_file = self.get_system_repo_file()
+        return repo_file.path
 
     @classmethod
     def delete_repo_file(cls) -> None:


### PR DESCRIPTION
If you currently run "subscription-manager repos" on a debian/ubuntu system, the directory `/etc/yum.repos.d/` and the file `/etc/yum.repos.d/redhat.repo` with only the header are created. This is confusing some debian/ubuntu users. 

This patch does fix this behaviour. 