### PR TITLE
fix: drop "autoattachinterval" from the rhsmcertd defaults

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -82,7 +82,6 @@ RHSM_DEFAULTS = {
 
 RHSMCERTD_DEFAULTS = {
     "certcheckinterval": "240",
-    "autoattachinterval": "1440",
     "splay": "1",
     "disable": "0",
     "auto_registration": "0",


### PR DESCRIPTION
That configuration option was recently removed, so there is no more need to specify a default value for it.

Fixes CCT-966

Followup of commit c124784a20276f1877248f15ed706050b7400dd5.