### PR TITLE
Skip to load default plugins on suse/sles

### DIFF
--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -182,7 +182,15 @@ class YumPluginManager:
 
         dist_info = HardwareCollector().get_distribution()
 
-        if dist_info[4] == "debian" or "debian" in dist_info[5]:
+        dist_id = dist_info[4]
+        dist_id_like = dist_info[5]
+
+        # If the system is Debian/SUSE based, do not enable yum plugins
+        if (
+            dist_id == "debian" or "debian" in dist_id_like or
+            dist_id == "sles" or "suse" in dist_id_like
+        ):
+            log.debug("The system is Debian/SUSE based. Skipping the enablement of yum plugins.")
             return []
 
         log.debug("The rhsm.auto_enable_yum_plugins is enabled")

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -1432,6 +1432,28 @@ class TestYumPluginManager(unittest.TestCase):
         plugin_list = YumPluginManager.enable_pkg_plugins()
         self.assertEqual(len(plugin_list), 0)
 
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "sles", []),
+    )
+    def test_enable_pkg_plugins_sles(self, mock_get_distribution):
+        """
+        Test not enabling of yum plugins on sles based systems (Test 1 of 2)
+        """
+        plugin_list = YumPluginManager.enable_pkg_plugins()
+        self.assertEqual(len(plugin_list), 0)
+
+    @patch(
+        "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",
+        return_value=("", "", "", "", "", ["suse"]),
+    )
+    def test_enable_pkg_plugins_suse_like(self, mock_get_distribution):
+        """
+        Test not enabling of yum plugins on suse based systems (Test 2 of 2)
+        """
+        plugin_list = YumPluginManager.enable_pkg_plugins()
+        self.assertEqual(len(plugin_list), 0)
+
     @patch.object(repolib, "conf", ConfigFromString(config_string=AUTO_ENABLE_PKG_PLUGINS_ENABLED))
     @patch(
         "rhsmlib.facts.hwprobe.HardwareCollector.get_distribution",


### PR DESCRIPTION
## Summary by Sourcery

Skip automatic enabling of yum plugins on SUSE/SLES systems in enable_pkg_plugins and cover the behavior with new unit tests

Bug Fixes:
- Prevent yum plugins from being enabled by default on SUSE/SLES systems

Enhancements:
- Extend yum plugin skip logic to include SLES and SUSE distributions alongside Debian

Tests:
- Add tests to verify yum plugins remain disabled on SLES and SUSE based systems