### PR TITLE
feat: drop ClassicCheck

### DIFF
--- a/src/plugins/dnf/subscription_manager.py
+++ b/src/plugins/dnf/subscription_manager.py
@@ -20,7 +20,6 @@ import signal
 from subscription_manager import injection as inj
 from subscription_manager.repolib import RepoActionInvoker
 from subscription_manager.entcertlib import EntCertActionInvoker
-from rhsmlib.facts.hwprobe import ClassicCheck
 from subscription_manager.utils import chroot, is_simple_content_access, is_process_running
 from subscription_manager.injectioninit import init_dep_injection
 from subscription_manager.i18n import ungettext, ugettext as _
@@ -204,8 +203,6 @@ class SubscriptionManager(dnf.Plugin):
         Either output a warning, or a usage message
         """
         msg = ""
-        if ClassicCheck().is_registered_with_classic():
-            return
         try:
             identity = inj.require(inj.IDENTITY)
             ent_dir = inj.require(inj.ENT_DIR)

--- a/src/rhsmlib/facts/hwprobe.py
+++ b/src/rhsmlib/facts/hwprobe.py
@@ -32,17 +32,6 @@ from typing import Callable, Dict, Optional, List, TextIO, Tuple, Union
 log = logging.getLogger(__name__)
 
 
-class ClassicCheck:
-    def is_registered_with_classic(self) -> bool:
-        try:
-            sys.path.append("/usr/share/rhn")
-            from up2date_client import up2dateAuth
-        except ImportError:
-            return False
-
-        return up2dateAuth.getSystemId() is not None
-
-
 # take a string like '1-4' and returns a list of
 # ints like [1,2,3,4]
 # 31-37 return [31,32,33,34,35,36,37]

--- a/src/subscription_manager/branding/__init__.py
+++ b/src/subscription_manager/branding/__init__.py
@@ -75,15 +75,6 @@ class DefaultBranding:
     def __init__(self):
         self.CLI_REGISTER = _("Register the system to the server")
         self.CLI_UNREGISTER = _("Unregister the system from the server")
-        self.RHSMD_REGISTERED_TO_OTHER = _("This system is registered to spacewalk")
-        self.REGISTERED_TO_OTHER_WARNING = (
-            _("WARNING") + "\n" + _("You have already registered with spacewalk.")
-        )
-
-        self.GUI_REGISTRATION_HEADER = _("Please enter your account information:")
-        self.GUI_FORGOT_LOGIN_TIP = _(
-            "Contact your system administrator if you have forgotten your login or password"
-        )
         self.REGISTERED_TO_SUBSCRIPTION_MANAGEMENT_SUMMARY = _("Red Hat Subscription Management")
 
 

--- a/src/subscription_manager/branding/redhat_branding.py
+++ b/src/subscription_manager/branding/redhat_branding.py
@@ -9,36 +9,4 @@ class Branding:
         self.CLI_UNREGISTER = _(
             "Unregister this system from the Customer Portal or another subscription management service"
         )
-        self.RHSMD_REGISTERED_TO_OTHER = _("This system is registered to RHN Classic.")
-        self.REGISTERED_TO_OTHER_WARNING = (
-            _("WARNING")
-            + "\n\n"
-            + _("This system has already been registered with Red Hat using RHN Classic.")
-            + "\n\n"
-            + _(
-                "Your system is being registered again using Red Hat Subscription Management. "
-                "Red Hat recommends that customers only register once."
-            )
-            + "\n\n"
-            + _(
-                "To learn how to unregister from either service please consult "
-                "this Knowledge Base Article: https://access.redhat.com/kb/docs/DOC-45563"
-            )
-        )
-        self.REGISTERED_TO_OTHER_SUMMARY = _("RHN Classic")
         self.REGISTERED_TO_SUBSCRIPTION_MANAGEMENT_SUMMARY = _("Red Hat Subscription Management")
-        self.GUI_REGISTRATION_HEADER = _("Please enter your Red Hat account information:")
-        self.REGISTERED_TO_BOTH_WARNING = (
-            _("This system is registered using both RHN Classic and Red Hat Subscription Management.")
-            + "\n\n"
-            + _("Red Hat recommends that customers only register with one service.")
-            + "\n\n"
-            + _(
-                "To learn more about RHN registration and technologies please consult "
-                "this Knowledge Base Article: https://access.redhat.com/kb/docs/DOC-45563"
-            )
-        )
-        self.REGISTERED_TO_BOTH_SUMMARY = _("RHN Classic and Red Hat Subscription Management")
-        self.GUI_FORGOT_LOGIN_TIP = _(
-            "Tip: Forgot your login or password? Look it up at https://redhat.com/forgot_password"
-        )

--- a/src/subscription_manager/cli_command/identity.py
+++ b/src/subscription_manager/cli_command/identity.py
@@ -18,12 +18,8 @@ import logging
 import os
 
 import rhsm.connection as connection
-import subscription_manager.injection as inj
-
-from rhsmlib.facts.hwprobe import ClassicCheck
 
 from subscription_manager import managerlib
-from subscription_manager.branding import get_branding
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import handle_exception
 from subscription_manager.cli_command.environments import MULTI_ENV
@@ -63,18 +59,6 @@ class IdentityCommand(UserPassCommand):
             system_exit(os.EX_USAGE, _("--username and --password can only be used with --force"))
 
     def _do_command(self):
-        # get current consumer identity
-        identity = inj.require(inj.IDENTITY)
-
-        # check for Classic before doing anything else
-        if ClassicCheck().is_registered_with_classic():
-            if identity.is_valid():
-                print(_("server type: {type}").format(type=get_branding().REGISTERED_TO_BOTH_SUMMARY))
-            else:
-                # no need to continue if user is only registered to Classic
-                print(_("server type: {type}").format(type=get_branding().REGISTERED_TO_OTHER_SUMMARY))
-                return
-
         try:
             self._validate_options()
             consumerid = self.identity.uuid

--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -28,7 +28,6 @@ from rhsm.connection import RemoteServerException
 from rhsm.https import ssl
 from rhsm.utils import LiveStatusMessage
 
-from rhsmlib.facts.hwprobe import ClassicCheck
 from rhsmlib.services import unregister, register, exceptions
 
 from subscription_manager import identity
@@ -212,10 +211,6 @@ class RegisterCommand(UserPassCommand):
         """
 
         self.log_client_version()
