### PR TITLE
feat: Better control over auto-reg waiting game

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -95,8 +95,10 @@ disable = 0
 # Setting this option makes sense only on machines running on public
 # clouds. Currently only AWS, Azure and GCP are supported
 auto_registration = 0
-# Interval to run auto-registration (in minutes):
-auto_registration_interval = 60
+# Interval to run auto-registration (in minutes or using HH:MM:SS format)
+auto_registration_interval = 1
+# Interval to get consumer identity (in minutes or using HH:MM:SS format)
+auto_registration_identity_interval = 1
 
 [logging]
 default_log_level = INFO

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -259,7 +259,12 @@ Set to 1 to enable automatic registration. Automatic registration can only work 
 .PP
 auto_registration_interval
 .RS 4
-The number of minutes between attempts to run auto\-registration on this system
+The time used for input for randomizing splay of auto\-registration. The value can use two formats. First format is HH:MM:SS. Second format is number meaning minutes. Default value is 1 minute.
+.RE
+.PP
+auto_registration_identity_interval
+.RS 4
+The time used for input for randomizing splay of gathering identity from entitlement server. Default value is 60 minutes.
 .SH "[LOGGING] OPTIONS"
 .PP
 default_log_level

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -85,7 +85,8 @@ RHSMCERTD_DEFAULTS = {
     "splay": "1",
     "disable": "0",
     "auto_registration": "0",
-    "auto_registration_interval": "60",
+    "auto_registration_interval": "1",
+    "auto_registration_identity_interval": "60",
 }
 
 LOGGING_DEFAULTS = {

--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -17,6 +17,7 @@ import random
 import signal
 import sys
 import time
+import datetime
 from argparse import SUPPRESS
 from typing import Dict, List, Union, TYPE_CHECKING
 
@@ -159,9 +160,50 @@ def _collect_cloud_info(cloud_list: List[str]) -> dict:
 
     return result
 
+def _auto_register_identity_wait() -> None:
+    """
+    Delay during the automatic registration between obtaining anonymous entitlement
+    ang getting proper consumer identity certificate.
+
+    We use different configuration option for this splay, because getting proper
+    identity certificate is not so urgent.
+    """
+    cfg = config.get_config_parser()
+    if cfg.get("rhsmcertd", "splay") == "0":
+        log.debug("Trying to obtain the identity immediately, splay is disabled.")
+    else:
+        splay_interval: int = 0
+        autoreg_interval = cfg.get("rhsmcertd", "auto_registration_identity_interval")
+
+        try:
+            # First try to parse interval as an integer representing minutes (backward compatibility)
+            registration_interval_minutes: int = int(autoreg_interval)
+        except ValueError:
+            try:
+                # Second try to parse it as a time: hours:minutes:seconds
+                t = time.strptime(autoreg_interval, "%H:%M:%S")
+            except ValueError:
+                log.error(f"Invalid autoregistration identity interval: {autoreg_interval}")
+            else:
+                delta = datetime.timedelta(hours=t.tm_hour, minutes=t.tm_min, seconds=t.tm_sec)
+                registration_interval_seconds = int(delta.total_seconds())
+                log.debug(f"Autoregistration identity interval: {autoreg_interval} "
+                          f"parsed as time delta: {registration_interval_seconds} [seconds]")
+                splay_interval = random.randint(0, registration_interval_seconds)
+        else:
+            log.debug(f"Autoregistration identity interval: {autoreg_interval} parsed as minutes")
+            splay_interval = random.randint(0, registration_interval_minutes * 60)
+
+        log.debug(
+            f"Waiting a period of {splay_interval} seconds "
+            f"(about {splay_interval // 60} minutes) before attempting to obtain the "
+            "non-anonymous identity."
+        )
+        time.sleep(splay_interval)
 
 def _auto_register_wait() -> None:
-    """Delay during the automatic registration.
+    """
+    Delay during the automatic registration.
 
     Wait for an amount of time during automatic registration, looking at the
     configured splay and autoregistration interval.
@@ -170,8 +212,28 @@ def _auto_register_wait() -> None:
     if cfg.get("rhsmcertd", "splay") == "0":
         log.debug("Trying to obtain the identity immediately, splay is disabled.")
     else:
-        registration_interval = int(cfg.get("rhsmcertd", "auto_registration_interval"))
-        splay_interval: int = random.randint(60, registration_interval * 60)
+        splay_interval: int = 0
+        autoreg_interval = cfg.get("rhsmcertd", "auto_registration_interval")
+
+        try:
+            # First try to parse interval as an integer representing minutes (backward compatibility)
+            registration_interval_minutes: int = int(autoreg_interval)
+        except ValueError:
+            try:
+                # Second try to parse it as a time: hours:minutes:seconds
+                t = time.strptime(autoreg_interval, "%H:%M:%S")
+            except ValueError:
+                log.error(f"Invalid autoregistration interval: {autoreg_interval}")
+            else:
+                delta = datetime.timedelta(hours=t.tm_hour, minutes=t.tm_min, seconds=t.tm_sec)
+                registration_interval_seconds = int(delta.total_seconds())
+                log.debug(f"Autoregistration interval: {autoreg_interval} "
+                          f"parsed as time delta: {registration_interval_seconds} [seconds]")
+                splay_interval = random.randint(0, registration_interval_seconds)
+        else:
+            log.debug(f"Autoregistration interval: {autoreg_interval} parsed as minutes")
+            splay_interval = random.randint(0, registration_interval_minutes * 60)
+
         log.debug(
             f"Waiting a period of {splay_interval} seconds "
             f"(about {splay_interval // 60} minutes) before attempting to obtain the identity."
@@ -208,7 +270,11 @@ def _auto_register(cp_provider: "CPProvider") -> ExitStatus:
     # Get connection not using any authentication
     uep: UEPConnection = cp_provider.get_no_auth_cp()
 
-    # Obtain automatic registration token
+    # Wait random time interval before getting token from candlepin server
+    _auto_register_wait()
+
+    # Try to obtain automatic registration token. It can be gathered from cache, but
+    # when cache does not exist (very likely), then try to get it from candlepin server
     try:
         token: Dict[str, str] = cache.CloudTokenCache.get(
             uep=uep,
@@ -254,8 +320,6 @@ def _auto_register_standard(uep: "UEPConnection", token: Dict[str, str]) -> None
     """
     log.debug("Registering the system through standard automatic registration.")
 
-    _auto_register_wait()
-
     service = RegisterService(cp=uep)
     service.register(org=None, jwt_token=token["token"])
 
@@ -280,8 +344,11 @@ def _auto_register_anonymous(uep: "UEPConnection", token: Dict[str, str]) -> Non
     manager = entcertlib.AnonymousCertificateManager(uep=uep)
     manager.install_temporary_certificates(uuid=token["anonymousConsumerUuid"], jwt=token["token"])
 
-    # Step 2: Wait
-    _auto_register_wait()
+    # Step 2: Wait random time again. The interval is random again (not the same as
+    # interval for waiting before obtaining "anonymous token"). We typically wait here
+    # almost one hour. Getting consumer certificate is not so urgent, because customer
+    # has access to content using temporary entitlement certificate ATM
+    _auto_register_identity_wait()
 
     # Step 3: Obtain the identity certificate
     log.debug("Obtaining system identity")


### PR DESCRIPTION
* Card ID: 1386
* We need better control how rhsmcertd waits during auto-reg. When we try to get token, then we need to splay the requests using seconds. The rhsmcertd can wait here max one minute. When temporary entitlement certificate is installed, then we can wait about one hour before we try to get consumer certificate, because customer has access to content via temporary entitlement certificate. To control this flow we cannot use only existing configuration option auto_registration_interval.
* The existing auto_registration_interval is used for splaying obtaining token and it is possible to set interval using second precision. The default value is one minute now.
* The format of auto_registration_interval is string that was converted to integer. The meaning of this integer was number of minutes and this values was used as an input for method `random.randint(60, 60 * int(auto_registration_interval)).
* It is possible now to set this value also using HH:MM:SS format. It gives use more freedom and it allows us to set the value in seconds.
* Added new option auto_registration_identity_interval that is used for splaying of getting consumer certificate after temporary entitlement certificate is installed. The default value is 60 minutes
* Updated template of rhsm.conf
* Updated documentation (man page or rhsm.conf)