### PR TITLE
fix:  Set timeout before trying to close TLS connection

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -538,6 +538,10 @@ def _encode_auth(username, password):
     return "Basic %s" % encoded
 
 
+# Give server one second to close the connection
+CLOSE_CONNECTION_TIMEOUT = 1
+
+
 # FIXME: this is terrible, we need to refactor
 # Restlib to be Restlib based on a https client class
 class ContentConnection(BaseConnection):
@@ -680,6 +684,8 @@ class BaseRestLib:
             if self.__conn.sock is not None:
                 log.debug(f"Closing HTTPS connection {self.__conn.sock}")
                 try:
+                    # Wait for 1 second to allow graceful shutdown of TLS connection
+                    self.__conn.sock.settimeout(CLOSE_CONNECTION_TIMEOUT)
                     self.__conn.sock.unwrap()
                 except Exception as err:
                     log.debug(f"Unable to close TLS connection: {err}")
@@ -687,9 +693,12 @@ class BaseRestLib:
                     log.debug("TLS connection closed")
             # Then it is possible to close TCP connection
             try:
+                log.debug("Closing TCP connection")
                 self.__conn.close()
             except Exception as err:
                 log.info(f"Unable to close TCP connection: {err}")
+            else:
+                log.debug("TCP connection closed")
         self.__conn = None
 
     def _get_cert_key_list(self) -> List[Tuple[str, str]]:

--- a/src/subscription_manager/cp_provider.py
+++ b/src/subscription_manager/cp_provider.py
@@ -166,15 +166,19 @@ class CPProvider:
         if self.consumer_auth_cp is not None:
             log.debug("Closing auth/consumer connection...")
             self.consumer_auth_cp.conn.close_connection()
+            log.debug("Auth/consumer connection closed")
         if self.no_auth_cp is not None:
             log.debug("Closing no auth connection...")
             self.no_auth_cp.conn.close_connection()
+            log.debug("No auth connection closed")
         if self.basic_auth_cp is not None:
             log.debug("Closing auth/basic connection...")
             self.basic_auth_cp.conn.close_connection()
+            log.debug("Auth/basic connection closed")
         if self.keycloak_auth_cp is not None:
             log.debug("Closing auth/keycloak connection...")
             self.keycloak_auth_cp.conn.close_connection()
+            log.debug("Auth/keycloak connection closed")
 
     def get_consumer_auth_cp(self) -> connection.UEPConnection:
         if not self.consumer_auth_cp:


### PR DESCRIPTION
* When server is not configured correctly and it ignores
  closing TLS connection, then subscription-manager is blocked
  for one minute
* Added timeout one second before trying to do TLS teardown
* Added more debug prints about closing TCP connection
* Added debug print that given connection was really closed,
  because it looked like that connection wasn't closed and
  it could gave false negative results.