### PR TITLE
feat: drop the --ondate option of "status"

### DIFF
--- a/etc-conf/subscription-manager.completion.sh
+++ b/etc-conf/subscription-manager.completion.sh
@@ -167,7 +167,7 @@ _subscription_manager_service_level()
 
 _subscription_manager_status()
 {
-  local opts="--ondate -h --help"
+  local opts="-h --help"
   COMPREPLY=($(compgen -W "${opts}" -- ${1}))
 }
 

--- a/man/subscription-manager.8
+++ b/man/subscription-manager.8
@@ -759,20 +759,6 @@ Overall Status: Registered
 .RE
 
 
-.TP
-.B --ondate=DATE
-Shows the system status for a specific date \fIin the future\fP. The format of the date is \fIYYYY-MM-DD\fP.
-
-.RS
-.nf
-[root@server ~]# subscription-manager status --ondate=2014-01-01
-+-------------------------------------------+
-     System Status Details
-+-------------------------------------------+
-Overall Status: Insufficient
-.fi
-.RE
-
 .SS DEPRECATED COMMANDS
 No commands are currently deprecated.
 

--- a/src/subscription_manager/cli_command/status.py
+++ b/src/subscription_manager/cli_command/status.py
@@ -15,14 +15,10 @@
 # in this software or its documentation.
 #
 import logging
-import os
 
-from rhsmlib.services import entitlement
 
-from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand
 from subscription_manager.i18n import ugettext as _
-from time import localtime, strftime
 
 log = logging.getLogger(__name__)
 
@@ -31,29 +27,9 @@ class StatusCommand(CliCommand):
     def __init__(self):
         shortdesc = _("Show status information for this system")
         super(StatusCommand, self).__init__("status", shortdesc, True)
-        self.parser.add_argument(
-            "--ondate",
-            dest="on_date",
-            help=_("future date to check status on, defaults to today's date (example: {example})").format(
-                example=strftime("%Y-%m-%d", localtime())
-            ),
-        )
 
     def require_connection(self):
         return False
-
-    def _get_date_cli_option(self):
-        """
-        Try to get and validate command line options date
-        :return: Return date or None, when date was not provided
-        """
-        on_date = None
-        if self.options.on_date:
-            try:
-                on_date = entitlement.EntitlementService.parse_date(self.options.on_date)
-            except ValueError as err:
-                system_exit(os.EX_DATAERR, err)
-        return on_date
 
     def _print_status_banner(self):
         print("+-------------------------------------------+")
@@ -64,9 +40,6 @@ class StatusCommand(CliCommand):
         """
         Print status and all reasons it is not valid
         """
-
-        # First get/check if provided date is valid
-        self._get_date_cli_option()
 
         self._print_status_banner()
 

--- a/test/cli_command/test_status.py
+++ b/test/cli_command/test_status.py
@@ -20,7 +20,6 @@ class TestStatusCommand(SubManFixture):
         Test status, when the system is registered
         """
         self.cc.options = Mock()
-        self.cc.options.on_date = None
         with Capture() as cap:
             self.cc._do_command()
         self.assertIn("Overall Status: Registered", cap.out)
@@ -31,7 +30,6 @@ class TestStatusCommand(SubManFixture):
         """
         inj.provide(inj.IDENTITY, StubIdentity())
         self.cc.options = Mock()
-        self.cc.options.on_date = None
         with Capture() as cap:
             self.cc._do_command()
         self.assertIn("Overall Status: Not registered", cap.out)


### PR DESCRIPTION
After the recent simplification of the "status" command, checks for the subscription/compliance status at arbitrary dates are no more supported, and thus the --ondate option was no more used.

Because of that, drop the --ondate option altogether.

Card ID: CCT-1158.