### PR TITLE
feat: Use rhsm group for concumer cert and key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,10 @@ install-files: dbus-install install-conf install-plugins
 	install -m 644 etc-conf/subscription-manager.conf.tmpfiles \
 		$(DESTDIR)/$(PREFIX)/lib/tmpfiles.d/subscription-manager.conf
 
+	# Install configuration file with system users and group (only rhsm group ATM)
+	install -d $(DESTDIR)/$(PREFIX)/lib/sysusers.d
+	install -m 644 etc-conf/rhsm-sysuser.conf $(DESTDIR)/$(PREFIX)/lib/sysusers.d/rhsm.conf
+
 	# SUSE Linux does not make use of consolehelper
 	if [ -f /etc/redhat-release ]; then \
 		ln -sf /usr/bin/consolehelper $(DESTDIR)/$(PREFIX)/bin/subscription-manager; \

--- a/etc-conf/rhsm-sysuser.conf
+++ b/etc-conf/rhsm-sysuser.conf
@@ -1,0 +1,2 @@
+#Type Name       ID                  GECOS              Home directory Shell
+g     rhsm       -                   -

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -527,6 +527,8 @@ find %{buildroot} -name \*.py* -exec touch -r %{SOURCE0} '{}' \;
 %{completion_dir}/rhsm-debug
 %{completion_dir}/rhsmcertd
 
+%{_sysusersdir}/rhsm.conf
+
 %dir %{python_sitearch}/subscription_manager
 
 # code, python modules and packages
@@ -689,6 +691,10 @@ if [ "$1" = "2" ] ; then
     killall rhsmd 2> /dev/null || true
 fi
 %endif
+
+# Make all consumer certificates and keys readable by group rhsm
+find /etc/pki/consumer -mindepth 1 -maxdepth 1 -name '*.pem' | xargs --no-run-if-empty chgrp rhsm
+find /etc/pki/consumer -mindepth 1 -maxdepth 1 -name '*.pem' | xargs --no-run-if-empty chmod g+r
 
 # Make all entitlement certificates and keys files readable by group and other
 find /etc/pki/entitlement -mindepth 1 -maxdepth 1 -name '*.pem' | xargs --no-run-if-empty chmod go+r


### PR DESCRIPTION
* Card ID: CCT-652
* Add rhsm group during installation of subman RPM
    * rhsm group is created during installation of
      subscription-manager rpm
    * System user conf file is installed to /usr/lib/sysuser.d
      directory.
    * Existing consumer certs and keys are updated during
      installation process of rpm. It means that group owner
      of all pem files in /etc/pki/consumer is changed to rhsm
      and group can read these files. It is important for
      systems that are already registered.
* Create consumer cert & key owned by rhsm group
    * When consumer certificate or key is created, then try to use
      rhsm group as a owner. When this group does not exist, then
      0 guid is used
    * Modified also function checking and correcting permissions
      to consumer cert & key
    * Not added any unit test for this case, because it would require
      to run unit tests as a root user