### PR TITLE
chore: [1.29] Update .pot file with strings for translation

### DIFF
--- a/po/keys.pot
+++ b/po/keys.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rhsm\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-21 14:41+0100\n"
+"POT-Creation-Date: 2026-08-14 15:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -168,66 +168,66 @@ msgstr ""
 msgid "%(prog)s: error: %(message)s\n"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:104
+#: src/daemons/rhsmcertd.c:106
 msgid "deprecated, see --cert-check-interval"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:107
+#: src/daemons/rhsmcertd.c:109
 msgid "interval to run cert check (in minutes)"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:111
+#: src/daemons/rhsmcertd.c:113
 msgid "deprecated, see --auto-attach-interval"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:114
+#: src/daemons/rhsmcertd.c:116
 msgid "interval to run auto-attach (in minutes)"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:117
+#: src/daemons/rhsmcertd.c:119
 msgid "interval to run auto-registration (in minutes)"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:120
+#: src/daemons/rhsmcertd.c:122
 msgid "run the initial checks immediately, with no delay"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:123
+#: src/daemons/rhsmcertd.c:125
 msgid "show debug messages"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:125
+#: src/daemons/rhsmcertd.c:127
 msgid "do not add an offset to the initial checks."
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:128
+#: src/daemons/rhsmcertd.c:130
 msgid "try to perform auto-registration."
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:570
+#: src/daemons/rhsmcertd.c:579
 #, c-format
 msgid "For more information run: rhsmcertd --help\n"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:687
+#: src/daemons/rhsmcertd.c:696
 msgid "Wrong number of arguments specified.\n"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:763
+#: src/daemons/rhsmcertd.c:772
 msgid "Invalid argument specified.\n"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:769
+#: src/daemons/rhsmcertd.c:778
 #, c-format
 msgid "WARN: Deprecated CLI arguments are being used.\n"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:784
+#: src/daemons/rhsmcertd.c:793
 #, c-format
 msgid "Invalid option: %s\n"
 msgstr ""
 
-#: src/daemons/rhsmcertd.c:798
+#: src/daemons/rhsmcertd.c:807
 #, c-format
 msgid "Invalid argument specified: %s\n"
 msgstr ""
@@ -236,7 +236,7 @@ msgstr ""
 msgid "Installed products updated."
 msgstr ""
 
-#: src/plugins/dnf/subscription_manager.py:46
+#: src/plugins/dnf/subscription_manager.py:47
 #, python-format
 msgid ""
 "\n"
@@ -249,28 +249,28 @@ msgid ""
 "active subscriptions, you can renew the expired subscription.  "
 msgstr ""
 
-#: src/plugins/dnf/subscription_manager.py:57
+#: src/plugins/dnf/subscription_manager.py:58
 msgid ""
 "\n"
 "This system is not registered with an entitlement server. You can use "
 "subscription-manager to register.\n"
 msgstr ""
 
-#: src/plugins/dnf/subscription_manager.py:63
+#: src/plugins/dnf/subscription_manager.py:64
 msgid ""
 "\n"
 "This system is not registered with an entitlement server. You can use \"rhc"
 "\" or \"subscription-manager\" to register.\n"
 msgstr ""
 
-#: src/plugins/dnf/subscription_manager.py:70
+#: src/plugins/dnf/subscription_manager.py:71
 msgid ""
 "\n"
 "This system is registered with an entitlement server, but is not receiving "
 "updates. You can use subscription-manager to assign subscriptions.\n"
 msgstr ""
 
-#: src/plugins/dnf/subscription_manager.py:77
+#: src/plugins/dnf/subscription_manager.py:78
 #, python-brace-format
 msgid ""
 "\n"
@@ -278,11 +278,20 @@ msgid ""
 "only for this release.\n"
 msgstr ""
 
-#: src/plugins/dnf/subscription_manager.py:112
+#: src/plugins/dnf/subscription_manager.py:84
+#, python-brace-format
+msgid ""
+"\n"
+"The system clock is skewed. There is a time difference of {time_drift} "
+"seconds with the entitlement server. Please check your clock settings to "
+"ensure access to all entitled content.\n"
+msgstr ""
+
+#: src/plugins/dnf/subscription_manager.py:120
 msgid "Not root, Subscription Management repositories not updated"
 msgstr ""
 
