### PR TITLE
ci: tweak the dependabot config for branches a bit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     target-branch: "subscription-manager-1.30.6"
     commit-message:
       prefix: "ci"
@@ -19,7 +19,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     target-branch: "subscription-manager-1.29"
     commit-message:
       prefix: "ci"
@@ -27,7 +27,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     target-branch: "subscription-manager-1.29.45"
     commit-message:
       prefix: "ci"
@@ -35,7 +35,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     target-branch: "subscription-manager-1.29.40"
     commit-message:
       prefix: "ci"
@@ -43,7 +43,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     target-branch: "subscription-manager-1.29.33"
     commit-message:
       prefix: "ci"
@@ -51,7 +51,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     target-branch: "subscription-manager-1.29.26"
     commit-message:
       prefix: "ci"
@@ -59,7 +59,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     target-branch: "subscription-manager-1.28"
     commit-message:
       prefix: "ci"
@@ -67,7 +67,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     target-branch: "subscription-manager-1.28.36"
     commit-message:
       prefix: "ci"
@@ -75,7 +75,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     target-branch: "subscription-manager-1.28.29"
     commit-message:
       prefix: "ci"
@@ -83,7 +83,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     target-branch: "subscription-manager-1.28.13"
     commit-message:
       prefix: "ci"
@@ -91,15 +91,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     target-branch: "subscription-manager-1.26"
-    commit-message:
-      prefix: "ci"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: "subscription-manager-1.24"
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
- drop the 1.24 branch for now: changes in the hosted GitHub runners [1][2][3] make it hard to test that branch based on EL 7
- demote the update frequency for branches different than "main" to monthly rather than weekly, as there is no rush to switch all of them to newer versions of actions

[1] https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
[2] https://github.com/actions/checkout/issues/1809
[3] https://github.com/actions/runner/pull/3503