### PR TITLE
[1.28.36] tests: cockpit: backport CI fixes from subscription-manager-cockpit

### DIFF
--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -122,9 +122,9 @@ class SubscriptionsCase(MachineCase):
         self.candlepin = self.machines['services']
         m = self.machine
 
-        # wait for candlepin to be active and verify
-        # this changed in https://github.com/cockpit-project/bots/pull/1768
-        self.candlepin.execute("if [ -x /root/run-candlepin ]; then /root/run-candlepin; else systemctl start tomcat; fi")
+        # start candlepin in the service machine;
+        # see https://github.com/cockpit-project/bots/pull/1768
+        self.candlepin.execute(["/root/run-candlepin"])
 
         # download product info from the candlepin machine
         def download_product(product):

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -371,9 +371,11 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_visible("#overview a:contains('3 hits, including important')")
 
         # test system purpose
-        m.execute("subscription-manager role --set 'Red Hat Enterprise Linux Workstation'")
-        m.execute("subscription-manager usage --set 'Development/Test'")
-        m.execute("subscription-manager service-level --set 'Standard'")
+        m.execute(
+            ["subscription-manager", "syspurpose", "role", "--set", "Red Hat Enterprise Linux Workstation"]
+        )
+        m.execute(["subscription-manager", "syspurpose", "usage", "--set", "Development/Test"])
+        m.execute(["subscription-manager", "syspurpose", "service-level", "--set", "Standard"])
         b.wait_in_text("#syspurpose", "Standard")
         b.wait_in_text("#syspurpose", "Development/Test")
         b.wait_in_text("#syspurpose", "Red Hat Enterprise Linux Workstation")

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -20,6 +20,7 @@
 
 import os
 import sys
+import uuid
 
 # import Cockpit's machinery for test VMs and its browser test API
 TEST_DIR = os.path.dirname(__file__)
@@ -416,8 +417,10 @@ class TestSubscriptions(SubscriptionsCase):
 
         b.wait_visible("button:contains('Connected to Insights')")
 
-        # Break the next upload and expect the warning triangle to tell us about it
-        m.execute("mv /etc/insights-client/machine-id /etc/insights-client/machine-id.lost")
+        # Break the next upload and expect the warning triangle to tell us about it;
+        # write over the original file so its SELinux attributes are preserved.
+        m.execute(["cp", "/etc/insights-client/machine-id", "/etc/insights-client/machine-id.orig"])
+        m.write("/etc/insights-client/machine-id", str(uuid.uuid4()))
         m.execute("systemctl start insights-client")
 
         with b.wait_timeout(60):
@@ -428,7 +431,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.click("button.cancel")
 
         # Unbreak it and retry.
-        m.execute("mv /etc/insights-client/machine-id.lost /etc/insights-client/machine-id")
+        m.execute(["mv", "/etc/insights-client/machine-id.orig", "/etc/insights-client/machine-id"])
         m.execute("systemctl start insights-client; while systemctl --quiet is-active insights-client; do sleep 1; done",
                   timeout=360)
 

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -229,7 +229,10 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # old error should disappear
-        b.wait_not_in_text("body", "User doc is member of more organizations, but no organization was selected")
+        with b.wait_timeout(60):
+            b.wait_not_in_text(
+                "body", "User doc is member of more organizations, but no organization was selected"
+            )
 
         # dialog should disappear
         b.wait_not_present(dialog_register_button_sel)
@@ -274,7 +277,8 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # dialog should disappear
-        b.wait_not_present(dialog_register_button_sel)
+        with b.wait_timeout(60):
+            b.wait_not_present(dialog_register_button_sel)
 
         # make sure this product isn't subscribed
         self.wait_subscription(PRODUCT_SNOWY, False)
@@ -315,7 +319,8 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # dialog should disappear
-        b.wait_not_present(dialog_register_button_sel)
+        with b.wait_timeout(60):
+            b.wait_not_present(dialog_register_button_sel)
 
         # this product should not be subscribed ATM, because auto-attach was skipped
         self.wait_subscription(PRODUCT_SHARED, False)
