### PR TITLE
[8.2] chore(ci): Use Vault for CentOS Stream 8

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,6 @@ jobs:
         include:
           - name: "CentOS Stream 8"
             image: "quay.io/centos/centos:stream8"
-            pytest_args: ''
 
     runs-on: ubuntu-latest
     container:
@@ -23,6 +22,10 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
+
+      - name: "Use CentOS Vault"
+        run: |
+          sed -i 's|#baseurl=http://mirror|baseurl=http://vault|' /etc/yum.repos.d/CentOS-Stream-*.repo
 
       - name: "Run container-pre-test.sh"
         run: |

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -20,20 +20,18 @@ jobs:
       image: ${{ matrix.image }}
 
     steps:
+      - name: "Use CentOS Vault"
+        run: |
+          sed -i 's|#baseurl=http://mirror|baseurl=http://vault|' /etc/yum.repos.d/CentOS-Stream-*.repo
+
       - name: Install core packages
         run: |
           dnf --setopt install_weak_deps=False install -y \
             git-core dnf-plugins-core rpm-build sudo which
 
       - name: Enable PowerTools repository
-        if: ${{ matrix.name == 'CentOS Stream 8' }}
         run: |
           dnf config-manager --enable powertools
-
-      - name: Enable CRB repository
-        if: ${{ matrix.name == 'CentOS Stream 9' }}
-        run: |
-          dnf config-manager --enable crb
 
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -54,7 +52,6 @@ jobs:
             subscription-manager.spec
 
       - name: Install tito
-        if: ${{ startsWith(matrix.name, 'CentOS') }}
         run: |
           dnf --setopt install_weak_deps=False install -y \
             python3-pip python3-setuptools

--- a/scripts/container-pre-test.sh
+++ b/scripts/container-pre-test.sh
@@ -4,14 +4,9 @@ source /etc/os-release
 # These repositories are required for the 'libdnf-devel' package.
 # Fedora has it available out of the box.
 # RHEL needs it to be enabled via 'subscription-manager repos'.
-if [[ $ID == "centos" ]]; then
-  dnf --setopt install_weak_deps=False install -y dnf-plugins-core
-  if [[ $VERSION == "8" ]]; then
-    dnf config-manager --set-enabled powertools
-  fi
-  if [[ $VERSION == "9" ]]; then
-    dnf config-manager --enable crb
-  fi
+if [[ $ID == "centos" && $VERSION == "8" ]]; then
+	dnf --setopt install_weak_deps=False install -y dnf-plugins-core
+    dnf config-manager --enable powertools
 fi
 
 # Install essential packages


### PR DESCRIPTION
CentOS Stream 8 reached EOL on 2024-05-31. This patch ensures we can still run EL8-equivalent tests on frozen version of Stream 8.10.

(Cherry-picked from b1beb790)