### PR TITLE
integration-test: Don't run "dnf" in vm.install

### DIFF
--- a/integration-tests/vm.install
+++ b/integration-tests/vm.install
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -eux
 
-dnf install -y cockpit-ws python3-devel openssl-devel intltool
-
 cd /var/tmp
 
 rm -rf /usr/share/cockpit/subscriptions


### PR DESCRIPTION
In the near future, the integration tests will run in a new environment that doesn't have access to internal Red Hat repositories. Instead, the images are expected to contain all necessary dependencies.