### PR TITLE
feat: new status messages for SCA & unregistered systems; removal of SCA support in status

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -167,7 +167,7 @@ _subscription_manager_service_level()
 
 _subscription_manager_status()
 {
-  local opts="${_subscription_manager_common_opts} --ondate"
+  local opts="--ondate -h --help"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }
 

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -746,7 +746,7 @@ This command has no options.
 .SS STATUS OPTIONS
 The
 .B status
-command shows the current status of the products and attached subscriptions for the system. If some products are not fully covered or subscriptions have expired, then the \fBstatus\fP command shows why subscriptions are not current and returns an error code.
+command shows the current status of the system.
 
 .RS
 .nf
@@ -754,7 +754,7 @@ command shows the current status of the products and attached subscriptions for 
 +-------------------------------------------+
      System Status Details
 +-------------------------------------------+
-Overall Status: Current
+Overall Status: Registered
 .fi
 .RE
 

--- a/src/subscription_manager/cli_command/status.py
+++ b/src/subscription_manager/cli_command/status.py
@@ -60,15 +60,18 @@ class StatusCommand(CliCommand):
                 system_exit(os.EX_DATAERR, err)
         return on_date
 
+    def _print_status_banner(self):
+        print("+-------------------------------------------+")
+        print("   " + _("System Status Details"))
+        print("+-------------------------------------------+")
+
     def _print_status(self, service_status):
         """
         Print only status
         :return: Print overall status
         """
 
