### PR TITLE
feat: PQC negotiation with candlepin server

### DIFF
--- a/etc-conf/rhsm.conf
+++ b/etc-conf/rhsm.conf
@@ -84,6 +84,10 @@ inotify = 1
 # Write progress messages when waiting for API response.
 progress_messages = 1
 
+# Request certificate algorithm preference to the server by setting "current".
+# Defaults to "legacy" now, which requests RSA-signed certificates.
+certificate_algorithms = legacy
+
 [rhsmcertd]
 # Interval to run cert check (in minutes):
 certCheckInterval = 240

--- a/man/rhsm.conf.5
+++ b/man/rhsm.conf.5
@@ -231,6 +231,17 @@ Set to
 \fI0\fR
 to disable progress reporting. When subscription-manager waits while fetching certificates or updating user information, it writes temporary informational messages to the standard output. This feature may not be desired in some situations, changing this option prevents those messages from being displayed.
 .RE
+.PP
+certificate_algorithms
+.RS 4
+Controls which cryptographic algorithms are requested for consumer and entitlement certificates during registration\&. When set to
+\fIcurrent\fR,
+\fBsubscription\-manager\fR
+queries the system's OpenSSL library for available public key and signature algorithms and sends them to the server, allowing the server to issue certificates using post\-quantum cryptography (PQC) or other modern algorithms supported by both the client and the server\&. When set to
+\fIlegacy\fR,
+no algorithm preferences are sent and the server issues traditional RSA\-signed certificates\&. The default is
+\fIlegacy\fR\&.
+.RE
 .SH "[RHSMCERTD] OPTIONS"
 .PP
 certCheckInterval

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -78,6 +78,7 @@ RHSM_DEFAULTS = {
     "package_profile_on_trans": "0",
     "inotify": "1",
     "progress_messages": "1",
+    "certificate_algorithms": "legacy",
 }
 
 RHSMCERTD_DEFAULTS = {

--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -230,6 +230,8 @@ class RhsmConfigParser(SafeConfigParser):
             super(RhsmConfigParser, self).set(section, name, value)
         if section == "logging" and name == "default_log_level":
             self.is_log_level_valid(value)
+        if section == "rhsm" and name == "certificate_algorithms":
+            self.is_certificate_algorithms_valid(value)
 
     def is_log_level_valid(self, value: str, print_warning: bool = True) -> bool:
         """
@@ -249,6 +251,33 @@ class RhsmConfigParser(SafeConfigParser):
                     _(
                         "Please use:  subscription-manager config --logging.default_log_level=<Log Level> to "
                         "set the default_log_level to a valid value."
+                    ),
+                    file=sys.stderr,
+                )
+                valid_str = ", ".join(valid)
+                print(_("Valid Values: {valid_str}").format(valid_str=valid_str), file=sys.stderr)
+            return False
+        return True
+
+    def is_certificate_algorithms_valid(self, value: str, print_warning: bool = True) -> bool:
+        """
+        Check if provided certificate_algorithms value is valid or not
+        :param value: value of certificate_algorithms
+        :param print_warning: print warning when provided value is not one of "legacy", "current"
+        :return: True, when value is valid. Otherwise, return False
+        """
+
+        valid: List[str] = ["legacy", "current"]
+        if value not in valid:
+            if print_warning is True:
+                print(
+                    _("Invalid value: {val}").format(val=value),
+                    file=sys.stderr,
+                )
+                print(
+                    _(
+                        "Please use:  subscription-manager config --rhsm.certificate_algorithms=<Preference> to "
+                        "set the certificate_algorithms to a valid value."
                     ),
                     file=sys.stderr,
                 )

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1602,6 +1602,8 @@ class UEPConnection(BaseConnection):
         service_level: str = None,
         usage: str = None,
         jwt_token: str = None,
+        key_algorithms: List[str] = None,
+        signature_algorithms: List[str] = None,
     ) -> dict:
         """
         Creates a consumer on candlepin server
@@ -1646,6 +1648,12 @@ class UEPConnection(BaseConnection):
         headers = {}
         if jwt_token:
             headers["Authorization"] = "Bearer {jwt_token}".format(jwt_token=jwt_token)
+
+        if key_algorithms and signature_algorithms:
+            params["cryptographicCapabilities"] = {
+                "keyAlgorithms": key_algorithms,
+                "signatureAlgorithms": signature_algorithms
+            }
 
         url = "/consumers"
         if environments and not self.has_capability(MULTI_ENV):

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1652,7 +1652,7 @@ class UEPConnection(BaseConnection):
         if key_algorithms and signature_algorithms:
             params["cryptographicCapabilities"] = {
                 "keyAlgorithms": key_algorithms,
-                "signatureAlgorithms": signature_algorithms
+                "signatureAlgorithms": signature_algorithms,
             }
 
         url = "/consumers"

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -16,6 +16,7 @@ import socket
 from typing import Callable, Optional
 
 from rhsm.connection import UEPConnection
+from rhsm.config import get_config_parser
 
 from rhsmlib.services import exceptions
 from rhsmlib.services.unregister import UnregisterService
@@ -24,6 +25,7 @@ from subscription_manager import injection as inj
 from subscription_manager import managerlib
 from subscription_manager import syspurposelib
 from subscription_manager.i18n import ugettext as _
+from subscription_manager.pqc import get_public_key_algorithms, get_signature_algorithms
 
 import typing
 
@@ -114,6 +116,22 @@ class RegisterService:
         environments = options["environments"]
         facts_dict = self.facts.get_facts()
 
+        config = get_config_parser()
+        key_algorithms = None
+        signature_algorithms = None
+        certificate_algorithms = config.get("rhsm", "certificate_algorithms")
+        if certificate_algorithms == "current":
+            key_algorithms = get_public_key_algorithms()
+            log.debug(f"The list of public key algorithms: {key_algorithms}")
+            signature_algorithms = get_signature_algorithms()
+            log.debug(f"The list of signature algorithms: {signature_algorithms}")
+        elif certificate_algorithms == "legacy":
+            log.debug("Using legacy cryptography algorithms for consumer and entitlement certificate")
+        else:
+            log.warning(
+                f"Unknown value for 'rhsm.certificate_algorithms' in rhsm.conf: {certificate_algorithms}"
+            )
+
         # Default to the hostname if no name is given
         consumer_name = options["name"] or socket.gethostname()
 
@@ -141,6 +159,8 @@ class RegisterService:
                 service_level=service_level,
                 usage=usage,
                 jwt_token=jwt_token,
+                key_algorithms=key_algorithms,
+                signature_algorithms=signature_algorithms,
             )
             # When new consumer is created, then close all existing connections
             # to be able to recreate new one

