### PR TITLE
ci: use official c10s container image

### DIFF
--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - name: "CentOS Stream 10"
-            image: "quay.io/centos/centos:stream10-development"
+            image: "quay.io/centos/centos:stream10"
           - name: "Fedora latest"
             image: "registry.fedoraproject.org/fedora:latest"
           - name: "Fedora Rawhide"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - name: "CentOS Stream 10"
-            image: "quay.io/centos/centos:stream10-development"
+            image: "quay.io/centos/centos:stream10"
             pytest_args: ''
           - name: "Fedora latest"
             image: "registry.fedoraproject.org/fedora:latest"

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - name: "CentOS Stream 10"
-            image: "quay.io/centos/centos:stream10-development"
+            image: "quay.io/centos/centos:stream10"
             packager: "dnf4"
           - name: "Fedora latest"
             image: "registry.fedoraproject.org/fedora:latest"


### PR DESCRIPTION
Now that CentOS Stream 10 is officially released, switch to it from the old development version of it.