### PR TITLE
blackified repolib.py

### DIFF
--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -186,10 +186,7 @@ class YumPluginManager:
         dist_id_like = dist_info[5]
 
         # If the system is Debian/SUSE based, do not enable yum plugins
-        if (
-            dist_id == "debian" or "debian" in dist_id_like or
-            dist_id == "sles" or "suse" in dist_id_like
-        ):
+        if dist_id == "debian" or "debian" in dist_id_like or dist_id == "sles" or "suse" in dist_id_like:
             log.debug("The system is Debian/SUSE based. Skipping the enablement of yum plugins.")
             return []
 


### PR DESCRIPTION
Card-ID: CCT-1490

black & flake8 & rmpbuild ci check fails.
I've run black manually and commit the changes to this PR.

It should make the check be happy.