### PR TITLE
fix: log invalid rhsm.certificate_algorithms value to rhsm.log

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -138,6 +138,40 @@ def in_container() -> bool:
     return False
 
 
+class InvalidConfigValueError(ValueError):
+    """Raised when an invalid value is set for a constrained config key.
+
+    Carries enough context to format user-facing messages and log entries.
+    """
+
+    def __init__(self, section: str, name: str, value: str, valid_values: List[str]) -> None:
+        self.section = section
+        self.name = name
+        self.value = value
+        self.valid_values = valid_values
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        valid_str = ", ".join(self.valid_values)
+        return _("Invalid value '{val}' for {section}.{name}. Valid values are: {valid}.").format(
+            val=self.value, section=self.section, name=self.name, valid=valid_str
+        )
+
+    def messages(self) -> List[str]:
+        """Return the full set of user-facing warning lines for this error."""
+        valid_str = ", ".join(self.valid_values)
+        return [
+            _("Invalid value '{val}' for {section}.{name}.").format(
+                val=self.value, section=self.section, name=self.name
+            ),
+            _(
+                "Please use:  subscription-manager config --{section}.{name}=<value>"
+                " to set {name} to a valid value."
+            ).format(section=self.section, name=self.name),
+            _("Valid Values: {valid_str}").format(valid_str=valid_str),
+        ]
+
+
 class RhsmConfigParser(SafeConfigParser):
     """Config file parser for rhsm configuration."""
 
@@ -240,65 +274,31 @@ class RhsmConfigParser(SafeConfigParser):
             if not self.has_section(section):
                 self.add_section(section)
             super(RhsmConfigParser, self).set(section, name, value)
-        self.is_value_valid(section, name, value)
+        try:
+            self.is_value_valid(section, name, value)
+        except InvalidConfigValueError as e:
+            for msg in e.messages():
+                print(msg, file=sys.stderr)
 
-    def is_value_valid(
-        self,
-        section: str,
-        name: str,
-        value: Optional[str],
-        print_warning: bool = True,
-        raise_on_invalid: bool = False,
-    ) -> bool:
+    def is_value_valid(self, section: str, name: str, value: Optional[str]) -> None:
         """Check whether a value is valid for the given config key.
-        The config key is a tuple of (section, name)
 
-        If the key is not in VALID_VALUES this is a no-op and returns True.
-        If the value is invalid and print_warning is True, a warning is printed to stderr.
-        If the value is invalid and raise_on_invalid is True, a ValueError is raised.
+        If the key is not in VALID_VALUES this is a no-op.
+        If the value is invalid, raises InvalidConfigValueError.
 
         :param section: config section
         :param name: config key
         :param value: the value to check
-        :param print_warning: print a warning to stderr when the value is invalid
-        :param raise_on_invalid: raise ValueError instead of returning False when invalid
-        :return: True when the value is valid or the key is unconstrained, otherwise False
-        :raises ValueError: when raise_on_invalid is True and the value is invalid
+        :raises InvalidConfigValueError: when the value is invalid for a constrained key
         """
         if (section, name) not in self.VALID_VALUES:
-            return True
+            return
 
         values = self.VALID_VALUES[(section, name)]["values"]
-
-        # no_hint is optional, so we must .get() it
         no_hint = self.VALID_VALUES[(section, name)].get("no_hint", [])
 