-#: src/plugins/dnf/subscription_manager.py:140
+#: src/plugins/dnf/subscription_manager.py:149
 #, python-format
 msgid ""
 "subscription-manager plugin disabled %d system repository with respect of "
@@ -293,15 +302,15 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/dnf/subscription_manager.py:158
+#: src/plugins/dnf/subscription_manager.py:167
 msgid "Updating Subscription Management repositories."
 msgstr ""
 
-#: src/plugins/dnf/subscription_manager.py:167
+#: src/plugins/dnf/subscription_manager.py:176
 msgid "Unable to read consumer identity"
 msgstr ""
 
-#: src/plugins/dnf/subscription_manager.py:170
+#: src/plugins/dnf/subscription_manager.py:179
 msgid "subscription-manager is operating in container mode."
 msgstr ""
 
@@ -634,7 +643,7 @@ msgstr ""
 msgid "Add-ons"
 msgstr ""
 
-#: src/rct/printing.py:78 src/subscription_manager/managerlib.py:431
+#: src/rct/printing.py:78 src/subscription_manager/managerlib.py:436
 msgid "Unlimited"
 msgstr ""
 
@@ -758,161 +767,172 @@ msgstr ""
 msgid "Unknown Certificate Type"
 msgstr ""
 
-#: src/rhsm/config.py:244
+#: src/rhsm/config.py:283
 #, python-brace-format
-msgid "Invalid Log Level: {lvl}, setting to INFO for this run."
+msgid "Invalid value '{val}' for {section}.{name}."
 msgstr ""
 
-#: src/rhsm/config.py:249
+#: src/rhsm/config.py:290
+#, python-brace-format
 msgid ""
-"Please use:  subscription-manager config --logging.default_log_level=<Log "
-"Level> to set the default_log_level to a valid value."
+"Please use:  subscription-manager config --{section}.{name}=<value> to set "
+"{name} to a valid value."
 msgstr ""
 
-#: src/rhsm/config.py:255
+#: src/rhsm/config.py:295
 #, python-brace-format
 msgid "Valid Values: {valid_str}"
 msgstr ""
 
-#: src/rhsm/connection.py:1444
+#: src/rhsm/config.py:298
+#, python-brace-format
+msgid "Invalid value '{val}' for {section}.{name}. Valid values are: {valid}."
+msgstr ""
+
+#: src/rhsm/connection.py:1515
 msgid "Fetching supported resources"
 msgstr ""
 
-#: src/rhsm/connection.py:1504
+#: src/rhsm/connection.py:1575
 msgid "Checking connection status"
 msgstr ""
 
-#: src/rhsm/connection.py:1528
+#: src/rhsm/connection.py:1599
 msgid "Fetching cloud token"
 msgstr ""
 
-#: src/rhsm/connection.py:1607
+#: src/rhsm/connection.py:1682
 msgid "Registering system"
 msgstr ""
 
-#: src/rhsm/connection.py:1637 src/rhsm/connection.py:1649
+#: src/rhsm/connection.py:1712 src/rhsm/connection.py:1724
 msgid "Updating detected virtual machines running on given host"
 msgstr ""
 
-#: src/rhsm/connection.py:1672
+#: src/rhsm/connection.py:1747
 msgid "Updating hypervisor information"
 msgstr ""
 
-#: src/rhsm/connection.py:1747
+#: src/rhsm/connection.py:1826
 msgid "Updating consumer information"
 msgstr ""
 
-#: src/rhsm/connection.py:1752 src/rhsm/connection.py:1756
+#: src/rhsm/connection.py:1831 src/rhsm/connection.py:1835
 msgid "Fetching guest information"
 msgstr ""
 
-#: src/rhsm/connection.py:1760
+#: src/rhsm/connection.py:1839
 msgid "Removing guests"
 msgstr ""
 
