### PR TITLE
Use the FQDN instead of the hostname

### DIFF
--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -100,7 +100,7 @@ class RegisterService:
         environments = options["environments"]
         facts_dict = self.facts.get_facts()
 
-        # Default to the hostname if no name is given
+        # Default to the FQDN if no name is given
         consumer_name = options["name"] or socket.getfqdn()
 
         self.plugin_manager.run("pre_register_consumer", name=consumer_name, facts=facts_dict)

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -101,7 +101,7 @@ class RegisterService:
         facts_dict = self.facts.get_facts()
 
         # Default to the hostname if no name is given
-        consumer_name = options["name"] or socket.gethostname()
+        consumer_name = options["name"] or socket.getfqdn()
 
         self.plugin_manager.run("pre_register_consumer", name=consumer_name, facts=facts_dict)
 


### PR DESCRIPTION
The `socket.gethostname()` method is not safe to return the FQDN for different operating system. 

# Debian12
```
root@debian12:~# cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
root@debian12:~# python3 test.py 
hostname is debian12
fqdn is debian12.master.dev.atix
```

# Ubuntu
```
root@ubuntu2204:~# cat /etc/os-release 
PRETTY_NAME="Ubuntu 22.04.3 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.3 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
root@ubuntu2204:~# python3 test.py 
hostname is ubuntu2204
fqdn is ubuntu2204.master.dev.atix
```

# RockyLinux
```
[root@or ~]# cat /etc/os-release 
NAME="Rocky Linux"
VERSION="8.9 (Green Obsidian)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="8.9"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Rocky Linux 8.9 (Green Obsidian)"
ANSI_COLOR="0;32"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:rocky:rocky:8:GA"
HOME_URL="https://rockylinux.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
SUPPORT_END="2029-05-31"
ROCKY_SUPPORT_PRODUCT="Rocky-Linux-8"
ROCKY_SUPPORT_PRODUCT_VERSION="8.9"
REDHAT_SUPPORT_PRODUCT="Rocky Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8.9"
[root@or ~]# /usr/libexec/platform-python test.py 
hostname is or
fqdn is or.master.dev.atix
```

# AlmaLinux
```
[root@almalinux8 ~]# cat /etc/os-release 
NAME="AlmaLinux"
VERSION="8.9 (Midnight Oncilla)"
ID="almalinux"
ID_LIKE="rhel centos fedora"
VERSION_ID="8.9"
PLATFORM_ID="platform:el8"
PRETTY_NAME="AlmaLinux 8.9 (Midnight Oncilla)"
ANSI_COLOR="0;34"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:almalinux:almalinux:8::baseos"
HOME_URL="https://almalinux.org/"
DOCUMENTATION_URL="https://wiki.almalinux.org/"
BUG_REPORT_URL="https://bugs.almalinux.org/"

ALMALINUX_MANTISBT_PROJECT="AlmaLinux-8"
ALMALINUX_MANTISBT_PROJECT_VERSION="8.9"
REDHAT_SUPPORT_PRODUCT="AlmaLinux"
REDHAT_SUPPORT_PRODUCT_VERSION="8.9"
[root@almalinux8 ~]# /usr/libexec/platform-python test.py 
hostname is almalinux8.master.dev.atix
fqdn is almalinux8.master.dev.atix
```

# Oracle
![image](https://github.com/candlepin/subscription-manager/assets/25485845/8ceb3ec7-ce2a-48a2-908c-0f9807a3db18)


# SLES
```
sles15sp5:~ # cat /etc/os-release 
NAME="SLES"
VERSION="15-SP5"
VERSION_ID="15.5"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP5"
ID="sles"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:15:sp5"
DOCUMENTATION_URL="https://documentation.suse.com/"
sles15sp5:~ # python3 test.py 
hostname is sles15sp5
fqdn is sles15sp5.master.dev.atix
```

As you see, even on EL variants like Rocky Linux the hostname is returend instead of the fqdn.  Therefore, the suggestion is to use `socket.getfqdn()` instead of `socket.gethostname()` to make sure, the FQDN is used for all OS.

Test script on all systems was:
```
import socket
print("hostname is %s" % socket.gethostname())
print("fqdn is %s" % socket.getfqdn())
```