--- a/src/rhsmlib/services/register.py
+++ b/src/rhsmlib/services/register.py
@@ -129,7 +129,8 @@ class RegisterService:
             log.debug("Using legacy cryptography algorithms for consumer and entitlement certificate")
         else:
             log.warning(
-                f"Unknown value for 'rhsm.certificate_algorithms' in rhsm.conf: {certificate_algorithms}"
+                f"Unknown value for 'rhsm.certificate_algorithms' in rhsm.conf: {certificate_algorithms}."
+                " Falling back to legacy cryptographic algorithms."
             )
 
         # Default to the hostname if no name is given

--- a/src/subscription_manager/pqc.py
+++ b/src/subscription_manager/pqc.py
@@ -1,0 +1,110 @@
+import re
+import subprocess
+
+"""
+This is POC of new functionality of subscription-manager. This module helps to negotiate
+PQC with candlepin server.
+"""
+
+
+def run(cmd, shell=True, cwd=None):
+    """
+    Run a command.
+    Return exitcode, stdout, stderr
+    """
+
+    proc = subprocess.Popen(
+        cmd,
+        shell=shell,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        errors="surrogateescape",
+    )
+
+    stdout, stderr = proc.communicate()
+    return proc.returncode, stdout, stderr
+
+
+# FIXME: We should get the list of OIDs from openssl library in the certificate.c. Parsing
+#        output of "openssl list -public-key-algorithms" is something we should avoid.
+
+
+def get_signature_algorithms():
+    """
+    Get signature algorithms supported by the system.
+    """
+    cmd = "openssl list -signature-algorithms"
+    return_code, stdout, stderr = run(cmd)
+    if return_code != 0:
+        raise RuntimeError(f"Failed to get public key algorithms: {stderr}")
+    lines = stdout.strip().splitlines()
+    algorithms = []
+    for i, line in enumerate(lines):
+        line = line.strip()
+        # Parse line like this:
+        # { 2.16.840.1.101.3.4.3.31, id-slh-dsa-shake-256f, SLH-DSA-SHAKE-256f } @ default
+        match = re.search(r"\{\s*([^,]+)", line)
+        if match:
+            algorithms.append(match.group(1).strip())
+    return algorithms
+
+
+def get_public_key_algorithms():
+    """
+    Get public key algorithms supported by the system.
+    """
+    cmd = "openssl list -public-key-algorithms"
+    return_code, stdout, stderr = run(cmd)
+    if return_code != 0:
+        raise RuntimeError(f"Failed to get public key algorithms: {stderr}")
+    lines = stdout.strip().splitlines()
+    algorithms = []
+    legacy = False
+    for i, line in enumerate(lines):
+        line = line.strip()
+        if line.startswith("Legacy:"):
+            legacy = True
+            continue
+        if line.startswith("Provided:"):
+            legacy = False
+            continue
+        # Parse line like this:
+        # IDs: { 2.16.840.1.101.3.4.3.21, id-slh-dsa-sha2-128f, SLH-DSA-SHA2-128f } @ default
+        if not legacy:
+            match = re.search(r"IDs: \{\s*([^,]+)", line)
+            if match:
+                algorithms.append(match.group(1).strip())
+    return algorithms
+
+
+def get_pub_key_and_sign_algorithms():
+    """
+    Returns a list containing supported public key and signature algorithms.
+    """
+    pub_key_algorithms = get_public_key_algorithms()
+    sig_algorithms = get_signature_algorithms()
+    all_algorithms = set(pub_key_algorithms).union(set(sig_algorithms))
+    return list(all_algorithms)
+
+
+def __smoke_test__():
+    """
+    Smoke testing of get_public_key_algorithms()
+    """
+    pub_key_algorithms = get_public_key_algorithms()
+    sig_algorithms = get_signature_algorithms()
+    print("Supported public key & signature algorithms:")
+    for algorithm in pub_key_algorithms:
+        if algorithm in sig_algorithms:
+            print(f"- {algorithm} (sig+pub)")
+        else:
+            print(f"- {algorithm} (pub only)")
+    for algorithm in sig_algorithms:
+        if algorithm not in pub_key_algorithms:
+            print(f"- {algorithm} (sig only)")
+
+
+if __name__ == "__main__":
+    __smoke_test__()

