### PR TITLE
spec: Consolidate dependencies on DNF & libdnf plugins in one place

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -165,6 +165,12 @@ Requires:  platform-python-setuptools
 Requires: python3-dnf
 Requires: python3-dnf-plugins-core
 Requires: python3-librepo
+# The libdnf plugin is in separate RPM, but shubscription-manager should be dependent
+# on this RPM, because somebody can install microdnf on host and installing of product
+# certs would not work as expected without libdnf plugin
+Requires: libdnf-plugin-subscription-manager = %{version}
+# The dnf plugin is now part of subscription-manager
+Obsoletes: dnf-plugin-subscription-manager < 1.29.0
 %else
 Requires: dnf-plugin-subscription-manager = %{version}
 %endif
@@ -208,17 +214,6 @@ Obsoletes: rhsm-gtk <= %{version}-%{release}
 
 %if !%{use_container_plugin}
 Obsoletes: subscription-manager-plugin-container <= %{version}
-%endif
-
-%if %{use_dnf}
-%if %{create_libdnf_rpm}
-# The libdnf plugin is in separate RPM, but shubscription-manager should be dependent
-# on this RPM, because somebody can install microdnf on host and installing of product
-# certs would not work as expected without libdnf plugin
-Requires: libdnf-plugin-subscription-manager = %{version}
-# The dnf plugin is now part of subscription-manager
-Obsoletes: dnf-plugin-subscription-manager < 1.29.0
-%endif
 %endif
 
 Obsoletes: %{py_package_prefix}-syspurpose <= %{version}


### PR DESCRIPTION
It's easier to understand if the `Requires` and `Obsoletes` on `libdnf-plugin-subscription-manager` and `dnf-plugin-subscription-manager` that depend upon the `use_dnf` and `create_libdnf_rpm` conditions are in one place.  The cognitive burden of tracking them across different parts of the file is needlessly high.