@@ -323,7 +328,8 @@ class TestSubscriptions(SubscriptionsCase):
         b.click("button:contains('Auto-attach')")
 
         # find another one that is subscribed
-        self.wait_subscription(PRODUCT_SHARED, True)
+        with b.wait_timeout(60):
+            self.wait_subscription(PRODUCT_SHARED, True)
 
     def testUnpriv(self):
         self.machine.execute("useradd junior; echo junior:foobar | chpasswd")
@@ -351,7 +357,8 @@ class TestSubscriptions(SubscriptionsCase):
 
         dialog_register_button_sel = "footer .pf-m-primary"
         b.click(dialog_register_button_sel)
-        b.wait_not_present(dialog_register_button_sel)
+        with b.wait_timeout(60):
+            b.wait_not_present(dialog_register_button_sel)
 
         b.click("button:contains('Not connected')")
         b.wait_visible('.pf-c-modal-box__body:contains("This system is not connected")')
@@ -413,7 +420,8 @@ class TestSubscriptions(SubscriptionsCase):
         m.execute("mv /etc/insights-client/machine-id /etc/insights-client/machine-id.lost")
         m.execute("systemctl start insights-client")
 
-        b.wait_visible("button .pf-c-button__icon svg[fill='orange']")
+        with b.wait_timeout(60):
+            b.wait_visible("button .pf-c-button__icon svg[fill='orange']")
 
         b.click("button:contains('Connected to Insights')")
         b.wait_visible('.pf-c-modal-box__body:contains("The last Insights data upload has failed")')
@@ -427,7 +435,8 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_not_present("button .pf-c-button__icon svg[fill='orange']")
 
         b.click("button:contains('Unregister')")
-        b.wait_not_in_text("#overview", "Insights")
+        with b.wait_timeout(60):
+            b.wait_not_in_text("#overview", "Insights")
         m.execute("test -f /etc/insights-client/.unregistered")
 
 

--- a/integration-tests/check-subscriptions
+++ b/integration-tests/check-subscriptions
@@ -364,7 +364,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.click("button:contains('Not connected')")
         b.wait_visible('.pf-c-modal-box__body:contains("This system is not connected")')
         b.click('footer button.apply')
-        with b.wait_timeout(360):
+        with b.wait_timeout(600):
             b.wait_not_present('.pf-c-modal-box')
 
         b.wait_visible("#overview a[href='http://cloud.redhat.com/insights/inventory/123-nice-id']")
@@ -415,7 +415,8 @@ class TestSubscriptions(SubscriptionsCase):
         with b.wait_timeout(360):
             b.wait_not_present(dialog_register_button_sel)
 
-        b.wait_visible("button:contains('Connected to Insights')")
+        with b.wait_timeout(600):
+            b.wait_visible("button:contains('Connected to Insights')")
 
         # Break the next upload and expect the warning triangle to tell us about it;
         # write over the original file so its SELinux attributes are preserved.

--- a/test/files/mock-insights
+++ b/test/files/mock-insights
@@ -52,12 +52,13 @@ class handler(BaseHTTPRequestHandler):
         m = self.match("/r/insights/v1/systems/([^/]+)")
         if m:
             machine_id = m[1]
+            if machine_id not in systems:
+                self.send_response(404)
+                self.end_headers()
+                return
             self.send_response(200)
             self.end_headers()
-            if machine_id in systems:
-                self.wfile.write(json.dumps(systems[machine_id]).encode('utf-8') + b"\n")
-            else:
-                self.wfile.write(b"{ }\n")
+            self.wfile.write(json.dumps(systems[machine_id]).encode("utf-8") + b"\n")
             return
 
         m = self.match("/r/insights/v1/branch_info")


### PR DESCRIPTION
Backport some commits from the separate subscription-manager-cockpit repository to fix the CI jobs, especially after recent-ish changes to insights-client/insights-core.