### PR TITLE
[1.28] feat: new status messages for SCA & unregistered systems

### DIFF
--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -3701,15 +3701,18 @@ class StatusCommand(CliCommand):
                 system_exit(os.EX_DATAERR, err)
         return on_date
 
+    def _print_status_banner(self):
+        print("+-------------------------------------------+")
+        print("   " + _("System Status Details"))
+        print("+-------------------------------------------+")
+
     def _print_status(self, service_status):
         """
         Print only status
         :return: Print overall status
         """
 
-        print("+-------------------------------------------+")
-        print("   " + _("System Status Details"))
-        print("+-------------------------------------------+")
+        self._print_status_banner()
 
         ca_message = ""
         has_cert = _(

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -3706,18 +3706,12 @@ class StatusCommand(CliCommand):
         print("   " + _("System Status Details"))
         print("+-------------------------------------------+")
 
-    def _print_status(self, service_status):
+    def _determine_whether_content_access_mode_is_sca(self, service_status):
         """
-        Print only status
-        :return: Print overall status
+        Try hard to determine whether the content access mode is SCA,
+        refreshing the caches if needed
+        :return: True if SCA, False if entitlement mode
         """
-
-        self._print_status_banner()
-
-        ca_message = ""
-        has_cert = _(
-            "Content Access Mode is set to Simple Content Access. This host has access to content, regardless of subscription status.\n"
-        )
 
         certs = self.entitlement_dir.list_with_content_access()
         sca_certs = [cert for cert in certs if cert.entitlement_type == CONTENT_ACCESS_CERT_TYPE]
@@ -3746,8 +3740,25 @@ class StatusCommand(CliCommand):
                     f"Found SCA cert, but status ID is not 'disabled' ({status_id}). Refreshing entitlement certs..."
                 )
                 refresh_service.refresh()
