### PR TITLE
Stop logging full lscpu output

### DIFF
--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -653,12 +653,10 @@ class HardwareCollector(collector.FactsCollector):
             log.warning("Failed to run 'lscpu --json': %s", e)
             return {}
 
-        log.debug("Parsing lscpu JSON: %s", output)
-
         try:
             output_json: dict = json.loads(output)
-        except json.JSONDecodeError as e:
-            log.warning("Failed to load the lscpu JSON: %s", e)
+        except json.JSONDecodeError:
+            log.exception("Failed to load the lscpu JSON: %s", output)
             return {}
 
         try:


### PR DESCRIPTION
It doesn't make sense to be logging full output of lscpu output in the log file -- it doesn't bring any new information when investigating issues. Only when it is not possible to decode it into dictionary we should include the raw output.