### PR TITLE
[1.29.33] ci: use Fedora 40 for stylish test

### DIFF
--- a/.github/workflows/stylish.yml
+++ b/.github/workflows/stylish.yml
@@ -9,7 +9,7 @@ jobs:
     name: "black & flake8 & rpmlint"
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: fedora:40
 
     steps:
     - name: Base setup


### PR DESCRIPTION
We use Fedora packages for flake8 and rpmlint checks; since new versions of Fedora may break this old branch, use a stable Fedora to avoid surprises in the future.