### PR TITLE
feat/cct-874: Autocompletion for option --servicelevel was removed

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -134,7 +134,7 @@ _subscription_manager_register()
 {
   local opts="--activationkey --baseurl --consumerid
               --environments --force --name --org --password --release
-              --servicelevel --username --token
+              --username --token
               ${_subscription_manager_common_url_opts}
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))


### PR DESCRIPTION
Autocompletion for option `--servicelevel` (`sub-man register --servicelevel`) was removed.
