### PR TITLE
fix: Do not send JSON document with empty signature

### DIFF
--- a/src/cloud_what/_base_provider.py
+++ b/src/cloud_what/_base_provider.py
@@ -83,6 +83,9 @@ class BaseCloudProvider:
     # (e.g. /var/lib/cloud-what/cache/cool_cloud_signature.json)
     SIGNATURE_CACHE_FILE = None
 
+    # Is a signature of metadata for the given cloud provider required?
+    SIGNATURE_REQUIRED = True
+
     # Custom HTTP headers like user-agent
     HTTP_HEADERS = {}
 
@@ -483,6 +486,12 @@ class BaseCloudProvider:
             return signature
 
         return self._get_signature_from_server()
+
+    def is_signature_required(self):
+        """
+        Return True, when signature of metadata is required for given cloud provider
+        """
+        return self.SIGNATURE_REQUIRED
 
     def get_metadata(self) -> Union[str, None]:
         """

--- a/src/cloud_what/providers/gcp.py
+++ b/src/cloud_what/providers/gcp.py
@@ -85,6 +85,10 @@ class GCPCloudProvider(BaseCloudProvider):
     # Nothing to cache for this cloud provider
     SIGNATURE_CACHE_FILE = None
 
+    # GCP does not have a special file for signature of metadata.
+    # Metadata and signature are provided in one JWT file
+    SIGNATURE_REQUIRED = False
+
     def __init__(self, hw_info, audience_url=None):
         """
         Initialize instance of GCPCloudDetector

--- a/src/subscription_manager/scripts/rhsmcertd_worker.py
+++ b/src/subscription_manager/scripts/rhsmcertd_worker.py
@@ -154,8 +154,9 @@ def _collect_cloud_info(cloud_list: List[str]) -> dict:
         # When it is not possible to get signature for given cloud provider,
         # then silently set signature to empty string, because some cloud
         # providers does not provide signatures
-        if signature is None:
-            signature = ""
+        if cloud_provider.is_signature_required() and signature is None:
+            log.error(f"No signature gathered for cloud provider: {cloud_provider_id}")
+            continue
 
         log.info(f"Metadata and signature gathered for cloud provider: {cloud_provider_id}")
 


### PR DESCRIPTION
* Card ID: CCT-1655
* When signature is required by given cloud provider, then do not send JSON document to candlepin with empty signature string