### PR TITLE
Add package persistence information to 1.29

### DIFF
--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -15,7 +15,7 @@ import logging
 import importlib.util
 import rpm
 import os.path
-from typing import List, Union
+from typing import List, Optional, Union
 
 from rhsm import ourjson as json
 from rhsm.utils import suppress_output
@@ -377,7 +377,7 @@ class Package:
         return value
 
 
-def parse_rpm_string(rpm_string: str) -> dict | None:
+def parse_rpm_string(rpm_string: str) -> Optional[dict]:
     """
     Parses a standard RPM package string into its NVR components using hawkey.
 
@@ -386,7 +386,7 @@ def parse_rpm_string(rpm_string: str) -> dict | None:
             Example: "NetworkManager-cloud-setup-1:1.54.0-2.fc43.x86_64"
 
         Returns:
-        dict | None: A dictionary with the following keys if the match is successful:
+        Optional[dict]: A dictionary with the following keys if the match is successful:
             - 'name': The package name (including any internal hyphens).
             - 'version': The version string (e.g., '1.54.0').
             - 'epoch': The epoch string (e.g., '1').

--- a/test/rhsm/functional/test_profile.py
+++ b/test/rhsm/functional/test_profile.py
@@ -38,6 +38,7 @@ class ProfileTests(unittest.TestCase):
             self.assertTrue("epoch" in pkg)
             self.assertTrue("arch" in pkg)
             self.assertTrue("vendor" in pkg)
+            self.assertTrue("persistence" in pkg)
 
     def test_package_objects(self):
         profile = get_profile("rpm")
@@ -49,8 +50,8 @@ class ProfileTests(unittest.TestCase):
 
     def test_load_profile_from_file(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
         self.assertEqual(2, len(profile.packages))
@@ -72,16 +73,16 @@ class ProfileTests(unittest.TestCase):
 
     def test_equality_different_object_type(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
         self.assertFalse(profile == "hello")
 
     def test_equality_no_change(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
 
@@ -90,19 +91,21 @@ class ProfileTests(unittest.TestCase):
 
     def test_equality_packages_added(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
 
-        dummy_pkgs.append(Package(name="package3", version="3.0.0", release="2", arch="x86_64"))
+        dummy_pkgs.append(
+            Package(name="package3", version="3.0.0", release="2", arch="x86_64", persistence="persistent")
+        )
         other = self._mock_pkg_profile(dummy_pkgs)
         self.assertFalse(profile == other)
 
     def test_equality_packages_removed(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
 
@@ -112,8 +115,8 @@ class ProfileTests(unittest.TestCase):
 
     def test_equality_packages_updated(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
 
@@ -124,13 +127,15 @@ class ProfileTests(unittest.TestCase):
 
     def test_equality_packages_replaced(self):
         dummy_pkgs = [
-            Package(name="package1", version="1.0.0", release="1", arch="x86_64"),
-            Package(name="package2", version="2.0.0", release="2", arch="x86_64"),
+            Package(name="package1", version="1.0.0", release="1", arch="x86_64", persistence="persistent"),
+            Package(name="package2", version="2.0.0", release="2", arch="x86_64", persistence="persistent"),
         ]
         profile = self._mock_pkg_profile(dummy_pkgs)
 
         # Remove package2, add package3:
         dummy_pkgs.pop()
-        dummy_pkgs.append(Package(name="package3", version="3.0.0", release="2", arch="x86_64"))
+        dummy_pkgs.append(
+            Package(name="package3", version="3.0.0", release="2", arch="x86_64", persistence="persistent")
+        )
         other = self._mock_pkg_profile(dummy_pkgs)
         self.assertFalse(profile == other)

--- a/test/rhsm/unit/test_profile.py
+++ b/test/rhsm/unit/test_profile.py
@@ -17,7 +17,13 @@ from unittest.mock import patch
 
 from cloud_what.providers import aws, azure, gcp
 
-from rhsm.profile import ModulesProfile, EnabledReposProfile
+from rhsm.profile import (
+    ModulesProfile,
+    EnabledReposProfile,
+    parse_rpm_string,
+    _is_ostree_system,
+    _get_immutable_packages,
+)
 
 
 class TestModulesProfile(unittest.TestCase):
@@ -225,3 +231,172 @@ class TestEnabledReposProfile(unittest.TestCase):
             self.assertEqual(
                 repo_list[0]["baseurl"], ["http://cdn.foo.com/content/dist/snakes/1.0/x86_64/os"]
             )
+
+
+class TestParseRpmString(unittest.TestCase):
+    """
+    Test case for parse_rpm_string function
+    """
+
+    def test_parse_valid_rpm_string_with_epoch(self):
+        """
+        Test parsing a valid RPM string with epoch
+        """
+        rpm_string = "NetworkManager-cloud-setup-1:1.54.0-2.fc43.x86_64"
+        result = parse_rpm_string(rpm_string)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["name"], "NetworkManager-cloud-setup")
+        self.assertEqual(result["ver"], "1:1.54.0")
+        self.assertEqual(result["rel"], "2.fc43")
+        self.assertEqual(result["arch"], "x86_64")
+
+    def test_parse_valid_rpm_string_without_epoch(self):
+        """
+        Test parsing a valid RPM string without epoch
+        """
+        rpm_string = "bash-completion-2.16-2.fc43.noarch"
+        result = parse_rpm_string(rpm_string)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["name"], "bash-completion")
+        self.assertEqual(result["ver"], "2.16")
+        self.assertEqual(result["rel"], "2.fc43")
+        self.assertEqual(result["arch"], "noarch")
+
+    def test_parse_rpm_string_with_hyphens_in_name(self):
+        """
+        Test parsing RPM string where package name contains multiple hyphens
+        """
+        rpm_string = "amd-ucode-firmware-20241210-164.fc42.noarch"
+        result = parse_rpm_string(rpm_string)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["name"], "amd-ucode-firmware")
+        self.assertEqual(result["ver"], "20241210")
+        self.assertEqual(result["rel"], "164.fc42")
+        self.assertEqual(result["arch"], "noarch")
+
+    def test_parse_rpm_string_with_leading_whitespace(self):
+        """
+        Test parsing RPM string with leading whitespace
+        """
+        rpm_string = "  bash-5.2.32-1.fc42.x86_64"
+        result = parse_rpm_string(rpm_string)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["name"], "bash")
+        self.assertEqual(result["ver"], "5.2.32")
+        self.assertEqual(result["rel"], "1.fc42")
+        self.assertEqual(result["arch"], "x86_64")
+
+    def test_parse_invalid_rpm_string(self):
+        """
+        Test parsing an invalid RPM string returns None
+        """
+        rpm_string = "invalid-package-string"
+        result = parse_rpm_string(rpm_string)
+        self.assertIsNone(result)
+
+    def test_parse_empty_string(self):
+        """
+        Test parsing an empty string returns None
+        """
+        rpm_string = ""
+        result = parse_rpm_string(rpm_string)
+        self.assertIsNone(result)
+
+
+class TestOstreeSystemDetection(unittest.TestCase):
+    """
+    Test case for ostree system detection functions
+    """
+
+    @patch("rhsm.profile.ostree_available", False)
+    def test_is_ostree_system_without_ostree_library(self):
+        """
+        Test detection when ostree library is not available
+        """
+        result = _is_ostree_system()
+        self.assertFalse(result)
+
+    @patch("rhsm.profile.ostree_available", True)
+    @patch("rhsm.profile.OSTree", create=True)
+    def test_is_ostree_system_with_booted_deployment(self, mock_ostree):
+        """
+        Test detection when there is a booted ostree deployment
+        """
+        mock_sysroot = mock.Mock()
+        mock_sysroot.load = mock.Mock()
+        mock_sysroot.get_booted_deployment = mock.Mock(return_value=mock.Mock())
+
+        mock_ostree.Sysroot.new_default.return_value = mock_sysroot
+
+        result = _is_ostree_system()
+        self.assertTrue(result)
+        mock_sysroot.load.assert_called_once_with(None)
+        mock_sysroot.get_booted_deployment.assert_called_once()
+
+    @patch("rhsm.profile.ostree_available", True)
+    @patch("rhsm.profile.OSTree", create=True)
+    def test_is_ostree_system_without_booted_deployment(self, mock_ostree):
+        """
+        Test detection when there is no booted ostree deployment
+        """
+        mock_sysroot = mock.Mock()
+        mock_sysroot.load = mock.Mock()
+        mock_sysroot.get_booted_deployment = mock.Mock(return_value=None)
+        mock_ostree.Sysroot.new_default.return_value = mock_sysroot
+        result = _is_ostree_system()
+        self.assertFalse(result)
+
+    @patch("rhsm.profile.ostree_available", True)
+    @patch("rhsm.profile.OSTree", create=True)
+    def test_is_ostree_system_with_ostree_api_exception(self, mock_ostree):
+        """
+        Test detection when OSTree API raises an exception
+        """
+        mock_ostree.Sysroot.new_default.side_effect = Exception("OSTree API error")
+
+        result = _is_ostree_system()
+        self.assertFalse(result)
+
+    @patch("subprocess.run")
+    @patch("rhsm.profile.json.loads")
+    def test_get_immutable_packages(self, mock_json_loads, mock_subprocess_run):
+        """
+        Test getting immutable packages from ostree system
+        """
+        # Mock rpm-ostree status output
+        mock_status = {"deployments": [{"checksum": "abc123def456"}]}
+
+        # Mock rpm-ostree db list output
+        mock_db_list_output = """ostree commit: abc123def456
+bash-5.2.32-1.fc42.x86_64
+systemd-257.3-1.fc42.x86_64
+NetworkManager-1:1.54.0-2.fc43.x86_64"""
+
+        mock_subprocess_run.side_effect = [
+            mock.Mock(stdout='{"deployments": [{"checksum": "abc123def456"}]}', returncode=0),
+            mock.Mock(stdout=mock_db_list_output, returncode=0),
+        ]
+
+        mock_json_loads.return_value = mock_status
+
+        result = _get_immutable_packages()
+
+        self.assertIsInstance(result, set)
+        self.assertIn("bash", result)
+        self.assertIn("systemd", result)
+        self.assertIn("NetworkManager", result)
+        self.assertEqual(len(result), 3)
+
+    @patch("subprocess.run")
+    def test_get_immutable_packages_command_failure(self, mock_run):
+        """
+        Test handling of rpm-ostree command failure
+        """
+        from subprocess import CalledProcessError
+
+        mock_run.side_effect = CalledProcessError(1, "rpm-ostree")
+
+        result = _get_immutable_packages()
+
+        self.assertIsInstance(result, set)
+        self.assertEqual(len(result), 0)

--- a/test/rhsm/unit/test_profile.py
+++ b/test/rhsm/unit/test_profile.py
@@ -246,8 +246,9 @@ class TestParseRpmString(unittest.TestCase):
         result = parse_rpm_string(rpm_string)
         self.assertIsNotNone(result)
         self.assertEqual(result["name"], "NetworkManager-cloud-setup")
-        self.assertEqual(result["ver"], "1:1.54.0")
-        self.assertEqual(result["rel"], "2.fc43")
+        self.assertEqual(result["version"], "1.54.0")
+        self.assertEqual(result["epoch"], 1)
+        self.assertEqual(result["release"], "2.fc43")
         self.assertEqual(result["arch"], "x86_64")
 
     def test_parse_valid_rpm_string_without_epoch(self):
@@ -258,8 +259,9 @@ class TestParseRpmString(unittest.TestCase):
         result = parse_rpm_string(rpm_string)
         self.assertIsNotNone(result)
         self.assertEqual(result["name"], "bash-completion")
-        self.assertEqual(result["ver"], "2.16")
-        self.assertEqual(result["rel"], "2.fc43")
+        self.assertEqual(result["version"], "2.16")
+        self.assertEqual(result["epoch"], 0)
+        self.assertEqual(result["release"], "2.fc43")
         self.assertEqual(result["arch"], "noarch")
 
     def test_parse_rpm_string_with_hyphens_in_name(self):
@@ -270,8 +272,9 @@ class TestParseRpmString(unittest.TestCase):
         result = parse_rpm_string(rpm_string)
         self.assertIsNotNone(result)
         self.assertEqual(result["name"], "amd-ucode-firmware")
-        self.assertEqual(result["ver"], "20241210")
-        self.assertEqual(result["rel"], "164.fc42")
+        self.assertEqual(result["version"], "20241210")
+        self.assertEqual(result["epoch"], 0)
+        self.assertEqual(result["release"], "164.fc42")
         self.assertEqual(result["arch"], "noarch")
 
     def test_parse_rpm_string_with_leading_whitespace(self):
@@ -282,8 +285,9 @@ class TestParseRpmString(unittest.TestCase):
         result = parse_rpm_string(rpm_string)
         self.assertIsNotNone(result)
         self.assertEqual(result["name"], "bash")
-        self.assertEqual(result["ver"], "5.2.32")
-        self.assertEqual(result["rel"], "1.fc42")
+        self.assertEqual(result["version"], "5.2.32")
+        self.assertEqual(result["epoch"], 0)
+        self.assertEqual(result["release"], "1.fc42")
         self.assertEqual(result["arch"], "x86_64")
 
     def test_parse_invalid_rpm_string(self):
@@ -382,9 +386,10 @@ NetworkManager-1:1.54.0-2.fc43.x86_64"""
         result = _get_immutable_packages()
 
         self.assertIsInstance(result, set)
-        self.assertIn("bash", result)
-        self.assertIn("systemd", result)
-        self.assertIn("NetworkManager", result)
+        # Check that result contains tuples with (name, version, epoch, release)
+        self.assertIn(("bash", "5.2.32", 0, "1.fc42"), result)
+        self.assertIn(("systemd", "257.3", 0, "1.fc42"), result)
+        self.assertIn(("NetworkManager", "1.54.0", 1, "2.fc43"), result)
         self.assertEqual(len(result), 3)
 
     @patch("subprocess.run")


### PR DESCRIPTION
## Description

This PR cherry-picks the following commits to add package persistence data to package profiles in 1.29 version:
* https://github.com/candlepin/subscription-manager/commit/fb4a5b96f9534e9ed1d8aeb55f4dc4a0519fa38f
* https://github.com/candlepin/subscription-manager/commit/7f10ecac199176317b2e3f74426332338f09d208