### PR TITLE
[1.28] ci: backport dependabot updates

### DIFF
--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Use CentOS Vault"
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Use CentOS Vault"
         run: |

--- a/.github/workflows/stylish.yml
+++ b/.github/workflows/stylish.yml
@@ -20,7 +20,7 @@ jobs:
             python3-pip \
             rpmlint
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup flake8 annotations
       uses: rbialon/flake8-annotations@v1

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -34,7 +34,7 @@ jobs:
           dnf config-manager --enable powertools
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # This step is required so Tito can properly read git history
       # See https://github.com/actions/checkout/issues/766

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -64,7 +64,7 @@ jobs:
           tito build --output=tito/ --test --rpm
 
       - name: Upload RPMs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: RPMs from tito (${{ matrix.name }})
           path: tito/


### PR DESCRIPTION
- `ci: bump actions/checkout from 3 to 4`
- `ci: bump actions/upload-artifact from 3 to 4`