### PR TITLE
feat: forcefully switch automatic cloud registration to v1

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1515,10 +1515,11 @@ class UEPConnection(BaseConnection):
         }
         headers = {
             "Content-Type": "application/json",
+            "Accept": "text/plain",
         }
 
         return self.conn.request_post(
-            method="/cloud/authorize?version=2",
+            method="/cloud/authorize",
             params=data,
             headers=headers,
             description=_("Fetching cloud token"),


### PR DESCRIPTION
- call the cloud endpoint without the new version, and with the Accept for the existing endpoint
- use `cache.CloudTokenCache._get_from_server()` directly: the v1 autoregistration does not need any caching of the received token, so use the internal API of `CloudTokenCache` only to fetch the token
- the received token is the JWT token to use directly, without any inspection or unpacking: pass it directly to `_auto_register_standard()`
- drop the leftover commented code for autoregistration v2 for now