### PR TITLE
feat: Remove deprecated syspurpose top-level commands

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -260,12 +260,11 @@ _subscription_manager()
   done
 
   # top-level commands and options
-  opts="addons attach auto-attach clean config environments facts identity list orgs
-        repo-override plugins redeem refresh register release remove repos role service-level status
-        syspurpose unregister usage version ${_subscription_manager_help_opts}"
+  opts="attach auto-attach clean config environments facts identity list orgs
+        repo-override plugins redeem refresh register release remove repos status
+        syspurpose unregister version ${_subscription_manager_help_opts}"
 
   case "${first}" in
-      addons|\
       clean|\
       config|\
       environments|\
@@ -279,17 +278,11 @@ _subscription_manager()
       register|\
       release|\
       repos|\
-      role|\
       status|\
       syspurpose|\
       unregister|\
-      usage|\
       version)
       "_subscription_manager_$first" "${cur}" "${prev}"
-      return 0
-      ;;
-      service-level)
-      "_subscription_manager_service_level" "${cur}" "${prev}"
       return 0
       ;;
       attach)

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -135,7 +135,7 @@ must be passed as system arguments in a non-interactive session.
 
 .RE
 
-Following commands were deprecated: addons, role, service-level, subscribe, unsubscribe, and usage
+Following commands were deprecated: subscribe and unsubscribe
 
 .SS COMMON OPTIONS
 .TP
@@ -1022,22 +1022,6 @@ This has been replaced with attach. A similar registration option, \fB--subscrib
 .TP
 .B unsubscribe
 This has been replaced with \fBremove\fP.
-
-.TP
-.B addons
-This has been replaced with \fBsyspurpose addons\fP.
-
-.TP
-.B role
-This has been replaced with \fBsyspurpose role\fP.
-
-.TP
-.B service-level
-This has been replaced with \fBsyspurpose service-level\fP.
-
-.TP
-.B usage
-This has been replaced with \fBsyspurpose usage\fP.
 
 .SH USAGE
 .B subscription-manager

--- a/src/subscription_manager/cli_command/syspurpose.py
+++ b/src/subscription_manager/cli_command/syspurpose.py
@@ -36,10 +36,9 @@ log = logging.getLogger(__name__)
 
 class SyspurposeCommand(CliCommand):
     """
-    Syspurpose command for generic actions. This command will be used for all
-    syspurpose actions in the future and it will replace addons, role,
-    service-level and usage commands. It will be possible to set service-type
-    using this command.
+    Syspurpose command for generic actions. This command is used for all
+    syspurpose actions. It will be possible to set service-type using this
+    command.
 
     Note: when the system is not registered, then it doesn't make any sense to
     synchronize syspurpose values with candlepin server, because consumer

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
 
 from subscription_manager import managerlib
 from subscription_manager.cli import CLI
-from subscription_manager.cli_command.addons import AddonsCommand
 from subscription_manager.cli_command.attach import AttachCommand
 from subscription_manager.cli_command.autoheal import AutohealCommand
 from subscription_manager.cli_command.clean import CleanCommand
@@ -41,12 +40,9 @@ from subscription_manager.cli_command.register import RegisterCommand
 from subscription_manager.cli_command.release import ReleaseCommand
 from subscription_manager.cli_command.remove import RemoveCommand
 from subscription_manager.cli_command.repos import ReposCommand
-from subscription_manager.cli_command.role import RoleCommand
-from subscription_manager.cli_command.service_level import ServiceLevelCommand
 from subscription_manager.cli_command.status import StatusCommand
 from subscription_manager.cli_command.syspurpose import SyspurposeCommand
 from subscription_manager.cli_command.unregister import UnRegisterCommand
-from subscription_manager.cli_command.usage import UsageCommand
 from subscription_manager.cli_command.version import VersionCommand
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.repolib import YumPluginManager
@@ -59,7 +55,6 @@ class ManagerCLI(CLI):
         commands: List[Type[CliCommand]] = [
             RegisterCommand,
             UnRegisterCommand,
-            AddonsCommand,
             ConfigCommand,
             ListCommand,
             IdentityCommand,
@@ -71,15 +66,12 @@ class ManagerCLI(CLI):
             ReleaseCommand,
             StatusCommand,
             EnvironmentsCommand,
-            ServiceLevelCommand,
             VersionCommand,
             RemoveCommand,
             AttachCommand,
             PluginsCommand,
             AutohealCommand,
             OverrideCommand,
-            RoleCommand,
-            UsageCommand,
             FactsCommand,
             SyspurposeCommand,
         ]

--- a/test/cli_command/test_addons.py
+++ b/test/cli_command/test_addons.py
@@ -4,7 +4,7 @@ from contextlib import ExitStack
 
 from ..test_managercli import TestCliCommand
 from subscription_manager import syspurposelib
-from subscription_manager import managercli
+from subscription_manager.cli_command.addons import AddonsCommand
 
 from ..fixture import Capture
 
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 
 class TestAddonsCommand(TestCliCommand):
-    command_class = managercli.AddonsCommand
+    command_class = AddonsCommand
 
     def _set_syspurpose(self, syspurpose):
         """
