### PR TITLE
fix: Really disable content

### DIFF
--- a/src/rhsmlib/dbus/objects/register.py
+++ b/src/rhsmlib/dbus/objects/register.py
@@ -25,6 +25,7 @@ from rhsmlib.services.register import RegisterService
 from rhsmlib.services.unregister import UnregisterService
 from rhsmlib.services.entitlement import EntitlementService
 from rhsmlib.services.environment import EnvironmentService
+from rhsmlib.services.config import Config
 from rhsmlib.client_info import DBusSender
 from subscription_manager.cp_provider import CPProvider
 
@@ -34,6 +35,7 @@ from subscription_manager.utils import is_true_value
 
 if TYPE_CHECKING:
     from rhsm.connection import UEPConnection
+    from rhsm.config import RhsmConfigParser
 
 log = logging.getLogger(__name__)
 
@@ -180,6 +182,9 @@ class DomainSocketRegisterDBusImplementation(base_object.BaseImplementation):
     where a D-Bus signal is emitted.
     """
 
+    def __init__(self, parser: "RhsmConfigParser" = None):
+        self.config = Config(parser)
+
     def get_organizations(self, options: dict) -> List[dict]:
         """Get user account organizations.
 
@@ -244,6 +249,8 @@ class DomainSocketRegisterDBusImplementation(base_object.BaseImplementation):
         # When consumer is created, we can try to enable content, if requested.
         if enable_content:
             self._enable_content(uep, consumer)
+        else:
+            self._disable_content()
 
         return consumer
 
@@ -268,6 +275,8 @@ class DomainSocketRegisterDBusImplementation(base_object.BaseImplementation):
         # When consumer is created, we can try to enable content, if requested.
         if enable_content:
             self._enable_content(uep, consumer)
+        else:
+            self._disable_content()
 
         return consumer
 
@@ -298,20 +307,39 @@ class DomainSocketRegisterDBusImplementation(base_object.BaseImplementation):
         enable_content = options.pop("enable_content")
         return is_true_value(enable_content)
 
-    @staticmethod
-    def _enable_content(uep: "UEPConnection", consumer: dict) -> None:
-        """Try to enable content: refresh SCA entitlement certs in SCA mode."""
+    def _enable_content(self, uep: "UEPConnection", consumer: dict) -> None:
+        """
+        Try to enable generating content from SCA certificates. This method
+        does several things:
+        1) It sets the value of manage_repos to 1 in rhsm.conf so it will
+           be possible to generate redhat.repo file from SCA certificate now
+           or later by subscription-manager or rhsmcertd.
+        2) It downloads SCA certificate and generate redhat.repo file
+        """
         content_access: str = consumer["owner"]["contentAccessMode"]
 
         if content_access == "entitlement":
             log.error("Entitlement content access mode is not supported")
         elif content_access == "org_environment":
+            log.info("Enabling generating content (redhat.repo) from SCA certificate in rhsm.conf.")
+            self.config["rhsm"]["manage_repos"] = "1"
+            self.config.persist()
             log.debug("Refreshing since 'enable_content' is true.")
             service = EntitlementService(uep)
             # TODO: try get anything useful from refresh result. It is not possible atm.
             service.refresh(remove_cache=False, force=False)
         else:
             log.error(f"Unable to enable content due to unsupported content access mode: '{content_access}'")
+
+    def _disable_content(self) -> None:
+        """
+        Try to disable generating content from SCA certificates. This method
+        sets the value of manage_repos to 0 in rhsm.conf to avoid generating redhat.repo
+        file from SCA certificates by subscription-manager or rhsmcertd.
+        """
+        log.info("Disabling generating content (redhat.repo) from SCA certificate in rhsm.conf.")
+        self.config["rhsm"]["manage_repos"] = "0"
+        self.config.persist()
 
     def _check_force_handling(self, register_options: dict, connection_options: dict) -> None:
         """

--- a/test/rhsmlib/dbus/test_register.py
+++ b/test/rhsmlib/dbus/test_register.py
@@ -20,6 +20,8 @@ from typing import Optional
 from rhsm import connection
 import rhsmlib.dbus.exceptions
 from rhsmlib.dbus.objects.register import DomainSocketRegisterDBusImplementation, RegisterDBusImplementation
+from rhsm.config import RhsmConfigParser
+from test.rhsmlib.services.test_config import TEST_CONFIG
 from rhsmlib.dbus.server import DomainSocketServer
 
 from unittest import mock
@@ -275,9 +277,28 @@ class RegisterDBusObjectTest(SubManDBusFixture):
 
 
 class DomainSocketRegisterDBusObjectTest(SubManDBusFixture):
+    config_file = None
+    """Attribute referencing file containing test configuration text."""
+    parser = None
+    """Attribute referencing configuration's parser object."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        cls.config_file = tempfile.NamedTemporaryFile()
+        with open(cls.config_file.name, "w") as handle:
+            handle.write(TEST_CONFIG)
+        cls.parser = RhsmConfigParser(cls.config_file.name)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.config_file = None
+        super().tearDownClass()
+
     def setUp(self) -> None:
         super().setUp()
-        self.impl = DomainSocketRegisterDBusImplementation()
+        self.impl = DomainSocketRegisterDBusImplementation(self.parser)
 
         register_patch = mock.patch(
             "rhsmlib.dbus.objects.register.RegisterService.register",


### PR DESCRIPTION
* CCT-1005
* When D-Bus method Register() or RegisterWithActivationKeys() is
   called with "enable_content": false, rhsm.service will not
   download and install SCA cerificate, but it is not enough,
    because later rhsmcertd or "subscription-manager status"
    will download SCA certificate and it will generated redhat.repo
    file
* For this reason, when "enable_content" is false, then
    manage_repos will be set to 0 to be sure that redhat.repo
    will not be generated later
* TODO: Do not download SCA certificate, when manage_repos is
    equal to "0", because it is useless activity and it
    consumes resources on candlepin server