### PR TITLE
integration tests for register with activation keys and environments

### DIFF
--- a/integration-tests/pytest.ini
+++ b/integration-tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = "-srxv -vvv --capture=sys"
+addopts = "-srxv -vvv --capture=sys --disable-log=pytest_client_tools"
 testpaths = "./"
 log_cli = true
 log_level = DEBUG

--- a/systemtest/tests/integration/main.fmf
+++ b/systemtest/tests/integration/main.fmf
@@ -1,3 +1,3 @@
 summary: Runs tmt tests
 test: ./test.sh
-duration: 1h
+duration: 2h

--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -42,6 +42,7 @@ candlepin.multi_org.orgs = ["admin", "snowwhite", "donaldduck"]
 EOF
 
 # run local candlepin for testing purpose
+./integration-tests/scripts/post-activation-keys.sh
 ./integration-tests/scripts/run-local-candlepin.sh
 
 sleep 10


### PR DESCRIPTION
Card-ID: CCT-1051

A DBus API provides  a way to specify environment when using activation keys to register a system.

This PR provides integration tests to verify the way.

I've fixed a file 'integration-tests/README.md' - there were wrong activation keys specified.
It will be necessary to merge the fix into previous PR's that has something to do with activation keys.

A test:

Given a DBus Call RegisterWithActivationKeys is used to register a system
and the system is unregistered

When an argument 'environments' is filled with the proper environments
Then the application registers the system
and the environments are active property of a system identity.

Another test verifies a case when nonexisting environment is used for registration.