-
-        # Always warn the user if registered to old RHN/Spacewalk
-        if ClassicCheck().is_registered_with_classic():
-            print(get_branding().REGISTERED_TO_OTHER_WARNING)
 
         self._validate_options()
 

--- a/src/subscription_manager/utils.py
+++ b/src/subscription_manager/utils.py
@@ -32,7 +32,6 @@ from rhsm.https import ssl
 
 from subscription_manager.branding import get_branding
 from subscription_manager.certdirectory import Path
-from rhsmlib.facts.hwprobe import ClassicCheck
 from subscription_manager import injection as inj
 
 # we moved quite a bit of code from this module to rhsm.
@@ -292,15 +291,8 @@ def get_server_versions(cp: "UEPConnection", exception_on_timeout: bool = False)
 
     identity = inj.require(inj.IDENTITY)
 
-    # check for Classic before doing anything else
-    if ClassicCheck().is_registered_with_classic():
-        if identity.is_valid():
-            server_type = get_branding().REGISTERED_TO_BOTH_SUMMARY
-        else:
-            server_type = get_branding().REGISTERED_TO_OTHER_SUMMARY
-    else:
-        if identity.is_valid():
-            server_type = get_branding().REGISTERED_TO_SUBSCRIPTION_MANAGEMENT_SUMMARY
+    if identity.is_valid():
+        server_type = get_branding().REGISTERED_TO_SUBSCRIPTION_MANAGEMENT_SUMMARY
 
     if cp:
         try:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -382,21 +382,8 @@ class TestGetServerVersions(fixture.SubManFixture):
         self.mock_get_resources.return_value = ["status"]
         self.addCleanup(self.mock_get_resources.stop)
 
-    @patch("subscription_manager.utils.ClassicCheck")
-    def test_get_server_versions_classic(self, MockClassicCheck):
-        self._inject_mock_invalid_consumer()
-        instance = MockClassicCheck.return_value
-        instance.is_registered_with_classic.return_value = True
-
-        sv = get_server_versions(None)
-        self.assertEqual(sv["server-type"], "RHN Classic")
-        self.assertEqual(sv["candlepin"], "Unknown")
-
     @patch("rhsm.connection.UEPConnection")
-    @patch("subscription_manager.utils.ClassicCheck")
-    def test_get_server_versions_cp_no_status(self, mock_classic, MockUep):
-        instance = mock_classic.return_value
-        instance.is_registered_with_classic.return_value = False
+    def test_get_server_versions_cp_no_status(self, MockUep):
         self._inject_mock_valid_consumer()
         MockUep.supports_resource.return_value = False
         sv = get_server_versions(MockUep)
@@ -404,10 +391,7 @@ class TestGetServerVersions(fixture.SubManFixture):
         self.assertEqual(sv["candlepin"], "Unknown")
 
     @patch("rhsm.connection.UEPConnection")
-    @patch("subscription_manager.utils.ClassicCheck")
-    def test_get_server_versions_cp_with_status(self, mock_classic, MockUep):
-        instance = mock_classic.return_value
-        instance.is_registered_with_classic.return_value = False
+    def test_get_server_versions_cp_with_status(self, MockUep):
         self._inject_mock_valid_consumer()
         MockUep.supports_resource.return_value = True
         MockUep.getStatus.return_value = {"version": "101", "release": "23423c", "rulesVersion": "6.1"}
