### PR TITLE
[8.6] chore(ci): Use Vault for CentOS Stream 8

### DIFF
--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -23,17 +23,14 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@v3
 
+      - name: "Use CentOS Vault"
+        run: |
+          sed -i 's|#baseurl=http://mirror|baseurl=http://vault|' /etc/yum.repos.d/CentOS-Stream-*.repo
+
       - name: "Enable PowerTools repository"
-        if: ${{ matrix.name == 'CentOS Stream 8' }}
         run: |
           dnf --setopt install_weak_deps=False install -y dnf-plugins-core
           dnf config-manager --enable powertools
-
-      - name: "Enable CRB repository"
-        if: ${{ matrix.name == 'CentOS Stream 9' }}
-        run: |
-          dnf --setopt install_weak_deps=False install -y dnf-plugins-core
-          dnf config-manager --enable crb
 
       - name: "Install packages"
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,6 @@ jobs:
         include:
           - name: "CentOS Stream 8"
             image: "quay.io/centos/centos:stream8"
-            pytest_args: ''
 
     runs-on: ubuntu-latest
     container:
@@ -29,6 +28,10 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
+
+      - name: "Use CentOS Vault"
+        run: |
+          sed -i 's|#baseurl=http://mirror|baseurl=http://vault|' /etc/yum.repos.d/CentOS-Stream-*.repo
 
       - name: "Run container-pre-test.sh"
         run: |
@@ -43,15 +46,14 @@ jobs:
             --cov-report 'xml:/tmp/coverage.xml' --junitxml '/tmp/pytest.xml'"
         run: |
           dbus-run-session \
-            python3 -m pytest ${{ matrix.pytest_args }}
+            python3 -m pytest
 
       - name: "Publish coverage"
         uses: MishaKav/pytest-coverage-comment@main
         if: |
           github.event.pull_request.head.repo.full_name == github.repository
-          && matrix.name == 'Fedora latest'
         with:
-          title: "Coverage (computed on ${{ matrix.name }})"
+          title: "Coverage"
           report-only-changed-files: true
           pytest-xml-coverage-path: /tmp/coverage.xml
           junitxml-path: /tmp/pytest.xml

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -20,20 +20,18 @@ jobs:
       image: ${{ matrix.image }}
 
     steps:
+      - name: "Use CentOS Vault"
+        run: |
+          sed -i 's|#baseurl=http://mirror|baseurl=http://vault|' /etc/yum.repos.d/CentOS-Stream-*.repo
+
       - name: Install core packages
         run: |
           dnf --setopt install_weak_deps=False install -y \
             git-core dnf-plugins-core rpm-build sudo
 
       - name: Enable PowerTools repository
-        if: ${{ matrix.name == 'CentOS Stream 8' }}
         run: |
           dnf config-manager --enable powertools
-
-      - name: Enable CRB repository
-        if: ${{ matrix.name == 'CentOS Stream 9' }}
-        run: |
-          dnf config-manager --enable crb
 
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -52,14 +50,7 @@ jobs:
             -D '%global python3_pkgversion 3' \
             subscription-manager.spec
 
-      - name: Install tito (using DNF)
-        if: ${{ startsWith(matrix.name, 'Fedora') }}
-        run: |
-          dnf --setopt install_weak_deps=False install -y \
-            tito
-
-      - name: Install tito (using pip)
-        if: ${{ startsWith(matrix.name, 'CentOS') }}
+      - name: Install tito
         run: |
           dnf --setopt install_weak_deps=False install -y \
             python3-pip python3-setuptools

--- a/scripts/container-pre-test.sh
+++ b/scripts/container-pre-test.sh
@@ -9,10 +9,8 @@ source /etc/os-release
 # Fedora has it available out of the box.
 # RHEL needs it to be enabled via 'subscription-manager repos'.
 if [[ $ID == "centos" && $VERSION == "8" ]]; then
+	dnf --setopt install_weak_deps=False install -y dnf-plugins-core
     dnf config-manager --enable powertools
-fi
-if [[ $ID == "centos" && $VERSION == "9" ]]; then
-    dnf config-manager --enable crb
 fi
 
 # Install system, build and runtime packages


### PR DESCRIPTION
CentOS Stream 8 reached EOL on 2024-05-31. This patch ensures we can still run EL8-equivalent tests on frozen version of Stream 8.10.

(Cherry-picked from b1beb790)