### PR TITLE
Respect the 'sbin' install location for the distro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ PREFIX ?= /usr/local
 SYSCONF ?= etc
 INSTALL_DIR = $(PREFIX)/share
 RUN_DIR ?= /run
+SBIN_DIR ?= $(PREFIX)/sbin
 
 OS = $(shell test -f /etc/os-release && source /etc/os-release; echo $$ID)
 OS_DIST ?= $(shell rpm --eval='%dist')
@@ -199,9 +200,9 @@ install-example-plugins: install-plugins
 install-via-setup: install-subpackages-via-setup
 	EXCLUDE_PACKAGES="$(EXCLUDE_PACKAGES)" $(PYTHON) ./setup.py install --root $(DESTDIR) --pkg-version=$(VERSION) --prefix=$(PREFIX) \
 	$(SETUP_PY_INSTALL_PARAMS)
-	mkdir -p $(DESTDIR)/$(PREFIX)/sbin/
+	mkdir -p $(DESTDIR)/$(SBIN_DIR)/
 	mkdir -p $(DESTDIR)/$(LIBEXEC_DIR)/
-	mv $(DESTDIR)/$(PREFIX)/bin/subscription-manager $(DESTDIR)/$(PREFIX)/sbin/
+	mv -n $(DESTDIR)/$(PREFIX)/bin/subscription-manager $(DESTDIR)/$(SBIN_DIR)/
 	mv $(DESTDIR)/$(PREFIX)/bin/rhsmcertd-worker $(DESTDIR)/$(LIBEXEC_DIR)/
 	mv $(DESTDIR)/$(PREFIX)/bin/rhsm-service $(DESTDIR)/$(LIBEXEC_DIR)/
 	mv $(DESTDIR)/$(PREFIX)/bin/rhsm-facts-service $(DESTDIR)/$(LIBEXEC_DIR)/

--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -384,6 +384,7 @@ make -f Makefile install VERSION=%{version}-%{release} \
     OS_VERSION=%{?fedora}%{?rhel}%{?suse_version} OS_DIST=%{dist} \
     COMPLETION_DIR=%{completion_dir} \
     RUN_DIR=%{run_dir} \
+    SBIN_DIR=%{_sbindir} \
     %{?install_ostree} %{?install_container} \
     %{?install_dnf_plugins} \
     %{?install_zypper_plugins} \


### PR DESCRIPTION
The build system hardcoded `sbin` as location where to install the `subscription-manager` executable. While that is generally correct, then:
- make it possible to customize that location to set it to right one according to the distribution policies
- actually set it in the RPM packaging according to the distribution configuration

This will make subscription-manager build again on Fedora Rawhide, following the recent implementation of https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin.

