### PR TITLE
spec: Avoid DNF warnings on traditional Fedora hosts and DNF on atomics

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -6,8 +6,10 @@
 # Plugin for container (docker, podman) is not supported on RHEL
 %if 0%{?rhel}
 %global use_container_plugin 0
+%global use_dnf 1
 %else
 %global use_container_plugin 1
+%global use_dnf 0
 %endif
 
 %global dmidecode_arches %{ix86} x86_64 aarch64
@@ -23,8 +25,7 @@
 %global use_inotify 0
 %endif
 
-%global use_dnf (0%{?fedora} || (0%{?rhel}))
-%global create_libdnf_rpm (0%{?fedora} || 0%{?rhel} > 8)
+%global create_libdnf_rpm (0%{?rhel} > 8)
 
 %global python_sitearch %python3_sitearch
 %global python_sitelib %python3_sitelib


### PR DESCRIPTION
It will be good to make it easier to have gratis, self-supported Red Hat Enterprise Linux OCI containers on Fedora Silverblue and Workstation through the [RHEL Developer Suite](https://developers.redhat.com/blog/2016/03/31/no-cost-rhel-developer-subscription-now-available) subscription.  This includes Toolbx containers created with:
```ShellSession
  $ toolbox create --distro rhel --release 9.5
```

However, when `subscription-manager` was installed on a Fedora host with DNF4, the `subscription-manager` DNF plugin printed some spurious warning messages that users didn't like because it made them think that something is wrong.  eg., when the host is unregistered:
```ShellSession
  $ sudo dnf update
  Updating Subscription Management repositories.
  Unable to read consumer identity

  This system is not registered with an entitlement server. You can use
      subscription-manager to register.

  Last metadata expiration check: ...
```

Or, when the host has been registered:
```ShellSession
  $ sudo dnf update
  Updating Subscription Management repositories.

  This system is registered with an entitlement server, but is not
      receiving updates. You can use subscription-manager to assign
      subscriptions.

  Last metadata expiration check: ...
```

These warnings have no relevance in Fedora, because the purpose of using `subscription-manager(8)` on a Fedora host is to access RHEL content in OCI containers.  There is no need for RHEL content on the Fedora host itself.

Note that these warnings aren't visible on Fedora hosts with DNF5 because the subscription-manager plugin doesn't work with it.

Secondly, until now, `subscription-manager` had `%{_bindir}/dnf-3` and `%{_bindir}/dnf4` in its dependency chain.  This meant that installing `subscription-manager` on Fedora Silverblue pulled them in, even though those executables shouldn't be present on Silverblue because they don't work there.

Both these problems can be addressed by disabling the DNF and libdnf plugins on Fedora.

https://bugzilla.redhat.com/show_bug.cgi?id=2246833 \
https://bugzilla.redhat.com/show_bug.cgi?id=2262228