### PR TITLE
chore: Remove the --token authentication

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -35,7 +35,7 @@ _subscription_manager_syspurpose()
 _subscription_manager_role()
 {
   local opts="--list --org --set --show
-            --unset --username --password --token
+            --unset --username --password
             ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }
@@ -43,7 +43,7 @@ _subscription_manager_role()
 _subscription_manager_usage()
 {
   local opts="--list --org --set --show
-            --unset --username --password --token
+            --unset --username --password
             ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }
@@ -72,7 +72,7 @@ _subscription_manager_config()
 
 _subscription_manager_environments()
 {
-  local opts="--org --password --username --token --set --list --list-enabled --list-disabled
+  local opts="--org --password --username --set --list --list-enabled --list-disabled
               ${_subscription_manager_common_url_opts}
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
@@ -87,7 +87,7 @@ _subscription_manager_facts()
 
 _subscription_manager_identity()
 {
-  local opts="--force --password --regenerate --username --token
+  local opts="--force --password --regenerate --username
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }
@@ -102,7 +102,7 @@ _subscription_manager_list()
 
 _subscription_manager_orgs()
 {
-  local opts="--password --username --token
+  local opts="--password --username
               ${_subscription_manager_common_url_opts}
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
@@ -134,7 +134,7 @@ _subscription_manager_register()
 {
   local opts="--activationkey --baseurl --consumerid
               --environments --force --name --org --password --release
-              --username --token
+              --username
               ${_subscription_manager_common_url_opts}
               ${_subscription_manager_common_opts}"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
@@ -159,7 +159,7 @@ _subscription_manager_repos()
 _subscription_manager_service_level()
 {
     local opts="--list --org --set --show
-                --unset --username --password --token
+                --unset --username --password
                 ${_subscription_manager_common_url_opts}
                 ${_subscription_manager_common_opts}"
     COMPREPLY=($(compgen -W "${opts}" -- ${1}))

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -173,10 +173,6 @@ Gives the username for the account which is registering the system; this user ac
 Gives the user account password.
 
 .TP
-.B --token=TOKEN
-Token to use when authorizing against the server.
-
-.TP
 .B --serverurl=SERVER_HOSTNAME
 Passes the name of the subscription service with which to register the system. The default value, if this is not given, is the Customer Portal Subscription Management service,
 .B subscription.rhsm.redhat.com.
@@ -341,10 +337,6 @@ Gives the username for the account to use to connect to the organization account
 Gives the user account password [Usable with --list on unregistered systems].
 
 .TP
-.B --token=TOKEN
-Token to use when authorizing against the server [Usable with --list on unregistered systems].
-
-.TP
 .B --org=ORG
 Identifies the organization for which the role applies [Usable with --list on unregistered systems].
 
@@ -389,10 +381,6 @@ Gives the username for the account to use to connect to the organization account
 Gives the user account password [Usable with --list on unregistered systems].
 
 .TP
-.B --token=TOKEN
-Token to use when authorizing against the server [Usable with --list on unregistered systems].
-
-.TP
 .B --set=SERVICE_LEVEL
 Service level to apply to this system
 
@@ -423,10 +411,6 @@ Gives the username for the account to use to connect to the organization account
 .TP
 .B --password=PASSWORD
 Gives the user account password [Usable with --list on unregistered systems].
-
-.TP
-.B --token=TOKEN
-Token to use when authorizing against the server [Usable with --list on unregistered systems].
 
 .TP
 .B --org=ORG
@@ -482,10 +466,6 @@ Gives the username for the account to use to connect to the organization account
 .TP
 .B --password=PASSWORD
 Gives the user account password.
-
-.TP
-.B --token=TOKEN
-Token to use when authorizing against the server.
 
 .TP
 .B --org=ORG
@@ -550,10 +530,6 @@ Gives the username for the account to use to connect to the organization account
 .TP
 .B --password=PASSWORD
 Gives the user account password.
-
-.TP
-.B --token=TOKEN
-Token to use when authorizing against the server.
 
 .TP
 .B --serverurl=SERVER_HOSTNAME
@@ -639,18 +615,14 @@ Gives the username for the account which is registering the system; this user ac
 Gives the user account password. Optional, for user-based authentication.
 
 .TP
-.B --token=TOKEN
-Token to use when authorizing against the server.
-
-.TP
 .B --force
-Regenerates the identity certificate for the system using username/password or token authentication. This is used with the
+Regenerates the identity certificate for the system using username/password authentication. This is used with the
 .B --regenerate
 option.
 .B --regenerate
 alone will use an existing identity certificate to authenticate to the subscription management service. If the certificate is missing or corrupted or in other circumstances, then it may be better to use user authentication rather than certificate-based authentication. In that case, the
 .B --force
-option requires the username or password or token to be given either as an argument or in response to a prompt.
+option requires the username or password to be given either as an argument or in response to a prompt.
 
 
 .SS FACTS OPTIONS
@@ -835,16 +807,16 @@ If a system has never been registered (not even during first boot), then the
 .B register
 command will register the system with whatever subscription management service is configured in the
 .B /etc/rhsm/rhsm.conf
-file. This command requires, at a minimum, the username and password or token for an account to connect to the subscription management service. If the credentials aren't passed with the command, then
+file. This command requires, at a minimum, the username and password for an account to connect to the subscription management service. If the credentials aren't passed with the command, then
 .B subscription-manager
 prompts for the username and password interactively.
 
 .PP
-When there is a single organization or when using the Customer Portal Subscription Management service, all that is required is the username/password set or the token is used. For example:
+When there is a single organization or when using the Customer Portal Subscription Management service, all that is required is the username/password set. For example:
 
 .RS
 .nf
-subscription-manager register --username=admin --password=secret or subscription-manager register --token=eyJhbGciOiJSUzI1NiIsI ... stGc_2bFDQC8CENEOo
+subscription-manager register --username=admin --password=secret
 .fi
 .RE
 
@@ -1009,17 +981,8 @@ subscription-manager repos --list
 subscription-manager environments --username=jsmith
 --password=secret --org=prod
 
- or
-
- subscription-manager environments --token=eyJhbGciOiJSUzI1NiIsI ... stGc_2bFDQC8CENEOo --org=prod
-
-
 subscription-manager orgs --username=jsmith
 --password=secret
-
-or
-
-subscription-manager orgs --token=eyJhbGciOiJSUzI1NiIsI ... stGc_2bFDQC8CENEOo
 .fi
 .RE
 

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -223,8 +223,7 @@ class RegisterService:
             # TODO: add more checks here
             pass
         elif not getattr(self.cp, "username", None) or not getattr(self.cp, "password", None):
-            if not getattr(self.cp, "token", None):
-                raise exceptions.ValidationError(_("Error: Missing username or password."))
+            raise exceptions.ValidationError(_("Error: Missing username or password."))
 
     def determine_owner_key(self, username: str, get_owner_cb: Callable, no_owner_cb: Callable) -> str:
         """

--- a/src/subscription_manager/cli_command/abstract_syspurpose.py
+++ b/src/subscription_manager/cli_command/abstract_syspurpose.py
@@ -145,11 +145,7 @@ class AbstractSyspurposeCommand(CliCommand):
 
         if not self.is_registered():
             if self.options.list:
-                if self.options.token and not self.options.username:
-                    pass
-                elif self.options.token and self.options.username:
-                    system_exit(os.EX_USAGE, _("Error: you can specify --username or --token not both"))
-                elif not self.options.username or not self.options.password:
+                if not self.options.username or not self.options.password:
                     system_exit(
                         os.EX_USAGE,
                         _(
@@ -164,15 +160,11 @@ class AbstractSyspurposeCommand(CliCommand):
         if self.is_registered() and (
             getattr(self.options, "username", None)
             or getattr(self.options, "password", None)
-            or getattr(self.options, "token", None)
             or getattr(self.options, "org", None)
         ):
             system_exit(
                 os.EX_USAGE,
-                _(
-                    "Error: --username, --password, --token and --org "
-                    "can be used only on unregistered systems"
-                ),
+                _("Error: --username, --password, and --org " "can be used only on unregistered systems"),
             )
 
     def _get_valid_fields(self):
@@ -241,11 +233,7 @@ class AbstractSyspurposeCommand(CliCommand):
         # When the system is not registered and no username & password was provided, then
         # these values will be set silently.
         if invalid_values_len > 0:
-            if (
-                self.is_registered()
-                or (self.options.username and self.options.password)
-                or self.options.token
-            ):
+            if self.is_registered() or (self.options.username and self.options.password):
                 if len(valid_fields.get(self.attr, [])) > 0:
                     # TRANSLATORS: this is used to quote a string
                     quoted_values = [_('"{value}"').format(value=value) for value in invalid_values]
@@ -423,17 +411,7 @@ class AbstractSyspurposeCommand(CliCommand):
             # If we have a username/password, we're going to use that, otherwise
             # we'll use the identity certificate. We already know one or the other
             # exists:
-            if self.options.token:
-                try:
-                    self.cp = self.cp_provider.get_keycloak_auth_cp(self.options.token)
-                except Exception as err:
-                    log.error(
-                        'unable to connect to candlepin server using token: "{token}", err: {err}'.format(
-                            token=self.options.token, err=err
-                        )
-                    )
-                    print(_("Unable to connect to server using token"))
-            elif self.options.username and self.options.password:
+            if self.options.username and self.options.password:
                 self.cp_provider.set_user_pass(self.options.username, self.options.password)
                 self.cp = self.cp_provider.get_basic_auth_cp()
             else:

--- a/src/subscription_manager/cli_command/environments.py
+++ b/src/subscription_manager/cli_command/environments.py
@@ -94,14 +94,11 @@ class EnvironmentsCommand(OrgCommand):
         if "environments" not in supported_resources:
             system_exit(os.EX_UNAVAILABLE, _("Error: Server does not support environments."))
         try:
-            if self.options.token:
-                self.cp = self.cp_provider.get_keycloak_auth_cp(self.options.token)
-            else:
-                if not self.options.enabled:
-                    if self.options.username is None or self.options.password is None:
-                        print(_("This operation requires user credentials"))
-                    self.cp_provider.set_user_pass(self.username, self.password)
-                    self.cp = self.cp_provider.get_basic_auth_cp()
+            if not self.options.enabled:
+                if self.options.username is None or self.options.password is None:
+                    print(_("This operation requires user credentials"))
+                self.cp_provider.set_user_pass(self.username, self.password)
+                self.cp = self.cp_provider.get_basic_auth_cp()
             self.identity = require(IDENTITY)
             if self.options.set:
                 self._set_environments()

--- a/src/subscription_manager/cli_command/identity.py
+++ b/src/subscription_manager/cli_command/identity.py
@@ -61,8 +61,6 @@ class IdentityCommand(UserPassCommand):
             system_exit(os.EX_USAGE, _("--force can only be used with --regenerate"))
         if (self.options.username or self.options.password) and not self.options.force:
             system_exit(os.EX_USAGE, _("--username and --password can only be used with --force"))
-        if self.options.token and not self.options.force:
-            system_exit(os.EX_USAGE, _("--token can only be used with --force"))
 
     def _do_command(self):
         # get current consumer identity
@@ -114,12 +112,9 @@ class IdentityCommand(UserPassCommand):
                     )
             else:
                 if self.options.force:
-                    # get an UEP with basic auth or keycloak auth
-                    if self.options.token:
-                        self.cp = self.cp_provider.get_keycloak_auth_cp(self.options.token)
-                    else:
-                        self.cp_provider.set_user_pass(self.username, self.password)
-                        self.cp = self.cp_provider.get_basic_auth_cp()
+                    # get an UEP with basic auth
+                    self.cp_provider.set_user_pass(self.username, self.password)
+                    self.cp = self.cp_provider.get_basic_auth_cp()
                 consumer = self.cp.regenIdCertificate(consumerid)
                 managerlib.persist_consumer_cert(consumer)
 

--- a/src/subscription_manager/cli_command/owners.py
+++ b/src/subscription_manager/cli_command/owners.py
@@ -44,11 +44,8 @@ class OwnersCommand(UserPassCommand):
     def _do_command(self):
         try:
             # get a UEP
-            if self.options.token:
-                self.cp = self.cp_provider.get_keycloak_auth_cp(self.options.token)
-            else:
-                self.cp_provider.set_user_pass(self.username, self.password)
-                self.cp = self.cp_provider.get_basic_auth_cp()
+            self.cp_provider.set_user_pass(self.username, self.password)
+            self.cp = self.cp_provider.get_basic_auth_cp()
             owners = self.cp.getOwnerList(self.username)
             log.debug("Successfully retrieved org list from server.")
             if len(owners):

--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -119,7 +119,7 @@ class RegisterCommand(UserPassCommand):
             system_exit(os.EX_USAGE, _("This system is already registered. Use --force to override"))
         elif self.options.consumername == "":
             system_exit(os.EX_USAGE, _("Error: system name can not be empty."))
-        elif (self.options.username or self.options.token) and self.options.activation_keys:
+        elif self.options.username and self.options.activation_keys:
             system_exit(os.EX_USAGE, _("Error: Activation keys do not require user credentials."))
         elif self.options.consumerid and self.options.activation_keys:
             system_exit(
@@ -257,9 +257,7 @@ class RegisterCommand(UserPassCommand):
 
         # Proceed with new registration:
         try:
-            if self.options.token:
-                admin_cp = self.cp_provider.get_keycloak_auth_cp(self.options.token)
-            elif not self.options.activation_keys:
+            if not self.options.activation_keys:
                 hostname = conf["server"]["hostname"]
                 if ":" in hostname:
                     normalized_hostname = "[{hostname}]".format(hostname=hostname)

--- a/src/subscription_manager/cli_command/service_level.py
+++ b/src/subscription_manager/cli_command/service_level.py
@@ -71,7 +71,7 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
 
         if not self.is_registered():
             if self.options.list:
-                if not (self.options.username and self.options.password) and not self.options.token:
+                if not (self.options.username and self.options.password):
                     system_exit(
                         os.EX_USAGE,
                         _(
@@ -89,14 +89,13 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
         if self.is_registered() and (
             getattr(self.options, "username", None)
             or getattr(self.options, "password", None)
-            or getattr(self.options, "token", None)
             or getattr(self.options, "org", None)
             or getattr(self.options, "server_url", None)
         ):
             system_exit(
                 os.EX_USAGE,
                 _(
-                    "Error: --username, --password, --token, --org and --serverurl "
+                    "Error: --username, --password, --org and --serverurl "
                     "can be used only on unregistered systems"
                 ),
             )
@@ -107,9 +106,7 @@ class ServiceLevelCommand(AbstractSyspurposeCommand, OrgCommand):
             # If we have a username/password, we're going to use that, otherwise
             # we'll use the identity certificate. We already know one or the other
             # exists:
-            if self.options.token:
-                self.cp = self.cp_provider.get_keycloak_auth_cp(self.options.token)
-            elif self.options.username and self.options.password:
+            if self.options.username and self.options.password:
                 self.cp_provider.set_user_pass(self.username, self.password)
                 self.cp = self.cp_provider.get_basic_auth_cp()
             elif not self.is_registered() and self.options.show:

--- a/src/subscription_manager/cli_command/user_pass.py
+++ b/src/subscription_manager/cli_command/user_pass.py
@@ -44,11 +44,6 @@ class UserPassCommand(CliCommand):
             dest="password",
             help=_("password to use when authorizing against the server"),
         )
-        self.parser.add_argument(
-            "--token",
-            dest="token",
-            help=_("token to use when authorizing against the server"),
-        )
 
     @staticmethod
     def _get_username_and_password(username, password):
@@ -82,9 +77,6 @@ class UserPassCommand(CliCommand):
     @property
     def username(self):
         if not self._username:
-            if self.options.token:
-                self._username = self.cp_provider.token_username
-                return self._username
             (self._username, self._password) = self._get_username_and_password(
                 self.options.username, self.options.password
             )
@@ -92,7 +84,7 @@ class UserPassCommand(CliCommand):
 
     @property
     def password(self):
-        if not self._password and not self.options.token:
+        if not self._password:
             (self._username, self._password) = self._get_username_and_password(
                 self.options.username, self.options.password
             )

--- a/test/cli_command/test_identity.py
+++ b/test/cli_command/test_identity.py
@@ -7,9 +7,3 @@ class TestIdentityCommand(TestCliProxyCommand):
 
     def test_regenerate_no_force(self):
         self.cc.main(["--regenerate"])
-
-    def test_token_no_force(self):
-        self._test_exception(["--token", "eyJhbGciOiJSUzI1NiIsInR5cCIg"])
-
-    def test_token_with_force(self):
-        self._test_no_exception(["--regenerate", "--token", "eyJhbGciOiJSUzI1NiIsInR5cCIg", "--force"])

--- a/test/cli_command/test_owners.py
+++ b/test/cli_command/test_owners.py
@@ -11,6 +11,3 @@ class TestOwnersCommand(TestCliProxyCommand):
 
     def test_insecure(self):
         self.cc.main(["--insecure"])
-
-    def test_token_(self):
-        self.cc.main(["--token", "eyJhbGciOiJSUzI1NiIsInR5cCIg"])

--- a/test/cli_command/test_register.py
+++ b/test/cli_command/test_register.py
@@ -65,6 +65,3 @@ class TestRegisterCommand(TestCliProxyCommand):
         with patch.object(self.mock_cfg_parser, "save") as mock_save:
             self._test_no_exception(["--insecure"])
             mock_save.assert_called_with()
-
-    def test_token(self):
-        self._test_no_exception(["--token", "eyJhbGciOiJSUzI1NiIsInR5cCIg"])

--- a/test/cli_command/test_role.py
+++ b/test/cli_command/test_role.py
@@ -63,25 +63,8 @@ class TestRoleCommand(TestCliProxyCommand):
         self.cc.options.to_add = False
         self.cc.options.to_remove = False
         self.cc.options.list = True
-        self.cc.options.token = None
         self.cc.options.username = "admin"
         self.cc.options.password = None
-        try:
-            self.cc._validate_options()
-        except SystemExit as e:
-            self.assertEqual(e.code, os.EX_USAGE)
-
-    def test_list_username_and_token(self):
-        self.cc.options = Mock()
-        self.cc.is_registered = Mock(return_value=False)
-        self.cc.options.set = False
-        self.cc.options.unset = False
-        self.cc.options.to_add = False
-        self.cc.options.to_remove = False
-        self.cc.options.list = True
-        self.cc.options.token = "TOKEN"
-        self.cc.options.username = "admin"
-        self.cc.options.password = "secret"
         try:
             self.cc._validate_options()
         except SystemExit as e:
@@ -126,22 +109,6 @@ class TestRoleCommand(TestCliProxyCommand):
         self.cc.options.show = None
         self.cc.options.list = True
         self.cc.options.password = "secret"
-        try:
-            self.cc._validate_options()
-        except SystemExit as e:
-            self.assertEqual(e.code, os.EX_USAGE)
-
-    def test_token_on_registered_system(self):
-        """Argument --token cannot be used on registered system."""
-        self.cc.is_registered = Mock(return_value=True)
-        self.cc.options = Mock()
-        self.cc.options.set = None
-        self.cc.options.unset = None
-        self.cc.options.to_add = None
-        self.cc.options.to_remove = None
-        self.cc.options.show = None
-        self.cc.options.list = True
-        self.cc.options.token = "TOKEN"
         try:
             self.cc._validate_options()
         except SystemExit as e:

--- a/test/cli_command/test_service_level.py
+++ b/test/cli_command/test_service_level.py
@@ -145,22 +145,6 @@ class TestServiceLevelCommand(TestCliProxyCommand):
         except SystemExit as e:
             self.assertEqual(e.code, os.EX_USAGE)
 
-    def test_token_on_registered_system(self):
-        """Argument --token cannot be used on registered system."""
-        self.cc.is_registered = Mock(return_value=True)
-        self.cc.options = Mock()
-        self.cc.options.set = None
-        self.cc.options.unset = None
-        self.cc.options.to_add = None
-        self.cc.options.to_remove = None
-        self.cc.options.show = None
-        self.cc.options.list = True
-        self.cc.options.token = "TOKEN"
-        try:
-            self.cc._validate_options()
-        except SystemExit as e:
-            self.assertEqual(e.code, os.EX_USAGE)
-
     def test_org_on_registered_system(self):
         """Argument --org cannot be used on registered system."""
         self.cc.is_registered = Mock(return_value=True)


### PR DESCRIPTION
* Card ID: CCT-1038

The token-based authentication method was deprecated in RHEL 9.2 and RHEL 8.8. As this feature is no longer relevant, and due to its deprecation, it is safe to remove `--token` starting with RHEL 10.