### PR TITLE
fix: 1.29 Do not try to test this branch on Fedora rawhide

### DIFF
--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -16,8 +16,6 @@ jobs:
             image: "quay.io/centos/centos:stream9"
           - name: "Fedora latest"
             image: "registry.fedoraproject.org/fedora:latest"
-          - name: "Fedora Rawhide"
-            image: "registry.fedoraproject.org/fedora:rawhide"
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -14,8 +14,6 @@ jobs:
         include:
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
-          - name: "Fedora latest"
-            image: "registry.fedoraproject.org/fedora:latest"
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,9 +22,6 @@ jobs:
           - name: "Fedora latest"
             image: "registry.fedoraproject.org/fedora:latest"
             pytest_args: ''
-          - name: "Fedora Rawhide"
-            image: "registry.fedoraproject.org/fedora:rawhide"
-            pytest_args: ''
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,9 +19,6 @@ jobs:
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
             pytest_args: ''
-          - name: "Fedora latest"
-            image: "registry.fedoraproject.org/fedora:latest"
-            pytest_args: ''
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -16,8 +16,6 @@ jobs:
             image: "quay.io/centos/centos:stream9"
           - name: "Fedora latest"
             image: "registry.fedoraproject.org/fedora:latest"
-          - name: "Fedora Rawhide"
-            image: "registry.fedoraproject.org/fedora:rawhide"
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -14,8 +14,6 @@ jobs:
         include:
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
-          - name: "Fedora latest"
-            image: "registry.fedoraproject.org/fedora:latest"
 
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
* This branch is intended only for RHEL 9. It does not make sense to try to test this for Fedora rawhide, which contains too many things not compatible with RHEL 9