### PR TITLE
Revert "ci: temporarily install 'which' on CentOS Stream 10"

### DIFF
--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -70,11 +70,6 @@ jobs:
             python3-pip python3-setuptools
           pip install https://github.com/rpm-software-management/tito/archive/refs/tags/tito-0.6.22-1.tar.gz
 
-      - name: Install which (RHEL-73048)
-        if: ${{ matrix.name == 'CentOS Stream 10' }}
-        run: |
-          dnf --setopt install_weak_deps=False install -y which
-
       - name: Build the package
         run: |
           tito build --output=tito/ --test --rpm


### PR DESCRIPTION
The underlying issue (i.e. https://issues.redhat.com/browse/RHEL-73048) was fixed a couple of weeks ago, so this workaround is no more needed.

This reverts commit 2a5904c92ebc74afe25fc9db1640d6d9d6029772.