### PR TITLE
chore: Remove artifacts of --auto-attach

### DIFF
--- a/example-plugins/dbus_event.py
+++ b/example-plugins/dbus_event.py
@@ -89,9 +89,3 @@ class DbusEventPlugin(SubManPlugin):
 
     def post_subscribe_hook(self, conduit):
         self._dbus_event("post_subscribe", conduit)
-
-    def pre_auto_attach_hook(self, conduit):
-        self._dbus_event("pre_auto_attach", conduit)
-
-    def post_auto_attach_hook(self, conduit):
-        self._dbus_event("post_auto_attach", conduit)

--- a/example-plugins/subscribe.py
+++ b/example-plugins/subscribe.py
@@ -37,9 +37,3 @@ class SubscribePlugin(SubManPlugin):
             conduit: A PostSubscriptionConduit()
         """
         conduit.log.debug("post subscribe called")
-
-    def pre_auto_attach_hook(self, conduit):
-        conduit.log.debug("pre auto attach called")
-
-    def post_auto_attach_hook(self, conduit):
-        conduit.log.debug("post auto attach called")

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -242,7 +242,7 @@ daemon
 .PP
 splay
 .RS 4
-1 to enable splay. 0 to disable splay. If enabled, this feature delays the initial auto attach and cert check by an amount between 0 seconds and the interval given for the action being delayed. For example if the
+1 to enable splay. 0 to disable splay. If enabled, this feature delays the initial attach and cert check by an amount between 0 seconds and the interval given for the action being delayed. For example if the
 .B certCheckInterval
 were set to 3 minutes, the initial cert check would begin somewhere between 2 minutes after start up (minimum delay) and 5 minutes after start up. This is useful to reduce peak load on the Satellite or entitlement service used by a large number of machines.
 .RE

--- a/src/rhsmlib/dbus/util.py
+++ b/src/rhsmlib/dbus/util.py
@@ -77,8 +77,6 @@ def dbus_handle_exceptions(func, *args, **kwargs):
         pattern = "^HTTP error \x28.*\x29: "
         err_msg = re.sub(pattern, "", str(err))
         # Modify severity of some exception here
-        if "Ignoring request to auto-attach. It is disabled for org" in err_msg:
-            severity = "warning"
         if hasattr(err, "severity"):
             severity = err.severity
         # Raise exception string as JSON string. Thus it can be parsed and printed properly.

--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -262,7 +262,7 @@ class AbstractSyspurposeCommand(CliCommand):
                     print(
                         _(
                             "Warning: This organization does not have any subscriptions that provide a "
-                            'system purpose "{attr}".  This setting will not influence auto-attaching '
+                            'system purpose "{attr}".  This setting will not influence attaching '
                             "subscriptions."
                         ).format(attr=self.attr)
                     )

--- a/src/subscription_manager/plugins.py
+++ b/src/subscription_manager/plugins.py
@@ -379,7 +379,6 @@ class SubscriptionConduit(BaseConduit):
             consumer_uuid: the UUID of the consumer being subscribed
             pool_id: the id of the pool the subscription will come from (None if 'auto' is False)
             quantity: the quantity to consume from the pool (None if 'auto' is False).
-            auto: is this an auto-attach/healing event.
         """
         super(SubscriptionConduit, self).__init__(clazz)
         self.consumer_uuid: str = consumer_uuid
@@ -400,33 +399,6 @@ class PostSubscriptionConduit(BaseConduit):
         super(PostSubscriptionConduit, self).__init__(clazz)
         self.consumer_uuid: str = consumer_uuid
         self.entitlement_data: Dict = entitlement_data
-
-
-class AutoAttachConduit(BaseConduit):
-    slots = ["pre_auto_attach"]
-
-    def __init__(self, clazz: Type[SubManPlugin], consumer_uuid: str):
-        """
-        init for AutoAttachConduit
-
-        Args:
-            consumer_uuid: the UUID of the consumer being auto-subscribed
-        """
-        super(AutoAttachConduit, self).__init__(clazz)
-        self.consumer_uuid: str = consumer_uuid
-
-
-class PostAutoAttachConduit(PostSubscriptionConduit):
-    slots = ["post_auto_attach"]
-
-    def __init__(self, clazz: Type[SubManPlugin], consumer_uuid: str, entitlement_data: Dict):
-        """init for PostAutoAttachConduit
-
-        Args:
-            consumer_uuid: the UUID of the consumer subscribed
-            entitlement_data: the data returned by the server
-        """
-        super(PostAutoAttachConduit, self).__init__(clazz, consumer_uuid, entitlement_data)
 
 
 class PluginConfig:
@@ -917,8 +889,6 @@ class PluginManager(BasePluginManager):
             SubscriptionConduit,
             UpdateContentConduit,
             PostSubscriptionConduit,
-            AutoAttachConduit,
-            PostAutoAttachConduit,
         ]
 
     def _get_modules(self):

--- a/test/data/anaconda-ks.cfg
+++ b/test/data/anaconda-ks.cfg
@@ -59,9 +59,6 @@ clearpart --all --initlabel --drives=sda
     # Yeah, strip()'ing passwords seems like a bad idea.
     password = password
 
-    auto-attach = True
-    # If we should attempt to auto-attach
-
     servicelevel = Premium
 %end
 

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -319,8 +319,6 @@ run_sm "0" repos --list
 # fully entitled, hence the '1'
 run_sm "1" register --activationkey "${ACTIVATION_KEY}" --org "${ORG}" --force
 run_sm "0" unregister
-run_sm "64" register --activationkey "${ACTIVATION_KEY}" --org "${ORG}" --force --auto-attach
-run_sm "1" unregister
 
 run_sm "0" clean
 

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1075,19 +1075,6 @@ class TestPostSubscriptionConduit(unittest.TestCase):
         self.assertEqual({}, conduit.entitlement_data)
 
 
-class TestAutoAttachConduit(unittest.TestCase):
-    def test_auto_attach_conduit(self):
-        conduit = plugins.AutoAttachConduit(StubPluginClass, "a-consumer-uuid")
-        self.assertEqual("a-consumer-uuid", conduit.consumer_uuid)
-
-
-class TestPostAutoAttachConduit(unittest.TestCase):
-    def test_post_auto_attach_conduit(self):
-        conduit = plugins.PostAutoAttachConduit(StubPluginClass, "a-consumer-uuid", {})
-        self.assertEqual("a-consumer-uuid", conduit.consumer_uuid)
-        self.assertEqual({}, conduit.entitlement_data)
-
-
 class BasePluginException(unittest.TestCase):
     """At least create and raise all the exceptions."""
 


### PR DESCRIPTION
Removed what remained after removing the `--auto-attach` option of `register`. A system is now always attached upon registration.

The option was removed in https://github.com/candlepin/subscription-manager/pull/3451 for [CCT-717](https://issues.redhat.com/browse/CCT-717).

Card IDs:
* [CCT-603](https://issues.redhat.com/browse/CCT-603)