### PR TITLE
fix: Do not upload profile from DNF, when it is disabled in conf

### DIFF
--- a/src/plugins/dnf/subscription_manager.py
+++ b/src/plugins/dnf/subscription_manager.py
@@ -242,7 +242,10 @@ class SubscriptionManager(dnf.Plugin):
         Call Package Profile
         """
         cfg = config.get_config_parser()
-        if "1" == cfg.get("rhsm", "package_profile_on_trans"):
+        if (
+            cfg.get("rhsm", "report_package_profile") == "1"
+            and cfg.get("rhsm", "package_profile_on_trans") == "1"
+        ):
             log.debug("Uploading package profile")
             self._upload_profile()
         else:


### PR DESCRIPTION
* Card ID: CCT-505
* When `rhsm.report_package_profile` is disabled in `rhsm.conf` and `rhsm.package_profile_on_trans` is enabled, then profile should not be uploaded, because the `rhsm.report_package_profile` has higher priority as it is described in man page of `rhsm.conf`