### PR TITLE
fix: [1.30.10] Require findutils in .spec file

### DIFF
--- a/subscription-manager.spec
+++ b/subscription-manager.spec
@@ -124,6 +124,7 @@ Requires:  python3-decorator
 Requires:  virt-what
 Requires:  python3-subscription-manager-rhsm = %{version}-%{release}
 Requires: subscription-manager-rhsm-certificates
+Requires(post): findutils
 %ifarch %{dmidecode_arches}
 Requires: dmidecode
 %endif
@@ -178,6 +179,7 @@ BuildRequires: gcc
 BuildRequires: python3-setuptools
 BuildRequires: gettext
 BuildRequires: glib2-devel
+BuildRequires: findutils
 
 %if 0%{?suse_version}
 BuildRequires: distribution-release


### PR DESCRIPTION
* Card ID: CCT-1635
* Backport to RHEL-10.1
  * Original PR: #3610
  - Original commit: a640252029de1e5e8e73e97bd8b82d1e010ee047
* Require findutils in .spec file to be able to install subscription-manager on UBI images
* The findutils RPM is required using Requires(post) to be available in %post section, because `find` and `xargs` are used in this section
* The `findutils` is also required for the build, because it is used in %install section