### PR TITLE
[1.24] fix: Add python-requests to the list of required RPMs

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -178,7 +178,8 @@ Requires:  virt-what
 Requires:  %{rhsm_package_name} = %{version}
 Requires:  %{py_package_prefix}-six
 Requires:  %{py_package_prefix}-dateutil
-Requires: %{py_package_prefix}-syspurpose
+Requires:  %{py_package_prefix}-syspurpose
+Requires:  %{py_package_prefix}-requests
 
 # rhel 8 has different naming for setuptools going forward
 %if (0%{?rhel} && 0%{?rhel} >= 8)


### PR DESCRIPTION
* Card ID: RHEL-11947
* RPM package python-requests was not required, but "requests" Python package is used by auto-registration code