### PR TITLE
ci: temporarily install 'which' on CentOS Stream 10

### DIFF
--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -70,6 +70,11 @@ jobs:
             python3-pip python3-setuptools
           pip install https://github.com/rpm-software-management/tito/archive/refs/tags/tito-0.6.22-1.tar.gz
 
+      - name: Install which (RHEL-73048)
+        if: ${{ matrix.name == 'CentOS Stream 10' }}
+        run: |
+          dnf --setopt install_weak_deps=False install -y which
+
       - name: Build the package
         run: |
           tito build --output=tito/ --test --rpm


### PR DESCRIPTION
Due to RHEL-73048, `gdb` does not work without `which`. While that bug is being addressed, temporarily install `which` so subscription-manager can be built with `tito`.