@@ -29,7 +29,7 @@ class TestAddonsCommand(TestCliCommand):
         sp_patch = syspurpose_patch.start()
         self.addCleanup(sp_patch.stop)
         super(TestAddonsCommand, self).setUp()
-        argv_patcher = patch.object(sys, "argv", ["subscription-manager", "addons"])
+        argv_patcher = patch.object(sys, "argv", ["subscription-manager", "syspurpose", "addons"])
         argv_patcher.start()
         self.addCleanup(argv_patcher.stop)
         syspurposelib.USER_SYSPURPOSE = self.write_tempfile("{}").name

--- a/test/cli_command/test_role.py
+++ b/test/cli_command/test_role.py
@@ -1,8 +1,8 @@
 import os
 
 from ..test_managercli import TestCliProxyCommand
-from subscription_manager import managercli
 from subscription_manager.cli_command.abstract_syspurpose import AbstractSyspurposeCommand
+from subscription_manager.cli_command.role import RoleCommand
 import subscription_manager.injection as inj
 
 from ..stubs import StubUEP
@@ -12,7 +12,7 @@ from unittest.mock import patch, Mock, MagicMock
 
 
 class TestSyspurposeCommand(TestCliProxyCommand):
-    command_class = managercli.RoleCommand
+    command_class = RoleCommand
 
     def setUp(self):
         synced_store_patch = patch("subscription_manager.cli_command.abstract_syspurpose.SyncedStore")
@@ -32,7 +32,7 @@ class TestSyspurposeCommand(TestCliProxyCommand):
 
 
 class TestRoleCommand(TestCliProxyCommand):
-    command_class = managercli.RoleCommand
+    command_class = RoleCommand
 
     def setUp(self):
         synced_store_patch = patch("subscription_manager.cli_command.abstract_syspurpose.SyncedStore")
@@ -399,7 +399,7 @@ class TestRoleOrgCheckingCommand(SubManFixture):
         self.handle_exception_mock.side_effect = self.do_reraise
         self.addCleanup(self.handle_exception_mock)
         super(TestRoleOrgCheckingCommand, self).setUp()
-        self.cc = managercli.RoleCommand()
+        self.cc = RoleCommand()
         self.cc.is_registered = Mock(return_value=False)
 
     def test_no_org(self):

--- a/test/cli_command/test_service_level.py
+++ b/test/cli_command/test_service_level.py
@@ -3,7 +3,7 @@ import tempfile
 
 from ..test_managercli import TestCliProxyCommand
 from subscription_manager import syspurposelib
-from subscription_manager import managercli
+from subscription_manager.cli_command.service_level import ServiceLevelCommand
 
 from ..stubs import StubConsumerIdentity, StubUEP
 from ..fixture import set_up_mock_sp_store
@@ -12,7 +12,7 @@ from unittest.mock import patch, Mock, call
 
 
 class TestServiceLevelCommand(TestCliProxyCommand):
-    command_class = managercli.ServiceLevelCommand
+    command_class = ServiceLevelCommand
 
     def setUp(self):
         syspurpose_patch = patch("syspurpose.files.SyncedStore")


### PR DESCRIPTION
Removes _addons_, _role_, _service-level_, and _usage_ commands. These are deprecated as top-level commands as they’ve been moved to the _syspurpose_ command as sub-commands.

[CCT-402](https://issues.redhat.com/browse/CCT-402)