### PR TITLE
Fix CentOS 7 CI for tests

### DIFF
--- a/scripts/container-pre-test.sh
+++ b/scripts/container-pre-test.sh
@@ -9,7 +9,7 @@ yum install -y \
 # Install system, build and runtime packages
 yum install -y \
   gtk3-devel python-ethtool \
-  openssl-devel swig
+  openssl-devel swig intltool
 
 localedef -c -i en_US -f ISO-8859-1 en_US
 localedef -c -i en_US -f UTF-8 en_US.UTF-8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,6 +16,8 @@ simplejson
 mock<4
 git+https://github.com/alikins/pyqver.git#egg=pyqver
 git+https://github.com/awood/nose-xvfb.git#egg=nose-xvfb
+# This version dropped support for Python 2 and <3.6
+lxml<5.1.0
 
 packaging<=20
 pyparsing<=2.4.5


### PR DESCRIPTION
The `lxml` library pushed a new version that does not support Python 2. The package does not use the package qualifiers like `python_requires` to limit the supported versions of Python understandable by Pip or PyPI, so we need to fix this manually.

This issue has also shown that we were missing the `intltool` dependency.