--- a/src/subscription_manager/pqc.py
+++ b/src/subscription_manager/pqc.py
@@ -1,5 +1,4 @@
-import re
-import subprocess
+from rhsm import _certificate
 
 """
 This is POC of new functionality of subscription-manager. This module helps to negotiate
@@ -7,76 +6,24 @@ PQC with candlepin server.
 """
 
 
-def run(cmd, shell=True, cwd=None):
-    """
-    Run a command.
-    Return exitcode, stdout, stderr
-    """
-
-    proc = subprocess.Popen(
-        cmd,
-        shell=shell,
-        cwd=cwd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        universal_newlines=True,
-        errors="surrogateescape",
-    )
-
-    stdout, stderr = proc.communicate()
-    return proc.returncode, stdout, stderr
-
-
-# FIXME: We should get the list of OIDs from openssl library in the certificate.c. Parsing
-#        output of "openssl list -public-key-algorithms" is something we should avoid.
-
-
 def get_signature_algorithms():
     """
     Get signature algorithms supported by the system.
+
+    Returns a list of OID strings representing available signature algorithms,
+    retrieved directly from OpenSSL via the C bindings.
     """
-    cmd = "openssl list -signature-algorithms"
-    return_code, stdout, stderr = run(cmd)
-    if return_code != 0:
-        raise RuntimeError(f"Failed to get public key algorithms: {stderr}")
-    lines = stdout.strip().splitlines()
-    algorithms = []
-    for i, line in enumerate(lines):
-        line = line.strip()
-        # Parse line like this:
-        # { 2.16.840.1.101.3.4.3.31, id-slh-dsa-shake-256f, SLH-DSA-SHAKE-256f } @ default
-        match = re.search(r"\{\s*([^,]+)", line)
-        if match:
-            algorithms.append(match.group(1).strip())
-    return algorithms
+    return _certificate.get_signature_algorithms()
 
 
 def get_public_key_algorithms():
     """
     Get public key algorithms supported by the system.
+
+    Returns a list of OID strings representing available public key algorithms,
+    retrieved directly from OpenSSL via the C bindings.
     """