-        if value in values or value in no_hint:
-            return True
-
-        valid_str = ", ".join(values)
-        if print_warning:
-            print(
-                _("Invalid value '{val}' for {section}.{name}.").format(
-                    val=value, section=section, name=name
-                ),
-                file=sys.stderr,
-            )
-            print(
-                _(
-                    "Please use:  subscription-manager config --{section}.{name}=<value>"
-                    " to set {name} to a valid value."
-                ).format(section=section, name=name),
-                file=sys.stderr,
-            )
-            print(_("Valid Values: {valid_str}").format(valid_str=valid_str), file=sys.stderr)
-        if raise_on_invalid:
-            raise ValueError(
-                _("Invalid value '{val}' for {section}.{name}. Valid values are: {valid}.").format(
-                    val=value, section=section, name=name, valid=valid_str
-                )
-            )
-        return False
+        if value not in values and value not in no_hint:
+            raise InvalidConfigValueError(section, name, value, values)
 
     def get_int(self, section: str, prop: str) -> Optional[int]:
         """Get an int value from the config.

--- a/src/rhsm/logutil.py
+++ b/src/rhsm/logutil.py
@@ -17,6 +17,7 @@ import logging.config
 import os
 import sys
 import rhsm.config
+from rhsm.config import InvalidConfigValueError
 
 from subscription_manager.i18n import ugettext as _
 
@@ -205,19 +206,22 @@ def init_logger(config: Optional[rhsm.config.RhsmConfigParser] = None) -> None:
 
             if len(option_value) == 2:
                 default_log_level = option_value[1]
-                # When invalid value is provided, then set default_log_level to None
-                # Warning message will be printed later, when not valid value will be
-                # saved to config file
-                if not config.is_value_valid(
-                    "logging", "default_log_level", default_log_level, print_warning=False
-                ):
+                # When invalid value is provided via CLI, silently ignore it;
+                # the config command will reject it with an error before it is saved.
+                try:
+                    config.is_value_valid("logging", "default_log_level", default_log_level)
+                except InvalidConfigValueError:
                     default_log_level = None
 
     if default_log_level is None:
         default_log_level = config.get("logging", "default_log_level")
-        if not config.is_value_valid("logging", "default_log_level", default_log_level):
-            # This is not a valid logging level, set to INFO
+        try:
+            config.is_value_valid("logging", "default_log_level", default_log_level)
+        except InvalidConfigValueError as e:
+            # This is not a valid logging level, fall back to the default
             default_log_level = config.get_default("logging", "default_log_level")
+            for msg in e.messages():
+                print(msg, file=sys.stderr)
             print(
                 _("Using default value '{level}' for this run.").format(level=default_log_level),
                 file=sys.stderr,

--- a/src/subscription_manager/cli_command/config.py
+++ b/src/subscription_manager/cli_command/config.py
@@ -15,8 +15,10 @@
 # in this software or its documentation.
 #
 import os
+import sys
 
 import rhsm.config
+from rhsm.config import InvalidConfigValueError
 
 from subscription_manager.cli import system_exit
 from subscription_manager.cli_command.cli import CliCommand, conf
@@ -90,8 +92,10 @@ class ConfigCommand(CliCommand):
                 if value is None:
                     continue
                 try:
-                    conf._parser.is_value_valid(s, name, value, print_warning=True, raise_on_invalid=True)
-                except ValueError:
+                    conf._parser.is_value_valid(s, name, value)
+                except InvalidConfigValueError as e:
+                    for msg in e.messages():
+                        print(msg, file=sys.stderr)
                     system_exit(os.EX_USAGE)
 
         if self.options.remove:

--- a/src/subscription_manager/pqc.py
+++ b/src/subscription_manager/pqc.py
@@ -3,7 +3,7 @@ import sys
 from typing import Tuple, List
 
 from rhsm import _certificate
-from rhsm.config import get_config_parser
+from rhsm.config import get_config_parser, InvalidConfigValueError
 from subscription_manager.i18n import ugettext as _
 
 """
@@ -59,12 +59,16 @@ def get_crypto_capabilities() -> Tuple[List[str], List[str]]:
     signature_algorithms = []
 
     certificate_algorithms = cfg.get("rhsm", "certificate_algorithms")
-    if not cfg.is_value_valid("rhsm", "certificate_algorithms", certificate_algorithms):
+    try:
+        cfg.is_value_valid("rhsm", "certificate_algorithms", certificate_algorithms)
+    except InvalidConfigValueError as e:
         certificate_algorithms = cfg.get_default("rhsm", "certificate_algorithms")
-        print(
-            _("Using default value '{value}' for this run.").format(value=certificate_algorithms),
-            file=sys.stderr,
-        )
+        for msg in e.messages():
+            log.warning(msg)
+            print(msg, file=sys.stderr)
+        fallback_msg = _("Using default value '{value}' for this run.").format(value=certificate_algorithms)
+        log.warning(fallback_msg)
+        print(fallback_msg, file=sys.stderr)
 
     if certificate_algorithms == "current":
         key_algorithms = get_public_key_algorithms()

--- a/test/rhsm/unit/test_config.py
+++ b/test/rhsm/unit/test_config.py
@@ -23,7 +23,7 @@ from tempfile import NamedTemporaryFile
 import unittest
 
 from unittest.mock import patch