-#: src/rhsm/connection.py:1790 src/rhsm/connection.py:1801
+#: src/rhsm/connection.py:1869 src/rhsm/connection.py:1880
 msgid "Updating profile information"
 msgstr ""
 
-#: src/rhsm/connection.py:1809
+#: src/rhsm/connection.py:1888
 msgid "Fetching consumer keys"
 msgstr ""
 
-#: src/rhsm/connection.py:1818
+#: src/rhsm/connection.py:1897
 msgid "Checking compliance status"
 msgstr ""
 
-#: src/rhsm/connection.py:1827
+#: src/rhsm/connection.py:1906
 msgid "Checking system purpose compliance status"
 msgstr ""
 
-#: src/rhsm/connection.py:1834
+#: src/rhsm/connection.py:1913
 msgid "Fetching available system purpose settings"
 msgstr ""
 
-#: src/rhsm/connection.py:1841 src/rhsm/connection.py:1849
+#: src/rhsm/connection.py:1920 src/rhsm/connection.py:1928
 msgid "Fetching organizations"
 msgstr ""
 
-#: src/rhsm/connection.py:1862
+#: src/rhsm/connection.py:1941
 msgid "Unregistering system"
 msgstr ""
 
-#: src/rhsm/connection.py:1886
+#: src/rhsm/connection.py:1965
 msgid "Fetching certificates"
 msgstr ""
 
-#: src/rhsm/connection.py:1895
+#: src/rhsm/connection.py:1974
 msgid "Fetching certificate serial numbers"
 msgstr ""
 
-#: src/rhsm/connection.py:1911
+#: src/rhsm/connection.py:1990
 msgid "Fetching content for a certificate"
 msgstr ""
 
-#: src/rhsm/connection.py:1924 src/rhsm/connection.py:1941
+#: src/rhsm/connection.py:2003 src/rhsm/connection.py:2020
 msgid "Updating subscriptions"
 msgstr ""
 
-#: src/rhsm/connection.py:1950 src/rhsm/connection.py:1960
-#: src/rhsm/connection.py:1969
+#: src/rhsm/connection.py:2029 src/rhsm/connection.py:2039
+#: src/rhsm/connection.py:2048
 msgid "Unsubscribing"
 msgstr ""
 
-#: src/rhsm/connection.py:2018
+#: src/rhsm/connection.py:2097
 msgid "Fetching pools"
 msgstr ""
 
-#: src/rhsm/connection.py:2029
+#: src/rhsm/connection.py:2108
 msgid "Fetching release information"
 msgstr ""
 
-#: src/rhsm/connection.py:2043
+#: src/rhsm/connection.py:2122
 msgid "Fetching available releases"
 msgstr ""
 
-#: src/rhsm/connection.py:2058
+#: src/rhsm/connection.py:2137
 msgid "Fetching entitlements"
 msgstr ""
 
-#: src/rhsm/connection.py:2067
+#: src/rhsm/connection.py:2146
 msgid "Fetching service levels"
 msgstr ""
 
-#: src/rhsm/connection.py:2078
+#: src/rhsm/connection.py:2157
 msgid "Fetching environments"
 msgstr ""
 
-#: src/rhsm/connection.py:2088
+#: src/rhsm/connection.py:2167
 msgid "Updating certificate"
 msgstr ""
 
-#: src/rhsm/connection.py:2107
+#: src/rhsm/connection.py:2186
 msgid "Updating certificates"
 msgstr ""
 
-#: src/rhsm/connection.py:2126
+#: src/rhsm/connection.py:2205
 msgid "Checking server status"
 msgstr ""
 
-#: src/rhsm/connection.py:2134
+#: src/rhsm/connection.py:2213
 msgid "Fetching content overrides"
 msgstr ""
 
-#: src/rhsm/connection.py:2145
+#: src/rhsm/connection.py:2224
 msgid "Updating content overrides"
 msgstr ""
 
-#: src/rhsm/connection.py:2158
+#: src/rhsm/connection.py:2237
 msgid "Removing content overrides"
 msgstr ""
 
