### PR TITLE
feat: [1.29] Added dnf4 warning about skewed clock

### DIFF
--- a/src/plugins/dnf/subscription_manager.py
+++ b/src/plugins/dnf/subscription_manager.py
@@ -16,6 +16,7 @@ import os
 import logging
 import shutil
 import signal
+import datetime
 
 from subscription_manager import injection as inj
 from subscription_manager.repolib import RepoActionInvoker
@@ -27,7 +28,7 @@ from subscription_manager.i18n import ungettext, ugettext as _
 from rhsm import logutil
 from rhsm import config
 from rhsm.utils import LiveStatusMessage
-from rhsm.connection import RemoteServerException
+from rhsm.connection import RemoteServerException, BaseRestLib
 
 from dnfpluginscore import logger
 import dnf
@@ -79,6 +80,13 @@ This system has release set to {release_version} and it receives updates only fo
 """
 )
 
+skew_clock_warning = _(
+    """
+The system clock is skewed. There is a time difference of {time_drift} seconds with the entitlement server. \
+Please check your clock settings to ensure access to all entitled content.
+"""
+)
+
 log = logging.getLogger("rhsm-app." + __name__)
 
 
@@ -111,6 +119,7 @@ class SubscriptionManager(dnf.Plugin):
             else:
                 logger.info(_("Not root, Subscription Management repositories not updated"))
             self._warn_expired()
+            self._warn_skew_clock()
         except Exception as e:
             log.error(str(e))
 
@@ -182,6 +191,20 @@ class SubscriptionManager(dnf.Plugin):
         log.debug("Generating redhat.repo")
         repo_action_invoker = RepoActionInvoker(cache_only=cache_only)
         repo_action_invoker.update()
+
+    @staticmethod
+    def _warn_skew_clock():
+        """
+        Display warning, when the time drift between host and candlepin server
+        is too big, and it could cause issue with accessing content on CDN or Pulp.
+        """
+        time_drift: datetime.timedelta = BaseRestLib.get_time_drift()
+        if time_drift is None:
+            return
+        elif time_drift > datetime.timedelta(seconds=2):
+            time_drift_seconds = time_drift.total_seconds()
+            msg = skew_clock_warning.format(time_drift=time_drift_seconds)
+            logger.info(msg)
 
     @staticmethod
     def _warn_expired():


### PR DESCRIPTION
* Card ID: CCT-1424
* Backport to 1.29 branch (RHEL 9)
  * Original PR: 3567
  * Original commit: 4a9f7a55006548e1930ad156b11a3f0a3f89deb3
* When the time drift between server and client is bigger then two seconds, then subscription-manager dnf plugin prints warning message about this issue.
* The latest time drift is stored in BaseRestLib class to be easily accessible using class method get_time_drift()
* Decreased thresholds for printing warning (15 minutes) and debug (2 seconds) messages to rhsm.log for each REST API call