-from rhsm.config import RhsmConfigParser, RhsmHostConfigParser, in_container
+from rhsm.config import RhsmConfigParser, RhsmHostConfigParser, InvalidConfigValueError, in_container
 
 TEST_CONFIG = """
 [foo]
@@ -528,50 +528,40 @@ class IsValueValidTests(unittest.TestCase):
         self.fid = write_temp_file(TEST_CONFIG)
         self.parser = RhsmConfigParser(self.fid.name)
 
-    def test_unconstrained_key_returns_true(self):
-        self.assertTrue(self.parser.is_value_valid("server", "hostname", "anything"))
+    def test_unconstrained_key_does_not_raise(self):
+        self.parser.is_value_valid("server", "hostname", "anything")
 
     def test_certificate_algorithms_valid(self):
         for val in ("legacy", "current"):
-            self.assertTrue(self.parser.is_value_valid("rhsm", "certificate_algorithms", val))
-
-    def test_certificate_algorithms_invalid_returns_false(self):
-        self.assertFalse(
-            self.parser.is_value_valid("rhsm", "certificate_algorithms", "bad", print_warning=False)
-        )
+            self.parser.is_value_valid("rhsm", "certificate_algorithms", val)
 
     def test_certificate_algorithms_invalid_raises(self):
-        with self.assertRaises(ValueError):
-            self.parser.is_value_valid(
-                "rhsm", "certificate_algorithms", "bad", print_warning=False, raise_on_invalid=True
-            )
+        with self.assertRaises(InvalidConfigValueError):
+            self.parser.is_value_valid("rhsm", "certificate_algorithms", "bad")
 
     def test_log_level_valid(self):
         for val in ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"):
-            self.assertTrue(self.parser.is_value_valid("logging", "default_log_level", val))
+            self.parser.is_value_valid("logging", "default_log_level", val)
 
     def test_log_level_notset_accepted(self):
         # NOTSET is unadvertised but still accepted for backward compatibility
-        self.assertTrue(
-            self.parser.is_value_valid("logging", "default_log_level", "NOTSET", print_warning=False)
-        )
+        self.parser.is_value_valid("logging", "default_log_level", "NOTSET")
 
-    def test_log_level_notset_no_warning_with_print_warning_true(self):
-        # NOTSET is in the nohint list; it should not emit a warning even when print_warning=True
+    def test_log_level_notset_no_warning(self):
+        # NOTSET is in no_hint; it should not appear in the error messages
         stderr_buffer = io.StringIO()
         with contextlib.redirect_stderr(stderr_buffer):
-            self.assertTrue(
-                self.parser.is_value_valid("logging", "default_log_level", "NOTSET", print_warning=True)
-            )
+            self.parser.is_value_valid("logging", "default_log_level", "NOTSET")
         self.assertEqual("", stderr_buffer.getvalue())
 
-    def test_log_level_invalid_returns_false(self):
-        self.assertFalse(
-            self.parser.is_value_valid("logging", "default_log_level", "VERBOSE", print_warning=False)
-        )
-
     def test_log_level_invalid_raises(self):
-        with self.assertRaises(ValueError):
-            self.parser.is_value_valid(
-                "logging", "default_log_level", "VERBOSE", print_warning=False, raise_on_invalid=True
-            )
+        with self.assertRaises(InvalidConfigValueError):
+            self.parser.is_value_valid("logging", "default_log_level", "VERBOSE")
+
+    def test_invalid_value_error_messages_contain_hint(self):
+        try:
+            self.parser.is_value_valid("rhsm", "certificate_algorithms", "bad")
+        except InvalidConfigValueError as e:
+            msgs = e.messages()
+            self.assertTrue(any("subscription-manager config" in m for m in msgs))
+            self.assertTrue(any("Valid Values" in m for m in msgs))


### PR DESCRIPTION
Added `InvalidConfigValueError(ValueError)` which holds the section, name, value, and valid values for a config key, and provides a method `.messages` to access user-facing warnings/hints.

Replaces the `print_warning`/`raise_on_invalid` flags on is_value_valid() with a simple raise, leaving each call site to handle the exception.

These changes allow the caller to control how warning messages are handled:
- `subscription-manager config ...` rejects invalid values, so warnings are only printed to stderr
- Invalid values can still be written manually to rhsm.conf, so those warnings will be printed both to stderr and rhsm.log


Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>