### PR TITLE
[1.29] fix: perform autoreg waiting when performing standard autoreg

### DIFF
--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -160,6 +160,25 @@ def _collect_cloud_info(cloud_list: List[str]) -> dict:
     return result
 
 
+def _auto_register_wait() -> None:
+    """Delay during the automatic registration.
+
+    Wait for an amount of time during automatic registration, looking at the
+    configured splay and autoregistration interval.
+    """
+    cfg = config.get_config_parser()
+    if cfg.get("rhsmcertd", "splay") == "0":
+        log.debug("Trying to obtain the identity immediately, splay is disabled.")
+    else:
+        registration_interval = int(cfg.get("rhsmcertd", "auto_registration_interval"))
+        splay_interval: int = random.randint(60, registration_interval * 60)
+        log.debug(
+            f"Waiting a period of {splay_interval} seconds "
+            f"(about {splay_interval // 60} minutes) before attempting to obtain the identity."
+        )
+        time.sleep(splay_interval)
+
+
 def _auto_register(cp_provider: "CPProvider") -> ExitStatus:
     """Try to perform automatic registration.
 
@@ -245,17 +264,7 @@ def _auto_register_anonymous(uep: "UEPConnection", token: Dict[str, str]) -> Non
     manager.install_temporary_certificates(uuid=token["anonymousConsumerUuid"], jwt=token["token"])
 
     # Step 2: Wait
-    cfg = config.get_config_parser()
-    if cfg.get("rhsmcertd", "splay") == "0":
-        log.debug("Trying to obtain the identity immediately, splay is disabled.")
-    else:
-        registration_interval = int(cfg.get("rhsmcertd", "auto_registration_interval"))
-        splay_interval: int = random.randint(60, registration_interval * 60)
-        log.debug(
-            f"Waiting a period of {splay_interval} seconds "
-            f"(about {splay_interval // 60} minutes) before attempting to obtain the identity."
-        )
-        time.sleep(splay_interval)
+    _auto_register_wait()
 
     # Step 3: Obtain the identity certificate
     log.debug("Obtaining system identity")

--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -239,6 +239,8 @@ def _auto_register_standard(uep: "UEPConnection", token: Dict[str, str]) -> None
     """
     log.debug("Registering the system through standard automatic registration.")
 
+    _auto_register_wait()
+
     service = RegisterService(cp=uep)
     service.register(org=None, jwt_token=token)
 


### PR DESCRIPTION
The initial delay when performing the standard autoregistration used to
be done directly in rhsmcertd (the C daemon). When the anonymous
autoregistration was implemented, since it has to start immediately,
that delay in rhsmcertd was dropped in favour of doing it "inline"
during the autoregistration. The waiting was added only during the
anonymous autoregistration flow and not during the standard
autoregistration.

Hence, add the autoregistration wait/delay before performing the
standard autoregistration, restoring the previous behaviour.

There is a small commit factorizing the code to an helper function.

Backport of PR #3461 to 1.29.