### PR TITLE
fix: set exit code during subscription-manager config --rhsm.certificate_algorithms

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -141,6 +141,18 @@ def in_container() -> bool:
 class RhsmConfigParser(SafeConfigParser):
     """Config file parser for rhsm configuration."""
 
+    # Maps (section, name) to a dict of accepted values for that config key.
+    # "values" is a list of valid values and must be defined for every entry.
+    # "no_hint" is an optional key that holds values that are accepted but excluded from warnings/hints
+    # Add an entry here to enforce validation for any config key.
+    VALID_VALUES: Dict[Tuple[str, str], Dict[str, List[str]]] = {
+        ("logging", "default_log_level"): {
+            "values": ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+            "no_hint": ["NOTSET"],
+        },
+        ("rhsm", "certificate_algorithms"): {"values": ["legacy", "current"]},
+    }
+
     # defaults unused but kept to preserve compatibility
     def __init__(self, config_file: Optional[str] = None, defaults=None):
         self.config_file: str = config_file
@@ -228,63 +240,65 @@ class RhsmConfigParser(SafeConfigParser):
             if not self.has_section(section):
                 self.add_section(section)
             super(RhsmConfigParser, self).set(section, name, value)
-        if section == "logging" and name == "default_log_level":
-            self.is_log_level_valid(value)
-        if section == "rhsm" and name == "certificate_algorithms":
-            self.is_certificate_algorithms_valid(value)
+        self.is_value_valid(section, name, value)
 
-    def is_log_level_valid(self, value: str, print_warning: bool = True) -> bool:
-        """
-        Check if provided default_log_level value is valid or not
-        :param value: value of default_log_level
-        :param print_warning: print warning, when provided value is not valid
-        :return: True, when value is valid. Otherwise return False
-        """
-        valid: List[str] = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]
-        if value not in valid + ["NOTSET"]:
-            if print_warning is True:
-                print(
-                    _("Invalid Log Level: {lvl}, setting to INFO for this run.").format(lvl=value),
-                    file=sys.stderr,
-                )
-                print(
-                    _(
-                        "Please use:  subscription-manager config --logging.default_log_level=<Log Level> to "
-                        "set the default_log_level to a valid value."
-                    ),
-                    file=sys.stderr,
-                )
-                valid_str = ", ".join(valid)
-                print(_("Valid Values: {valid_str}").format(valid_str=valid_str), file=sys.stderr)
-            return False
-        return True
+    def is_value_valid(
+        self,
+        section: str,
+        name: str,
+        value: Optional[str],
+        print_warning: bool = True,
+        raise_on_invalid: bool = False,
+    ) -> bool:
+        """Check whether a value is valid for the given config key.
+        The config key is a tuple of (section, name)
 
-    def is_certificate_algorithms_valid(self, value: str, print_warning: bool = True) -> bool:
-        """
-        Check if provided certificate_algorithms value is valid or not
-        :param value: value of certificate_algorithms
-        :param print_warning: print warning when provided value is not one of "legacy", "current"
-        :return: True, when value is valid. Otherwise, return False
-        """
+        If the key is not in VALID_VALUES this is a no-op and returns True.
+        If the value is invalid and print_warning is True, a warning is printed to stderr.
+        If the value is invalid and raise_on_invalid is True, a ValueError is raised.
 
-        valid: List[str] = ["legacy", "current"]
-        if value not in valid:
-            if print_warning is True:
-                print(
-                    _("Invalid value: {val}").format(val=value),
-                    file=sys.stderr,
+        :param section: config section
+        :param name: config key
+        :param value: the value to check
+        :param print_warning: print a warning to stderr when the value is invalid
+        :param raise_on_invalid: raise ValueError instead of returning False when invalid
+        :return: True when the value is valid or the key is unconstrained, otherwise False
+        :raises ValueError: when raise_on_invalid is True and the value is invalid
+        """
+        if (section, name) not in self.VALID_VALUES:
+            return True
+
+        values = self.VALID_VALUES[(section, name)]["values"]
+
+        # no_hint is optional, so we must .get() it
+        no_hint = self.VALID_VALUES[(section, name)].get("no_hint", [])
+
+        if value in values or value in no_hint:
+            return True
+
+        valid_str = ", ".join(values)
+        if print_warning:
+            print(
+                _("Invalid value '{val}' for {section}.{name}.").format(
+                    val=value, section=section, name=name
+                ),
+                file=sys.stderr,
+            )
+            print(
+                _(
+                    "Please use:  subscription-manager config --{section}.{name}=<value>"
+                    " to set {name} to a valid value."
+                ).format(section=section, name=name),
+                file=sys.stderr,
+            )
+            print(_("Valid Values: {valid_str}").format(valid_str=valid_str), file=sys.stderr)
+        if raise_on_invalid:
+            raise ValueError(
+                _("Invalid value '{val}' for {section}.{name}. Valid values are: {valid}.").format(
+                    val=value, section=section, name=name, valid=valid_str
                 )
-                print(
-                    _(
-                        "Please use:  subscription-manager config --rhsm.certificate_algorithms=<Preference>"
-                        " to set the certificate_algorithms to a valid value."
-                    ),
-                    file=sys.stderr,
-                )
-                valid_str = ", ".join(valid)
-                print(_("Valid Values: {valid_str}").format(valid_str=valid_str), file=sys.stderr)
-            return False
-        return True
+            )
+        return False
 
     def get_int(self, section: str, prop: str) -> Optional[int]:
         """Get an int value from the config.

--- a/src/rhsm/logutil.py
+++ b/src/rhsm/logutil.py
@@ -18,6 +18,8 @@ import os
 import sys
 import rhsm.config
 
+from subscription_manager.i18n import ugettext as _
+
 LOGFILE_DIR = "/var/log/rhsm/"
 LOGFILE_PATH = os.path.join(LOGFILE_DIR, "rhsm.log")
 USER_LOGFILE_DIR = os.path.join(
@@ -206,14 +208,20 @@ def init_logger(config: Optional[rhsm.config.RhsmConfigParser] = None) -> None:
                 # When invalid value is provided, then set default_log_level to None
                 # Warning message will be printed later, when not valid value will be
                 # saved to config file
-                if config.is_log_level_valid(default_log_level, print_warning=False) is False:
+                if not config.is_value_valid(
+                    "logging", "default_log_level", default_log_level, print_warning=False
+                ):
                     default_log_level = None
 
     if default_log_level is None:
         default_log_level = config.get("logging", "default_log_level")
-        if not config.is_log_level_valid(default_log_level):
+        if not config.is_value_valid("logging", "default_log_level", default_log_level):
             # This is not a valid logging level, set to INFO
-            default_log_level = "INFO"
+            default_log_level = config.get_default("logging", "default_log_level")
+            print(
+                _("Using default value '{level}' for this run.").format(level=default_log_level),
+                file=sys.stderr,
+            )
 
     pending_error_messages: List[Exception] = []
 

--- a/src/subscription_manager/cli_command/config.py
+++ b/src/subscription_manager/cli_command/config.py
@@ -84,6 +84,16 @@ class ConfigCommand(CliCommand):
                 # if no options are given, default to --list
                 self.options.list = True
 
+        for s in list(conf.keys()):
+            for name in list(conf[s].keys()):
+                value = getattr(self.options, s + "." + name, None)
+                if value is None:
+                    continue
+                try:
+                    conf._parser.is_value_valid(s, name, value, print_warning=True, raise_on_invalid=True)
+                except ValueError:
+                    system_exit(os.EX_USAGE)
+
         if self.options.remove:
             for r in self.options.remove:
                 if "." not in r:

--- a/src/subscription_manager/pqc.py
+++ b/src/subscription_manager/pqc.py
@@ -1,8 +1,10 @@
 import logging
+import sys
 from typing import Tuple, List
 
 from rhsm import _certificate
 from rhsm.config import get_config_parser
+from subscription_manager.i18n import ugettext as _
 
 """
 This module helps to negotiate PQC with candlepin server.
