### PR TITLE
build: cockpit: fix installation of sub-man with newer Fedora

### DIFF
--- a/cockpit-tests/vm.install
+++ b/cockpit-tests/vm.install
@@ -3,6 +3,8 @@ set -eux
 
 dnf install -y cockpit-ws python3-devel openssl-devel gcc
 
+rm -f /usr/*bin/subscription-manager
+
 cd /var/tmp
 
 tar -xzf subscription-manager.tar.gz --transform 's,[^/]*,/sm,'
@@ -14,4 +16,4 @@ python3 ./setup.py build
 RPM_BUILD_ROOT="/" python3 ./setup.py install --prefix /usr --root /
 
 mv /usr/bin/{rhsm-facts-service,rhsm-service,rhsmcertd-worker} /usr/libexec
-mv /usr/bin/subscription-manager /usr/sbin
+mv -n /usr/bin/subscription-manager /usr/sbin


### PR DESCRIPTION
Newer versions of Fedora implement:
https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin Because of that, now the "subscription-manager" executable is installed in `/usr/bin`, and the old usermode symlink is gone. To properly handle those changes, then:
- remove all the "subscription-manager" executables before installing subscription-manager from the wanted sources
- use "-n" when moving the "subscription-manager" executable to not error out in case the "sbin" install location is set to be "bin"

Backport of https://github.com/candlepin/subscription-manager-cockpit/pull/90.