### PR TITLE
doc: drop references to "activate"

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -135,7 +135,7 @@ must be passed as system arguments in a non-interactive session.
 
 .RE
 
-Following commands were deprecated: addons, role, service-level, subscribe, unsubscribe, usage, and activate
+Following commands were deprecated: addons, role, service-level, subscribe, unsubscribe, and usage
 
 .SS COMMON OPTIONS
 .TP
@@ -1022,10 +1022,6 @@ This has been replaced with attach. A similar registration option, \fB--subscrib
 .TP
 .B unsubscribe
 This has been replaced with \fBremove\fP.
-
-.TP
-.B activate
-This has been replaced with \fBredeem\fP.
 
 .TP
 .B addons


### PR DESCRIPTION
It was the old name of "redeem", and it was removed long ago.