-#: src/rhsm/connection.py:2174
+#: src/rhsm/connection.py:2253
 msgid "Activating"
 msgstr ""
 
-#: src/rhsm/connection.py:2183
+#: src/rhsm/connection.py:2262
 msgid "Fetching job"
+msgstr ""
+
+#: src/rhsm/logutil.py:211
+#, python-brace-format
+msgid "Using default value '{level}' for this run."
 msgstr ""
 
 #: src/rhsm_debug/debug_commands.py:39
@@ -954,17 +974,17 @@ msgid ""
 "exist on the same file system as the data assembly directory '{assembly}'."
 msgstr ""
 
-#: src/rhsm_debug/debug_commands.py:212
+#: src/rhsm_debug/debug_commands.py:216
 #, python-brace-format
 msgid "Wrote: {final_path}"
 msgstr ""
 
-#: src/rhsm_debug/debug_commands.py:226
+#: src/rhsm_debug/debug_commands.py:230
 #, python-brace-format
 msgid "Wrote: {destination_dir_name}"
 msgstr ""
 
-#: src/rhsm_debug/debug_commands.py:229
+#: src/rhsm_debug/debug_commands.py:233
 #, python-brace-format
 msgid "Unable to create zip file of system information: {error}"
 msgstr ""
@@ -1023,7 +1043,7 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: src/rhsmlib/services/entitlement.py:124 src/rhsmlib/services/register.py:64
+#: src/rhsmlib/services/entitlement.py:124 src/rhsmlib/services/register.py:66
 #, python-format
 msgid "Unknown arguments: %s"
 msgstr ""
@@ -1105,32 +1125,32 @@ msgstr ""
 msgid "Error: this system is not registered"
 msgstr ""
 
-#: src/rhsmlib/services/register.py:68
+#: src/rhsmlib/services/register.py:70
 msgid "Environment IDs and environment names are mutually exclusive"
 msgstr ""
 
-#: src/rhsmlib/services/register.py:167
+#: src/rhsmlib/services/register.py:174
 #, python-brace-format
 msgid ""
 "Environment: '{env_names}' does not have required type '{environment_type}'"
 msgstr ""
 
-#: src/rhsmlib/services/register.py:175
+#: src/rhsmlib/services/register.py:182
 #, python-brace-format
 msgid ""
 "Environments: '{env_names}' do not have required type '{environment_type}'"
 msgstr ""
 
-#: src/rhsmlib/services/register.py:238
+#: src/rhsmlib/services/register.py:245
 msgid "This system is already registered. Add force to options to override."
 msgstr ""
 
-#: src/rhsmlib/services/register.py:241
+#: src/rhsmlib/services/register.py:248
 #: src/subscription_manager/cli_command/register.py:146
 msgid "Error: system name can not be empty."
 msgstr ""
 
-#: src/rhsmlib/services/register.py:245
+#: src/rhsmlib/services/register.py:252
 #: src/subscription_manager/cli_command/register.py:168
 msgid ""
 "Error: Can not force registration while attempting to recover registration "
@@ -1138,22 +1158,22 @@ msgid ""
 "use the clean command and try again without --force."
 msgstr ""
 
-#: src/rhsmlib/services/register.py:255
+#: src/rhsmlib/services/register.py:262
 #: src/subscription_manager/cli_command/register.py:159
 msgid "Error: Must specify an activation key"
 msgstr ""
 
-#: src/rhsmlib/services/register.py:257
+#: src/rhsmlib/services/register.py:264
 #: src/subscription_manager/cli_command/register.py:148
 msgid "Error: Activation keys do not require user credentials."
 msgstr ""
 
-#: src/rhsmlib/services/register.py:260
+#: src/rhsmlib/services/register.py:267
 #: src/subscription_manager/cli_command/register.py:151
 msgid "Error: Activation keys can not be used with previously registered IDs."
 msgstr ""
 
-#: src/rhsmlib/services/register.py:267
+#: src/rhsmlib/services/register.py:274
 msgid "Error: Missing username or password."
 msgstr ""
 
