### PR TITLE
fix: make SyspurposeComplianceStatusCache.get_overall_status() always usable

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -395,9 +395,9 @@ class SyspurposeComplianceStatusCache(StatusCache):
 
     def get_overall_status(self) -> str:
         if self.server_status is not None:
-            return self.syspurpose_service.get_overall_status(self.server_status["status"])
+            return syspurpose.Syspurpose.get_overall_status(self.server_status["status"])
         else:
-            return self.syspurpose_service.get_overall_status("unknown")
+            return syspurpose.Syspurpose.get_overall_status("unknown")
 
     def get_overall_status_code(self) -> str:
         if self.server_status is not None:


### PR DESCRIPTION
This is a "regression" exposed by the recent commit 4801f23913a3ebf30d9c39d25ed75fe5d9b4db48:
- `_sync_with_server()` is now called only when the system has an identity
- in `SyspurposeComplianceStatusCache`,` _sync_with_server()` also creates `syspurpose_service`
- calling `get_overall_status()` in a system without an identity tries to use `self.syspurpose_service` which is not defined

Call the `Syspurpose.get_overall_status()` method as proper class method (as it is declared as such), rather than calling it as instance method; this way, it works even when the `syspurpose_service` object was not created. This fixes the usage of `get_overall_status()` in case the system does not have an identity.

Card ID: CCT-589