-    cmd = "openssl list -public-key-algorithms"
-    return_code, stdout, stderr = run(cmd)
-    if return_code != 0:
-        raise RuntimeError(f"Failed to get public key algorithms: {stderr}")
-    lines = stdout.strip().splitlines()
-    algorithms = []
-    legacy = False
-    for i, line in enumerate(lines):
-        line = line.strip()
-        if line.startswith("Legacy:"):
-            legacy = True
-            continue
-        if line.startswith("Provided:"):
-            legacy = False
-            continue
-        # Parse line like this:
-        # IDs: { 2.16.840.1.101.3.4.3.21, id-slh-dsa-sha2-128f, SLH-DSA-SHA2-128f } @ default
-        if not legacy:
-            match = re.search(r"IDs: \{\s*([^,]+)", line)
-            if match:
-                algorithms.append(match.group(1).strip())
-    return algorithms
+    return _certificate.get_public_key_algorithms()
 
 
 def get_pub_key_and_sign_algorithms():

--- a/src/subscription_manager/pqc.py
+++ b/src/subscription_manager/pqc.py
@@ -1,8 +1,7 @@
 from rhsm import _certificate
 
 """
-This is POC of new functionality of subscription-manager. This module helps to negotiate
-PQC with candlepin server.
+This module helps to negotiate PQC with candlepin server.
 """
 
 
@@ -24,34 +23,3 @@ def get_public_key_algorithms():
     retrieved directly from OpenSSL via the C bindings.
     """
     return _certificate.get_public_key_algorithms()
-
-
-def get_pub_key_and_sign_algorithms():
-    """
-    Returns a list containing supported public key and signature algorithms.
-    """
-    pub_key_algorithms = get_public_key_algorithms()
-    sig_algorithms = get_signature_algorithms()
-    all_algorithms = set(pub_key_algorithms).union(set(sig_algorithms))
-    return list(all_algorithms)
-
-
-def __smoke_test__():
-    """
-    Smoke testing of get_public_key_algorithms()
-    """
-    pub_key_algorithms = get_public_key_algorithms()
-    sig_algorithms = get_signature_algorithms()
-    print("Supported public key & signature algorithms:")
-    for algorithm in pub_key_algorithms:
-        if algorithm in sig_algorithms:
-            print(f"- {algorithm} (sig+pub)")
-        else:
-            print(f"- {algorithm} (pub only)")
-    for algorithm in sig_algorithms:
-        if algorithm not in pub_key_algorithms:
-            print(f"- {algorithm} (sig only)")
-
-
-if __name__ == "__main__":
-    __smoke_test__()

--- a/src/subscription_manager/pqc.py
+++ b/src/subscription_manager/pqc.py
@@ -12,7 +12,10 @@ def get_signature_algorithms():
     Returns a list of OID strings representing available signature algorithms,
     retrieved directly from OpenSSL via the C bindings.
     """
-    return _certificate.get_signature_algorithms()
+    try:
+        return _certificate.get_signature_algorithms()
+    except Exception as e:
+        raise RuntimeError("Failed to get list of signature algorithms") from e
 
 
 def get_public_key_algorithms():
