### PR TITLE
feat: 1.29 Deprecate redeem sub-command

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -350,7 +350,7 @@ Shows whether auto-attach is enabled on the systems.
 .SS REMOVE OPTIONS
 The
 .B remove
-Deprecated, this command will be removed from the future major releases. This command is no-op, when simple content access mode is used. This command tries to remove a subscription from the system. (This does not uninstall the associated products.)
+command is deprecated, this command will be removed from the future major releases. This command is no-op, when simple content access mode is used. This command tries to remove a subscription from the system. (This does not uninstall the associated products.)
 
 .TP
 .B --serial=SERIALNUMBER

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -603,7 +603,7 @@ Points to a certificate PEM file which contains the subscription certificate. Th
 .SS REDEEM OPTIONS
 The
 .B redeem
-command is used for systems that are purchased from third-party vendors that include a subscription. The redemption process essentially auto-attaches the preselected subscription that the vendor supplied to the system.
+command is deprecated, this command will be removed from the future major releases. This command is no-op, when simple content access mode is used. Command is used for systems that are purchased from third-party vendors that include a subscription. The redemption process essentially try to auto-attach the preselected subscription that the vendor supplied to the system.
 
 .TP
 .B --email=EMAIL
@@ -1355,7 +1355,7 @@ its existing subscriptions.
 .PP
 After registration, subscriptions on preconfigured systems can be claimed using the
 .B redeem
-command, which essentially auto-attaches the system to its preexisting subscriptions.
+command, which essentially try to auto-attach the system to its preexisting subscriptions.
 
 .RS
 .nf

--- a/src/subscription_manager/cli_command/redeem.py
+++ b/src/subscription_manager/cli_command/redeem.py
@@ -26,7 +26,11 @@ from subscription_manager.i18n import ugettext as _
 
 class RedeemCommand(CliCommand):
     def __init__(self):
-        shortdesc = _("Attempt to redeem a subscription for a preconfigured system")
+        shortdesc = _(
+            "Deprecated, this command will be removed from the future major releases."
+            " This command is no-op in simple content access mode."
+            " Attempt to redeem a subscription for a preconfigured system"
+        )
         super(RedeemCommand, self).__init__("redeem", shortdesc, False)
 
         self.parser.add_argument(


### PR DESCRIPTION
* Card ID: CCT-400
* Modified short description of command
* Modified description in manual page of subscription-manager
* Information about "remove" command introduced in this commit:
   ceacba0bb21a98153bc9c1bb3f0adafbf907ed79 wasn't 100% correct.
   This should fix this issue.