### PR TITLE
[1.29] fix: Handle Retry-After headers better for 429 responses

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -500,10 +500,14 @@ class RateLimitExceededException(RestlibException):
     The retry_after attribute may not be included in the response.
     """
 
-    def __init__(self, code: int, msg: str = None, headers: str = None) -> None:
+    def __init__(self, code: int, msg: str = None, headers: dict = None) -> None:
         super(RateLimitExceededException, self).__init__(code, msg)
         self.headers = headers or {}
-        self.retry_after = safe_int(self.headers.get("retry-after"))
+        self.retry_after = None
+        for header, value in self.headers.items():
+            if header.lower() == "retry-after":
+                self.retry_after = safe_int(value)
+                break
         self.msg = msg or "Access rate limit exceeded"
         if self.retry_after is not None:
             self.msg += ", retry access after: %s seconds." % self.retry_after

--- a/test/rhsm/unit/test_connection.py
+++ b/test/rhsm/unit/test_connection.py
@@ -871,6 +871,18 @@ class BaseRestLibValidateResponseTests(unittest.TestCase):
         else:
             self.fail("Should have raised a RateLimitExceededException")
 
+    def test_429_weird_case(self):
+        content = '{"errors": ["TooFast"]}'
+        headers = {"RETry-aFteR": 20}
+        try:
+            self.vr("429", content, headers)
+        except RateLimitExceededException as e:
+            self.assertEqual(20, e.retry_after)
+            self.assertEqual("TooFast, retry access after: 20 seconds.", e.msg)
+            self.assertEqual("429", e.code)
+        else:
+            self.fail("Should have raised a RateLimitExceededException")
+
     def test_500_empty(self):
         try:
             self.vr("500", "")


### PR DESCRIPTION
* Card ID: CCT-759

We have to ensure we normalize the headers before we search for the `Retry-After` header.

Backport of PR #3464 to 1.29.