@@ -57,6 +59,13 @@ def get_crypto_capabilities() -> Tuple[List[str], List[str]]:
     signature_algorithms = []
 
     certificate_algorithms = cfg.get("rhsm", "certificate_algorithms")
+    if not cfg.is_value_valid("rhsm", "certificate_algorithms", certificate_algorithms):
+        certificate_algorithms = cfg.get_default("rhsm", "certificate_algorithms")
+        print(
+            _("Using default value '{value}' for this run.").format(value=certificate_algorithms),
+            file=sys.stderr,
+        )
+
     if certificate_algorithms == "current":
         key_algorithms = get_public_key_algorithms()
         log.debug(f"The list of public key algorithms: {key_algorithms}")
@@ -64,10 +73,5 @@ def get_crypto_capabilities() -> Tuple[List[str], List[str]]:
         log.debug(f"The list of signature algorithms: {signature_algorithms}")
     elif certificate_algorithms == "legacy":
         log.debug("Using legacy cryptography algorithms for consumer and entitlement certificate")
-    else:
-        log.warning(
-            f"Unknown value for 'rhsm.certificate_algorithms' in rhsm.conf: {certificate_algorithms}."
-            " Falling back to legacy cryptographic algorithms."
-        )
 
     return key_algorithms, signature_algorithms

--- a/test/cli_command/test_config.py
+++ b/test/cli_command/test_config.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from rhsmlib.services import config
@@ -76,3 +77,37 @@ class TestConfigCommand(TestCliCommand):
     def test_remove_config_key_not_dotted(self):
         self.cc._do_command = self._orig_do_command
         self.assertRaises(SystemExit, self.cc.main, ["--remove", "notdotted"])
