### PR TITLE
[1.29] fix cache handling for unregistered systems

### DIFF
--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -219,7 +219,7 @@ class StatusCache(CacheManager):
         self.last_error: Optional[Exception] = None
 
     def load_status(
-        self, uep: connection.UEPConnection, uuid: str, on_date: Optional[datetime.datetime] = None
+        self, uep: connection.UEPConnection, uuid: Optional[str], on_date: Optional[datetime.datetime] = None
     ) -> Optional[Dict]:
         """
         Load status from wherever is appropriate.
@@ -232,6 +232,10 @@ class StatusCache(CacheManager):
         Returns None if we cannot reach the server, or use the cache.
         """
         try:
+            # If UUID is None, then we cannot get anything from server
+            # and None has to be returned
+            if uuid is None:
+                return None
             self._sync_with_server(uep, uuid, on_date)
             self.write_cache()
             self.last_error = False

--- a/src/subscription_manager/cache.py
+++ b/src/subscription_manager/cache.py
@@ -395,9 +395,9 @@ class SyspurposeComplianceStatusCache(StatusCache):
 
     def get_overall_status(self) -> str:
         if self.server_status is not None:
-            return self.syspurpose_service.get_overall_status(self.server_status["status"])
+            return syspurpose.Syspurpose.get_overall_status(self.server_status["status"])
         else:
-            return self.syspurpose_service.get_overall_status("unknown")
+            return syspurpose.Syspurpose.get_overall_status("unknown")
 
     def get_overall_status_code(self) -> str:
         if self.server_status is not None:

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -321,7 +321,7 @@ class YumReleaseverSource:
         #       so a new created YumReleaseverSource needs to be created when
         #       you think there may be a new release set. We assume it will be
         #       the same for the lifetime of a RepoUpdateActionCommand
-        if not self.is_set(result) or result is None:
+        if result is None or not self.is_set(result):
             # we got a result indicating we don't know the release, use the
             # default. This could be server error or just an "unset" release.
             self._expansion = self.default


### PR DESCRIPTION
- avoid Cache fetches from server in case the system is not registered (i.e. there is no identity/UUID)
- fix `SyspurposeComplianceStatusCache` to work in this situation

Backport to 1.29.x:
- #3420
- #3421