@@ -417,10 +401,7 @@ class TestGetServerVersions(fixture.SubManFixture):
         self.assertEqual(sv["rules-version"], "6.1")
 
     @patch("rhsm.connection.UEPConnection")
-    @patch("subscription_manager.utils.ClassicCheck")
-    def test_get_server_versions_cp_with_status_no_rules_version(self, mock_classic, MockUep):
-        instance = mock_classic.return_value
-        instance.is_registered_with_classic.return_value = False
+    def test_get_server_versions_cp_with_status_no_rules_version(self, MockUep):
         self._inject_mock_valid_consumer()
         MockUep.supports_resource.return_value = True
         MockUep.getStatus.return_value = {"version": "101", "release": "23423c"}
@@ -430,10 +411,7 @@ class TestGetServerVersions(fixture.SubManFixture):
         self.assertEqual(sv["rules-version"], "Unknown")
 
     @patch("rhsm.connection.UEPConnection")
-    @patch("subscription_manager.utils.ClassicCheck")
-    def test_get_server_versions_cp_with_status_no_keys(self, mock_classic, MockUep):
-        instance = mock_classic.return_value
-        instance.is_registered_with_classic.return_value = False
+    def test_get_server_versions_cp_with_status_no_keys(self, MockUep):
         self._inject_mock_valid_consumer()
         MockUep.supports_resource.return_value = True
         MockUep.getStatus.return_value = {}
@@ -443,10 +421,7 @@ class TestGetServerVersions(fixture.SubManFixture):
         self.assertEqual(sv["rules-version"], "Unknown")
 
     @patch("rhsm.connection.UEPConnection")
-    @patch("subscription_manager.utils.ClassicCheck")
-    def test_get_server_versions_cp_with_status_bad_data(self, mock_classic, MockUep):
-        instance = mock_classic.return_value
-        instance.is_registered_with_classic.return_value = False
+    def test_get_server_versions_cp_with_status_bad_data(self, MockUep):
         self._inject_mock_valid_consumer()
         MockUep.supports_resource.return_value = True
 
@@ -469,46 +444,15 @@ class TestGetServerVersions(fixture.SubManFixture):
             self.assertEqual(sv["rules-version"], "Unknown")
 
     @patch("rhsm.connection.UEPConnection")
-    @patch("subscription_manager.utils.ClassicCheck")
-    def test_get_server_versions_cp_with_status_and_classic(self, mock_classic, MockUep):
-        instance = mock_classic.return_value
-        instance.is_registered_with_classic.return_value = True
-        self._inject_mock_valid_consumer()
-        MockUep.supports_resource.return_value = True
-        MockUep.getStatus.return_value = {"version": "101", "release": "23423c", "rulesVersion": "6.1"}
-        sv = get_server_versions(MockUep)
-        self.assertEqual(sv["server-type"], "RHN Classic and Red Hat Subscription Management")
-        self.assertEqual(sv["candlepin"], "101-23423c")
-        self.assertEqual(sv["rules-version"], "6.1")
-
-    @patch("rhsm.connection.UEPConnection")
-    @patch("subscription_manager.utils.ClassicCheck")
-    def test_get_server_versions_cp_exception(self, mock_classic, MockUep):
+    def test_get_server_versions_cp_exception(self, MockUep):
         def raise_exception(arg):
             raise Exception("boom")
 
-        instance = mock_classic.return_value
-        instance.is_registered_with_classic.return_value = False
         self._inject_mock_valid_consumer()
         self.mock_get_resources.side_effect = raise_exception
         MockUep.getStatus.return_value = {"version": "101", "release": "23423c"}
         sv = get_server_versions(MockUep)
         self.assertEqual(sv["server-type"], "Red Hat Subscription Management")
-        self.assertEqual(sv["candlepin"], "Unknown")
-
-    @patch("rhsm.connection.UEPConnection")
-    @patch("subscription_manager.utils.ClassicCheck")
-    def test_get_server_versions_cp_exception_and_classic(self, mock_classic, MockUep):
-        def raise_exception(arg):
-            raise Exception("boom")
-
-        instance = mock_classic.return_value
-        instance.is_registered_with_classic.return_value = True
-        self._inject_mock_invalid_consumer()
-        self.mock_get_resources.side_effect = raise_exception
-        MockUep.getStatus.return_value = {"version": "101", "release": "23423c"}
-        sv = get_server_versions(MockUep)
-        self.assertEqual(sv["server-type"], "RHN Classic")
         self.assertEqual(sv["candlepin"], "Unknown")
 
 


### PR DESCRIPTION
Satellite 5 is EOL for some years now, so there is no more need to ensure that systems to be registered to RHSM/Candlepin are not also registered to Satellite 5.

As result, also drop branding strings that are no more needed.