### PR TITLE
[1.29.45] ci: use the right distro for coverage reporting

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,7 +47,7 @@ jobs:
         uses: MishaKav/pytest-coverage-comment@main
         if: |
           github.event.pull_request.head.repo.full_name == github.repository
-          && matrix.name == 'Fedora latest'
+          && matrix.name == 'CentOS Stream 9'
         with:
           title: "Coverage (computed on ${{ matrix.name }})"
           report-only-changed-files: true


### PR DESCRIPTION
This branch tests only on CentOS Stream 9, so use it as reference for the coverage reporting.

Fixes commit f1138bd7eb608feaa8b502ef286d82cf895543e2