### PR TITLE
chore: Remove artifacts of autoheal

### DIFF
--- a/src/subscription_manager/action_client.py
+++ b/src/subscription_manager/action_client.py
@@ -47,8 +47,7 @@ class ActionClient(base_action_client.BaseActionClient):
         self.syspurposelib = SyspurposeSyncActionInvoker()
 
         # WARNING: order is important here, we need to update a number
-        # of things before attempting to autoheal, and we need to autoheal
-        # before attempting to fetch our certificates:
+        # of things before attempting to fetch our certificates:
         lib_set: List[BaseActionInvoker] = [
             self.entcertlib,
             self.idcertlib,

--- a/test/rhsmlib/dbus/test_register.py
+++ b/test/rhsmlib/dbus/test_register.py
@@ -28,7 +28,6 @@ from test.rhsmlib.base import SubManDBusFixture
 
 CONSUMER_CONTENT_JSON_SCA = """{"hypervisorId": null,
         "serviceLevel": "",
-        "autoheal": true,
         "idCert": {
           "key": "FAKE_KEY",
           "cert": "FAKE_CERT",

--- a/test/rhsmlib/services/test_products.py
+++ b/test/rhsmlib/services/test_products.py
@@ -72,7 +72,6 @@ NO_CONTENT_JSON = [
         "capabilities": [],
         "hypervisorId": None,
         "contentTags": [],
-        "autoheal": True,
         "contentAccessMode": None,
         "recipientOwnerKey": None,
         "annotations": None,

--- a/test/rhsmlib/services/test_register.py
+++ b/test/rhsmlib/services/test_register.py
@@ -32,7 +32,6 @@ from rhsmlib.services import register, exceptions
 
 CONSUMER_CONTENT_JSON = """{"hypervisorId": null,
         "serviceLevel": "",
-        "autoheal": true,
         "idCert": {
           "key": "FAKE_KEY",
           "cert": "FAKE_CERT",

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -282,7 +282,6 @@ run_rhsmcertd "0"
 run_rhsmcertd "0" -n
 
 run_rhsmcertd_worker "0"
-run_rhsmcertd_worker "0" --autoheal
 
 # too slow
 # run_rhsm_debug "0" system

--- a/test/test_certmgr.py
+++ b/test/test_certmgr.py
@@ -38,7 +38,6 @@ CONSUMER_DATA = {
     "releaseVer": {"id": 1, "releaseVer": "123123"},
     "serviceLevel": "Pro Turbo HD Plus Ultra",
     "owner": {"key": "admin"},
-    "autoheal": 1,
     "idCert": {"serial": {"serial": 3787455826750723380}},
 }
 


### PR DESCRIPTION
Removed what remained after removing the `autoheal` option from Action clients.

Parts of option was removed in https://github.com/candlepin/subscription-manager/pull/3451 and https://github.com/candlepin/subscription-manager/pull/3225 for [CCT-717](https://issues.redhat.com/browse/CCT-717) and [ENT-5549](https://issues.redhat.com/browse/ENT-5549).

Card IDs:
* CCT-603