### PR TITLE
tests: update location of pytest-client-tools

### DIFF
--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -2,7 +2,7 @@
 # please update the version there in case it is bumped here
 black==24.3.0
 flake8
-git+https://github.com/ptoscano/pytest-client-tools@main
+git+https://github.com/RedHatInsights/pytest-client-tools@main
 pytest
 pyyaml
 simplejson


### PR DESCRIPTION
Now it lives in the RedHatInsights organization.