### PR TITLE
cockpit-test: make vm.install run offline

### DIFF
--- a/cockpit-tests/vm.install
+++ b/cockpit-tests/vm.install
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -eux
 
-dnf install -y cockpit-ws python3-devel openssl-devel gcc
-
 rm -f /usr/*bin/subscription-manager
 
 cd /var/tmp


### PR DESCRIPTION
These packages are now included in test images so they no longer need to be installed during image-prepare. New AWS runners do not have access to RHEL repositories during this step so RHEL CI needs to run offline.