### PR TITLE
chore: logging.warn() -> logging.warning()

### DIFF
--- a/src/plugins/zypper/commit/product-id
+++ b/src/plugins/zypper/commit/product-id
@@ -110,7 +110,7 @@ class ZypperProductManager(ProductManager):
                     continue
                 certs_and_repos.append((cert, repo_id))
             except Exception as e:
-                log.warn("Error loading productid metadata for %s." % repo.alias())
+                log.warning("Error loading productid metadata for %s." % repo.alias())
                 log.exception(e)
                 self.meta_data_errors.append(repo_id)
 

--- a/src/rhsmlib/candlepin/api.py
+++ b/src/rhsmlib/candlepin/api.py
@@ -106,7 +106,7 @@ class Candlepin:
             self.last_error = ex
 
             msg = "Unable to reach server."
-            log.warn(msg)
+            log.warning(msg)
             raise CandlepinApiNetworkError("%s: %s" % (msg, ex))
 
 

--- a/src/rhsmlib/facts/custom.py
+++ b/src/rhsmlib/facts/custom.py
@@ -39,7 +39,7 @@ class CustomFacts:
         try:
             data = ourjson.loads(json_blob)
         except ValueError:
-            log.warn("Unable to load custom facts file.")
+            log.warning("Unable to load custom facts file.")
 
         custom_facts.data = data
         return custom_facts
@@ -62,7 +62,7 @@ class CustomFactsFile:
             with open(self.path, "r") as fd:
                 return fd.read()
         except IOError:
-            log.warn("Unable to open custom facts file: %s" % self.path)
+            log.warning("Unable to open custom facts file: %s" % self.path)
             raise
 
     def read(self) -> str:

--- a/src/rhsmlib/facts/virt.py
+++ b/src/rhsmlib/facts/virt.py
@@ -139,9 +139,9 @@ class VirtUuidCollector(collector.FactsCollector):
                     vm_uuid: str = contents.strip(string.whitespace + "\0")
                     return vm_uuid
             except IOError as e:
-                log.warn("Tried to read %s but there was an error: %s", uuid_path, e)
+                log.warning("Tried to read %s but there was an error: %s", uuid_path, e)
 
-        log.warn("No available file for UUID on %s", self.arch)
+        log.warning("No available file for UUID on %s", self.arch)
         return None
 
 

--- a/src/subscription_manager/identity.py
+++ b/src/subscription_manager/identity.py
@@ -71,7 +71,7 @@ class ConsumerIdentity:
                 cls.read()
                 return True
             except Exception as e:
-                log.warn("possible certificate corruption")
+                log.warning("possible certificate corruption")
                 log.error(e)
         return False
 

--- a/src/subscription_manager/managerlib.py
+++ b/src/subscription_manager/managerlib.py
@@ -757,7 +757,7 @@ def format_date(dt: datetime.datetime) -> str:
         try:
             return dt.astimezone(tzlocal()).strftime("%x")
         except ValueError:
-            log.warn("Datetime does not contain timezone information")
+            log.warning("Datetime does not contain timezone information")
             return dt.strftime("%x")
     else:
         return ""
@@ -847,7 +847,7 @@ def clean_all_data(backup: bool = True) -> None:
             log.debug("Removing entitlement cert: %s" % f)
             os.remove(certpath)
     else:
-        log.warn("Entitlement cert directory does not exist: %s" % ent_cert_dir)
+        log.warning("Entitlement cert directory does not exist: %s" % ent_cert_dir)
 
     # Subclasses of cache.CacheManager have a @classmethod delete_cache
     # for deleting persistent caches

--- a/src/subscription_manager/plugin/container/__init__.py
+++ b/src/subscription_manager/plugin/container/__init__.py
@@ -132,8 +132,8 @@ class ContainerCertDir:
     def sync(self, expected_keypairs):
         log.debug("Syncing container certificates to %s" % self.path)
         if not os.path.exists(self.host_cert_dir):
-            log.warn("Container cert directory does not exist: %s" % self.host_cert_dir)
-            log.warn("Exiting plugin")
+            log.warning("Container cert directory does not exist: %s" % self.host_cert_dir)
+            log.warning("Exiting plugin")
             return
         if not os.path.exists(self.path):
             log.info("Container cert directory does not exist, creating it.")

--- a/src/subscription_manager/plugin/ostree/action_invoker.py
+++ b/src/subscription_manager/plugin/ostree/action_invoker.py
@@ -106,7 +106,7 @@ class OstreeContentUpdateActionCommand:
         try:
             ostree_config.load()
         except configparser.Error:
-            log.warn(
+            log.warning(
                 "No ostree content config file found at: %s. Not loading ostree config.",
                 ostree_config.repo_file_path,
             )

--- a/src/subscription_manager/plugin/ostree/config.py
+++ b/src/subscription_manager/plugin/ostree/config.py
@@ -112,7 +112,7 @@ class KeyFileConfigParser(RhsmConfigParser):
         # create /ostree/repo/config if /ostree/repo exists
         dir_name = os.path.dirname(self.config_file)
         if not os.path.exists(dir_name):
-            log.warn("%s does not exist, so unable to save %s", dir_name, self.config_file)
+            log.warning("%s does not exist, so unable to save %s", dir_name, self.config_file)
             return
 
         super(KeyFileConfigParser, self).save()

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -127,7 +127,7 @@ class YumPluginManager:
                 continue
 
             if len(result) == 0:
-                log.warn(
+                log.warning(
                     'Configuration file of %s plugin: "%s" cannot be read' % (pkg_mgr_name, plugin_file_name)
                 )
                 continue

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -323,7 +323,9 @@ def get_server_versions(cp: "UEPConnection", exception_on_timeout: bool = False)
             # otherwise, ignore the timeout exception
         except Exception as e:
             if isinstance(e, GoneException):
-                log.warn("Server Versions: Error: consumer has been deleted, unable to check server version")
+                log.warning(
+                    "Server Versions: Error: consumer has been deleted, unable to check server version"
+                )
             else:
                 # a more useful error would be handy here
                 log.error("Error while checking server version: %s" % e)


### PR DESCRIPTION
The `warn()` method is officially marked as deprecated since Python 3.2, and `warning()` is the proper method to use. Starting from Python 3.12, the usage of `warn()` triggers deprecation warnings. Hence switch from `warn()` to `warning()`.

There are no behaviour changes.