-            else:
-                ca_message = has_cert
+                sca_mode_detected = False
+
+        return sca_mode_detected
+
+    def _print_status(self, service_status, is_sca):
+        """
+        Print only status
+        :return: Print overall status
+        """
+
+        self._print_status_banner()
+
+        ca_message = ""
+
+        if is_sca:
+            ca_message = _(
+                "Content Access Mode is set to Simple Content Access. "
+                "This host has access to content, regardless of subscription status.\n"
+            )
 
         print(
             _("Overall Status: {status}\n{message}").format(
@@ -3804,7 +3815,9 @@ class StatusCommand(CliCommand):
 
         service_status = entitlement.EntitlementService(cp=self.cp).get_status(on_date)
 
-        self._print_status(service_status)
+        is_sca = self._determine_whether_content_access_mode_is_sca(service_status)
+
+        self._print_status(service_status, is_sca)
 
         self._print_reasons(service_status)
 

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -3753,18 +3753,16 @@ class StatusCommand(CliCommand):
         self._print_status_banner()
 
         ca_message = ""
+        status_message = service_status["status"]
 
         if is_sca:
             ca_message = _(
                 "Content Access Mode is set to Simple Content Access. "
                 "This host has access to content, regardless of subscription status.\n"
             )
+            status_message = _("Registered")
 
-        print(
-            _("Overall Status: {status}\n{message}").format(
-                status=service_status["status"], message=ca_message
-            )
-        )
+        print(_("Overall Status: {status}\n{message}").format(status=status_message, message=ca_message))
 
     def _print_reasons(self, service_status):
         """

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -3824,9 +3824,10 @@ class StatusCommand(CliCommand):
 
         self._print_status(service_status, is_sca)
 
-        self._print_reasons(service_status)
+        if not is_sca:
+            self._print_reasons(service_status)
 
-        self._print_syspurpose_status(on_date)
+            self._print_syspurpose_status(on_date)
 
         if service_status["valid"]:
             result = 0

--- a/src/subscription_manager/managercli.py
+++ b/src/subscription_manager/managercli.py
@@ -3813,6 +3813,13 @@ class StatusCommand(CliCommand):
         # First get/check if provided date is valid
         on_date = self._get_date_cli_option()
 
+        # In case we are not registered, then simply print that and avoid
+        # all the rest of the checks
+        if not self.is_consumer_cert_present():
+            self._print_status_banner()
+            print(_("Overall Status: Not registered\n"))
+            return 1
+
         service_status = entitlement.EntitlementService(cp=self.cp).get_status(on_date)
 
         is_sca = self._determine_whether_content_access_mode_is_sca(service_status)

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -34,6 +34,7 @@ from rhsm.certificate import GMT
 from subscription_manager.gui.utils import AsyncWidgetUpdater, handle_gui_exception
 from rhsm.certificate2 import Version
 from subscription_manager.certdirectory import EntitlementDirectory, ProductDirectory
+from subscription_manager.identity import Identity
 
 from rhsm.certificate import parse_tags
 from rhsm.certificate2 import EntitlementCertificate, ProductCertificate, \
@@ -412,6 +413,13 @@ class StubConsumerIdentity(object):
     @classmethod
     def keypath(cls):
         return ""
+
+
+class StubIdentity(Identity):
+    _consumer = None
+
+    def _get_consumer_identity(self):
+        return self._consumer
 
 
 class StubUEP(object):

--- a/test/test_identitycertlib.py
+++ b/test/test_identitycertlib.py
@@ -15,7 +15,7 @@ from __future__ import print_function, division, absolute_import
 
 import mock
 
-from . import fixture
+from . import fixture, stubs
 
 from subscription_manager import identity
 from subscription_manager import identitycertlib
@@ -34,18 +34,11 @@ mock_consumer_identity.getConsumerId.return_value = "11111-00000-11111-0000"
 
 
 # Identities to inject for testing
-class StubIdentity(identity.Identity):
-    _consumer = None
-
-    def _get_consumer_identity(self):
-        return self._consumer
-
-
-class InvalidIdentity(StubIdentity):
+class InvalidIdentity(stubs.StubIdentity):
     pass
 
 
-class ValidIdentity(StubIdentity):
+class ValidIdentity(stubs.StubIdentity):
     _consumer = mock_consumer_identity
 
 
@@ -55,7 +48,7 @@ different_mock_consumer_identity.getConsumerName.return_value = "A Different Moc
 different_mock_consumer_identity.getConsumerId.return_value = "AAAAAA-BBBBB-CCCCCC-DDDDD"
 
 
-class DifferentValidConsumerIdentity(StubIdentity):
+class DifferentValidConsumerIdentity(stubs.StubIdentity):
     _consumer = different_mock_consumer_identity
 
 

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -25,7 +25,7 @@ from subscription_manager.cache import ContentAccessCache, \
 from subscription_manager.entcertlib import CONTENT_ACCESS_CERT_TYPE
 from subscription_manager.injection import provide, require, \
         CERT_SORTER, PROD_DIR, CONTENT_ACCESS_CACHE, CONTENT_ACCESS_MODE_CACHE, \
-        CP_PROVIDER
+        CP_PROVIDER, IDENTITY
 from rhsmlib.services.products import InstalledProducts
 from subscription_manager.managercli import AVAILABLE_SUBS_MATCH_COLUMNS
 from subscription_manager.printing_utils import format_name, columnize, \
@@ -35,7 +35,7 @@ from subscription_manager.overrides import Override
 
 from .stubs import StubProductCertificate, StubEntitlementCertificate, \
         StubConsumerIdentity, StubProduct, StubUEP, StubProductDirectory, \
-        StubCertSorter, StubPool
+        StubCertSorter, StubPool, StubIdentity
 from .fixture import FakeException, FakeLogger, SubManFixture, \
         Capture, Matcher, set_up_mock_sp_store
 
@@ -401,6 +401,17 @@ class TestStatusCommand(SubManFixture):
             self.cc._do_command()
         self.assertIn("Overall Status: Current", cap.out)
         self.assertIn("System Purpose Status: Matched", cap.out)
+
+    def test_status_unregistered(self):
+        """
+        Test status, when the system is not registered
+        """
+        provide(IDENTITY, StubIdentity())
+        self.cc.options = Mock()
+        self.cc.options.on_date = None
+        with Capture() as cap:
+            self.cc._do_command()
+        self.assertIn("Overall Status: Not registered", cap.out)
 
     def test_purpose_status_success(self):
         self.cc.cp = StubUEP()

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -343,7 +343,6 @@ class TestStatusCommand(SubManFixture):
         """
         Test status, when SCA mode is used
         """
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({"status": "disabled"})
         self.cc.cp._capabilities = ["syspurpose"]
@@ -362,7 +361,6 @@ class TestStatusCommand(SubManFixture):
         """
         # Note that server sent response with "Current" status
         self.mock_entitlement_instance.get_status = Mock(return_value=self.MOCK_SERVICE_STATUS_ENTITLEMENT)
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({"status": "valid"})
         self.cc.cp._capabilities = ["syspurpose"]
@@ -386,7 +384,6 @@ class TestStatusCommand(SubManFixture):
         """
         # Note that server sent response with "Current" status
         self.mock_entitlement_instance.get_status = Mock(return_value=self.MOCK_SERVICE_STATUS_ENTITLEMENT)
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({"status": "valid"})
         self.cc.cp._capabilities = ["syspurpose"]
@@ -406,7 +403,6 @@ class TestStatusCommand(SubManFixture):
         self.assertIn("System Purpose Status: Matched", cap.out)
 
     def test_purpose_status_success(self):
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({'status': 'valid'})
         self.cc.cp._capabilities = ["syspurpose"]
@@ -417,7 +413,6 @@ class TestStatusCommand(SubManFixture):
         self.assertTrue('System Purpose Status: Matched' in cap.out)
 
     def test_purpose_status_consumer_lack(self):
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({'status': 'unknown'})
         self.cc.cp._capabilities = ["syspurpose"]
@@ -428,7 +423,6 @@ class TestStatusCommand(SubManFixture):
         self.assertTrue('System Purpose Status: Unknown' in cap.out)
 
     def test_purpose_status_consumer_no_capability(self):
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({'status': 'unknown'})
         self.cc.cp._capabilities = []
@@ -439,7 +433,6 @@ class TestStatusCommand(SubManFixture):
         self.assertTrue('System Purpose Status: Unknown' in cap.out)
 
     def test_purpose_status_mismatch(self):
-        self.cc.consumerIdentity = StubConsumerIdentity
         self.cc.cp = StubUEP()
         self.cc.cp.setSyspurposeCompliance({'status': 'mismatched', 'reasons': ['unsatisfied usage: Production']})
         self.cc.cp._capabilities = ["syspurpose"]

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -339,7 +339,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.entitlement_dir.list_with_content_access = Mock(return_value=cert_list)
         self.cc.entcertlib = Mock()
 
-    def test_disabled_status_sca_mode(self):
+    def test_status_sca_mode_registered(self):
         """
         Test status, when SCA mode is used
         """
@@ -350,7 +350,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.options.on_date = None
         with Capture() as cap:
             self.cc._do_command()
-        self.assertIn("Overall Status: Disabled", cap.out)
+        self.assertIn("Overall Status: Registered", cap.out)
         self.assertIn("Content Access Mode is set to Simple Content Access.", cap.out)
         self.assertIn("This host has access to content, regardless of subscription status.", cap.out)
         self.assertIn("System Purpose Status: Disabled", cap.out)

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -352,8 +352,6 @@ class TestStatusCommand(SubManFixture):
             self.cc._do_command()
         self.assertIn("Overall Status: Registered", cap.out)
         self.assertIn("Content Access Mode is set to Simple Content Access.", cap.out)
-        self.assertIn("This host has access to content, regardless of subscription status.", cap.out)
-        self.assertIn("System Purpose Status: Disabled", cap.out)
 
     def test_current_status_entitlement_mode(self):
         """

--- a/test/test_managercli.py
+++ b/test/test_managercli.py
@@ -408,6 +408,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.cp._capabilities = ["syspurpose"]
         self.cc.options = Mock()
         self.cc.options.on_date = None
+        self.cc._determine_whether_content_access_mode_is_sca = Mock(return_value=False)
         with Capture() as cap:
             self.cc._do_command()
         self.assertTrue('System Purpose Status: Matched' in cap.out)
@@ -418,6 +419,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.cp._capabilities = ["syspurpose"]
         self.cc.options = Mock()
         self.cc.options.on_date = None
+        self.cc._determine_whether_content_access_mode_is_sca = Mock(return_value=False)
         with Capture() as cap:
             self.cc._do_command()
         self.assertTrue('System Purpose Status: Unknown' in cap.out)
@@ -428,6 +430,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.cp._capabilities = []
         self.cc.options = Mock()
         self.cc.options.on_date = None
+        self.cc._determine_whether_content_access_mode_is_sca = Mock(return_value=False)
         with Capture() as cap:
             self.cc._do_command()
         self.assertTrue('System Purpose Status: Unknown' in cap.out)
@@ -438,6 +441,7 @@ class TestStatusCommand(SubManFixture):
         self.cc.cp._capabilities = ["syspurpose"]
         self.cc.options = Mock()
         self.cc.options.on_date = None
+        self.cc._determine_whether_content_access_mode_is_sca = Mock(return_value=False)
         with Capture() as cap:
             self.cc._do_command()
         self.assertTrue('System Purpose Status: Mismatched' in cap.out)


### PR DESCRIPTION
The message printed for the "overall status" comes directly from the compliance status of the system. Compliance is a concept strictly specific to entitlement mode, and in case of SCA there is nothing to be said, and thus the "unknown" status gets used. While this is technically correct, in practice it tends to confuse users a lot, as it does not clearly give the important detail about the system properly registered.

Hence, in case the content access mode is really SCA (after checking the certificates, potentially refreshing caches and status), use the simple status string "registered" for a system in SCA mode. This, together with the message already printed out about the fact that the host should get access to content, should improve the feedback that users get when reading the output of "status" on a system registered to an SCA organization.
The output of `subscription-manager status` on a SCA system thus changes from this:
```
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Disabled
Content Access Mode is set to Simple Content Access. This host has access to content, regardless of subscription status.

System Purpose Status: Disabled

```
to this:
```
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Registered

```

Change/simplify the message also for a not registered systems: because of the reasons mentioned above, printing "unknown" is confusing, and also not correct (subscription-manager knows the system is not registered). In that case there is also no need to print the syspurpose status, as it is not relevant on unregistered systems.
The output of `subscription-manager status` on an unregistered system thus changes from this:
```
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Unknown

System Purpose Status: Unknown

```
to this:
```
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Not registered

```

The changes requires some additional cleanups/refactors in tests.

Card ID: CCT-848

Backport of most of PR #3504 excluding the removal of non-SCA bits (still supported in this branch).