-        print("+-------------------------------------------+")
-        print("   " + _("System Status Details"))
-        print("+-------------------------------------------+")
+        self._print_status_banner()
 
         ca_message = ""
         has_cert = _(

--- a/src/subscription_manager/cli_command/status.py
+++ b/src/subscription_manager/cli_command/status.py
@@ -184,9 +184,10 @@ class StatusCommand(CliCommand):
 
         self._print_status(service_status, is_sca)
 
-        self._print_reasons(service_status)
+        if not is_sca:
+            self._print_reasons(service_status)
 
-        self._print_syspurpose_status(on_date)
+            self._print_syspurpose_status(on_date)
 
         if service_status["valid"]:
             result = 0

--- a/src/subscription_manager/cli_command/status.py
+++ b/src/subscription_manager/cli_command/status.py
@@ -113,18 +113,16 @@ class StatusCommand(CliCommand):
         self._print_status_banner()
 
         ca_message = ""
+        status_message = service_status["status"]
 
         if is_sca:
             ca_message = _(
                 "Content Access Mode is set to Simple Content Access. "
                 "This host has access to content, regardless of subscription status.\n"
             )
+            status_message = _("Registered")
 
-        print(
-            _("Overall Status: {status}\n{message}").format(
-                status=service_status["status"], message=ca_message
-            )
-        )
+        print(_("Overall Status: {status}\n{message}").format(status=status_message, message=ca_message))
 
     def _print_reasons(self, service_status):
         """

--- a/src/subscription_manager/cli_command/status.py
+++ b/src/subscription_manager/cli_command/status.py
@@ -173,6 +173,13 @@ class StatusCommand(CliCommand):
         # First get/check if provided date is valid
         on_date = self._get_date_cli_option()
 
+        # In case we are not registered, then simply print that and avoid
+        # all the rest of the checks
+        if not self.is_consumer_cert_present():
+            self._print_status_banner()
+            print(_("Overall Status: Not registered\n"))
+            return 1
+
         service_status = entitlement.EntitlementService(cp=self.cp).get_status(on_date)
 
         is_sca = self._determine_whether_content_access_mode_is_sca(service_status)

--- a/test/cli_command/test_status.py
+++ b/test/cli_command/test_status.py
@@ -113,6 +113,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.options = Mock()
         self.cc.options.on_date = None
         self.cc.entcertlib = Mock()
+        self.cc._determine_whether_content_access_mode_is_sca = Mock(return_value=False)
         with Capture() as cap:
             self.cc._do_command()
         self.assertTrue("System Purpose Status: Matched" in cap.out)
@@ -124,6 +125,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.options = Mock()
         self.cc.options.on_date = None
         self.cc.entcertlib = Mock()
+        self.cc._determine_whether_content_access_mode_is_sca = Mock(return_value=False)
         with Capture() as cap:
             self.cc._do_command()
         self.assertTrue("System Purpose Status: Unknown" in cap.out)
@@ -135,6 +137,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.options = Mock()
         self.cc.options.on_date = None
         self.cc.entcertlib = Mock()
+        self.cc._determine_whether_content_access_mode_is_sca = Mock(return_value=False)
         with Capture() as cap:
             self.cc._do_command()
         self.assertTrue("System Purpose Status: Unknown" in cap.out)
@@ -148,6 +151,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.options = Mock()
         self.cc.options.on_date = None
         self.cc.entcertlib = Mock()
+        self.cc._determine_whether_content_access_mode_is_sca = Mock(return_value=False)
         with Capture() as cap:
             self.cc._do_command()
         self.assertTrue("System Purpose Status: Mismatched" in cap.out)

--- a/test/cli_command/test_status.py
+++ b/test/cli_command/test_status.py
@@ -39,7 +39,7 @@ class TestStatusCommand(SubManFixture):
         self.mock_entitlement_instance.get_status = Mock(return_value=MOCK_SERVICE_STATUS_SCA)
         self.entitlement_mock.EntitlementService = Mock(return_value=self.mock_entitlement_instance)
 
-    def test_disabled_status_sca_mode(self):
+    def test_status_sca_mode_registered(self):
         """
         Test status, when SCA mode is used
         """
@@ -56,7 +56,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.entcertlib = Mock()
         with Capture() as cap:
             self.cc._do_command()
-        self.assertIn("Overall Status: Disabled", cap.out)
+        self.assertIn("Overall Status: Registered", cap.out)
         self.assertIn("Content Access Mode is set to Simple Content Access.", cap.out)
         self.assertIn("This host has access to content, regardless of subscription status.", cap.out)
         self.assertIn("System Purpose Status: Disabled", cap.out)

--- a/test/cli_command/test_status.py
+++ b/test/cli_command/test_status.py
@@ -58,8 +58,6 @@ class TestStatusCommand(SubManFixture):
             self.cc._do_command()
         self.assertIn("Overall Status: Registered", cap.out)
         self.assertIn("Content Access Mode is set to Simple Content Access.", cap.out)
-        self.assertIn("This host has access to content, regardless of subscription status.", cap.out)
-        self.assertIn("System Purpose Status: Disabled", cap.out)
 
     def test_current_status_entitlement_mode(self):
         """

--- a/test/cli_command/test_status.py
+++ b/test/cli_command/test_status.py
@@ -1,7 +1,7 @@
 from subscription_manager import managercli
 from rhsm.certificate2 import CONTENT_ACCESS_CERT_TYPE
 
-from ..stubs import StubConsumerIdentity, StubUEP
+from ..stubs import StubUEP
 from ..fixture import SubManFixture, Capture
 
 from unittest.mock import Mock, patch
@@ -41,7 +41,6 @@ class TestStatusCommand(SubManFixture):
         """
         Test status, when SCA mode is used
         """
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({"status": "disabled"})
         self.cc.cp._capabilities = ["syspurpose"]
@@ -66,7 +65,6 @@ class TestStatusCommand(SubManFixture):
         """
         # Note that server sent response with "Current" status
         self.mock_entitlement_instance.get_status = Mock(return_value=MOCK_SERVICE_STATUS_ENTITLEMENT)
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({"status": "valid"})
         self.cc.cp._capabilities = ["syspurpose"]
@@ -90,7 +88,6 @@ class TestStatusCommand(SubManFixture):
         """
         # Note that server sent response with "Current" status
         self.mock_entitlement_instance.get_status = Mock(return_value=MOCK_SERVICE_STATUS_ENTITLEMENT)
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({"status": "valid"})
         self.cc.cp._capabilities = ["syspurpose"]
@@ -110,7 +107,6 @@ class TestStatusCommand(SubManFixture):
         self.assertIn("System Purpose Status: Matched", cap.out)
 
     def test_purpose_status_success(self):
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({"status": "valid"})
         self.cc.cp._capabilities = ["syspurpose"]
@@ -122,7 +118,6 @@ class TestStatusCommand(SubManFixture):
         self.assertTrue("System Purpose Status: Matched" in cap.out)
 
     def test_purpose_status_consumer_lack(self):
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({"status": "unknown"})
         self.cc.cp._capabilities = ["syspurpose"]
@@ -134,7 +129,6 @@ class TestStatusCommand(SubManFixture):
         self.assertTrue("System Purpose Status: Unknown" in cap.out)
 
     def test_purpose_status_consumer_no_capability(self):
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({"status": "unknown"})
         self.cc.cp._capabilities = []
@@ -146,7 +140,6 @@ class TestStatusCommand(SubManFixture):
         self.assertTrue("System Purpose Status: Unknown" in cap.out)
 
     def test_purpose_status_mismatch(self):
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance(
             {"status": "mismatched", "reasons": ["unsatisfied usage: Production"]}

--- a/test/cli_command/test_status.py
+++ b/test/cli_command/test_status.py
@@ -1,10 +1,12 @@
 from subscription_manager import managercli
 from rhsm.certificate2 import CONTENT_ACCESS_CERT_TYPE
 
-from ..stubs import StubUEP
+from ..stubs import StubUEP, StubIdentity
 from ..fixture import SubManFixture, Capture
 
 from unittest.mock import Mock, patch
+
+from subscription_manager import injection as inj
 
 
 MOCK_SERVICE_STATUS_SCA = {
@@ -105,6 +107,17 @@ class TestStatusCommand(SubManFixture):
             self.cc._do_command()
         self.assertIn("Overall Status: Current", cap.out)
         self.assertIn("System Purpose Status: Matched", cap.out)
+
+    def test_status_unregistered(self):
+        """
+        Test status, when the system is not registered
+        """
+        inj.provide(inj.IDENTITY, StubIdentity())
+        self.cc.options = Mock()
+        self.cc.options.on_date = None
+        with Capture() as cap:
+            self.cc._do_command()
+        self.assertIn("Overall Status: Not registered", cap.out)
 
     def test_purpose_status_success(self):
         self.cc.cp = StubUEP()

--- a/test/cli_command/test_status.py
+++ b/test/cli_command/test_status.py
@@ -1,29 +1,11 @@
 from subscription_manager import managercli
-from rhsm.certificate2 import CONTENT_ACCESS_CERT_TYPE
 
-from ..stubs import StubUEP, StubIdentity
+from ..stubs import StubIdentity
 from ..fixture import SubManFixture, Capture
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from subscription_manager import injection as inj
-
-
-MOCK_SERVICE_STATUS_SCA = {
-    "status": "Disabled",
-    "status_id": "disabled",
-    "reasons": {},
-    "reason_ids": {},
-    "valid": True,
-}
-
-MOCK_SERVICE_STATUS_ENTITLEMENT = {
-    "status": "Current",
-    "status_id": "valid",
-    "reasons": {},
-    "reason_ids": {},
-    "valid": True,
-}
 
 
 class TestStatusCommand(SubManFixture):
@@ -32,79 +14,16 @@ class TestStatusCommand(SubManFixture):
     def setUp(self):
         super(TestStatusCommand, self).setUp()
         self.cc = self.command_class()
-        patcher = patch("subscription_manager.cli_command.status.entitlement")
-        self.entitlement_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-        self.mock_entitlement_instance = Mock()
-        self.mock_entitlement_instance.get_status = Mock(return_value=MOCK_SERVICE_STATUS_SCA)
-        self.entitlement_mock.EntitlementService = Mock(return_value=self.mock_entitlement_instance)
 
-    def test_status_sca_mode_registered(self):
+    def test_status_registered(self):
         """
-        Test status, when SCA mode is used
+        Test status, when the system is registered
         """
-        self.cc.cp = StubUEP()
-        self.cc.cp.setSyspurposeCompliance({"status": "disabled"})
-        self.cc.cp._capabilities = ["syspurpose"]
         self.cc.options = Mock()
         self.cc.options.on_date = None
-        mock_cert = Mock()
-        mock_cert.entitlement_type = CONTENT_ACCESS_CERT_TYPE
-        cert_list = [mock_cert]
-        self.cc.entitlement_dir = Mock()
-        self.cc.entitlement_dir.list_with_content_access = Mock(return_value=cert_list)
-        self.cc.entcertlib = Mock()
         with Capture() as cap:
             self.cc._do_command()
         self.assertIn("Overall Status: Registered", cap.out)
-        self.assertIn("Content Access Mode is set to Simple Content Access.", cap.out)
-
-    def test_current_status_entitlement_mode(self):
-        """
-        Test status, when old entitlement mode is used
-        """
-        # Note that server sent response with "Current" status
-        self.mock_entitlement_instance.get_status = Mock(return_value=MOCK_SERVICE_STATUS_ENTITLEMENT)
-        self.cc.cp = StubUEP()
-        self.cc.cp.setSyspurposeCompliance({"status": "valid"})
-        self.cc.cp._capabilities = ["syspurpose"]
-        self.cc.options = Mock()
-        self.cc.options.on_date = None
-        # There is not SCA certificate (only old entitlement)
-        mock_cert = Mock()
-        mock_cert.entitlement_type = "entitlement"
-        cert_list = [mock_cert]
-        self.cc.entitlement_dir = Mock()
-        self.cc.entitlement_dir.list_with_content_access = Mock(return_value=cert_list)
-        self.cc.entcertlib = Mock()
-        with Capture() as cap:
-            self.cc._do_command()
-        self.assertIn("Overall Status: Current", cap.out)
-        self.assertIn("System Purpose Status: Matched", cap.out)
-
-    def test_status_content_access_mode_changed(self):
-        """
-        Test status, when old entitlement mode is used
-        """
-        # Note that server sent response with "Current" status
-        self.mock_entitlement_instance.get_status = Mock(return_value=MOCK_SERVICE_STATUS_ENTITLEMENT)
-        self.cc.cp = StubUEP()
-        self.cc.cp.setSyspurposeCompliance({"status": "valid"})
-        self.cc.cp._capabilities = ["syspurpose"]
-        self.cc.options = Mock()
-        self.cc.options.on_date = None
-        # But entitlement directory still contain SCA certificate
-        mock_cert = Mock()
-        mock_cert.entitlement_type = CONTENT_ACCESS_CERT_TYPE
-        cert_list = [mock_cert]
-        self.cc.entitlement_dir = Mock()
-        self.cc.entitlement_dir.list_with_content_access = Mock(return_value=cert_list)
-        self.cc.entcertlib = Mock()
-        # sub-man should be able to resurrect from this situation
-        with Capture() as cap:
-            self.cc._do_command()
-        self.assertIn("Overall Status: Current", cap.out)
-        self.assertIn("System Purpose Status: Matched", cap.out)
 
     def test_status_unregistered(self):
         """
@@ -116,54 +35,3 @@ class TestStatusCommand(SubManFixture):
         with Capture() as cap:
             self.cc._do_command()
         self.assertIn("Overall Status: Not registered", cap.out)
-
-    def test_purpose_status_success(self):
-        self.cc.cp = StubUEP()
-        self.cc.cp.setSyspurposeCompliance({"status": "valid"})
-        self.cc.cp._capabilities = ["syspurpose"]
-        self.cc.options = Mock()
-        self.cc.options.on_date = None
-        self.cc.entcertlib = Mock()
-        self.cc._determine_whether_content_access_mode_is_sca = Mock(return_value=False)
-        with Capture() as cap:
-            self.cc._do_command()
-        self.assertTrue("System Purpose Status: Matched" in cap.out)
-
-    def test_purpose_status_consumer_lack(self):
-        self.cc.cp = StubUEP()
-        self.cc.cp.setSyspurposeCompliance({"status": "unknown"})
-        self.cc.cp._capabilities = ["syspurpose"]
-        self.cc.options = Mock()
-        self.cc.options.on_date = None
-        self.cc.entcertlib = Mock()
-        self.cc._determine_whether_content_access_mode_is_sca = Mock(return_value=False)
-        with Capture() as cap:
-            self.cc._do_command()
-        self.assertTrue("System Purpose Status: Unknown" in cap.out)
-
-    def test_purpose_status_consumer_no_capability(self):
-        self.cc.cp = StubUEP()
-        self.cc.cp.setSyspurposeCompliance({"status": "unknown"})
-        self.cc.cp._capabilities = []
-        self.cc.options = Mock()
-        self.cc.options.on_date = None
-        self.cc.entcertlib = Mock()
-        self.cc._determine_whether_content_access_mode_is_sca = Mock(return_value=False)
-        with Capture() as cap:
-            self.cc._do_command()
-        self.assertTrue("System Purpose Status: Unknown" in cap.out)
-
-    def test_purpose_status_mismatch(self):
-        self.cc.cp = StubUEP()
-        self.cc.cp.setSyspurposeCompliance(
-            {"status": "mismatched", "reasons": ["unsatisfied usage: Production"]}
-        )
-        self.cc.cp._capabilities = ["syspurpose"]
-        self.cc.options = Mock()
-        self.cc.options.on_date = None
-        self.cc.entcertlib = Mock()
-        self.cc._determine_whether_content_access_mode_is_sca = Mock(return_value=False)
-        with Capture() as cap:
-            self.cc._do_command()
-        self.assertTrue("System Purpose Status: Mismatched" in cap.out)
-        self.assertTrue("unsatisfied usage: Production" in cap.out)

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -38,6 +38,7 @@ from subscription_manager.facts import Facts
 from rhsm.certificate import GMT
 from rhsm.certificate2 import Version
 from subscription_manager.certdirectory import EntitlementDirectory, ProductDirectory
+from subscription_manager.identity import Identity
 
 from rhsm.certificate import parse_tags
 from rhsm.certificate2 import EntitlementCertificate, ProductCertificate, Product, Content, Order
@@ -461,6 +462,13 @@ class StubConsumerIdentity:
     @classmethod
     def keypath(cls):
         return ""
+
+
+class StubIdentity(Identity):
+    _consumer = None
+
+    def _get_consumer_identity(self):
+        return self._consumer
 
 
 class StubUEP:

--- a/test/test_identitycertlib.py
+++ b/test/test_identitycertlib.py
@@ -12,7 +12,7 @@
 
 from unittest import mock
 
-from . import fixture
+from . import fixture, stubs
 
 from subscription_manager import identity
 from subscription_manager import identitycertlib
@@ -33,18 +33,11 @@ mock_consumer_identity.getConsumerId.return_value = "11111-00000-11111-0000"
 
 
 # Identities to inject for testing
-class StubIdentity(identity.Identity):
-    _consumer = None
-
-    def _get_consumer_identity(self):
-        return self._consumer
-
-
-class InvalidIdentity(StubIdentity):
+class InvalidIdentity(stubs.StubIdentity):
     pass
 
 
-class ValidIdentity(StubIdentity):
+class ValidIdentity(stubs.StubIdentity):
     _consumer = mock_consumer_identity
 
 
@@ -54,7 +47,7 @@ different_mock_consumer_identity.getConsumerName.return_value = "A Different Moc
 different_mock_consumer_identity.getConsumerId.return_value = "AAAAAA-BBBBB-CCCCCC-DDDDD"
 
 
-class DifferentValidConsumerIdentity(StubIdentity):
+class DifferentValidConsumerIdentity(stubs.StubIdentity):
     _consumer = different_mock_consumer_identity
 
 

--- a/test/test_printing_utils.py
+++ b/test/test_printing_utils.py
@@ -1,6 +1,5 @@
 import unittest
 
-from subscription_manager.cli_command import status
 from subscription_manager.printing_utils import (
     format_name,
     columnize,
@@ -12,7 +11,7 @@ from subscription_manager.printing_utils import (
     FONT_NORMAL,
 )
 
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 
 TEST_COLUMNS = [
@@ -138,11 +137,10 @@ class TestNoneWrap(unittest.TestCase):
 
 class TestColumnize(unittest.TestCase):
     def setUp(self):
-        self.old_method = status.get_terminal_width
-        status.get_terminal_width = Mock(return_value=500)
-
-    def tearDown(self):
-        status.get_terminal_width = self.old_method
+        patcher = patch("subscription_manager.printing_utils.get_terminal_width")
+        self.get_terminal_width_mock = patcher.start()
+        self.get_terminal_width_mock.return_value = 500
+        self.addCleanup(patcher.stop)
 
     def test_columnize(self):
         result = columnize(["Hello:", "Foo:"], echo_columnize_callback, "world", "bar")
@@ -156,9 +154,8 @@ class TestColumnize(unittest.TestCase):
         result = columnize(["Hello:", "Foo:"], echo_columnize_callback, [], "bar")
         self.assertEqual(result, "Hello: \nFoo:   bar")
 
-    @patch("subscription_manager.printing_utils.get_terminal_width")
-    def test_columnize_with_small_term(self, term_width_mock):
-        term_width_mock.return_value = None
+    def test_columnize_with_small_term(self):
+        self.get_terminal_width_mock.return_value = None
         result = columnize(
             ["Hello Hello Hello Hello:", "Foo Foo Foo Foo:"],
             echo_columnize_callback,
@@ -171,7 +168,7 @@ class TestColumnize(unittest.TestCase):
             "This_i\n      s_anot\n      her_te\n      sting_\n      string"
         )
         self.assertNotEqual(result, expected)
-        term_width_mock.return_value = 12
+        self.get_terminal_width_mock.return_value = 12
         result = columnize(
             ["Hello Hello Hello Hello:", "Foo Foo Foo Foo:"],
             echo_columnize_callback,
@@ -209,14 +206,13 @@ class TestColumnize(unittest.TestCase):
         expected = "a" * 9 + "\n " + "a" * 9 + "\n " + "aa"
         self.assertEqual(result, expected)
 
-    @patch("subscription_manager.printing_utils.get_terminal_width")
-    def test_columnize_multibyte(self, term_width_mock):
+    def test_columnize_multibyte(self):
         multibyte_str = "このシステム用に"
-        term_width_mock.return_value = 40
+        self.get_terminal_width_mock.return_value = 40
         result = columnize([multibyte_str], echo_columnize_callback, multibyte_str)
         expected = "このシステム用に このシステム用に"
         self.assertEqual(result, expected)
-        term_width_mock.return_value = 14
+        self.get_terminal_width_mock.return_value = 14
         result = columnize([multibyte_str], echo_columnize_callback, multibyte_str)
         expected = "このシ\nステム\n用に   このシ\n       ステム\n       用に"
         self.assertEqual(result, expected)


### PR DESCRIPTION
The message printed for the "overall status" comes directly from the compliance status of the system. Compliance is a concept strictly specific to entitlement mode, and in case of SCA there is nothing to be said, and thus the "unknown" status gets used. While this is technically correct, in practice it tends to confuse users a lot, as it does not clearly give the important detail about the system properly registered.

Hence, in case the content access mode is really SCA (after checking the certificates, potentially refreshing caches and status), use the simple status string "registered" for a system in SCA mode. This, together with the message already printed out about the fact that the host should get access to content, should improve the feedback that users get when reading the output of "status" on a system registered to an SCA organization.
The output of `subscription-manager status` on a SCA system thus changes from this:
```
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Disabled
Content Access Mode is set to Simple Content Access. This host has access to content, regardless of subscription status.

System Purpose Status: Disabled

```
to this:
```
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Registered

```

Change/simplify the message also for a not registered systems: because of the reasons mentioned above, printing "unknown" is confusing, and also not correct (subscription-manager knows the system is not registered). In that case there is also no need to print the syspurpose status, as it is not relevant on unregistered systems.
The output of `subscription-manager status` on an unregistered system thus changes from this:
```
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Unknown

System Purpose Status: Unknown

```
to this:
```
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Not registered

```

An additional commit also drops all the bits related to entitlement mode, compliance, and syspurpose in the implementation of the "status" command, as only SCA is supported. This is kept separate to ease the review of the other changes, and also the backport of almost the whole series (i.e. everything but this commit) to branches of older versions that still do support the entitlement mode.

The changes requires some additional cleanups/refactors in tests.

Card ID: CCT-848