### PR TITLE
feat: support registering specifying environments with activation keys

### DIFF
--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -239,10 +239,6 @@ class RegisterService:
                 raise exceptions.ValidationError(
                     _("Error: Activation keys can not be used with previously" " registered IDs.")
                 )
-            elif options["environments"]:
-                raise exceptions.ValidationError(
-                    _("Error: Activation keys do not allow environments to be" " specified.")
-                )
         elif options.get("jwt_token") is not None:
             # TODO: add more checks here
             pass

--- a/test/rhsmlib/services/test_register.py
+++ b/test/rhsmlib/services/test_register.py
@@ -508,15 +508,6 @@ class RegisterServiceTest(InjectionMockingTest):
         with self.assertRaisesRegex(exceptions.ValidationError, r".*do not require user credentials.*"):
             register.RegisterService(self.mock_cp).validate_options(options)
 
-    def test_does_not_allow_environment_with_activation_keys(self):
-        self.mock_cp.username = None
-        self.mock_cp.password = None
-
-        self.mock_identity.is_valid.return_value = False
-        options = self._build_options(activation_keys=[1], environments="environment")
-        with self.assertRaisesRegex(exceptions.ValidationError, r".*do not allow environments.*"):
-            register.RegisterService(self.mock_cp).validate_options(options)
-
     def test_does_not_allow_environment_with_consumerid(self):
         self.mock_cp.username = None
         self.mock_cp.password = None


### PR DESCRIPTION
Open questions:
- If the user specifies an activation key with one environment, and manually specifies a different environment, what should  happen? Should this PR handle that case?
- Should the validation be removed from the CLI too? Or just the internal DBus method?

* Card-ID: CCT-762
* Removes validation to prevent specifying environment during registration with activation key