### PR TITLE
Jhnidek/1.28 cct 384 more azure facts

### DIFF
--- a/src/cloud_what/providers/azure.py
+++ b/src/cloud_what/providers/azure.py
@@ -41,7 +41,7 @@ class AzureCloudProvider(BaseCloudProvider):
     # for very long time. It would be good to update the version from time to time,
     # because old versions (three years) are deprecated. It would be good to update
     # the API version with every minor version of RHEL
-    API_VERSION = "2021-02-01"
+    API_VERSION = "2023-07-01"
 
     BASE_CLOUD_PROVIDER_METADATA_URL = "http://169.254.169.254/metadata/instance?api-version="
 

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -106,12 +106,13 @@ class CloudFactsCollector(collector.FactsCollector):
 
     def get_azure_facts(self):
         """
-        Try to get facts of VM running on Azure public cloud. Returned dictionary has following format:
+        Try to get facts of VM running on Azure public cloud. Returned dictionary has the following format:
             {
                 "azure_instance_id": some_instance_ID,
                 "azure_offer": some_offer,
                 "azure_sku": some_sku,
                 "azure_subscription_id": some_subscription_ID
+                "azure_location: azure region the VM is running in
             }
         :return: dictionary containing Azure facts, when the machine is able to gather metadata
             from Azure cloud provider; otherwise returns empty dictionary {}
@@ -131,6 +132,8 @@ class CloudFactsCollector(collector.FactsCollector):
                     facts['azure_offer'] = values['compute']['offer']
                 if "subscriptionId" in values["compute"]:
                     facts["azure_subscription_id"] = values["compute"]["subscriptionId"]
+                if "location" in values["compute"]:
+                    facts["azure_location"] = values["compute"]["location"]
         return facts
 
     def get_gcp_facts(self):

--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -134,6 +134,11 @@ class CloudFactsCollector(collector.FactsCollector):
                     facts["azure_subscription_id"] = values["compute"]["subscriptionId"]
                 if "location" in values["compute"]:
                     facts["azure_location"] = values["compute"]["location"]
+                if "extendedLocation" in values["compute"]:
+                    if "name" in values["compute"]["extendedLocation"]:
+                        facts["azure_extended_location_name"] = values["compute"]["extendedLocation"]["name"]
+                    if "type" in values["compute"]["extendedLocation"]:
+                        facts["azure_extended_location_type"] = values["compute"]["extendedLocation"]["type"]
         return facts
 
     def get_gcp_facts(self):

--- a/test/rhsmlib_test/test_cloud_facts.py
+++ b/test/rhsmlib_test/test_cloud_facts.py
@@ -154,6 +154,7 @@ AZURE_INSTANCE_ID = "12345678-1234-1234-1234-123456789abc"
 AZURE_SKU = "8.1-ci"
 AZURE_OFFER = "RHEL"
 AZURE_SUBSCRIPTION_ID = "01234567-0123-0123-0123-012345679abc"
+AZURE_LOCATION = "westeurope"
 
 
 def mock_prepare_request(request):
@@ -303,6 +304,8 @@ class TestCloudCollector(unittest.TestCase):
         self.assertEqual(facts["azure_offer"], AZURE_OFFER)
         self.assertIn("azure_subscription_id", facts)
         self.assertEqual(facts["azure_subscription_id"], AZURE_SUBSCRIPTION_ID)
+        self.assertIn("azure_location", facts)
+        self.assertEqual(facts["azure_location"], AZURE_LOCATION)
 
     @patch('cloud_what.providers.gcp.GCPCloudProvider._write_token_to_cache_file')
     @patch('cloud_what.providers.gcp.GCPCloudProvider._get_metadata_from_cache')

--- a/test/rhsmlib_test/test_cloud_facts.py
+++ b/test/rhsmlib_test/test_cloud_facts.py
@@ -51,6 +51,10 @@ AZURE_METADATA = """
 {
     "compute": {
         "azEnvironment": "AzurePublicCloud",
+        "extendedLocation": {
+            "type": "edgeZone",
+            "name": "microsoftlondon"
+        },
         "customData": "",
         "location": "westeurope",
         "name": "foo-bar",
@@ -154,7 +158,12 @@ AZURE_INSTANCE_ID = "12345678-1234-1234-1234-123456789abc"
 AZURE_SKU = "8.1-ci"
 AZURE_OFFER = "RHEL"
 AZURE_SUBSCRIPTION_ID = "01234567-0123-0123-0123-012345679abc"
+# There is no list of valid values of locations, extended locations and
+# types of extended locations. Value "microsoftlondon" probably does not
+# exist at all, and it was added only for testing purpose.
 AZURE_LOCATION = "westeurope"
+AZURE_EXTENDED_LOCATION_NAME = "microsoftlondon"
+AZURE_EXTENDED_LOCATION_TYPE = "edgeZone"
 
 
 def mock_prepare_request(request):
@@ -306,6 +315,10 @@ class TestCloudCollector(unittest.TestCase):
         self.assertEqual(facts["azure_subscription_id"], AZURE_SUBSCRIPTION_ID)
         self.assertIn("azure_location", facts)
         self.assertEqual(facts["azure_location"], AZURE_LOCATION)
+        self.assertIn("azure_extended_location_name", facts)
+        self.assertEqual(facts["azure_extended_location_name"], AZURE_EXTENDED_LOCATION_NAME)
+        self.assertIn("azure_extended_location_type", facts)
+        self.assertEqual(facts["azure_extended_location_type"], AZURE_EXTENDED_LOCATION_TYPE)
 
     @patch('cloud_what.providers.gcp.GCPCloudProvider._write_token_to_cache_file')
     @patch('cloud_what.providers.gcp.GCPCloudProvider._get_metadata_from_cache')


### PR DESCRIPTION
* Backport PR to 1.28 branch
* Original PR: #3389
  * Original commits: c9acace928f6f63a6016d0481eb8f73be0085575, 76253dc8ae01b9491b1f61466520196987f7decc, 0bba05ead9f12234e49dcc05c1681a3e34d7171b
* Card ID: CCT-384
* Add azure_location to facts, when available
* Updated the version of metadata we try to get from Azure IMDS server, because we need facts from new
   version of metadata and old version of metadata could be deprecated in the future
* Added new facts from Azure IMDS metadata available since `2021-03-01`
   Metadata with given version provides extendedLocation.name and extendedLocation.type
* Extended unit tests to include new facts

