### PR TITLE
test(ci): Drop intltool dependency in the container

### DIFF
--- a/scripts/container-pre-test.sh
+++ b/scripts/container-pre-test.sh
@@ -16,7 +16,7 @@ fi
 
 # Install system, build and runtime packages
 dnf --setopt install_weak_deps=False install -y --nobest \
-  intltool python3-setuptools \
+  python3-setuptools \
   openssl-devel libdnf-devel \
   python3-rpm python3-librepo python3-gobject \
   python3-dateutil python3-requests python3-iniparse \


### PR DESCRIPTION
Since 73cdff454182c126d7b97f16e inltool was dropped but leftover container-pre-test script.

---

Unless I am missing something this can be removed.