### PR TITLE
Collect Azure VM Name and Resource Group Name as a cloud fact.

### DIFF
--- a/src/rhsmlib/facts/cloud_facts.py
+++ b/src/rhsmlib/facts/cloud_facts.py
@@ -123,6 +123,8 @@ class CloudFactsCollector(collector.FactsCollector):
                 "azure_instance_id": some_instance_ID,
                 "azure_offer": some_offer,
                 "azure_sku": some_sku,
+                "azure_vm_name": some_vm_name
+                "azure_resource_group_name": some_resource_group_name
                 "azure_subscription_id": some_subscription_ID
                 "azure_location: azure region the VM is running in
             }
@@ -142,6 +144,10 @@ class CloudFactsCollector(collector.FactsCollector):
                     facts["azure_sku"] = values["compute"]["sku"]
                 if "offer" in values["compute"]:
                     facts["azure_offer"] = values["compute"]["offer"]
+                if "name" in values["compute"]:
+                    facts["azure_vm_name"] = values["compute"]["name"]
+                if "resourceGroupName" in values["compute"]:
+                    facts["azure_resource_group_name"] = values["compute"]["resourceGroupName"]
                 if "subscriptionId" in values["compute"]:
                     facts["azure_subscription_id"] = values["compute"]["subscriptionId"]
                 if "location" in values["compute"]:

--- a/test/rhsmlib/facts/test_cloud_facts.py
+++ b/test/rhsmlib/facts/test_cloud_facts.py
@@ -172,6 +172,8 @@ AWS_REGION = "eu-central-1"
 AZURE_INSTANCE_ID = "12345678-1234-1234-1234-123456789abc"
 AZURE_SKU = "8.1-ci"
 AZURE_OFFER = "RHEL"
+AZURE_VM_NAME = "foo-bar"
+AZURE_RESOURCE_GROUP_NAME = "foo-bar"
 AZURE_SUBSCRIPTION_ID = "01234567-0123-0123-0123-012345679abc"
 # There is no list of valid values of locations, extended locations and
 # types of extended locations. Value "microsoftlondon" probably does not
@@ -324,6 +326,10 @@ class TestCloudCollector(unittest.TestCase):
         self.assertEqual(facts["azure_sku"], AZURE_SKU)
         self.assertIn("azure_offer", facts)
         self.assertEqual(facts["azure_offer"], AZURE_OFFER)
+        self.assertIn("azure_vm_name", facts)
+        self.assertEqual(facts["azure_vm_name"], AZURE_VM_NAME)
+        self.assertIn("azure_resource_group_name", facts)
+        self.assertEqual(facts["azure_resource_group_name"], AZURE_RESOURCE_GROUP_NAME)
         self.assertIn("azure_subscription_id", facts)
         self.assertEqual(facts["azure_subscription_id"], AZURE_SUBSCRIPTION_ID)
         self.assertIn("azure_location", facts)

--- a/test/rhsmlib/facts/test_cloud_facts.py
+++ b/test/rhsmlib/facts/test_cloud_facts.py
@@ -54,7 +54,7 @@ AZURE_METADATA = """
         },
         "customData": "",
         "location": "westeurope",
-        "name": "foo-bar",
+        "name": "foo-vm-name",
         "offer": "RHEL",
         "osType": "Linux",
         "placementGroupId": "",
@@ -73,7 +73,7 @@ AZURE_METADATA = """
             }
         ],
         "publisher": "RedHat",
-        "resourceGroupName": "foo-bar",
+        "resourceGroupName": "foo-group-name",
         "resourceId": "/subscriptions/01234567-0123-0123-0123-012345679abc/resourceGroups/foo-bar/providers/Microsoft.Compute/virtualMachines/foo",
         "sku": "8.1-ci",
         "storageProfile": {
@@ -172,8 +172,8 @@ AWS_REGION = "eu-central-1"
 AZURE_INSTANCE_ID = "12345678-1234-1234-1234-123456789abc"
 AZURE_SKU = "8.1-ci"
 AZURE_OFFER = "RHEL"
-AZURE_VM_NAME = "foo-bar"
-AZURE_RESOURCE_GROUP_NAME = "foo-bar"
+AZURE_VM_NAME = "foo-vm-name"
+AZURE_RESOURCE_GROUP_NAME = "foo-group-name"
 AZURE_SUBSCRIPTION_ID = "01234567-0123-0123-0123-012345679abc"
 # There is no list of valid values of locations, extended locations and
 # types of extended locations. Value "microsoftlondon" probably does not


### PR DESCRIPTION
* Obtain the VM Name from the instance metadata API
* Obtain the Resource Group Name from the instance metadata API
* These items will improve deduplication logic within Subscription Watch metering