@@ -1632,7 +1652,7 @@ msgid ""
 msgstr ""
 
 #: src/subscription_manager/cli_command/clean.py:31
-#: src/subscription_manager/cli_command/register.py:316
+#: src/subscription_manager/cli_command/register.py:315
 msgid "All local data removed"
 msgstr ""
 
@@ -1740,33 +1760,33 @@ msgid ""
 "removing configurations."
 msgstr ""
 
-#: src/subscription_manager/cli_command/config.py:93
+#: src/subscription_manager/cli_command/config.py:103
 msgid ""
 "Error: configuration entry designation for removal must be of format "
 "[section.name]"
 msgstr ""
 
-#: src/subscription_manager/cli_command/config.py:108
+#: src/subscription_manager/cli_command/config.py:118
 #, python-brace-format
 msgid "Error: Section {section} and name {name} does not exist."
 msgstr ""
 
-#: src/subscription_manager/cli_command/config.py:133
+#: src/subscription_manager/cli_command/config.py:143
 msgid "[] - Default value in use"
 msgstr ""
 
-#: src/subscription_manager/cli_command/config.py:143
-#: src/subscription_manager/cli_command/config.py:150
+#: src/subscription_manager/cli_command/config.py:153
+#: src/subscription_manager/cli_command/config.py:160
 #, python-brace-format
 msgid "You have removed the value for section {section} and name {name}."
 msgstr ""
 
-#: src/subscription_manager/cli_command/config.py:154
+#: src/subscription_manager/cli_command/config.py:164
 #, python-brace-format
 msgid "The default value for {name} will now be used."
 msgstr ""
 
-#: src/subscription_manager/cli_command/config.py:157
+#: src/subscription_manager/cli_command/config.py:167
 #, python-brace-format
 msgid "Section {section} and name {name} cannot be removed."
 msgstr ""
@@ -1800,7 +1820,7 @@ msgid "You may not specify an --org for environments when registered."
 msgstr ""
 
 #: src/subscription_manager/cli_command/environments.py:90
-#: src/subscription_manager/cli_command/register.py:464
+#: src/subscription_manager/cli_command/register.py:466
 msgid "Error: Server does not support environments."
 msgstr ""
 
@@ -1808,35 +1828,41 @@ msgstr ""
 msgid "This operation requires user credentials"
 msgstr ""
 
-#: src/subscription_manager/cli_command/environments.py:111
+#: src/subscription_manager/cli_command/environments.py:108
+msgid ""
+"Error: At least one environment must be set; use --list to get list of "
+"environments."
+msgstr ""
+
+#: src/subscription_manager/cli_command/environments.py:121
 msgid "Error: Unable to retrieve environment list from server"
 msgstr ""
 
-#: src/subscription_manager/cli_command/environments.py:126
+#: src/subscription_manager/cli_command/environments.py:136
 msgid "Environments updated."
 msgstr ""
 
-#: src/subscription_manager/cli_command/environments.py:128
+#: src/subscription_manager/cli_command/environments.py:138
 msgid "Error: Server does not support environment updates."
 msgstr ""
 
-#: src/subscription_manager/cli_command/environments.py:136
+#: src/subscription_manager/cli_command/environments.py:146
 msgid "Error: Server does not support multi-environment operations."
 msgstr ""
 
-#: src/subscription_manager/cli_command/environments.py:154
+#: src/subscription_manager/cli_command/environments.py:164
 msgid "Environments"
 msgstr ""
 
-#: src/subscription_manager/cli_command/environments.py:167
+#: src/subscription_manager/cli_command/environments.py:177
 msgid "This list operation does not have any environments to report."
 msgstr ""
 
-#: src/subscription_manager/cli_command/environments.py:203
+#: src/subscription_manager/cli_command/environments.py:213
 msgid "Error: The same environment may not be listed more than once. "
 msgstr ""
 
-#: src/subscription_manager/cli_command/environments.py:209
+#: src/subscription_manager/cli_command/environments.py:219
 #, python-brace-format
 msgid "No such environment: {names}"
 msgid_plural "No such environments: {names}"
