### PR TITLE
All debian/ubuntu systems supports arch 'all' pkgs

### DIFF
--- a/src/rhsmlib/facts/pkg_arches.py
+++ b/src/rhsmlib/facts/pkg_arches.py
@@ -60,6 +60,9 @@ class SupportedArchesCollector(collector.FactsCollector):
         except Exception as e:
             log.error("Error getting dpkg foreign architecture: %s", e)
 
+        # All debian systems supports no-architecture packages (= 'all'), too
+        arches.append("all")
+
         return {"supported_architectures": ",".join(arches)}
 
     def get_all(self) -> Dict[str, str]:


### PR DESCRIPTION
Arch 'all' is noarch in debian/ubuntu. In case users want to do limit for repository only supported arch 'all', this information need to be send to candlepin as fact.

## Summary by Sourcery

Enhancements:
- Include 'all' as a supported package architecture for Debian/Ubuntu systems