### PR TITLE
Fix package upload during initial register

### DIFF
--- a/src/subscription_manager/cli_command/register.py
+++ b/src/subscription_manager/cli_command/register.py
@@ -182,6 +182,7 @@ class RegisterCommand(UserPassCommand):
                 rhsmcertd_pid = int(lock_file.readline())
         except (IOError, ValueError) as err:
             log.info(f"Unable to read rhsmcertd lock file: {err}")
+            self._upload_profile_blocking(consumer)
         else:
             if is_process_running("rhsmcertd", rhsmcertd_pid) is True:
                 # This will only send SIGUSR1 signal, which triggers gathering and uploading


### PR DESCRIPTION
On first registration if there is no rhsmcertd running, it should fallback to upload_profile_blocking method to upload the host profile.