@@ -1859,77 +1885,77 @@ msgstr ""
 msgid "Successfully updated the system facts."
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:40
+#: src/subscription_manager/cli_command/identity.py:41
 msgid "Display the identity certificate for this system or request a new one"
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:47
+#: src/subscription_manager/cli_command/identity.py:48
 msgid "request a new certificate be generated"
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:53
+#: src/subscription_manager/cli_command/identity.py:54
 msgid ""
 "force certificate regeneration (requires username and password); Only used "
 "with --regenerate"
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:61
+#: src/subscription_manager/cli_command/identity.py:62
 msgid "--force can only be used with --regenerate"
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:63
+#: src/subscription_manager/cli_command/identity.py:64
 msgid "--username and --password can only be used with --force"
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:65
+#: src/subscription_manager/cli_command/identity.py:66
 msgid "--token can only be used with --force"
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:74
-#: src/subscription_manager/cli_command/identity.py:77
+#: src/subscription_manager/cli_command/identity.py:75
+#: src/subscription_manager/cli_command/identity.py:78
 #: src/subscription_manager/cli_command/version.py:33
 #, python-brace-format
 msgid "server type: {type}"
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:89
+#: src/subscription_manager/cli_command/identity.py:90
 #, python-brace-format
 msgid "system identity: {consumerid}"
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:90
+#: src/subscription_manager/cli_command/identity.py:91
 #, python-brace-format
 msgid "name: {consumer_name}"
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:91
+#: src/subscription_manager/cli_command/identity.py:92
 #, python-brace-format
 msgid "org name: {ownername}"
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:92
+#: src/subscription_manager/cli_command/identity.py:93
 #, python-brace-format
 msgid "org ID: {ownerid}"
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:107
+#: src/subscription_manager/cli_command/identity.py:108
 #: src/subscription_manager/printing_utils.py:165
 #: src/subscription_manager/printing_utils.py:184
 msgid "None"
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:110
+#: src/subscription_manager/cli_command/identity.py:111
 #, python-brace-format
 msgid "environment name: {environment_name}"
 msgid_plural "environment names: {environment_name}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/subscription_manager/cli_command/identity.py:130
+#: src/subscription_manager/cli_command/identity.py:137
 msgid "Identity certificate has been regenerated."
 msgstr ""
 
-#: src/subscription_manager/cli_command/identity.py:143
+#: src/subscription_manager/cli_command/identity.py:150
 msgid "Error: Unable to generate a new identity for the system"
 msgstr ""
 
@@ -2363,12 +2389,12 @@ msgid "specify an organization"
 msgstr ""
 
 #: src/subscription_manager/cli_command/org.py:46
-#: src/subscription_manager/cli_command/register.py:526
+#: src/subscription_manager/cli_command/register.py:528
 msgid "Error: --org is a required parameter in non-interactive mode."
 msgstr ""
 
 #: src/subscription_manager/cli_command/org.py:48
-#: src/subscription_manager/cli_command/register.py:531
+#: src/subscription_manager/cli_command/register.py:533
 msgid "Organization: "
 msgstr ""
 
@@ -2378,7 +2404,7 @@ msgid "Error: User {username} is not member of any organization."
 msgstr ""
 
 #: src/subscription_manager/cli_command/org.py:74
-#: src/subscription_manager/cli_command/register.py:517
+#: src/subscription_manager/cli_command/register.py:519
 #, python-brace-format
 msgid "Hint: User \"{name}\" is member of following organizations: {orgs}"
 msgstr ""
@@ -2642,7 +2668,7 @@ msgid "Error: The --type option has been deprecated and may not be used."
 msgstr ""
 
 #: src/subscription_manager/cli_command/register.py:180
-#: src/subscription_manager/cli_command/register.py:495
+#: src/subscription_manager/cli_command/register.py:497
 msgid "The entitlement server does not allow multiple environments"
 msgstr ""
 
@@ -2650,60 +2676,60 @@ msgstr ""
 msgid "Uploading DNF profile"
 msgstr ""
 
