### PR TITLE
test(ci): Improve container pre-test script

### DIFF
--- a/scripts/container-pre-test.sh
+++ b/scripts/container-pre-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Install essential packages
 dnf --setopt install_weak_deps=False install -y \
   dnf-plugins-core git gcc cmake python3 python3-devel python3-pip
@@ -13,7 +15,7 @@ if [[ $ID == "centos" ]]; then
 fi
 
 # Install system, build and runtime packages
-dnf --setopt install_weak_deps=False install -y \
+dnf --setopt install_weak_deps=False install -y --nobest \
   intltool python3-setuptools \
   openssl-devel libdnf-devel \
   python3-rpm python3-librepo python3-gobject \


### PR DESCRIPTION
C10S, being a development build, doesn't always have all packages set up correctly. As of now, two packages (rpm-devel, python3-rpm) depend on different releases of rpm-libs, making the dnf command fail.

To make these issues more obvious next time, `set -euo pipefail` will ensure the script fails instead of continuing.