### PR TITLE
feat(ci): Update testing matrix

### DIFF
--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "CentOS Stream 9"
-            image: "quay.io/centos/centos:stream9"
+          - name: "CentOS Stream 10"
+            image: "quay.io/centos/centos:stream10-development"
           - name: "Fedora latest"
             image: "registry.fedoraproject.org/fedora:latest"
           - name: "Fedora Rawhide"
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Enable CRB repository"
-        if: ${{ matrix.name == 'CentOS Stream 9' }}
+        if: ${{ matrix.name == 'CentOS Stream 10' }}
         run: |
           dnf --setopt install_weak_deps=False install -y dnf-plugins-core
           dnf config-manager --enable crb

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "CentOS Stream 9"
-            image: "quay.io/centos/centos:stream9"
+          - name: "CentOS Stream 10"
+            image: "quay.io/centos/centos:stream10-development"
             pytest_args: ''
           - name: "Fedora latest"
             image: "registry.fedoraproject.org/fedora:latest"

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -12,12 +12,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "CentOS Stream 9"
-            image: "quay.io/centos/centos:stream9"
+          - name: "CentOS Stream 10"
+            image: "quay.io/centos/centos:stream10-development"
+            packager: "dnf4"
           - name: "Fedora latest"
             image: "registry.fedoraproject.org/fedora:latest"
+            packager: "dnf4"
           - name: "Fedora Rawhide"
             image: "registry.fedoraproject.org/fedora:rawhide"
+            packager: "dnf5"
 
     runs-on: ubuntu-latest
     container:
@@ -30,7 +33,7 @@ jobs:
             git-core dnf-plugins-core rpm-build sudo
 
       - name: Enable CRB repository
-        if: ${{ matrix.name == 'CentOS Stream 9' }}
+        if: ${{ matrix.name == 'CentOS Stream 10' }}
         run: |
           dnf config-manager --enable crb
 
@@ -42,6 +45,11 @@ jobs:
       - name: Trust git repository path
         run: |
           git config --global --add safe.directory '*'
+
+      - name: "Install builddep subcommand"
+        run: |
+          dnf --setopt install_weak_deps=False install -y "dnf5-command(builddep)"
+        if: matrix.packager == 'dnf5'
 
       - name: Install packages
         run: |

--- a/scripts/container-pre-test.sh
+++ b/scripts/container-pre-test.sh
@@ -8,7 +8,7 @@ source /etc/os-release
 # These repositories are required for the 'libdnf-devel' package.
 # Fedora has it available out of the box.
 # RHEL needs it to be enabled via 'subscription-manager repos'.
-if [[ $ID == "centos" && $VERSION == "9" ]]; then
+if [[ $ID == "centos" ]]; then
   dnf config-manager --enable crb
 fi
 


### PR DESCRIPTION
- Test on CentOS Stream 10 instead of 9 RHEL 9 has been branched off to `subscription-manager-1.29`
- Rawhide runs dnf5, we need to install builddep subcommand