@@ -22,4 +25,7 @@ def get_public_key_algorithms():
     Returns a list of OID strings representing available public key algorithms,
     retrieved directly from OpenSSL via the C bindings.
     """
-    return _certificate.get_public_key_algorithms()
+    try:
+        return _certificate.get_public_key_algorithms()
+    except Exception as e:
+        raise RuntimeError("Failed to get list of public key algorithms") from e

--- a/test/rhsmlib/services/test_register.py
+++ b/test/rhsmlib/services/test_register.py
@@ -382,6 +382,7 @@ class RegisterServiceTest(InjectionMockingTest):
             addons=[],
             service_level="",
             usage="",
+            crypto_algorithms=None,
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -420,6 +421,7 @@ class RegisterServiceTest(InjectionMockingTest):
             addons=[],
             service_level="",
             usage="",
+            crypto_algorithms=None,
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -458,6 +460,7 @@ class RegisterServiceTest(InjectionMockingTest):
             addons=[],
             service_level="",
             usage="",
+            crypto_algorithms=None,
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -501,6 +504,7 @@ class RegisterServiceTest(InjectionMockingTest):
             addons=[],
             service_level="",
             usage="",
+            crypto_algorithms=None,
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -660,6 +664,7 @@ class RegisterServiceTest(InjectionMockingTest):
             addons=[],
             service_level="",
             usage="",
+            crypto_algorithms=None,
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -701,6 +706,7 @@ class RegisterServiceTest(InjectionMockingTest):
             addons=[],
             service_level="",
             usage="",
+            crypto_algorithms=None,
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -788,6 +794,7 @@ class RegisterServiceTest(InjectionMockingTest):
             service_level="test_sla",
             consumer_type="system",
             usage="test_usage",
+            crypto_algorithms=None,
         )
         mock_write_cache.assert_called_once()
 

--- a/test/rhsmlib/services/test_register.py
+++ b/test/rhsmlib/services/test_register.py
@@ -382,7 +382,8 @@ class RegisterServiceTest(InjectionMockingTest):
             addons=[],
             service_level="",
             usage="",
-            crypto_algorithms=None,
+            key_algorithms=None,
+            signature_algorithms=None,
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -421,7 +422,8 @@ class RegisterServiceTest(InjectionMockingTest):
             addons=[],
             service_level="",
             usage="",
-            crypto_algorithms=None,
+            key_algorithms=None,
+            signature_algorithms=None,
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -460,7 +462,8 @@ class RegisterServiceTest(InjectionMockingTest):
             addons=[],
             service_level="",
             usage="",
-            crypto_algorithms=None,
+            key_algorithms=None,
+            signature_algorithms=None,
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -504,7 +507,8 @@ class RegisterServiceTest(InjectionMockingTest):
             addons=[],
             service_level="",
             usage="",
-            crypto_algorithms=None,
+            key_algorithms=None,
+            signature_algorithms=None,
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -664,7 +668,8 @@ class RegisterServiceTest(InjectionMockingTest):
             addons=[],
             service_level="",
             usage="",
-            crypto_algorithms=None,
+            key_algorithms=None,
+            signature_algorithms=None,
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -706,7 +711,8 @@ class RegisterServiceTest(InjectionMockingTest):
             addons=[],
             service_level="",
             usage="",
-            crypto_algorithms=None,
+            key_algorithms=None,
+            signature_algorithms=None,
         )
         self.mock_installed_products.write_cache.assert_called()
 
@@ -794,7 +800,8 @@ class RegisterServiceTest(InjectionMockingTest):
             service_level="test_sla",
             consumer_type="system",
             usage="test_usage",
-            crypto_algorithms=None,
+            key_algorithms=None,
+            signature_algorithms=None,
         )
         mock_write_cache.assert_called_once()
 


### PR DESCRIPTION
* Introduced a new configuration option `certificate_algorithms`. It can have two possible options: `"legacy"` and `"current"`. Default value is `"legacy"`. When an user set the value to `"current"`, then it opts-in using PQC for consumer and entitlement certificates and thus related connections.
* When the `certificate_algorithms` option is set, then client (`subscription-manager` or `rhsm.service`) adds the list of supported public key algorithms to the JSON object that is sent during "register" (`POST /consumers?owner=$OWNER`)
* Fixed unit tests