### PR TITLE
feat: Add warning message about release version to dnf plugin

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -316,7 +316,7 @@ class StatusCache(CacheManager):
 
     def read_status(
         self, uep: connection.UEPConnection, uuid: str, on_date: Optional[datetime.datetime] = None
-    ) -> Optional[str]:
+    ) -> Optional[dict]:
         """
         Return status, from cache if it exists, otherwise load_status
         and write cache and return it.


### PR DESCRIPTION
* Card ID: CCT-171
* New feature: when a release is set by subscription-manager, then dnf plugin "subscription-manager" prints warning about this release
* The information about release is read only from cache file to not slow down DNF.