### PR TITLE
chore: Removed dead code of rhsmcertd binary

### DIFF
--- a/etc-conf/rhsmcertd.completion.sh
+++ b/etc-conf/rhsmcertd.completion.sh
@@ -11,7 +11,7 @@ _rhsmcertd()
 	first="${COMP_WORDS[1]}"
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	opts="-h --help -c --cert-check-interval -d --debug -n --now -s --no-splay -a --auto-registration -r --auto-registration-interval"
+	opts="-h --help -c --cert-check-interval -d --debug -n --now -s --no-splay -a --auto-registration"
 
 	case "${cur}" in
 		-*)

--- a/man/rhsmcertd.8
+++ b/man/rhsmcertd.8
@@ -60,9 +60,9 @@ file are used (unless the argument is passed again).
 
 .TP
 .B -r, --auto-registration-interval=MINUTES
-Resets the interval for automatic registration. This value is in minutes. The default is 60, or 1 hour. This interval is in effect until the daemon restarts, and then the values in the
+This CLI option is no-op and is deprecated. The auto-registration interval is read only from
 .B /etc/rhsm/rhsm.conf
-file are used (unless the argument is passed again).
+file.
 
 .TP
 .B -s, --no-splay


### PR DESCRIPTION
* Card ID: CCT-1420
* When `rhsmcertd` binary was started with `--auto-registration-interval` CLI option, then the value of interval was ignored. The old logic of waiting was not used. The file `/run/rhsm/next_auto_register_update` was useless.
* This commit does not change behavior (much). When the CLI option `--auto-registration-interval` is used, then it is still ignored, but we print warning messages that this CLI option is no-op and deprecated
* Note: We also introduced another interval in: #3575 and changed manner of existing auto-registration interval.
* Manual page of rhsmcertd is updated
* Removed `-r` and `--auto-registration-interval` CLI option from bash completion script