### PR TITLE
[1.29] fix: Hide subscription management "errors" in container mode

### DIFF
--- a/src/plugins/dnf/subscription_manager.py
+++ b/src/plugins/dnf/subscription_manager.py
@@ -104,7 +104,8 @@ class SubscriptionManager(dnf.Plugin):
             if os.getuid() == 0:
                 # Try to update entitlement certificates and redhat.repo file
                 self._update(cache_only)
-                self._warn_or_give_usage_message()
+                if not config.in_container():
+                    self._warn_or_give_usage_message()
             else:
                 logger.info(_("Not root, Subscription Management repositories not updated"))
             self._warn_expired()
@@ -159,7 +160,7 @@ class SubscriptionManager(dnf.Plugin):
         # valid entitlement certificates, but does not yet have any identity.
         # We have access to the content, so we shouldn't be reporting missing
         # identity certificate.
-        if not identity.is_valid() and len(ent_dir.list_valid()) == 0:
+        if not config.in_container() and not identity.is_valid() and len(ent_dir.list_valid()) == 0:
             logger.info(_("Unable to read consumer identity"))
 
         if config.in_container():


### PR DESCRIPTION
* Card ID: CCT-322
* Card ID: RHEL-7199

When `dnf` is run in a container that gets its content from a host, extra messages were displayed:

```
- Updating Subscription Management repositories.
> Unable to read consumer identity
- subscription-manager is operating in container mode.
> This system is not registered with an entitlement server. You can use
  subscription-manager to register.
```

Only the first line and third should be displayed; the second and fourth are not relevant in container mode.

(Cherry-picked from a3265e48c9339bf0ee7428c51fe89d410e8a20d3)