### PR TITLE
Allow to call RegisterWithActivationKeys() with enable_content

### DIFF
--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -31,6 +31,7 @@ from subscription_manager.cp_provider import CPProvider
 from subscription_manager.i18n import Locale
 from subscription_manager.i18n import ugettext as _
 from subscription_manager.entcertlib import EntCertActionInvoker
+from subscription_manager.utils import is_true_value
 
 if TYPE_CHECKING:
     from rhsm.connection import UEPConnection
@@ -284,15 +285,20 @@ class DomainSocketRegisterDBusImplementation(base_object.BaseImplementation):
         """
         raise NoOrganizationException(username=username)
 
-    def _remove_enable_content_option(self, options: dict) -> bool:
+    @staticmethod
+    def _remove_enable_content_option(options: dict, default: bool = False) -> bool:
         """Try to remove enable_content option from options dictionary.
 
         :returns: The value of 'enable_content' key.
         """
         if "enable_content" not in options:
-            return False
+            return default
 
-        return bool(options.pop("enable_content"))
+        enable_content = options.pop("enable_content")
+        if is_true_value(enable_content):
+            return True
+        else:
+            return False
 
     def _enable_content(self, uep: "UEPConnection", consumer: dict) -> None:
         """Try to enable content: refresh SCA entitlement certs in SCA mode."""

--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -300,10 +300,10 @@ class DomainSocketRegisterDBusImplementation(base_object.BaseImplementation):
         else:
             return False
 
-    def _enable_content(self, uep: "UEPConnection", consumer: dict) -> None:
+    @staticmethod
+    def _enable_content(uep: "UEPConnection", consumer: dict) -> None:
         """Try to enable content: refresh SCA entitlement certs in SCA mode."""
         content_access: str = consumer["owner"]["contentAccessMode"]
-        enabled_content = None
 
         if content_access == "entitlement":
             log.error("Entitlement content access mode is not supported")
@@ -312,12 +312,8 @@ class DomainSocketRegisterDBusImplementation(base_object.BaseImplementation):
             service = EntitlementService(uep)
             # TODO: try get anything useful from refresh result. It is not possible atm.
             service.refresh(remove_cache=False, force=False)
-
         else:
             log.error(f"Unable to enable content due to unsupported content access mode: '{content_access}'")
-
-        if enabled_content is not None:
-            consumer["enabledContent"] = enabled_content
 
     def _check_force_handling(self, register_options: dict, connection_options: dict) -> None:
         """

--- a/test/rhsmlib/dbus/test_register.py
+++ b/test/rhsmlib/dbus/test_register.py
@@ -299,20 +299,12 @@ class DomainSocketRegisterDBusObjectTest(SubManDBusFixture):
         self.patches["is_registered"] = is_registered_patch.start()
         self.addCleanup(is_registered_patch.stop)
 
-        update_patch = mock.patch(
-            "rhsmlib.dbus.objects.register.EntCertActionInvoker.update",
-            name="update",
-        )
-        self.patches["update"] = update_patch.start()
-        self.addCleanup(update_patch.stop)
-
         build_uep_patch = mock.patch(
             "rhsmlib.dbus.base_object.BaseImplementation.build_uep",
             name="build_uep",
         )
         self.patches["build_uep"] = build_uep_patch.start()
         self.addCleanup(build_uep_patch.stop)
-        self.patches["update"].return_value = None
 
     def test_Register(self):
         expected = json.loads(CONSUMER_CONTENT_JSON_SCA)
@@ -427,6 +419,30 @@ class DomainSocketRegisterDBusObjectTest(SubManDBusFixture):
         result = self.impl.register_with_activation_keys(
             "username",
             {"keys": ["key1", "key2"], "force": True},
+            {"host": "localhost", "port": "8443", "handler": "/candlepin"},
+        )
+        self.assertEqual(expected, result)
+
+    def test_RegisterWithActivationKeys__with_enable_content_option(self):
+        expected = json.loads(CONSUMER_CONTENT_JSON_SCA)
+        self.patches["is_registered"].return_value = False
+        self.patches["register"].return_value = expected
+
+        result = self.impl.register_with_activation_keys(
+            "username",
+            {"keys": ["key1", "key2"], "enable_content": "true"},
+            {"host": "localhost", "port": "8443", "handler": "/candlepin"},
+        )
+        self.assertEqual(expected, result)
+
+    def test_RegisterWithActivationKeys__with_disable_content_option(self):
+        expected = json.loads(CONSUMER_CONTENT_JSON_SCA)
+        self.patches["is_registered"].return_value = False
+        self.patches["register"].return_value = expected
+
+        result = self.impl.register_with_activation_keys(
+            "username",
+            {"keys": ["key1", "key2"], "enable_content": "false"},
             {"host": "localhost", "port": "8443", "handler": "/candlepin"},
         )
         self.assertEqual(expected, result)


### PR DESCRIPTION
* Allow to call D-Bus method `RegisterWithActivationKeys()` with
  register option `enable_content`. When this option is not set,
  then behavior is still the same. It means that content is
  enabled by default, when system is registered with this D-Bus
  method.
* Added two unit tests
* Some refactoring and bug fixes in separate commits