-#: src/subscription_manager/cli_command/register.py:294
+#: src/subscription_manager/cli_command/register.py:293
 #: src/subscription_manager/cli_command/unregister.py:41
 #, python-brace-format
 msgid "Unregistering from: {hostname}:{port}{prefix}"
 msgstr ""
 
-#: src/subscription_manager/cli_command/register.py:305
+#: src/subscription_manager/cli_command/register.py:304
 #, python-brace-format
 msgid "The system with UUID {old_uuid} has been unregistered"
 msgstr ""
 
-#: src/subscription_manager/cli_command/register.py:329
+#: src/subscription_manager/cli_command/register.py:328
 #, python-brace-format
 msgid "Registering to: {hostname}:{port}{prefix}"
 msgstr ""
 
-#: src/subscription_manager/cli_command/register.py:369
+#: src/subscription_manager/cli_command/register.py:368
 #, python-brace-format
 msgid "Error during registration: {e}"
 msgstr ""
 
-#: src/subscription_manager/cli_command/register.py:372
+#: src/subscription_manager/cli_command/register.py:371
 #, python-brace-format
 msgid "The system has been registered with ID: {id}"
 msgstr ""
 
-#: src/subscription_manager/cli_command/register.py:373
+#: src/subscription_manager/cli_command/register.py:372
 #, python-brace-format
 msgid "The registered system name is: {name}"
 msgstr ""
 
-#: src/subscription_manager/cli_command/register.py:375
+#: src/subscription_manager/cli_command/register.py:374
 #, python-brace-format
 msgid "Service level set to: {level}"
 msgstr ""
 
-#: src/subscription_manager/cli_command/register.py:442
+#: src/subscription_manager/cli_command/register.py:444
 msgid "Error: --environments is a required parameter in non-interactive mode."
 msgstr ""
 
-#: src/subscription_manager/cli_command/register.py:446
+#: src/subscription_manager/cli_command/register.py:448
 msgid "Environments: "
 msgstr ""
 
-#: src/subscription_manager/cli_command/register.py:448
+#: src/subscription_manager/cli_command/register.py:450
 msgid "Environment: "
 msgstr ""
 
-#: src/subscription_manager/cli_command/register.py:489
+#: src/subscription_manager/cli_command/register.py:491
 #, python-brace-format
 msgid "Hint: Organization \"{key}\" contains following environments: {list}"
 msgstr ""
 
-#: src/subscription_manager/cli_command/register.py:505
+#: src/subscription_manager/cli_command/register.py:507
 #, python-brace-format
 msgid "{name} cannot register with any organizations."
 msgstr ""
@@ -3285,6 +3311,11 @@ msgstr ""
 msgid "Deleted:"
 msgstr ""
 
+#: src/subscription_manager/pqc.py:65
+#, python-brace-format
+msgid "Using default value '{value}' for this run."
+msgstr ""
+
 #: src/subscription_manager/reasons.py:102
 msgid "Product "
 msgstr ""
@@ -3344,21 +3375,21 @@ msgstr ""
 msgid "Error uploading package profile: %s\n"
 msgstr ""
 
-#: src/subscription_manager/scripts/rhsmcertd_worker.py:343
+#: src/subscription_manager/scripts/rhsmcertd_worker.py:445
 msgid ""
 "This system is already registered, ignoring request to automatically "
 "register."
 msgstr ""
 
-#: src/subscription_manager/scripts/rhsmcertd_worker.py:346
+#: src/subscription_manager/scripts/rhsmcertd_worker.py:449
 msgid "Registering the system"
 msgstr ""
 
-#: src/subscription_manager/scripts/rhsmcertd_worker.py:357
+#: src/subscription_manager/scripts/rhsmcertd_worker.py:460
 msgid "Updating entitlement certificates & repositories."
 msgstr ""
 
-#: src/subscription_manager/scripts/rhsmcertd_worker.py:430
+#: src/subscription_manager/scripts/rhsmcertd_worker.py:552
 msgid "Unable to update entitlement certificates and repositories"
 msgstr ""
 


### PR DESCRIPTION
* New version of keys.pot file including a few new strings for `subscription-manager-1.29` release branch