### PR TITLE
[1.29.33] ci: backport dependabot updates

### DIFF
--- a/.github/workflows/libdnf.yml
+++ b/.github/workflows/libdnf.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Enable CRB repository"
         if: ${{ matrix.name == 'CentOS Stream 9' }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Run container-pre-test.sh"
         run: |

--- a/.github/workflows/stylish.yml
+++ b/.github/workflows/stylish.yml
@@ -20,7 +20,7 @@ jobs:
             python3-pip \
             rpmlint
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: psf/black@stable
       with:

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -63,7 +63,7 @@ jobs:
           tito build --output=tito/ --test --rpm
 
       - name: Upload RPMs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: RPMs from tito (${{ matrix.name }})
           path: tito/

--- a/.github/workflows/tito.yml
+++ b/.github/workflows/tito.yml
@@ -31,7 +31,7 @@ jobs:
           dnf config-manager --enable crb
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # This step is required so Tito can properly read git history
       # See https://github.com/actions/checkout/issues/766


### PR DESCRIPTION
- `ci: bump actions/checkout from 3 to 4`
- `ci: bump actions/upload-artifact from 3 to 4`