### PR TITLE
feat: added package persistence info in packages profile

### DIFF
--- a/test/rhsm/functional/test_profile.py
+++ b/test/rhsm/functional/test_profile.py
@@ -38,6 +38,7 @@ class ProfileTests(unittest.TestCase):
             self.assertTrue("epoch" in pkg)
             self.assertTrue("arch" in pkg)
             self.assertTrue("vendor" in pkg)
+            self.assertTrue("persistence" in pkg)
 
     def test_package_objects(self):
         profile = get_profile("rpm")
@@ -49,8 +50,8 @@ class ProfileTests(unittest.TestCase):
 
     def test_load_profile_from_file(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
         self.assertEqual(2, len(profile.packages))
@@ -72,16 +73,16 @@ class ProfileTests(unittest.TestCase):
 
     def test_equality_different_object_type(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
         self.assertFalse(profile == "hello")
 
     def test_equality_no_change(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
 
@@ -90,19 +91,21 @@ class ProfileTests(unittest.TestCase):
 
     def test_equality_packages_added(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
 
-        dummy_pkgs.append(Package(name="package3", version="3.0.0", release="2", arch="x86_64"))
+        dummy_pkgs.append(
+            Package(name="package3", version="3.0.0", release="2", arch="x86_64", persistence="persistent")
+        )
         other = self._mock_pkg_profile(dummy_pkgs)
         self.assertFalse(profile == other)
 
     def test_equality_packages_removed(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
 
@@ -112,8 +115,8 @@ class ProfileTests(unittest.TestCase):
 
     def test_equality_packages_updated(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
 
@@ -124,13 +127,15 @@ class ProfileTests(unittest.TestCase):
 
     def test_equality_packages_replaced(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
 
         # Remove package2, add package3:
         dummy_pkgs.pop()
-        dummy_pkgs.append(Package(name="package3", version="3.0.0", release="2", arch="x86_64"))
+        dummy_pkgs.append(
+            Package(name="package3", version="3.0.0", release="2", arch="x86_64", persistence="persistent")
+        )
         other = self._mock_pkg_profile(dummy_pkgs)
         self.assertFalse(profile == other)

--- a/test/rhsm/unit/test_profile.py
+++ b/test/rhsm/unit/test_profile.py
@@ -17,7 +17,13 @@ from unittest.mock import patch
 
 from cloud_what.providers import aws, azure, gcp
 
-from rhsm.profile import ModulesProfile, EnabledReposProfile
+from rhsm.profile import (
+    ModulesProfile,
+    EnabledReposProfile,
+    parse_rpm_string,
+    _is_ostree_system,
+    _get_immutable_packages,
+)
 
 
 class TestModulesProfile(unittest.TestCase):
@@ -225,3 +231,172 @@ class TestEnabledReposProfile(unittest.TestCase):
             self.assertEqual(
                 repo_list[0]["baseurl"], ["http://cdn.foo.com/content/dist/snakes/1.0/x86_64/os"]
             )
+
+
+class TestParseRpmString(unittest.TestCase):
+    """
+    Test case for parse_rpm_string function
+    """
+
+    def test_parse_valid_rpm_string_with_epoch(self):
+        """
+        Test parsing a valid RPM string with epoch
+        """
+        rpm_string = "NetworkManager-cloud-setup-1:1.54.0-2.fc43.x86_64"
+        result = parse_rpm_string(rpm_string)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["name"], "NetworkManager-cloud-setup")
+        self.assertEqual(result["ver"], "1:1.54.0")
+        self.assertEqual(result["rel"], "2.fc43")
+        self.assertEqual(result["arch"], "x86_64")
+
+    def test_parse_valid_rpm_string_without_epoch(self):
+        """
+        Test parsing a valid RPM string without epoch
+        """
+        rpm_string = "bash-completion-2.16-2.fc43.noarch"
+        result = parse_rpm_string(rpm_string)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["name"], "bash-completion")
+        self.assertEqual(result["ver"], "2.16")
+        self.assertEqual(result["rel"], "2.fc43")
+        self.assertEqual(result["arch"], "noarch")
+
+    def test_parse_rpm_string_with_hyphens_in_name(self):
+        """
+        Test parsing RPM string where package name contains multiple hyphens
+        """
+        rpm_string = "amd-ucode-firmware-20241210-164.fc42.noarch"
+        result = parse_rpm_string(rpm_string)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["name"], "amd-ucode-firmware")
+        self.assertEqual(result["ver"], "20241210")
+        self.assertEqual(result["rel"], "164.fc42")
+        self.assertEqual(result["arch"], "noarch")
+
+    def test_parse_rpm_string_with_leading_whitespace(self):
+        """
+        Test parsing RPM string with leading whitespace
+        """
+        rpm_string = "  bash-5.2.32-1.fc42.x86_64"
+        result = parse_rpm_string(rpm_string)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["name"], "bash")
+        self.assertEqual(result["ver"], "5.2.32")
+        self.assertEqual(result["rel"], "1.fc42")
+        self.assertEqual(result["arch"], "x86_64")
+
+    def test_parse_invalid_rpm_string(self):
+        """
+        Test parsing an invalid RPM string returns None
+        """
+        rpm_string = "invalid-package-string"
+        result = parse_rpm_string(rpm_string)
+        self.assertIsNone(result)
+
+    def test_parse_empty_string(self):
+        """
+        Test parsing an empty string returns None
+        """
+        rpm_string = ""
+        result = parse_rpm_string(rpm_string)
+        self.assertIsNone(result)
+
+
+class TestOstreeSystemDetection(unittest.TestCase):
+    """
+    Test case for ostree system detection functions
+    """
+
+    @patch("rhsm.profile.ostree_available", False)
+    def test_is_ostree_system_without_ostree_library(self):
+        """
+        Test detection when ostree library is not available
+        """
+        result = _is_ostree_system()
+        self.assertFalse(result)
+
+    @patch("rhsm.profile.ostree_available", True)
+    @patch("rhsm.profile.OSTree", create=True)
+    def test_is_ostree_system_with_booted_deployment(self, mock_ostree):
+        """
+        Test detection when there is a booted ostree deployment
+        """
+        mock_sysroot = mock.Mock()
+        mock_sysroot.load = mock.Mock()
+        mock_sysroot.get_booted_deployment = mock.Mock(return_value=mock.Mock())
+
+        mock_ostree.Sysroot.new_default.return_value = mock_sysroot
+
+        result = _is_ostree_system()
+        self.assertTrue(result)
+        mock_sysroot.load.assert_called_once_with(None)
+        mock_sysroot.get_booted_deployment.assert_called_once()
+
+    @patch("rhsm.profile.ostree_available", True)
+    @patch("rhsm.profile.OSTree", create=True)
+    def test_is_ostree_system_without_booted_deployment(self, mock_ostree):
+        """
+        Test detection when there is no booted ostree deployment
+        """
+        mock_sysroot = mock.Mock()
+        mock_sysroot.load = mock.Mock()
+        mock_sysroot.get_booted_deployment = mock.Mock(return_value=None)
+        mock_ostree.Sysroot.new_default.return_value = mock_sysroot
+        result = _is_ostree_system()
+        self.assertFalse(result)
+
+    @patch("rhsm.profile.ostree_available", True)
+    @patch("rhsm.profile.OSTree", create=True)
+    def test_is_ostree_system_with_ostree_api_exception(self, mock_ostree):
+        """
+        Test detection when OSTree API raises an exception
+        """
+        mock_ostree.Sysroot.new_default.side_effect = Exception("OSTree API error")
+
+        result = _is_ostree_system()
+        self.assertFalse(result)
+
+    @patch("subprocess.run")
+    @patch("rhsm.profile.json.loads")
+    def test_get_immutable_packages(self, mock_json_loads, mock_subprocess_run):
+        """
+        Test getting immutable packages from ostree system
+        """
+        # Mock rpm-ostree status output
+        mock_status = {"deployments": [{"checksum": "abc123def456"}]}
+
+        # Mock rpm-ostree db list output
+        mock_db_list_output = """ostree commit: abc123def456
+bash-5.2.32-1.fc42.x86_64
+systemd-257.3-1.fc42.x86_64
+NetworkManager-1:1.54.0-2.fc43.x86_64"""
+
+        mock_subprocess_run.side_effect = [
+            mock.Mock(stdout='{"deployments": [{"checksum": "abc123def456"}]}', returncode=0),
+            mock.Mock(stdout=mock_db_list_output, returncode=0),
+        ]
+
+        mock_json_loads.return_value = mock_status
+
+        result = _get_immutable_packages()
+
+        self.assertIsInstance(result, set)
+        self.assertIn("bash", result)
+        self.assertIn("systemd", result)
+        self.assertIn("NetworkManager", result)
+        self.assertEqual(len(result), 3)
+
+    @patch("subprocess.run")
+    def test_get_immutable_packages_command_failure(self, mock_run):
+        """
+        Test handling of rpm-ostree command failure
+        """
+        from subprocess import CalledProcessError
+
+        mock_run.side_effect = CalledProcessError(1, "rpm-ostree")
+
+        result = _get_immutable_packages()
+
+        self.assertIsInstance(result, set)
+        self.assertEqual(len(result), 0)

--- a/test/rhsm/unit/test_profile.py
+++ b/test/rhsm/unit/test_profile.py
@@ -246,8 +246,9 @@ class TestParseRpmString(unittest.TestCase):
         result = parse_rpm_string(rpm_string)
         self.assertIsNotNone(result)
         self.assertEqual(result["name"], "NetworkManager-cloud-setup")
-        self.assertEqual(result["ver"], "1:1.54.0")
-        self.assertEqual(result["rel"], "2.fc43")
+        self.assertEqual(result["version"], "1.54.0")
+        self.assertEqual(result["epoch"], 1)
+        self.assertEqual(result["release"], "2.fc43")
         self.assertEqual(result["arch"], "x86_64")
 
     def test_parse_valid_rpm_string_without_epoch(self):
@@ -258,8 +259,9 @@ class TestParseRpmString(unittest.TestCase):
         result = parse_rpm_string(rpm_string)
         self.assertIsNotNone(result)
         self.assertEqual(result["name"], "bash-completion")
-        self.assertEqual(result["ver"], "2.16")
-        self.assertEqual(result["rel"], "2.fc43")
+        self.assertEqual(result["version"], "2.16")
+        self.assertEqual(result["epoch"], 0)
+        self.assertEqual(result["release"], "2.fc43")
         self.assertEqual(result["arch"], "noarch")
 
     def test_parse_rpm_string_with_hyphens_in_name(self):
@@ -270,8 +272,9 @@ class TestParseRpmString(unittest.TestCase):
         result = parse_rpm_string(rpm_string)
         self.assertIsNotNone(result)
         self.assertEqual(result["name"], "amd-ucode-firmware")
-        self.assertEqual(result["ver"], "20241210")
-        self.assertEqual(result["rel"], "164.fc42")
+        self.assertEqual(result["version"], "20241210")
+        self.assertEqual(result["epoch"], 0)
+        self.assertEqual(result["release"], "164.fc42")
         self.assertEqual(result["arch"], "noarch")
 
     def test_parse_rpm_string_with_leading_whitespace(self):
@@ -282,8 +285,9 @@ class TestParseRpmString(unittest.TestCase):
         result = parse_rpm_string(rpm_string)
         self.assertIsNotNone(result)
         self.assertEqual(result["name"], "bash")
-        self.assertEqual(result["ver"], "5.2.32")
-        self.assertEqual(result["rel"], "1.fc42")
+        self.assertEqual(result["version"], "5.2.32")
+        self.assertEqual(result["epoch"], 0)
+        self.assertEqual(result["release"], "1.fc42")
         self.assertEqual(result["arch"], "x86_64")
 
     def test_parse_invalid_rpm_string(self):
@@ -382,9 +386,10 @@ NetworkManager-1:1.54.0-2.fc43.x86_64"""
         result = _get_immutable_packages()
 
         self.assertIsInstance(result, set)
-        self.assertIn("bash", result)
-        self.assertIn("systemd", result)
-        self.assertIn("NetworkManager", result)
+        # Check that result contains tuples with (name, version, epoch, release)
+        self.assertIn(("bash", "5.2.32", 0, "1.fc42"), result)
+        self.assertIn(("systemd", "257.3", 0, "1.fc42"), result)
+        self.assertIn(("NetworkManager", "1.54.0", 1, "2.fc43"), result)
         self.assertEqual(len(result), 3)
 
     @patch("subprocess.run")


### PR DESCRIPTION
* Card ID: RHEL-108712

## Description

Hi team,

this PR introduces the tracking of persistence information for packages using `rpm-ostree` to check which packages are persistent or transient in a layered system.


## Testing

<details><summary>RHEL 10</summary>

This development has been tested in the following machine:

Testing machine:
```console
[vagrant@vm-rhel10 subscription-manager]$ cat /etc/os-release 
NAME="Red Hat Enterprise Linux"
VERSION="10.1 (Coughlan)"
ID="rhel"
ID_LIKE="centos fedora"
VERSION_ID="10.1"
PLATFORM_ID="platform:el10"
PRETTY_NAME="Red Hat Enterprise Linux 10.1 (Coughlan)"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:redhat:enterprise_linux:10.1"
HOME_URL="https://www.redhat.com/"
VENDOR_NAME="Red Hat"
VENDOR_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/10"
BUG_REPORT_URL="https://issues.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 10"
REDHAT_BUGZILLA_PRODUCT_VERSION=10.1
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="10.1"
```

In this type of system, all the packages are understood to be persistent since there are no layers of installed packages.

The following command is run to upload the packages profile:
```console
[vagrant@vm-rhel10 subscription-manager]$ sudo PYTHONPATH=./src python3 -m subscription_manager.scripts.package_profile_upload
```

Then the following information appears related to the persistence of the packages:
```console 
[vagrant@vm-rhel10 subscription-manager]$ sudo cat /var/lib/rhsm/cache/profile.json
...
{"name": "gcc", "version": "14.3.1", "release": "2.1.el10", "arch": "x86_64", "epoch": 0, "vendor": "Red Hat, Inc.", "persistence": "persistent"},
...
``` 

And as expected, no packages are shown as transient:
```console 
[vagrant@vm-rhel10 subscription-manager]$ sudo cat /var/lib/rhsm/cache/profile.json | grep transcient
[vagrant@vm-rhel10 subscription-manager]$ 
``` 

</details>

<details><summary>Fedora 43 CoreOS</summary>

To test this development

Testing machine:
```console
vagrant@fedora41:~$ cat /etc/os-release 
NAME="Fedora Linux"
VERSION="43.20251120.3.0 (CoreOS)"
RELEASE_TYPE=stable
ID=fedora
VERSION_ID=43
VERSION_CODENAME=""
PRETTY_NAME="Fedora CoreOS 43.20251120.3.0"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:43"
HOME_URL="https://getfedora.org/coreos/"
DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora-coreos/"
SUPPORT_URL="https://github.com/coreos/fedora-coreos-tracker/"
BUG_REPORT_URL="https://github.com/coreos/fedora-coreos-tracker/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=43
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=43
SUPPORT_END=2026-12-02
VARIANT="CoreOS"
VARIANT_ID=coreos
OSTREE_VERSION='43.20251120.3.0'
IMAGE_VERSION='43.20251120.3.0'
```

This system is layered and uses the `rpm-ostree` tool to install packages in layers that can be rolled back to older versions, allowing the user to better manage the installed packages.

This system, as seen below, does not allow the user to install, by default, packages using `dnf`:
```console
vagrant@fedora41:~$ sudo dnf install tree
Updating and loading repositories:
 Fedora 43 - x86_64                                                                                                                                   100% |  15.9 KiB/s |  22.3 KiB |  00m01s
 Fedora 43 - x86_64 - Updates Archive                                                                                                                 100% |  12.6 KiB/s |   3.4 KiB |  00m00s
 Fedora 43 - x86_64 - Updates                                                                                                                         100% |   8.3 KiB/s |   7.1 KiB |  00m01s
Repositories loaded.
Package                                                          Arch           Version                                                          Repository                               Size
Installing:
 tree                                                            x86_64         2.2.1-2.fc43                                                     fedora                              112.2 KiB

Transaction Summary:
 Installing:         1 package

Total size of inbound packages is 61 KiB. Need to download 61 KiB.
After this operation, 112 KiB extra will be used (install 112 KiB, remove 0 B).
Error: this bootc system is configured to be read-only. For more information, run `bootc --help`.
```

To allow the installation of packages with dnf, it's required to run the following command:
``` 
vagrant@fedora41:~$ sudo rpm-ostree usroverlay
Development mode enabled.  A writable overlayfs is now mounted on /usr.
All changes there will be discarded on reboot.
```  

As seen in the command output, the installed packages using `dnf` will be present in the system until it's rebooted, this means these packages are the ones to be marked as transient.

The `tree` package is installed to test if the implemented mechanism is able to detect it as a transient package:
```console
vagrant@fedora41:~$ sudo dnf install tree
Updating and loading repositories:                                                                                                                                                               
Repositories loaded.
Package                                                          Arch           Version                                                          Repository                               Size
Installing:
 tree                                                            x86_64         2.2.1-2.fc43                                                     fedora                              112.2 KiB

Transaction Summary:
 Installing:         1 package

Total size of inbound packages is 61 KiB. Need to download 61 KiB.
After this operation, 112 KiB extra will be used (install 112 KiB, remove 0 B).
Is this ok [y/N]: y
[1/1] tree-0:2.2.1-2.fc43.x86_64                                                                                                                      100% | 631.5 KiB/s |  61.3 KiB |  00m00s
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[1/1] Total                                                                                                                                           100% |  76.4 KiB/s |  61.3 KiB |  00m01s
Running transaction
Importing OpenPGP key 0x31645531:
 UserID     : "Fedora (43) <fedora-43-primary@fedoraproject.org>"
 Fingerprint: C6E7F081CF80E13146676E88829B606631645531
 From       : file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-43-x86_64
Is this ok [y/N]: y
The key was successfully imported.
[1/3] Verify package files                                                                                                                            100% | 500.0   B/s |   1.0   B |  00m00s
[2/3] Prepare transaction                                                                                                                             100% |  14.0   B/s |   1.0   B |  00m00s
[3/3] Installing tree-0:2.2.1-2.fc43.x86_64                                                                                                           100% | 326.3 KiB/s | 113.6 KiB |  00m00s
Complete!
```

To test the implemented functions easily, the following script is provided:

<details><summary>test.py</summary>

```python 
import rpm

def parse_rpm_string(rpm_string: str) -> dict | None:
    """
    Parses a standard RPM package string into its NVR (Name, Version, Release) components.
    This function uses a greedy regular expression to correctly handle package names 
    that contain hyphens (e.g., 'amd-ucode-firmware'). It follows the RPM naming 
    convention where the version and release are separated by the last two 
    hyphens before the architecture suffix.
    Args:
        rpm_string (str): The full package string to parse. 
            Example: "NetworkManager-cloud-setup-1:1.54.0-2.fc43.x86_64"
    Returns:
        dict | None: A dictionary with the following keys if the match is successful:
            - 'name': The package name (including any internal hyphens).
            - 'ver': The version string (including Epoch if present).
            - 'rel': The release string (e.g., '2.fc43').
            - 'arch': The architecture (e.g., 'x86_64', 'noarch').
            Returns None if the string does not follow the expected RPM format.
    Example:
        >>> parse_rpm_string("bash-completion-1:2.16-2.fc43.noarch")
        {'name': 'bash-completion', 'ver': '1:2.16', 'rel': '2.fc43', 'arch': 'noarch'}
    """
    from re import match

    # Regex Logic:
    # ^\s* -> Ignore leading whitespace.
    # (?P<name>.+)     -> Greedy match for the name (captures all hyphens until the last two).
    # -                -> Separator between name and version.
    # (?P<ver>[^-]+)   -> Version: matches everything until the next hyphen.
    # -                -> Separator between version and release.
    # (?P<rel>[^-]+)   -> Release: matches everything until the last dot.
    # \.               -> The dot separating release and architecture.
    # (?P<arch>[^.]+)$ -> Architecture: everything after the last dot.

    regex_pattern = r"^\s*(?P<name>.+)-(?P<ver>[^-]+)-(?P<rel>[^-]+)\.(?P<arch>[^.]+)$"

    result = match(regex_pattern, rpm_string.strip())
    if result:
        return result.groupdict()
    return None

def _get_immutable_packages() -> set:
    """
    Get the set of packages from the immutable ostree deployment.
    For bootc systems, uses rpm-ostree to get the true base commit packages.
    Returns a set of (name, version, release, arch, epoch) tuples.
    """
    immutable_packages = set()

    try:
        import subprocess, json

        # Get rpm-ostree status to find the base commits
        result = subprocess.run(['rpm-ostree', 'status', '--json'],
                              capture_output=True, text=True, check=True)
        status = json.loads(result.stdout)

        deployments = status.get('deployments', [])
        if not deployments:
            print("No deployments found in rpm-ostree status")
            return immutable_packages

        # Use deployments[0] since it's the most recent
        base_checksum = deployments[0].get('checksum')
        if not base_checksum:
            print("No base checksum found")
            return immutable_packages

        print(f"Using checksum: {base_checksum[:10]} to get for immutable packages")

        # Use rpm-ostree db list to get packages from the base_checksum
        result = subprocess.run(['rpm-ostree', 'db', 'list', base_checksum],
                              capture_output=True, text=True, check=True)

        # Skip first line since there is returned the consulted base_checksum
        for line in result.stdout.strip().split('\n')[1:]:
            line = line.strip()

            try:
                package_dict = parse_rpm_string(line)
                immutable_packages.add(package_dict["name"])

            except (ValueError, IndexError) as e:
                print(f"Failed to parse package line '{line}': {e}")
                continue

        print(f"Found {len(immutable_packages)} packages in base ostree commit {base_checksum[:10]}")

    except subprocess.CalledProcessError as e:
        print(f"rpm-ostree command failed: {e}")
    except ImportError:
        print("subprocess module not available")
    except Exception as e:
        print(f"Failed to get immutable packages via rpm-ostree: {e}")

    return immutable_packages

ts = rpm.TransactionSet()
ts.setVSFlags(-1)
db = ts.dbMatch()
packages = []

for p in db:
#    print(p["name"])
    packages.append(p["name"])

p_not_in_inmutable_p = []
p_inmutable_not_in_p = []

inmutable_p = _get_immutable_packages()
print("Number of persistent packages: ", len(inmutable_p))

for p in packages:
   if p not in inmutable_p:
      p_not_in_inmutable_p.append(p)

print("p_not_in_inmutable_p (transient): ", p_not_in_inmutable_p)
```
</details>

After the previous package installation, the testing script is run and the obtained result is the expected:

```console
vagrant@fedora41:~$ python3 test.py 
Using checksum: d91a98a1e9 to get for immutable packages
Found 461 packages in base ostree commit d91a98a1e9
Number of persistent packages:  461
p_not_in_inmutable_p (transient):  ['gpg-pubkey', 'tree']
```


</details>