+
+    def test_set_certificate_algorithms_valid(self):
+        self.cc._do_command = self._orig_do_command
+        self.cc.main(["--rhsm.certificate_algorithms", "legacy"])
+        self.assertEqual(config_command.conf["rhsm"]["certificate_algorithms"], "legacy")
+
+    def test_set_certificate_algorithms_invalid_exits(self):
+        self.cc._do_command = self._orig_do_command
+        with self.assertRaises(SystemExit) as ctx:
+            self.cc.main(["--rhsm.certificate_algorithms", "badvalue"])
+        self.assertEqual(ctx.exception.code, os.EX_USAGE)
+
+    def test_set_log_level_valid(self):
+        self.cc._do_command = self._orig_do_command
+        self.cc.main(["--logging.default_log_level", "DEBUG"])
+        self.assertEqual(config_command.conf["logging"]["default_log_level"], "DEBUG")
+
+    def test_set_log_level_invalid_exits(self):
+        self.cc._do_command = self._orig_do_command
+
+        # Capture the current log level so we can verify it is not changed
+        previous_level = config_command.conf["logging"]["default_log_level"]
+
+        with self.assertRaises(SystemExit) as ctx:
+            self.cc.main(["--logging.default_log_level", "BADLEVEL"])
+
+        # Invalid log level should result in EX_USAGE
+        self.assertEqual(ctx.exception.code, os.EX_USAGE)
+
+        # The configuration should remain unchanged on validation failure
+        self.assertEqual(
+            config_command.conf["logging"]["default_log_level"],
+            previous_level,
+        )

--- a/test/rhsm/unit/test_config.py
+++ b/test/rhsm/unit/test_config.py
@@ -17,6 +17,8 @@ from iniparse.compat import (
     InterpolationDepthError,
     NoSectionError,
 )
+import contextlib
+import io
 from tempfile import NamedTemporaryFile
 import unittest
 
@@ -519,3 +521,57 @@ class InContainerTests(unittest.TestCase):
 
         result: bool = in_container()
         self.assertFalse(result)
+
+
+class IsValueValidTests(unittest.TestCase):
+    def setUp(self):
+        self.fid = write_temp_file(TEST_CONFIG)
+        self.parser = RhsmConfigParser(self.fid.name)
+
+    def test_unconstrained_key_returns_true(self):
+        self.assertTrue(self.parser.is_value_valid("server", "hostname", "anything"))
+
+    def test_certificate_algorithms_valid(self):
+        for val in ("legacy", "current"):
+            self.assertTrue(self.parser.is_value_valid("rhsm", "certificate_algorithms", val))
+
+    def test_certificate_algorithms_invalid_returns_false(self):
+        self.assertFalse(
+            self.parser.is_value_valid("rhsm", "certificate_algorithms", "bad", print_warning=False)
+        )
+
+    def test_certificate_algorithms_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            self.parser.is_value_valid(
+                "rhsm", "certificate_algorithms", "bad", print_warning=False, raise_on_invalid=True
+            )
+
+    def test_log_level_valid(self):
+        for val in ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"):
+            self.assertTrue(self.parser.is_value_valid("logging", "default_log_level", val))
+
+    def test_log_level_notset_accepted(self):
+        # NOTSET is unadvertised but still accepted for backward compatibility
+        self.assertTrue(
+            self.parser.is_value_valid("logging", "default_log_level", "NOTSET", print_warning=False)
+        )
+
+    def test_log_level_notset_no_warning_with_print_warning_true(self):
+        # NOTSET is in the nohint list; it should not emit a warning even when print_warning=True
+        stderr_buffer = io.StringIO()
+        with contextlib.redirect_stderr(stderr_buffer):
+            self.assertTrue(
+                self.parser.is_value_valid("logging", "default_log_level", "NOTSET", print_warning=True)
+            )
+        self.assertEqual("", stderr_buffer.getvalue())
+
+    def test_log_level_invalid_returns_false(self):
+        self.assertFalse(
+            self.parser.is_value_valid("logging", "default_log_level", "VERBOSE", print_warning=False)
+        )
+
+    def test_log_level_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            self.parser.is_value_valid(
+                "logging", "default_log_level", "VERBOSE", print_warning=False, raise_on_invalid=True
+            )


### PR DESCRIPTION
- Card-ID: RHEL-183208
- Extended the config parser to allow validating a given value against a list of valid values
- Combined `is_log_level_valid` and `is_certificate_algorithms_valid` into one `is_value_valid` function which works for any config option with a list of valid values
- When an invalid value is passed to `subscription-manager config --rhsm.certificate_algorithms`, an exit code will be set
- If an invalid value is set in rhsm.conf manually, subscription-manager will print warnings and use `legacy` as the default option


Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>