### PR TITLE
[1.28] fix: Hide subscription management "errors" in container mode

### DIFF
--- a/src/plugins/subscription-manager.py
+++ b/src/plugins/subscription-manager.py
@@ -96,7 +96,7 @@ def update(conduit, cache_only):
 
     identity = inj.require(inj.IDENTITY)
 
-    if not identity.is_valid():
+    if not config.in_container() and not identity.is_valid():
         conduit.info(3, "Unable to read consumer identity")
 
     # In containers we have no identity, but we may have entitlements inherited
@@ -208,7 +208,8 @@ def postconfig_hook(conduit):
     # It is save to display following warning messages for all yum commands, because following functions
     # does not communicate with candlepin server. See: https://bugzilla.redhat.com/show_bug.cgi?id=1621275
     try:
-        warn_or_usage_message(conduit)
+        if not config.in_container():
+            warn_or_usage_message(conduit)
         warn_expired_entitlements(conduit)
     except Exception as e:
         conduit.error(2, str(e))


### PR DESCRIPTION
* Card ID: CCT-322
* Card ID: RHEL-7199

When `dnf` is run in a container that gets its content from a host, extra messages were displayed:

```
- Updating Subscription Management repositories.
> Unable to read consumer identity
- subscription-manager is operating in container mode.
> This system is not registered with an entitlement server. You can use
  subscription-manager to register.
```

Only the first line and third should be displayed; the second and fourth are not relevant in container mode.