### PR TITLE
[1.29] feat/cct-868: Subset of list command options marked as deprecated

### DIFF
--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -612,23 +612,23 @@ command lists all of the subscriptions that are compatible with a system. The op
 
 .TP
 .B --afterdate=YYYY-MM-DD
-Shows pools that are active on or after the given date. This is only used with the
+Deprecated, this option will be removed in future major releases. Shows pools that are active on or after the given date. This is only used with the
 .B --available
 option.
 
 .TP
 .B --all
-Lists all possible subscriptions that have been purchased, even if they don't match the architecture of the system. This is used with the
+Deprecated, this option will be removed in future major releases. Lists all possible subscriptions that have been purchased, even if they don't match the architecture of the system. This is used with the
 .B --available
 option.
 
 .TP
 .B --available
-Lists available subscriptions which are not yet attached to the system.
+Deprecated, this option will be removed in future major releases. Lists available subscriptions which are not yet attached to the system.
 
 .TP
 .B --consumed
-Lists all of the subscriptions currently attached to the system.
+Deprecated, this option will be removed in future major releases. Lists all of the subscriptions currently attached to the system.
 
 .TP
 .B --installed
@@ -636,19 +636,19 @@ Lists products which are currently installed on the system which may (or may not
 
 .TP
 .B --ondate=YYYY-MM-DD
-Sets the date to use to search for active and available subscriptions. The default (if not explicitly passed) is today's date; using a later date looks for subscriptions which will be active then. This is only used with the
+Deprecated, this option will be removed in future major releases. Sets the date to use to search for active and available subscriptions. The default (if not explicitly passed) is today's date; using a later date looks for subscriptions which will be active then. This is only used with the
 .B --available
 option.
 
 .TP
 .B --no-overlap
-Shows pools which provide products that are not already covered; only used with
+Deprecated, this option will be removed in future major releases. Shows pools which provide products that are not already covered; only used with
 .B --available
 option.
 
 .TP
 .B --match-installed
-Shows only subscriptions matching products that are currently installed; only used with
+Deprecated, this option will be removed in future major releases. Shows only subscriptions matching products that are currently installed; only used with
 .B --available
 option.
 
@@ -661,7 +661,7 @@ question mark or asterisk. Likewise, to represent a backslash, it must be escape
 
 .TP
 .B --pool-only
-Limits the output of --available and --consumed such that only the pool IDs are displayed. No labels or errors will be printed if this option is specified.
+Deprecated, this option will be removed in future major releases. Limits the output of --available and --consumed such that only the pool IDs are displayed. No labels or errors will be printed if this option is specified.
 
 .SS REFRESH OPTIONS
 The

--- a/src/subscription_manager/cli_command/list.py
+++ b/src/subscription_manager/cli_command/list.py
@@ -217,29 +217,41 @@ class ListCommand(CliCommand):
         self.parser.add_argument(
             "--available",
             action="store_true",
-            help=_("show those subscriptions which are available"),
+            help=_(
+                "deprecated, this option will be removed from the future major releases; "
+                "show those subscriptions which are available"
+            ),
         )
         self.parser.add_argument(
             "--all",
             action="store_true",
-            help=_("used with --available to ensure all subscriptions are returned"),
+            help=_(
+                "deprecated, this option will be removed from the future major releases; "
+                "used with --available to ensure all subscriptions are returned"
+            ),
         )
         self.parser.add_argument(
             "--ondate",
             dest="on_date",
             help=_(
-                "date to search on, defaults to today's date, only used with --available (example: {example})"
+                "deprecated, this option will be removed from the future major releases; "
+                "date to search on, defaults to today's date, "
+                "only used with --available (example: {example})"
             ).format(example=strftime("%Y-%m-%d", localtime())),
         )
         self.parser.add_argument(
             "--consumed",
             action="store_true",
-            help=_("show the subscriptions being consumed by this system"),
+            help=_(
+                "deprecated, this option will be removed from the future major releases; "
+                "show the subscriptions being consumed by this system"
+            ),
         )
         self.parser.add_argument(
             "--servicelevel",
             dest="service_level",
             help=_(
+                "deprecated, this option will be removed from the future major releases; "
                 "shows only subscriptions matching the specified service level; "
                 "only used with --available and --consumed"
             ),
@@ -248,6 +260,7 @@ class ListCommand(CliCommand):
             "--no-overlap",
             action="store_true",
             help=_(
+                "deprecated, this option will be removed from the future major releases; "
                 "shows pools which provide products that are not already covered; "
                 "only used with --available"
             ),
@@ -256,6 +269,7 @@ class ListCommand(CliCommand):
             "--match-installed",
             action="store_true",
             help=_(
+                "deprecated, this option will be removed from the future major releases; "
                 "shows only subscriptions matching products that are currently installed; "
                 "only used with --available"
             ),
@@ -274,6 +288,7 @@ class ListCommand(CliCommand):
             dest="pid_only",
             action="store_true",
             help=_(
+                "deprecated, this option will be removed from the future major releases; "
                 "lists only the pool IDs for applicable available or consumed subscriptions; "
                 "only used with --available and --consumed"
             ),
@@ -282,6 +297,7 @@ class ListCommand(CliCommand):
             "--afterdate",
             dest="after_date",
             help=_(
+                "deprecated, this option will be removed from the future major releases; "
                 "show pools that are active on or after the given date; "
                 "only used with --available (example: {example})"
             ).format(example=strftime("%Y-%m-%d", localtime())),


### PR DESCRIPTION
Options 
```
--available 
--all 
--ondate 
--servicelevel 
--no-overlap
--match-install 
--pool-only 
--afterdate
``` 
were marked as deprecated
in ListCommand definition of their help string.

The options were marked as deprecated in list command manuald page.
