### PR TITLE
CCT-266: Update TLS flags

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -758,20 +758,12 @@ class BaseRestLib:
 
         log.debug("Creating new connection")
 
-        # See https://www.openssl.org/docs/ssl/SSL_CTX_new.html
-        # This ends up invoking SSLv23_method, which is the catch all
-        # "be compatible" protocol, even though it explicitly is not
-        # using sslv2. This will by default potentially include sslv3
-        # if not used with post-poodle openssl. If however, the server
-        # intends to not offer sslv3, it's workable.
-        #
-        # So this supports tls1.2, 1.1, 1.0, and/or sslv3 if supported.
-        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        # Select the highest TLS version supported by both the client and the server.
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
-        # Disable SSLv2 and SSLv3 support to avoid poodles.
-        context.options = ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3
-
-        if self.insecure:  # allow clients to work insecure mode if required..
+        if self.insecure:
+            # Allow clients to connect to servers with missing or invalid certificates.
+            context.check_hostname = False
             context.verify_mode = ssl.CERT_NONE
         else:
             context.verify_mode = ssl.CERT_REQUIRED

--- a/test/rhsm/unit/test_connection.py
+++ b/test/rhsm/unit/test_connection.py
@@ -593,7 +593,7 @@ class ConnectionTests(unittest.TestCase):
         restlib = BaseRestLib("somehost", "123", "somehandler")
         restlib.ca_dir = self.temp_ent_dir.name
         with self.assertRaises(BadCertificateException):
-            restlib._load_ca_certificates(ssl.SSLContext(ssl.PROTOCOL_SSLv23))
+            restlib._load_ca_certificates(ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT))
 
     def test_hypervisor_check_in_capability_and_reporter(self):
         self.cp.conn = Mock()


### PR DESCRIPTION
* Card ID: CCT-266

- The flag `PROTOCOL_SSLv23` is an alias to `PROTOCOL_TLS` since Python 3.6.
- The flag `PROTOCOL_TLS` is deprecated since Python 3.10.
- The flag `PROTOCOL_TLS_CLIENT` has been introduced in Python 3.6 and should be used for client-side contexts.

This patch uses `PROTOCOL_TLS_CLIENT` instead of `PROTOCOL_SSLv23`.

- There is no need to use `OP_NO_SSLv2` and `OP_NO_SSLv3` flags explicitly now; SSLContext disables these by default.

- The flag `PROTOCOL_TLS_CLIENT` enables the `check_hostname` by default. For insecure contexts we need to disable this flag explicitly.