### PR TITLE
chore(ci): Use Vault for CentOS Stream 8

### DIFF
--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -12,8 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "CentOS Stream 9"
-            image: "quay.io/centos/centos:stream9"
           - name: "CentOS Stream 8"
             image: "quay.io/centos/centos:stream8"
 
@@ -25,17 +23,14 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@v3
 
+      - name: "Use CentOS Vault"
+        run: |
+          sed -i 's|#baseurl=http://mirror|baseurl=http://vault|' /etc/yum.repos.d/CentOS-Stream-*.repo
+
       - name: "Enable PowerTools repository"
-        if: ${{ matrix.name == 'CentOS Stream 8' }}
         run: |
           dnf --setopt install_weak_deps=False install -y dnf-plugins-core
           dnf config-manager --enable powertools
-
-      - name: "Enable CRB repository"
-        if: ${{ matrix.name == 'CentOS Stream 9' }}
-        run: |
-          dnf --setopt install_weak_deps=False install -y dnf-plugins-core
-          dnf config-manager --enable crb
 
       - name: "Install packages"
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,12 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "CentOS Stream 9"
-            image: "quay.io/centos/centos:stream9"
-            pytest_args: ''
           - name: "CentOS Stream 8"
             image: "quay.io/centos/centos:stream8"
-            pytest_args: ''
 
     runs-on: ubuntu-latest
     container:
@@ -32,6 +28,10 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
+
+      - name: "Use CentOS Vault"
+        run: |
+          sed -i 's|#baseurl=http://mirror|baseurl=http://vault|' /etc/yum.repos.d/CentOS-Stream-*.repo
 
       - name: "Run container-pre-test.sh"
         run: |
@@ -46,15 +46,14 @@ jobs:
             --cov-report 'xml:/tmp/coverage.xml' --junitxml '/tmp/pytest.xml'"
         run: |
           dbus-run-session \
-            python3 -m pytest ${{ matrix.pytest_args }}
+            python3 -m pytest
 
       - name: "Publish coverage"
         uses: MishaKav/pytest-coverage-comment@main
         if: |
           github.event.pull_request.head.repo.full_name == github.repository
-          && matrix.name == 'CentOS Stream 9'
         with:
-          title: "Coverage (computed on ${{ matrix.name }})"
+          title: "Coverage"
           report-only-changed-files: true
           pytest-xml-coverage-path: /tmp/coverage.xml
           junitxml-path: /tmp/pytest.xml

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -14,28 +14,24 @@ jobs:
         include:
           - name: "CentOS Stream 8"
             image: "quay.io/centos/centos:stream8"
-          - name: "CentOS Stream 9"
-            image: "quay.io/centos/centos:stream9"
 
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}
 
     steps:
+      - name: "Use CentOS Vault"
+        run: |
+          sed -i 's|#baseurl=http://mirror|baseurl=http://vault|' /etc/yum.repos.d/CentOS-Stream-*.repo
+
       - name: Install core packages
         run: |
           dnf --setopt install_weak_deps=False install -y \
             git-core dnf-plugins-core rpm-build sudo
 
       - name: Enable PowerTools repository
-        if: ${{ matrix.name == 'CentOS Stream 8' }}
         run: |
           dnf config-manager --enable powertools
-
-      - name: Enable CRB repository
-        if: ${{ matrix.name == 'CentOS Stream 9' }}
-        run: |
-          dnf config-manager --enable crb
 
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -46,14 +42,7 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
 
-      - name: Install npm (Fedora)
-        if: ${{ startsWith(matrix.name, 'Fedora') }}
-        run: |
-          dnf --setopt install_weak_deps=False install -y \
-            nodejs-npm
-
-      - name: Install npm (CentOS)
-        if: ${{ startsWith(matrix.name, 'CentOS') }}
+      - name: Install npm
         run: |
           dnf --setopt install_weak_deps=False install -y \
             npm
@@ -64,14 +53,7 @@ jobs:
             -D '%global python3_pkgversion 3' \
             subscription-manager.spec
 
-      - name: Install tito (using DNF)
-        if: ${{ startsWith(matrix.name, 'Fedora') }}
-        run: |
-          dnf --setopt install_weak_deps=False install -y \
-            tito
-
-      - name: Install tito (using pip)
-        if: ${{ startsWith(matrix.name, 'CentOS') }}
+      - name: Install tito
         run: |
           dnf --setopt install_weak_deps=False install -y \
             python3-pip python3-setuptools

--- a/scripts/container-pre-test.sh
+++ b/scripts/container-pre-test.sh
@@ -11,9 +11,6 @@ source /etc/os-release
 if [[ $ID == "centos" && $VERSION == "8" ]]; then
     dnf config-manager --enable powertools
 fi
-if [[ $ID == "centos" && $VERSION == "9" ]]; then
-    dnf config-manager --enable crb
-fi
 
 # Install system, build and runtime packages
 dnf --setopt install_weak_deps=False install -y \


### PR DESCRIPTION
CentOS Stream 8 reached EOL on 2024-05-31. This patch ensures we can still run EL8-equivalent tests on frozen version of Stream 8.

Since 1.28 only tracks EL8, CentOS Stream 9 specific code is being dropped as well.