### PR TITLE
fix: Restart rhsm service after installation

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -725,6 +725,7 @@ fi
 %endif
 
 %posttrans
+%systemd_posttrans_with_restart rhsm.service
 # Remove old *.egg-info empty directories not removed be previous versions of RPMs
 # due to this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1927245
 rmdir %{python_sitearch}/subscription_manager-*-*.egg-info --ignore-fail-on-non-empty


### PR DESCRIPTION
* Card ID: CCT-1027

Following the installation of the subscription-manager package, the dbus service was not loaded as expected. This update addresses the problem by ensuring that the dbus service is properly restarted after the installation or upgrade process.