### PR TITLE
fix(backport): skip package profile upload when disabled in config

### DIFF
--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -249,8 +249,7 @@ class RegisterCommand(UserPassCommand):
                 # of DNF profile by rhsmcertd. We try to "outsource" this activity to rhsmcertd
                 # server to not block registration process.
                 # Note: rhsmcertd tries to upload profile using Python script and this script
-                # is always triggered with --force-upload CLI option. We ignore report_package_config
-                # configure option here due to BZ: 767265
+                # is always triggered with --force-upload CLI option.
                 log.debug("Sending SIGUSR1 signal to rhsmcertd process")
                 try:
                     os.kill(rhsmcertd_pid, signal.SIGUSR1)
@@ -420,7 +419,10 @@ class RegisterCommand(UserPassCommand):
             # FIXME: aside from the overhead, should this be cert_action_client.update?
             self.entcertlib.update()
 
-        self._upload_profile(consumer)
+        if conf["rhsm"].get_int("report_package_profile") == 1:
+            self._upload_profile(consumer)
+        else:
+            log.info("Skipping package profile upload due to report_package_profile config setting.")
 
         subscribed = 0
         if self.options.activation_keys or self.autoattach:

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock, NonCallableMock, patch, MagicMock
 
 from .stubs import StubUEP
 
+from subscription_manager.cli_command import register
 from subscription_manager.cli_command.register import RegisterCommand
 from subscription_manager import injection as inj
 from subscription_manager import cache
@@ -321,6 +322,44 @@ class CliRegistrationTests(SubManFixture):
             with Capture(silent=True):
                 with self.assertRaises(SystemExit):
                     rc._process_environments(mock_uep, "owner")
+
+    def test_registration_with_package_profile_disabled(self):
+        rhsm_conf_original_value = register.conf["rhsm"].get_int
+
+        def get_package_profile_disabled(key):
+            return 0 if key == "report_package_profile" else rhsm_conf_original_value(key)
+
+        with patch("rhsm.connection.UEPConnection", new_callable=StubUEP) as mock_uep:
+            self.stub_cp_provider.basic_auth_cp = mock_uep
+            cmd = RegisterCommand()
+            cmd._upload_profile = Mock()
+
+            with patch.object(register.conf["rhsm"], "get_int", side_effect=get_package_profile_disabled):
+                with Capture() as cap:
+                    cmd.main(["--force", "--username", "admin", "--password", "admin", "--org", "admin"])
+                output = cap.out
+            self.assertTrue("The system has been registered with ID" in output)
+            self.assertTrue("The registered system name is:" in output)
+            cmd._upload_profile.assert_not_called()
+
+    def test_registration_with_package_profile_enabled(self):
+        rhsm_conf_original_value = register.conf["rhsm"].get_int("report_package_profile")
+
+        def get_package_profile_enabled(key):
+            return 1 if key == "report_package_profile" else rhsm_conf_original_value(key)
+
+        with patch("rhsm.connection.UEPConnection", new_callable=StubUEP) as mock_uep:
+            self.stub_cp_provider.basic_auth_cp = mock_uep
+            cmd = RegisterCommand()
+            cmd._upload_profile = Mock()
+
+            with patch.object(register.conf["rhsm"], "get_int", side_effect=get_package_profile_enabled):
+                with Capture() as cap:
+                    cmd.main(["--force", "--username", "admin", "--password", "admin", "--org", "admin"])
+                output = cap.out
+            self.assertTrue("The system has been registered with ID" in output)
+            self.assertTrue("The registered system name is:" in output)
+            cmd._upload_profile.assert_called_once()
 
     def test_registration_with_failed_profile_upload(self):
         with patch("rhsm.connection.UEPConnection", new_callable=StubUEP) as mock_uep:


### PR DESCRIPTION
This commit is a backport of PR #3714.
This patch checks the rhsm config to ensure the
"report_package_profile" setting is not ignored during registration. Previously, this setting was ignored and the package profile was forced to upload.

Resolves: RHEL-155198

AI Usage Disclosure: This commit contains test cases that were created with the assistance of AI tools.