### PR TITLE
[10.0] fix: Handle improperly closed connections

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -677,12 +677,15 @@ class BaseRestLib:
                 log.debug(f"Closing HTTPS connection {self.__conn.sock}")
                 try:
                     self.__conn.sock.unwrap()
-                except ssl.SSLError as err:
-                    log.debug(f"Unable to close TLS connection properly: {err}")
+                except Exception as err:
+                    log.debug(f"Unable to close TLS connection: {err}")
                 else:
                     log.debug("TLS connection closed")
             # Then it is possible to close TCP connection
-            self.__conn.close()
+            try:
+                self.__conn.close()
+            except Exception as err:
+                log.info(f"Unable to close TCP connection: {err}")
         self.__conn = None
 
     def _get_cert_key_list(self) -> List[Tuple[str, str]]:


### PR DESCRIPTION
* Card ID: CCT-1261
* Card ID: RHEL-85108

Sometimes, the TLS connection wouldn't get closed properly (various implementations of various TLS versions handle things differently), and the socket unwrap would raise BrokenPipeError.

This patch ensures that all exceptions raised by TLS are logged and ignored -- we're closing the connection, there's no harm in pretending the issue didn't happen.

At the same time, we're wrapping the TLS connection close() in try/except as well. While we haven't seen anything that would suggest this code is faulty as well, it's better to be safe, and log that something unexpected happened.

(cherry picked from commit 82671638a86894098fe584192cbe2b196518bff4)