### PR TITLE
Fix upload profile if rhsmcertd is not running at all

### DIFF
--- a/src/plugins/dnf/subscription_manager.py
+++ b/src/plugins/dnf/subscription_manager.py
@@ -275,6 +275,7 @@ class SubscriptionManager(dnf.Plugin):
                 rhsmcertd_pid = int(lock_file.readline())
         except (IOError, ValueError) as err:
             log.info(f"Unable to read rhsmcertd lock file: {err}")
+            self._upload_profile_blocking()
         else:
             if is_process_running("rhsmcertd", rhsmcertd_pid) is True:
                 # This will only send SIGUSR1 signal, which triggers gathering and uploading


### PR DESCRIPTION
In case the rhsmcertd doesn't run or the rhsmcertd lock file can not be opened, use the integrated upload_profile_blocking() method to send the profile to the server.

We saw this during host provisioning with foreman/katello. At this time, no rhsmcertd may run and therefore the initial upload fail. This can happen in scenarios, if there is no rhsmcertd used. 

## Summary by Sourcery

Ensure DNF subscription profiles are uploaded directly if rhsmcertd is unavailable or its lock file cannot be read

Bug Fixes:
- Fallback to blocking upload when the rhsmcertd lock file is unreadable or the daemon process isn't running

Enhancements:
- Only send SIGUSR1 to rhsmcertd if the process is confirmed running
- Add logging for missing lock file and non-running rhsmcertd scenarios