### PR TITLE
fix: [1.29] Require findutils in .spec file

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -136,6 +136,7 @@ Requires:  %{py_package_prefix}-decorator
 Requires:  virt-what
 Requires:  %{rhsm_package_name} = %{version}
 Requires: subscription-manager-rhsm-certificates
+Requires(post): findutils
 %ifarch %{dmidecode_arches}
 Requires: dmidecode
 %endif
@@ -187,6 +188,7 @@ BuildRequires: gcc
 BuildRequires: %{py_package_prefix}-setuptools
 BuildRequires: gettext
 BuildRequires: glib2-devel
+BuildRequires: findutils
 
 %if 0%{?suse_version}
 BuildRequires: distribution-release


### PR DESCRIPTION
* Card ID: CCT-1635
* Backport to 1.29 branch (RHEL9)
  * Original PR: #3610
  * Original commit: a640252029de1e5e8e73e97bd8b82d1e010ee047
* Require findutils in .spec file to be able to install subscription-manager on UBI images
* The findutils RPM is required using Requires(post) to be available in %post section, because `find` and `xargs` are used in this section
* The `findutils` is also required for the build, because it is used in %install section