### PR TITLE
feat: Deprecate import command

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -80,9 +80,6 @@ must be passed as system arguments in a non-interactive session.
 3. release
 
 .IP
-4. import
-
-.IP
 5. list
 
 .IP
@@ -126,7 +123,7 @@ must be passed as system arguments in a non-interactive session.
 
 .RE
 
-Following commands were deprecated: addons, attach, auto-attach, remove, redeem, role, service-level, subscribe, unsubscribe, usage, and activate
+Following commands were deprecated: addons, attach, auto-attach, import, remove, redeem, role, service-level, subscribe, unsubscribe, usage, and activate
 
 .SS COMMON OPTIONS
 .TP
@@ -588,7 +585,7 @@ Removes any previously set usage preference.
 .SS IMPORT OPTIONS
 The
 .B import
-command imports and applies a subscription certificate for the system which was generated externally, such as in the Customer Portal, and then copied over to the system. Importing can be necessary if a system is preconfigured in the subscription management service or if it is offline or unable to access the subscription management service but it has the proper, relevant subscriptions attached to the system.
+command is \fBdeprecated\fP and will be removed from the future major releases. Command imports and applies a subscription certificate for the system which was generated externally, such as in the Customer Portal, and then copied over to the system. Importing can be necessary if a system is preconfigured in the subscription management service or if it is offline or unable to access the subscription management service but it has the proper, relevant subscriptions attached to the system.
 
 .TP
 .B --certificate=CERTIFICATE_FILE

--- a/src/subscription_manager/cli_command/import_cert.py
+++ b/src/subscription_manager/cli_command/import_cert.py
@@ -27,7 +27,11 @@ log = logging.getLogger(__name__)
 
 class ImportCertCommand(CliCommand):
     def __init__(self):
-        shortdesc = _("Import certificates which were provided outside of the tool")
+        shortdesc = _(
+            "Deprecated, this command will be removed from the future major releases."
+            " This command is no-op in simple content access mode."
+            " Import certificates which were provided outside of the tool"
+        )
         super(ImportCertCommand, self).__init__("import", shortdesc, False)
 
         self.parser.add_argument(


### PR DESCRIPTION
This update aims to add deprecation notices to the import command.
Changes Made

    Added deprecation notices to man page.
    Added deprecation notice to import module description.

Resolves: CCT-591
